### PR TITLE
feat(tables, curves): 3D view toggle on all tables + click-drag curve editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,27 @@ relevant.
 
 ## [Unreleased]
 
+### Jul 8, 2026 — Table 3D toggle & curve drag editing
+
+#### Added
+- **3D view toggle on all table editors** — `TableEditor2D` (standalone header
+  + compact embedded title bar) and `tables/TableToolbar` (view controls) now
+  expose a 3D toggle (Box icon) that swaps the grid for the existing
+  react-three-fiber `TableEditor3D` (heatmap scheme, cell-selection sync,
+  back-to-2D button). Brings the standalone and dialog-embedded editors to
+  parity with the tab-based `tuner-ui/TableEditor`.
+- **Click-drag curve editing** — the curve editor now lets you click anywhere
+  in the plot area to grab the nearest point and drag it (direct point-grab
+  still works). Drag is tracked at the window level so it continues outside
+  the SVG bounds and always commits on release; crosshair/ns-resize cursor
+  feedback and undo/redo history are preserved.
+
+#### Fixed
+- **Curve editor crash** — guarded remaining `undefined` bin accesses in the
+  curve data points and table cells, eliminating the
+  "Cannot read properties of undefined (reading 'toFixed')" render error when
+  x/y bin arrays momentarily mismatch in length.
+
 ### Sprint 3 — Spec wrap-up (S-5..S-7)
 
 #### Added

--- a/crates/libretune-app/public/manual/changelog.md
+++ b/crates/libretune-app/public/manual/changelog.md
@@ -5,6 +5,12 @@ All notable changes to LibreTune will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- **3D view on every table** — The 3D view toggle is now available on all table
+  editors, including tables embedded in dialogs. Click the 3D button to switch
+  between the 2D grid and an interactive 3D surface.
+- **Click-and-drag curve editing** — Edit 1D curves by clicking anywhere on the
+  chart to grab the nearest point and dragging it up or down. The drag keeps
+  tracking even if the cursor leaves the chart and commits when you release.
 - **Base Map Generator** — Create safe, driveable starting tunes from engine specifications (cylinder count, displacement, injector size, fuel type, aspiration, etc.). Generates VE, ignition, AFR tables plus enrichment curves. Accessible from Welcome View and Tools menu.
 - **File-centric workflow** — Projects are now created automatically when you open a tune file. The Welcome View shows three main actions: Open Tune File, Connect to ECU, and Import TS Project.
 - **Open Tune File dialog** — Browse for .msq/.xml files with automatic INI signature matching, preview panel, and one-click project creation.

--- a/crates/libretune-app/public/manual/features/table-editing.md
+++ b/crates/libretune-app/public/manual/features/table-editing.md
@@ -100,6 +100,19 @@ Enable **Follow Mode** to automatically highlight the cell corresponding to curr
 2. Click the crosshair icon in the toolbar
 3. The current operating cell is highlighted
 
+## Editing Curves
+
+1D curves (for example, warmup enrichment or fan PWM vs. temperature) open in
+the curve editor, which shows the values as a draggable line chart alongside a
+data table.
+
+- **Drag to edit** — Click anywhere on the chart to grab the nearest point and
+  drag it up or down. You can also grab a point marker directly. The drag keeps
+  tracking even if the cursor leaves the chart area and commits when you release.
+- **Type exact values** — Double-click any cell in the data table to enter a
+  precise number.
+- **Undo/Redo** — `Ctrl+Z` / `Ctrl+Y` work the same as in table editing.
+
 ## Next Steps
 
 - [2D Tables](./table-editing/2d-tables.md) - Detailed 2D table editing

--- a/crates/libretune-app/public/manual/features/table-editing/3d-visualization.md
+++ b/crates/libretune-app/public/manual/features/table-editing/3d-visualization.md
@@ -8,6 +8,10 @@ View tables in three dimensions for better understanding.
 2. Click the **3D** button in the toolbar
 3. The 3D view appears alongside or replaces the 2D grid
 
+> The 3D toggle is available on every table editor — standalone tables opened
+> in a tab as well as tables embedded inside dialogs (via the compact title-bar
+> button).
+
 ## Navigation
 
 ### Mouse Controls

--- a/crates/libretune-app/src/components/curves/CurveEditor.tsx
+++ b/crates/libretune-app/src/components/curves/CurveEditor.tsx
@@ -480,21 +480,53 @@ export default function CurveEditor({
     setSelectedPoint(index);
   };
 
-  // Handle mouse move for dragging
-  const handleMouseMove = useCallback((e: React.MouseEvent) => {
-    if (!isDragging || dragPointIndex === null || !svgRef.current) return;
-    
+  /** Move the currently dragged point to the given clientY (shared by point-grab, chart-grab, and window listeners). */
+  const updateDragFromClientY = useCallback((clientY: number, pointIndex: number | null = dragPointIndex) => {
+    if (pointIndex === null || !svgRef.current) return;
     const rect = svgRef.current.getBoundingClientRect();
-    const screenY = e.clientY - rect.top;
+    const screenY = clientY - rect.top;
     let newY = unscaleY(screenY);
-    
     // Clamp to axis bounds
     newY = Math.max(yAxis.min, Math.min(yAxis.max, newY));
-    
-    const newYBins = [...localYBins];
-    newYBins[dragPointIndex] = newY;
-    setLocalYBins(newYBins);
-  }, [isDragging, dragPointIndex, unscaleY, yAxis, localYBins]);
+    setLocalYBins(prev => {
+      const next = [...prev];
+      next[pointIndex] = newY;
+      return next;
+    });
+  }, [dragPointIndex, unscaleY, yAxis]);
+
+  // Click anywhere in the plot area to grab the nearest point and drag it
+  // (TS-style curve editing — no need to hit the small point circles).
+  const handleChartMouseDown = (e: React.MouseEvent) => {
+    if (e.button !== 0 || !svgRef.current || !hasValidData || localXBins.length === 0) return;
+    const rect = svgRef.current.getBoundingClientRect();
+    const sx = e.clientX - rect.left;
+    const sy = e.clientY - rect.top;
+    // Only react to clicks inside the plot area
+    if (
+      sx < padding.left || sx > chartWidth - padding.right ||
+      sy < padding.top || sy > chartHeight - padding.bottom
+    ) {
+      return;
+    }
+    // Find the nearest bin by screen X distance
+    let nearest = 0;
+    let bestDist = Infinity;
+    localXBins.forEach((x, i) => {
+      const d = Math.abs(scaleX(x) - sx);
+      if (d < bestDist) {
+        bestDist = d;
+        nearest = i;
+      }
+    });
+    e.preventDefault();
+    pushHistory();
+    setIsDragging(true);
+    setDragPointIndex(nearest);
+    setSelectedPoint(nearest);
+    // Immediately snap the grabbed point to the clicked Y
+    updateDragFromClientY(e.clientY, nearest);
+  };
 
   // Handle mouse up to end dragging
   const handleMouseUp = useCallback(() => {
@@ -504,6 +536,20 @@ export default function CurveEditor({
     setIsDragging(false);
     setDragPointIndex(null);
   }, [isDragging, dragPointIndex, localXBins, localYBins, persistCurveValues]);
+
+  // While dragging, track the mouse at window level so the drag continues
+  // smoothly outside the SVG and always commits on release.
+  useEffect(() => {
+    if (!isDragging) return;
+    const onMove = (e: MouseEvent) => updateDragFromClientY(e.clientY);
+    const onUp = () => handleMouseUp();
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
+    return () => {
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mouseup', onUp);
+    };
+  }, [isDragging, updateDragFromClientY, handleMouseUp]);
 
   const commitCellEdit = useCallback(
     (index: number, axis: 'x' | 'y') => {
@@ -690,8 +736,9 @@ Suggestion: {errorInfo.suggestion}
 
   const renderCurveTableBody = () =>
     localXBins.map((x, i) => {
-      const yValue = localYBins[i];
-      const xCellStyle = getHeatmapCellStyle(x, xAxis.min, xAxis.max);
+      const xValue = x ?? 0;
+      const yValue = localYBins[i] ?? 0;
+      const xCellStyle = getHeatmapCellStyle(xValue, xAxis.min, xAxis.max);
       const yCellStyle = getHeatmapCellStyle(yValue, yAxis.min, yAxis.max);
       const editingX = editingCell?.index === i && editingCell.axis === 'x';
       const editingY = editingCell?.index === i && editingCell.axis === 'y';
@@ -717,7 +764,7 @@ Suggestion: {errorInfo.suggestion}
                 autoFocus
               />
             ) : (
-              x.toFixed(2)
+              xValue.toFixed(2)
             )}
           </td>
           <td
@@ -797,9 +844,8 @@ Suggestion: {errorInfo.suggestion}
             width={chartWidth}
             height={chartHeight}
             className="curve-svg"
-            onMouseMove={handleMouseMove}
-            onMouseUp={handleMouseUp}
-            onMouseLeave={handleMouseUp}
+            style={{ cursor: isDragging ? 'ns-resize' : 'crosshair' }}
+            onMouseDown={handleChartMouseDown}
           >
             {/* Background */}
             <rect
@@ -888,8 +934,8 @@ Suggestion: {errorInfo.suggestion}
             {localXBins.map((x, i) => (
               <circle
                 key={i}
-                cx={scaleX(x)}
-                cy={scaleY(localYBins[i])}
+                cx={scaleX(x ?? 0)}
+                cy={scaleY(localYBins[i] ?? 0)}
                 r={selectedPoint === i ? 8 : 6}
                 fill={selectedPoint === i ? '#fff' : '#f5d742'}
                 stroke="#000"

--- a/crates/libretune-app/src/components/tables/TableEditor2D.tsx
+++ b/crates/libretune-app/src/components/tables/TableEditor2D.tsx
@@ -1,8 +1,9 @@
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { invoke } from '@tauri-apps/api/core';
-import { ArrowLeft, Save, Zap, ExternalLink, AlertTriangle, Palette, MapPin, Crosshair } from 'lucide-react';
+import { ArrowLeft, Save, Zap, ExternalLink, AlertTriangle, Palette, MapPin, Crosshair, Box } from 'lucide-react';
 import TableToolbar from './TableToolbar';
 import TableGrid, { SelectionRange } from './TableGrid';
+import TableEditor3D from './TableEditor3D';
 import TableContextMenu from './TableContextMenu';
 import RebinDialog from '../dialogs/RebinDialog';
 import CellEditDialog from '../dialogs/CellEditDialog';
@@ -151,6 +152,7 @@ export default function TableEditor2D({
   const [historyTrail, setHistoryTrail] = useState<[number, number][]>([]);
   const [showColorShade, setShowColorShade] = useState(true);
   const [showHistoryTrail, setShowHistoryTrail] = useState(false);
+  const [show3D, setShow3D] = useState(false);
   
   // History Stack
   type HistorySnapshot = {
@@ -1029,6 +1031,14 @@ export default function TableEditor2D({
           >
             <Palette size={14} />
           </button>
+          <button 
+            className={`embedded-toggle ${show3D ? 'active' : ''}`}
+            onClick={() => setShow3D(!show3D)}
+            title="Toggle 3D View"
+            aria-label="Toggle 3D View"
+          >
+            <Box size={14} />
+          </button>
           {onOpenInTab && (
             <button 
               className="pop-out-btn" 
@@ -1074,6 +1084,14 @@ export default function TableEditor2D({
             >
               <span className="action-icon"><Crosshair size={16} /></span>
             </button>
+            <button 
+              className={`action-btn ${show3D ? 'active' : ''}`}
+              onClick={() => setShow3D(!show3D)}
+              title="Toggle 3D View"
+              aria-label="Toggle 3D View"
+            >
+              <span className="action-icon"><Box size={16} /></span>
+            </button>
             <button className="action-btn" onClick={handleSave} title="Save (S)">
               <Save size={18} />
             </button>
@@ -1105,9 +1123,25 @@ export default function TableEditor2D({
           onFollowModeToggle={() => setFollowMode(!followMode)}
           showColorShade={showColorShade}
           onColorShadeToggle={() => setShowColorShade(!showColorShade)}
+          show3D={show3D}
+          onToggle3D={() => setShow3D(!show3D)}
         />
       )}
 
+      {show3D ? (
+        <TableEditor3D
+          title={title}
+          x_bins={localXBins}
+          y_bins={localYBins}
+          z_values={localZValues}
+          x_label={x_axis_name}
+          y_label={y_axis_name}
+          onBack={() => setShow3D(false)}
+          selectedCell={selectionRange ? { x: selectionRange.start[0], y: selectionRange.start[1] } : null}
+          onCellSelect={(x, y) => setSelectionRange({ start: [x, y], end: [x, y] })}
+          heatmapScheme={heatmapSettings.valueScheme}
+        />
+      ) : (
       <div 
         className={`editor-content${hasEmbeddedTableLiveReadout(table_name, x_output_channel, y_output_channel) ? ' editor-content--with-live' : ''}`}
         onContextMenu={e => {
@@ -1153,6 +1187,7 @@ export default function TableEditor2D({
           />
         )}
       </div>
+      )}
 
       <TableContextMenu
         visible={contextMenu.visible}

--- a/crates/libretune-app/src/components/tables/TableToolbar.tsx
+++ b/crates/libretune-app/src/components/tables/TableToolbar.tsx
@@ -11,7 +11,8 @@ import {
   TrendingUp,
   Grid3X3,
   Crosshair,
-  Palette
+  Palette,
+  Box
 } from 'lucide-react';
 
 interface TableToolbarProps {
@@ -33,6 +34,8 @@ interface TableToolbarProps {
   onFollowModeToggle?: () => void;
   showColorShade?: boolean;
   onColorShadeToggle?: () => void;
+  show3D?: boolean;
+  onToggle3D?: () => void;
 }
 
 export default function TableToolbar({ 
@@ -54,6 +57,8 @@ export default function TableToolbar({
   onFollowModeToggle,
   showColorShade = false,
   onColorShadeToggle,
+  show3D = false,
+  onToggle3D,
 }: TableToolbarProps) {
   return (
     <div className="ts-toolbar">
@@ -182,6 +187,15 @@ export default function TableToolbar({
             onClick={onColorShadeToggle}
           >
             <Palette size={14} />
+          </button>
+        )}
+        {onToggle3D && (
+          <button 
+            className={`ts-toolbar-btn ${show3D ? 'ts-toolbar-btn-active' : ''}`}
+            title="Toggle 3D View"
+            onClick={onToggle3D}
+          >
+            <Box size={14} />
           </button>
         )}
       </div>

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -5,6 +5,12 @@ All notable changes to LibreTune will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- **3D view on every table** — The 3D view toggle is now available on all table
+  editors, including tables embedded in dialogs. Click the 3D button to switch
+  between the 2D grid and an interactive 3D surface.
+- **Click-and-drag curve editing** — Edit 1D curves by clicking anywhere on the
+  chart to grab the nearest point and dragging it up or down. The drag keeps
+  tracking even if the cursor leaves the chart and commits when you release.
 - **Base Map Generator** — Create safe, driveable starting tunes from engine specifications (cylinder count, displacement, injector size, fuel type, aspiration, etc.). Generates VE, ignition, AFR tables plus enrichment curves. Accessible from Welcome View and Tools menu.
 - **File-centric workflow** — Projects are now created automatically when you open a tune file. The Welcome View shows three main actions: Open Tune File, Connect to ECU, and Import TS Project.
 - **Open Tune File dialog** — Browse for .msq/.xml files with automatic INI signature matching, preview panel, and one-click project creation.

--- a/docs/src/features/table-editing.md
+++ b/docs/src/features/table-editing.md
@@ -100,6 +100,19 @@ Enable **Follow Mode** to automatically highlight the cell corresponding to curr
 2. Click the crosshair icon in the toolbar
 3. The current operating cell is highlighted
 
+## Editing Curves
+
+1D curves (for example, warmup enrichment or fan PWM vs. temperature) open in
+the curve editor, which shows the values as a draggable line chart alongside a
+data table.
+
+- **Drag to edit** — Click anywhere on the chart to grab the nearest point and
+  drag it up or down. You can also grab a point marker directly. The drag keeps
+  tracking even if the cursor leaves the chart area and commits when you release.
+- **Type exact values** — Double-click any cell in the data table to enter a
+  precise number.
+- **Undo/Redo** — `Ctrl+Z` / `Ctrl+Y` work the same as in table editing.
+
 ## Next Steps
 
 - [2D Tables](./table-editing/2d-tables.md) - Detailed 2D table editing

--- a/docs/src/features/table-editing/3d-visualization.md
+++ b/docs/src/features/table-editing/3d-visualization.md
@@ -8,6 +8,10 @@ View tables in three dimensions for better understanding.
 2. Click the **3D** button in the toolbar
 3. The 3D view appears alongside or replaces the 2D grid
 
+> The 3D toggle is available on every table editor — standalone tables opened
+> in a tab as well as tables embedded inside dialogs (via the compact title-bar
+> button).
+
 ## Navigation
 
 ### Mouse Controls


### PR DESCRIPTION
## Summary
Adds a 3D view toggle to every table surface and makes 1D curves editable by
click-and-drag anywhere on the chart, plus a crash-hardening fix for the curve
editor. Includes matching documentation updates.

## Tables — 3D view toggle
- `TableEditor2D` (standalone header + compact embedded title bar) and
  `TableToolbar` (view controls) now expose a 3D toggle (Box icon).
- Toggling swaps the grid for the existing react-three-fiber `TableEditor3D`
  (heatmap scheme, cell-selection sync, back-to-2D button).
- Brings the standalone and dialog-embedded table editors to parity with the
  tab-based `tuner-ui/TableEditor`, which already had a 3D toggle.

## Curves — click-drag editing + crash fix
- Click anywhere in the plot area to grab the *nearest* point and drag it —
  no need to hit the small point circles (direct point-grab still works).
- Drag is tracked at the window level, so it continues smoothly outside the
  SVG bounds and always commits on release.
- Cursor feedback: crosshair over the chart, ns-resize while dragging.
- History pushed before each drag (undo/redo works); X and Y bins persist via
  the existing `persistCurveValues` path.
- Guarded remaining `undefined` bin accesses (data-point circles + table cells)
  to eliminate the "Cannot read properties of undefined (reading 'toFixed')"
  crash when x/y bin arrays mismatch in length.

## Documentation
- Root `CHANGELOG.md` — dated Added/Fixed entries.
- User-facing changelog (`docs/src/changelog.md` + `public/manual` mirror).
- `table-editing/3d-visualization.md` — 3D toggle available on all table editors.
- `table-editing.md` — new "Editing Curves" section (both mirrors).

## Testing
- `npm run typecheck` — passes
- `npm run test:run` — 68 passing; the 5 failures are pre-existing and unrelated
  (App.integration packet-mode, DialogRenderer CommandButton)
