### PR TITLE
Add 2way 4 Graph Log to data logging

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/data_logging.rs
+++ b/crates/libretune-app/src-tauri/src/commands/data_logging.rs
@@ -125,20 +125,38 @@ pub async fn clear_log(state: tauri::State<'_, AppState>) -> Result<(), String> 
 #[tauri::command]
 pub async fn save_log(state: tauri::State<'_, AppState>, path: String) -> Result<(), String> {
     let logger = state.data_logger.lock().await;
+    let channels = logger.channels();
+
+    // Skip columns that are zero for the entire log: an INI defines far more
+    // output channels than the ECU (or demo simulator) actually streams, and
+    // those never-seen channels are logged as 0.0. Writing them out buries
+    // the real data in hundreds of dead columns.
+    let mut has_data = vec![false; channels.len()];
+    for entry in logger.entries() {
+        for (i, &val) in entry.values.iter().enumerate() {
+            if val != 0.0 {
+                has_data[i] = true;
+            }
+        }
+    }
 
     let mut csv = String::new();
     csv.push_str("Time (ms)");
-    for channel in logger.channels() {
-        csv.push(',');
-        csv.push_str(channel);
+    for (i, channel) in channels.iter().enumerate() {
+        if has_data[i] {
+            csv.push(',');
+            csv.push_str(channel);
+        }
     }
     csv.push('\n');
 
     for entry in logger.entries() {
         csv.push_str(&format!("{}", entry.timestamp.as_millis()));
-        for val in &entry.values {
-            csv.push(',');
-            csv.push_str(&format!("{:.4}", val));
+        for (i, val) in entry.values.iter().enumerate() {
+            if has_data[i] {
+                csv.push(',');
+                csv.push_str(&format!("{:.4}", val));
+            }
         }
         csv.push('\n');
     }

--- a/crates/libretune-app/src-tauri/src/commands/data_logging.rs
+++ b/crates/libretune-app/src-tauri/src/commands/data_logging.rs
@@ -28,7 +28,18 @@ pub async fn start_logging(
     let def_guard = state.definition.lock().await;
     let def = def_guard.as_ref().ok_or("Definition not loaded")?;
 
-    let channels: Vec<String> = def.output_channels.keys().cloned().collect();
+    let mut channels: Vec<String> = def.output_channels.keys().cloned().collect();
+
+    // Also log the canonical alias names (RPM, MAP, TPS, …) that the realtime
+    // stream adds via apply_channel_aliases, so recorded logs and saved CSVs
+    // use the same channel names as the dashboards and graph pages.
+    let mut probe: HashMap<String, f64> = channels.iter().map(|c| (c.clone(), 0.0)).collect();
+    super::realtime_stream::apply_channel_aliases(&mut probe);
+    for name in probe.keys() {
+        if !channels.iter().any(|c| c == name) {
+            channels.push(name.clone());
+        }
+    }
 
     let mut logger = state.data_logger.lock().await;
 

--- a/crates/libretune-app/src-tauri/src/commands/data_logging.rs
+++ b/crates/libretune-app/src-tauri/src/commands/data_logging.rs
@@ -31,7 +31,18 @@ pub async fn start_logging(
     let channels: Vec<String> = def.output_channels.keys().cloned().collect();
 
     let mut logger = state.data_logger.lock().await;
-    *logger = DataLogger::new(channels);
+
+    // Recording appends to the current session (one continuous log until the
+    // user clears it). Only build a fresh logger when there is no session yet
+    // or the channel set changed (e.g. a different INI was loaded).
+    let mut existing: Vec<&String> = logger.channels().iter().collect();
+    let mut incoming: Vec<&String> = channels.iter().collect();
+    existing.sort();
+    incoming.sort();
+    if existing != incoming {
+        *logger = DataLogger::new(channels);
+    }
+
     if let Some(rate) = sample_rate {
         logger.set_sample_rate(rate);
     }

--- a/crates/libretune-app/src-tauri/src/commands/data_logging.rs
+++ b/crates/libretune-app/src-tauri/src/commands/data_logging.rs
@@ -87,9 +87,26 @@ pub async fn get_log_entries(
     state: tauri::State<'_, AppState>,
     start_index: Option<usize>,
     count: Option<usize>,
+    channels: Option<Vec<String>>,
 ) -> Result<Vec<LogEntryData>, String> {
     let logger = state.data_logger.lock().await;
-    let channels = logger.channels();
+    let all_channels = logger.channels();
+
+    // Only serialize the requested channels: an INI defines 1000+ output
+    // channels and shipping all of them per entry over IPC at high sample
+    // rates (100 Hz) is several MB per poll — enough to OOM the webview.
+    let selected: Vec<(usize, &String)> = match &channels {
+        Some(filter) => {
+            let wanted: std::collections::HashSet<&str> =
+                filter.iter().map(|s| s.as_str()).collect();
+            all_channels
+                .iter()
+                .enumerate()
+                .filter(|(_, name)| wanted.contains(name.as_str()))
+                .collect()
+        }
+        None => all_channels.iter().enumerate().collect(),
+    };
 
     let start = start_index.unwrap_or(0);
     let max_count = count.unwrap_or(1000);
@@ -99,10 +116,10 @@ pub async fn get_log_entries(
         .skip(start)
         .take(max_count)
         .map(|entry| {
-            let mut values = HashMap::new();
-            for (i, channel) in channels.iter().enumerate() {
-                if let Some(&val) = entry.values.get(i) {
-                    values.insert(channel.clone(), val);
+            let mut values = HashMap::with_capacity(selected.len());
+            for (i, channel) in &selected {
+                if let Some(&val) = entry.values.get(*i) {
+                    values.insert((*channel).clone(), val);
                 }
             }
             LogEntryData {

--- a/crates/libretune-app/src-tauri/src/commands/data_logging.rs
+++ b/crates/libretune-app/src-tauri/src/commands/data_logging.rs
@@ -187,3 +187,8 @@ pub async fn save_log(state: tauri::State<'_, AppState>, path: String) -> Result
 pub async fn read_text_file(path: String) -> Result<String, String> {
     std::fs::read_to_string(&path).map_err(|e| format!("Failed to read file: {}", e))
 }
+
+#[tauri::command]
+pub async fn write_text_file(path: String, contents: String) -> Result<(), String> {
+    std::fs::write(&path, contents).map_err(|e| format!("Failed to write file: {}", e))
+}

--- a/crates/libretune-app/src-tauri/src/commands/realtime_stream.rs
+++ b/crates/libretune-app/src-tauri/src/commands/realtime_stream.rs
@@ -162,6 +162,25 @@ pub(crate) fn apply_channel_aliases(data: &mut HashMap<String, f64>) {
     }
 }
 
+/// Feed the current realtime snapshot to the data logger when a recording is
+/// active. The logger applies its own sample-rate limiting in `record()`.
+pub(crate) async fn feed_data_logger(app_state: &AppState, data: &HashMap<String, f64>) {
+    // try_lock: never stall the stream tick on logger contention
+    let mut logger = match app_state.data_logger.try_lock() {
+        Ok(l) => l,
+        Err(_) => return,
+    };
+    if !logger.is_recording() {
+        return;
+    }
+    let values: Vec<f64> = logger
+        .channels()
+        .iter()
+        .map(|name| data.get(name).copied().unwrap_or(0.0))
+        .collect();
+    logger.record(values);
+}
+
 pub(crate) async fn feed_autotune_data(
     app_state: &AppState,
     data: &HashMap<String, f64>,
@@ -536,6 +555,9 @@ pub async fn start_realtime_stream(
                     // Feed data to AutoTune if running
                     feed_autotune_data(&app_state, &data, current_time_ms).await;
 
+                    // Feed data to the data logger if recording
+                    feed_data_logger(&app_state, &data).await;
+
                     local_ticks_success += 1;
                 }
             } else {
@@ -728,6 +750,9 @@ pub async fn start_realtime_stream(
                             stream_log(&format!("tick #{}: T6-autotune", tick_count));
                         }
                         feed_autotune_data(&app_state, &data, current_time_ms).await;
+
+                        // Feed data to the data logger if recording
+                        feed_data_logger(&app_state, &data).await;
 
                         local_ticks_success += 1;
                     }

--- a/crates/libretune-app/src-tauri/src/lib.rs
+++ b/crates/libretune-app/src-tauri/src/lib.rs
@@ -77,7 +77,7 @@ use commands::dash_layout::{
 };
 use commands::data_logging::{
     clear_log, get_log_entries, get_logging_status, read_text_file, save_log, start_logging,
-    stop_logging,
+    stop_logging, write_text_file,
 };
 use commands::debug_realtime::debug_single_realtime_read;
 use commands::demo::{get_demo_mode, set_demo_mode};
@@ -339,6 +339,7 @@ pub fn run() {
             clear_log,
             save_log,
             read_text_file,
+            write_text_file,
             // Diagnostic commands (stubs)
             start_tooth_logger,
             stop_tooth_logger,

--- a/crates/libretune-app/src/components/tuner-ui/DataLogView.css
+++ b/crates/libretune-app/src/components/tuner-ui/DataLogView.css
@@ -192,6 +192,30 @@
   cursor: not-allowed;
 }
 
+.chart-mode-toggle {
+  display: flex;
+  gap: 0;
+}
+
+.chart-mode-toggle .log-button {
+  padding: 6px 12px;
+}
+
+.chart-mode-toggle .log-button:first-child {
+  border-radius: 6px 0 0 6px;
+}
+
+.chart-mode-toggle .log-button:last-child {
+  border-radius: 0 6px 6px 0;
+  border-left: none;
+}
+
+.chart-mode-toggle .log-button.active {
+  background: var(--accent-color, #4f8fe8);
+  color: white;
+  border-color: var(--accent-color, #4f8fe8);
+}
+
 @keyframes pulse {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.8; }

--- a/crates/libretune-app/src/components/tuner-ui/DataLogView.css
+++ b/crates/libretune-app/src/components/tuner-ui/DataLogView.css
@@ -233,6 +233,15 @@
   flex-shrink: 0;
 }
 
+/* App.css declares a global .status-indicator as an 8x8 dot; undo that here
+   where the class is a text label, otherwise the neighboring stats overlap it. */
+.log-status .status-indicator {
+  width: auto;
+  height: auto;
+  border-radius: 0;
+  background-color: transparent;
+}
+
 .status-indicator {
   font-weight: 600;
   font-size: 14px;

--- a/crates/libretune-app/src/components/tuner-ui/DataLogView.css
+++ b/crates/libretune-app/src/components/tuner-ui/DataLogView.css
@@ -197,10 +197,6 @@
   gap: 0;
 }
 
-.chart-mode-toggle .log-button {
-  padding: 6px 12px;
-}
-
 .chart-mode-toggle .log-button:first-child {
   border-radius: 6px 0 0 6px;
 }
@@ -224,11 +220,17 @@
 .log-status {
   display: flex;
   align-items: center;
-  gap: 24px;
+  flex-wrap: wrap;
+  gap: 12px 24px;
   padding: 10px 16px;
   background: var(--bg-secondary);
   border-radius: 8px;
   border: 1px solid var(--border-color);
+}
+
+.log-status > * {
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .status-indicator {

--- a/crates/libretune-app/src/components/tuner-ui/DataLogView.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/DataLogView.tsx
@@ -584,16 +584,13 @@ export const DataLogView: React.FC = () => {
   // Get display values - use playback or realtime based on mode
   const displayValues = viewMode === 'playback' ? getCurrentPlaybackValues() : liveValues;
 
-  // Samples for the Graph Log: the session log whenever one exists — growing
-  // while recording, frozen after Stop, replaced by file data in playback.
-  // Only when no log exists yet (or after Clear) does GraphLog fall back to
-  // live-sampling the realtime store as a preview.
-  const graphSamples = useMemo<GraphSample[] | undefined>(() => {
-    if (logData.length > 0) {
-      return logData.map((d) => ({ t: d.x, values: d.values }));
-    }
-    return undefined;
-  }, [logData]);
+  // Samples for the Graph Log: the session log — growing while recording,
+  // frozen after Stop, replaced by file data in playback, empty until the
+  // first recording or after Clear.
+  const graphSamples = useMemo<GraphSample[]>(
+    () => logData.map((d) => ({ t: d.x, values: d.values })),
+    [logData],
+  );
   
   return (
     <div className="datalog-view">

--- a/crates/libretune-app/src/components/tuner-ui/DataLogView.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/DataLogView.tsx
@@ -227,33 +227,43 @@ export const DataLogView: React.FC = () => {
     return () => window.removeEventListener('resize', updateSize);
   }, []);
   
+  // Append newly recorded entries to the accumulated session log.
+  // The session is one continuous log across Record/Stop cycles; only
+  // Clear (or loading a file for playback) replaces it.
+  const mergeEntries = useCallback((entries: LogEntry[]) => {
+    setLogData(prev => {
+      const lastT = prev.length > 0 ? prev[prev.length - 1].x : -1;
+      const fresh = entries
+        .filter(e => e.timestamp_ms > lastT)
+        .map(e => ({ x: e.timestamp_ms, values: e.values }));
+      return fresh.length > 0 ? [...prev, ...fresh] : prev;
+    });
+  }, []);
+
+  const fetchLatestEntries = useCallback(async () => {
+    const newStatus = await invoke<LoggingStatus>('get_logging_status');
+    setStatus(newStatus);
+    const entries = await invoke<LogEntry[]>('get_log_entries', {
+      startIndex: Math.max(0, newStatus.entry_count - 500),
+      count: 500
+    });
+    mergeEntries(entries);
+  }, [mergeEntries]);
+
   // Poll status while recording
   useEffect(() => {
     if (!isRecording) return;
-    
+
     const interval = setInterval(async () => {
       try {
-        const newStatus = await invoke<LoggingStatus>('get_logging_status');
-        setStatus(newStatus);
-        
-        // Fetch latest entries for chart
-        const entries = await invoke<LogEntry[]>('get_log_entries', {
-          startIndex: Math.max(0, newStatus.entry_count - 500),
-          count: 500
-        });
-        
-        setLogData(entries.map(e => ({
-          x: e.timestamp_ms,
-          values: e.values
-        })));
-        
+        await fetchLatestEntries();
       } catch (err) {
         console.error('Failed to get logging status:', err);
       }
     }, 200);
-    
+
     return () => clearInterval(interval);
-  }, [isRecording]);
+  }, [isRecording, fetchLatestEntries]);
   
   // Seed channel list once when ECU data first arrives (avoid subscribing to all channels at 20Hz).
   useEffect(() => {
@@ -317,26 +327,25 @@ export const DataLogView: React.FC = () => {
   
   const handleStartLogging = useCallback(async () => {
     try {
+      // Recording appends to the current session log until Clear is pressed
       await invoke('start_logging', { sampleRate });
       setIsRecording(true);
-      setLogData([]);
     } catch (err) {
       console.error('Failed to start logging:', err);
     }
   }, [sampleRate]);
-  
+
   const handleStopLogging = useCallback(async () => {
     try {
       await invoke('stop_logging');
       setIsRecording(false);
-      
-      // Fetch final status
-      const finalStatus = await invoke<LoggingStatus>('get_logging_status');
-      setStatus(finalStatus);
+
+      // Fetch final status and any entries the last poll missed
+      await fetchLatestEntries();
     } catch (err) {
       console.error('Failed to stop logging:', err);
     }
-  }, []);
+  }, [fetchLatestEntries]);
   
   const handleClearLog = useCallback(async () => {
     try {
@@ -575,14 +584,16 @@ export const DataLogView: React.FC = () => {
   // Get display values - use playback or realtime based on mode
   const displayValues = viewMode === 'playback' ? getCurrentPlaybackValues() : liveValues;
 
-  // Samples for the Graph Log: recorded/playback data when present; undefined
-  // while idle-live so GraphLog samples the realtime store itself.
+  // Samples for the Graph Log: the session log whenever one exists — growing
+  // while recording, frozen after Stop, replaced by file data in playback.
+  // Only when no log exists yet (or after Clear) does GraphLog fall back to
+  // live-sampling the realtime store as a preview.
   const graphSamples = useMemo<GraphSample[] | undefined>(() => {
-    if ((viewMode === 'playback' || isRecording) && logData.length > 0) {
+    if (logData.length > 0) {
       return logData.map((d) => ({ t: d.x, values: d.values }));
     }
     return undefined;
-  }, [viewMode, isRecording, logData]);
+  }, [logData]);
   
   return (
     <div className="datalog-view">

--- a/crates/libretune-app/src/components/tuner-ui/DataLogView.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/DataLogView.tsx
@@ -1,10 +1,11 @@
-import React, { useState, useEffect, useRef, useCallback } from 'react';
-import { BarChart3, Circle, FolderOpen, Key, Square, CircleDot, Trash2, Save, Pause, Play } from 'lucide-react';
+import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import { BarChart3, Circle, FolderOpen, Key, Square, CircleDot, Trash2, Save, Pause, Play, LayoutList, LineChart as LineChartIcon } from 'lucide-react';
 import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
 import { save, open } from '@tauri-apps/plugin-dialog';
 import { useChannels, useRealtimeStore } from '../../stores/realtimeStore';
 import LoggerStatsPanel from './LoggerStatsPanel';
+import GraphLog, { GraphSample } from './GraphLog';
 import './DataLogView.css';
 
 interface LoggingStatus {
@@ -205,6 +206,7 @@ export const DataLogView: React.FC = () => {
   const [playbackSpeed, setPlaybackSpeed] = useState<PlaybackSpeed>(1);
   const [loadedFileName, setLoadedFileName] = useState<string | null>(null);
   const [showStats, setShowStats] = useState(false);
+  const [chartMode, setChartMode] = useState<'graphlog' | 'overlay'>('graphlog');
   const [selectedStatsChannel, setSelectedStatsChannel] = useState<string | null>(null);
   const playbackIntervalRef = useRef<number | null>(null);
   
@@ -569,9 +571,18 @@ export const DataLogView: React.FC = () => {
   };
   
   const liveValues = useChannels(selectedChannels);
-  
+
   // Get display values - use playback or realtime based on mode
   const displayValues = viewMode === 'playback' ? getCurrentPlaybackValues() : liveValues;
+
+  // Samples for the Graph Log: recorded/playback data when present; undefined
+  // while idle-live so GraphLog samples the realtime store itself.
+  const graphSamples = useMemo<GraphSample[] | undefined>(() => {
+    if ((viewMode === 'playback' || isRecording) && logData.length > 0) {
+      return logData.map((d) => ({ t: d.x, values: d.values }));
+    }
+    return undefined;
+  }, [viewMode, isRecording, logData]);
   
   return (
     <div className="datalog-view">
@@ -589,6 +600,24 @@ export const DataLogView: React.FC = () => {
         </div>
         
         <div className="datalog-controls">
+          <div className="control-group chart-mode-toggle">
+            <button
+              type="button"
+              className={`log-button secondary ${chartMode === 'graphlog' ? 'active' : ''}`}
+              onClick={() => setChartMode('graphlog')}
+              title="Stacked graph pages (TunerStudio-style graph log)"
+            >
+              <LayoutList size={14} /> Graph Log
+            </button>
+            <button
+              type="button"
+              className={`log-button secondary ${chartMode === 'overlay' ? 'active' : ''}`}
+              onClick={() => setChartMode('overlay')}
+              title="Single chart with overlaid channels"
+            >
+              <LineChartIcon size={14} /> Overlay
+            </button>
+          </div>
           {viewMode === 'live' ? (
             <>
               <div className="control-group">
@@ -725,48 +754,58 @@ export const DataLogView: React.FC = () => {
       )}
       
       <div className="datalog-content">
-        <div className="channel-selector">
-          <h4>Channels</h4>
-          <div className="channel-list">
-            {availableChannels.map((channel) => (
-              <label 
-                key={channel} 
-                className={`channel-item ${selectedChannels.includes(channel) ? 'selected' : ''}`}
-              >
-                <input
-                  type="checkbox"
-                  checked={selectedChannels.includes(channel)}
-                  onChange={() => toggleChannel(channel)}
-                />
-                <span 
-                  className="channel-color"
-                  style={{ 
-                    background: selectedChannels.includes(channel) 
-                      ? ['#00ff88', '#00aaff', '#ff6644', '#ffcc00', '#ff44ff', '#44ffff'][
-                          selectedChannels.indexOf(channel) % 6
-                        ]
-                      : '#444'
-                  }}
-                />
-                <span className="channel-name">{channel}</span>
-                <span className="channel-value">
-                  {displayValues[channel]?.toFixed(2) ?? '-'}
-                </span>
-              </label>
-            ))}
+        {chartMode === 'overlay' && (
+          <div className="channel-selector">
+            <h4>Channels</h4>
+            <div className="channel-list">
+              {availableChannels.map((channel) => (
+                <label
+                  key={channel}
+                  className={`channel-item ${selectedChannels.includes(channel) ? 'selected' : ''}`}
+                >
+                  <input
+                    type="checkbox"
+                    checked={selectedChannels.includes(channel)}
+                    onChange={() => toggleChannel(channel)}
+                  />
+                  <span
+                    className="channel-color"
+                    style={{
+                      background: selectedChannels.includes(channel)
+                        ? ['#00ff88', '#00aaff', '#ff6644', '#ffcc00', '#ff44ff', '#44ffff'][
+                            selectedChannels.indexOf(channel) % 6
+                          ]
+                        : '#444'
+                    }}
+                  />
+                  <span className="channel-name">{channel}</span>
+                  <span className="channel-value">
+                    {displayValues[channel]?.toFixed(2) ?? '-'}
+                  </span>
+                </label>
+              ))}
+            </div>
           </div>
-        </div>
-        
+        )}
+
         <div className="chart-container" ref={chartContainerRef}>
-          <LineChart
-            data={logData}
-            channels={availableChannels}
-            selectedChannels={selectedChannels}
-            width={chartSize.width}
-            height={chartSize.height}
-            cursorPosition={viewMode === 'playback' ? playbackPosition : undefined}
-            onSeek={viewMode === 'playback' ? handleSeek : undefined}
-          />
+          {chartMode === 'graphlog' ? (
+            <GraphLog
+              samples={graphSamples}
+              availableChannels={availableChannels}
+              cursorPosition={viewMode === 'playback' ? playbackPosition : null}
+            />
+          ) : (
+            <LineChart
+              data={logData}
+              channels={availableChannels}
+              selectedChannels={selectedChannels}
+              width={chartSize.width}
+              height={chartSize.height}
+              cursorPosition={viewMode === 'playback' ? playbackPosition : undefined}
+              onSeek={viewMode === 'playback' ? handleSeek : undefined}
+            />
+          )}
         </div>
 
         {showStats && (

--- a/crates/libretune-app/src/components/tuner-ui/DataLogView.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/DataLogView.tsx
@@ -4,9 +4,13 @@ import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
 import { save, open } from '@tauri-apps/plugin-dialog';
 import { useChannels, useRealtimeStore } from '../../stores/realtimeStore';
+import { useGraphLogStore } from '../../stores/graphLogStore';
 import LoggerStatsPanel from './LoggerStatsPanel';
 import GraphLog, { GraphSample } from './GraphLog';
 import './DataLogView.css';
+
+/** Hard cap on samples kept in the frontend; the oldest are dropped beyond it. */
+const MAX_FRONTEND_SAMPLES = 100_000;
 
 interface LoggingStatus {
   is_recording: boolean;
@@ -227,6 +231,23 @@ export const DataLogView: React.FC = () => {
     return () => window.removeEventListener('resize', updateSize);
   }, []);
   
+  // Channels worth fetching from the recorded log: what the graph-log panes
+  // (across all tabs) and the overlay selection display. Fetching every INI
+  // channel per entry is megabytes per poll at high sample rates.
+  const graphTabs = useGraphLogStore((s) => s.tabs);
+  const neededChannels = React.useMemo(() => {
+    const set = new Set<string>(selectedChannels);
+    for (const tab of graphTabs) {
+      for (const pane of tab.panes) {
+        if (pane.left.channel) set.add(pane.left.channel);
+        if (pane.right.channel) set.add(pane.right.channel);
+      }
+    }
+    return Array.from(set);
+  }, [graphTabs, selectedChannels]);
+  const neededChannelsRef = useRef(neededChannels);
+  neededChannelsRef.current = neededChannels;
+
   // Append newly recorded entries to the accumulated session log.
   // The session is one continuous log across Record/Stop cycles; only
   // Clear (or loading a file for playback) replaces it.
@@ -236,7 +257,11 @@ export const DataLogView: React.FC = () => {
       const fresh = entries
         .filter(e => e.timestamp_ms > lastT)
         .map(e => ({ x: e.timestamp_ms, values: e.values }));
-      return fresh.length > 0 ? [...prev, ...fresh] : prev;
+      if (fresh.length === 0) return prev;
+      const merged = [...prev, ...fresh];
+      return merged.length > MAX_FRONTEND_SAMPLES
+        ? merged.slice(merged.length - MAX_FRONTEND_SAMPLES)
+        : merged;
     });
   }, []);
 
@@ -245,10 +270,35 @@ export const DataLogView: React.FC = () => {
     setStatus(newStatus);
     const entries = await invoke<LogEntry[]>('get_log_entries', {
       startIndex: Math.max(0, newStatus.entry_count - 500),
-      count: 500
+      count: 500,
+      channels: neededChannelsRef.current
     });
     mergeEntries(entries);
   }, [mergeEntries]);
+
+  // When a channel is newly assigned to a pane, past samples don't contain it
+  // (they were fetched filtered). Refetch the whole log with the new set.
+  const needKey = neededChannels.join('|');
+  const logDataRef = useRef(logData);
+  logDataRef.current = logData;
+  useEffect(() => {
+    if (logDataRef.current.length === 0 || viewMode === 'playback') return;
+    (async () => {
+      try {
+        const st = await invoke<LoggingStatus>('get_logging_status');
+        if (st.entry_count === 0) return;
+        const entries = await invoke<LogEntry[]>('get_log_entries', {
+          startIndex: 0,
+          count: st.entry_count,
+          channels: neededChannelsRef.current
+        });
+        setLogData(entries.map(e => ({ x: e.timestamp_ms, values: e.values })));
+      } catch (err) {
+        console.error('Failed to refetch log with new channels:', err);
+      }
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [needKey]);
 
   // Poll status while recording
   useEffect(() => {

--- a/crates/libretune-app/src/components/tuner-ui/DataLogView.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/DataLogView.tsx
@@ -1,10 +1,10 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
-import { BarChart3, Circle, FolderOpen, Key, Square, CircleDot, Trash2, Save, Pause, Play, LayoutList, LineChart as LineChartIcon } from 'lucide-react';
+import { BarChart3, Circle, FolderOpen, Key, Square, CircleDot, Trash2, Save, Pause, Play, LayoutList, LineChart as LineChartIcon, FileUp, FileDown } from 'lucide-react';
 import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
 import { save, open } from '@tauri-apps/plugin-dialog';
 import { useChannels, useRealtimeStore } from '../../stores/realtimeStore';
-import { useGraphLogStore } from '../../stores/graphLogStore';
+import { useGraphLogStore, exportGraphLogSetup, importGraphLogSetup } from '../../stores/graphLogStore';
 import LoggerStatsPanel from './LoggerStatsPanel';
 import GraphLog, { GraphSample } from './GraphLog';
 import './DataLogView.css';
@@ -407,6 +407,44 @@ export const DataLogView: React.FC = () => {
     }
   }, []);
   
+  const handleExportSetup = useCallback(async () => {
+    try {
+      const path = await save({
+        defaultPath: 'graphlog_setup.json',
+        filters: [{ name: 'Graph Log Setup', extensions: ['json'] }]
+      });
+      if (!path) return;
+      const setup = exportGraphLogSetup(sampleRate);
+      await invoke('write_text_file', { path, contents: JSON.stringify(setup, null, 2) });
+    } catch (err) {
+      console.error('Failed to export setup:', err);
+      alert(`Failed to export setup: ${err}`);
+    }
+  }, [sampleRate]);
+
+  const handleImportSetup = useCallback(async () => {
+    try {
+      const path = await open({
+        filters: [{ name: 'Graph Log Setup', extensions: ['json'] }],
+        multiple: false
+      });
+      if (!path || Array.isArray(path)) return;
+      const text = await invoke<string>('read_text_file', { path });
+      const data = JSON.parse(text);
+      const error = importGraphLogSetup(data);
+      if (error) {
+        alert(error);
+        return;
+      }
+      if (typeof data.sampleRate === 'number' && !isRecording) {
+        setSampleRate(data.sampleRate);
+      }
+    } catch (err) {
+      console.error('Failed to import setup:', err);
+      alert(`Failed to import setup: ${err}`);
+    }
+  }, [isRecording]);
+
   const handleSaveLog = useCallback(async () => {
     try {
       const path = await save({
@@ -730,12 +768,29 @@ export const DataLogView: React.FC = () => {
                 <Save size={14} /> Save
               </button>
               
-              <button 
+              <button
                 className="log-button secondary"
                 onClick={handleLoadLog}
                 disabled={isRecording}
               >
                 <FolderOpen size={14} /> Load
+              </button>
+
+              <button
+                className="log-button secondary"
+                onClick={handleExportSetup}
+                title="Export graph tabs, scales and sample rate to a file"
+              >
+                <FileUp size={14} /> Export
+              </button>
+
+              <button
+                className="log-button secondary"
+                onClick={handleImportSetup}
+                disabled={isRecording}
+                title="Import graph tabs, scales and sample rate from a file"
+              >
+                <FileDown size={14} /> Import
               </button>
             </>
           ) : (

--- a/crates/libretune-app/src/components/tuner-ui/GraphLog.css
+++ b/crates/libretune-app/src/components/tuner-ui/GraphLog.css
@@ -80,23 +80,34 @@
 
 .graphlog-window-select {
   margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 4px;
   font-size: 11px;
   color: var(--text-secondary, #9aa4b8);
 }
 
-.graphlog-window-select label {
+.graphlog-window-select button {
   display: flex;
   align-items: center;
-  gap: 6px;
-}
-
-.graphlog-window-select select {
-  background: var(--bg-primary, #0e121c);
-  color: var(--text-primary, #e6eaf2);
+  justify-content: center;
+  background: transparent;
   border: 1px solid var(--border-color, rgba(128, 140, 160, 0.25));
   border-radius: 4px;
-  font-size: 11px;
-  padding: 2px 4px;
+  color: var(--text-secondary, #9aa4b8);
+  cursor: pointer;
+  padding: 3px;
+}
+
+.graphlog-window-select button:hover {
+  color: var(--text-primary, #e6eaf2);
+  background: rgba(128, 140, 160, 0.2);
+}
+
+.graphlog-window-label {
+  min-width: 48px;
+  text-align: center;
+  font-family: monospace;
 }
 
 /* ---- Panes ---- */

--- a/crates/libretune-app/src/components/tuner-ui/GraphLog.css
+++ b/crates/libretune-app/src/components/tuner-ui/GraphLog.css
@@ -184,49 +184,72 @@
 }
 
 /* ---- Pane config dialog ---- */
+.graphlog-config-dialog .lt-dialog__body,
+.graphlog-config-dialog {
+  overflow-x: hidden;
+}
+
 .graphlog-slot-config {
+  box-sizing: border-box;
+  width: 100%;
   border: 1px solid var(--border-color, rgba(128, 140, 160, 0.25));
   border-radius: 6px;
-  padding: 8px 10px;
-  margin-bottom: 10px;
+  padding: 10px 12px;
+  margin: 0 0 12px 0;
   font-size: 12px;
   color: var(--text-secondary, #9aa4b8);
 }
 
 .graphlog-slot-config legend {
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 600;
-  padding: 0 4px;
+  padding: 0 6px;
 }
 
 .graphlog-slot-config label {
   display: flex;
   align-items: center;
-  gap: 8px;
-  margin: 6px 0;
+  gap: 10px;
+  margin: 8px 0;
+  min-width: 0;
 }
 
 .graphlog-slot-config select,
 .graphlog-slot-config input[type='number'] {
   flex: 1;
+  width: 100%;
   min-width: 0;
+  box-sizing: border-box;
   background: var(--bg-secondary, #1a2030);
   color: var(--text-primary, #e6eaf2);
   border: 1px solid var(--border-color, rgba(128, 140, 160, 0.25));
   border-radius: 4px;
   font-size: 12px;
-  padding: 3px 6px;
+  padding: 5px 8px;
 }
 
 .graphlog-slot-auto {
   user-select: none;
 }
 
+.graphlog-slot-auto input[type='checkbox'] {
+  flex: 0 0 auto;
+}
+
 .graphlog-slot-range {
   display: flex;
-  gap: 10px;
+  gap: 12px;
 }
 
 .graphlog-slot-range label {
   flex: 1;
+  min-width: 0;
+}
+
+.graphlog-latest-btn {
+  font-size: 11px;
+  font-weight: 600;
+  padding: 3px 8px !important;
+  color: var(--accent-color, #4f8fe8) !important;
+  border-color: var(--accent-color, #4f8fe8) !important;
 }

--- a/crates/libretune-app/src/components/tuner-ui/GraphLog.css
+++ b/crates/libretune-app/src/components/tuner-ui/GraphLog.css
@@ -159,48 +159,20 @@
   transform: translateX(-50%);
 }
 
-/* ---- Config popover ---- */
-.graphlog-config-overlay {
+/* ---- Empty state ---- */
+.graphlog-empty-hint {
   position: absolute;
   inset: 0;
-  background: rgba(0, 0, 0, 0.45);
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 30;
-}
-
-.graphlog-config {
-  background: var(--bg-primary, #10141f);
-  border: 1px solid var(--border-color, rgba(128, 140, 160, 0.3));
-  border-radius: 8px;
-  padding: 14px;
-  width: 340px;
-  max-width: 90%;
-  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.5);
-}
-
-.graphlog-config-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 10px;
-}
-
-.graphlog-config-header h3 {
   font-size: 13px;
-  margin: 0;
-  color: var(--text-primary, #e6eaf2);
-}
-
-.graphlog-config-header button {
-  background: transparent;
-  border: none;
   color: var(--text-secondary, #9aa4b8);
-  cursor: pointer;
-  padding: 2px;
+  pointer-events: none;
+  z-index: 5;
 }
 
+/* ---- Pane config dialog ---- */
 .graphlog-slot-config {
   border: 1px solid var(--border-color, rgba(128, 140, 160, 0.25));
   border-radius: 6px;

--- a/crates/libretune-app/src/components/tuner-ui/GraphLog.css
+++ b/crates/libretune-app/src/components/tuner-ui/GraphLog.css
@@ -1,0 +1,249 @@
+.graphlog {
+  --graphlog-pane-bg: var(--bg-secondary, #141824);
+  --graphlog-grid: rgba(128, 140, 160, 0.15);
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  width: 100%;
+  height: 100%;
+}
+
+/* ---- Tab bar ---- */
+.graphlog-tabbar {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 4px 6px 0 6px;
+  border-bottom: 1px solid var(--border-color, rgba(128, 140, 160, 0.25));
+  flex-shrink: 0;
+}
+
+.graphlog-tab {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 6px 6px 0 0;
+  cursor: pointer;
+  user-select: none;
+  font-size: 12px;
+  color: var(--text-secondary, #9aa4b8);
+  background: transparent;
+  border: 1px solid transparent;
+  border-bottom: none;
+}
+
+.graphlog-tab:hover {
+  color: var(--text-primary, #e6eaf2);
+}
+
+.graphlog-tab.active {
+  color: var(--text-primary, #e6eaf2);
+  background: var(--bg-secondary, #1a2030);
+  border-color: var(--border-color, rgba(128, 140, 160, 0.25));
+}
+
+.graphlog-tab input {
+  width: 90px;
+  font-size: 12px;
+  background: var(--bg-primary, #0e121c);
+  color: var(--text-primary, #e6eaf2);
+  border: 1px solid var(--accent-color, #4f8fe8);
+  border-radius: 3px;
+  padding: 1px 4px;
+}
+
+.graphlog-tab-close,
+.graphlog-tab-add {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  color: var(--text-secondary, #9aa4b8);
+  cursor: pointer;
+  padding: 2px;
+  border-radius: 3px;
+}
+
+.graphlog-tab-close:hover,
+.graphlog-tab-add:hover {
+  color: var(--text-primary, #e6eaf2);
+  background: rgba(128, 140, 160, 0.2);
+}
+
+.graphlog-tab-add {
+  margin-left: 4px;
+  padding: 4px;
+}
+
+.graphlog-window-select {
+  margin-left: auto;
+  font-size: 11px;
+  color: var(--text-secondary, #9aa4b8);
+}
+
+.graphlog-window-select label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.graphlog-window-select select {
+  background: var(--bg-primary, #0e121c);
+  color: var(--text-primary, #e6eaf2);
+  border: 1px solid var(--border-color, rgba(128, 140, 160, 0.25));
+  border-radius: 4px;
+  font-size: 11px;
+  padding: 2px 4px;
+}
+
+/* ---- Panes ---- */
+.graphlog-panes {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  position: relative;
+}
+
+.graphlog-pane {
+  position: relative;
+  border-bottom: 1px solid var(--border-color, rgba(128, 140, 160, 0.25));
+}
+
+.graphlog-pane canvas {
+  display: block;
+}
+
+.graphlog-pane-config {
+  position: absolute;
+  top: 4px;
+  right: 56px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(20, 26, 40, 0.6);
+  border: 1px solid var(--border-color, rgba(128, 140, 160, 0.25));
+  border-radius: 4px;
+  color: var(--text-secondary, #9aa4b8);
+  cursor: pointer;
+  padding: 3px;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+.graphlog-pane:hover .graphlog-pane-config {
+  opacity: 1;
+}
+
+.graphlog-pane-config:hover {
+  color: var(--text-primary, #e6eaf2);
+}
+
+/* ---- Time axis ---- */
+.graphlog-timeaxis {
+  position: relative;
+  flex-shrink: 0;
+  font-size: 10px;
+  font-family: monospace;
+  color: var(--text-secondary, #9aa4b8);
+  background: var(--bg-secondary, #1a2030);
+}
+
+.graphlog-timeaxis span {
+  position: absolute;
+  top: 4px;
+  transform: translateX(-50%);
+}
+
+/* ---- Config popover ---- */
+.graphlog-config-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 30;
+}
+
+.graphlog-config {
+  background: var(--bg-primary, #10141f);
+  border: 1px solid var(--border-color, rgba(128, 140, 160, 0.3));
+  border-radius: 8px;
+  padding: 14px;
+  width: 340px;
+  max-width: 90%;
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.5);
+}
+
+.graphlog-config-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+.graphlog-config-header h3 {
+  font-size: 13px;
+  margin: 0;
+  color: var(--text-primary, #e6eaf2);
+}
+
+.graphlog-config-header button {
+  background: transparent;
+  border: none;
+  color: var(--text-secondary, #9aa4b8);
+  cursor: pointer;
+  padding: 2px;
+}
+
+.graphlog-slot-config {
+  border: 1px solid var(--border-color, rgba(128, 140, 160, 0.25));
+  border-radius: 6px;
+  padding: 8px 10px;
+  margin-bottom: 10px;
+  font-size: 12px;
+  color: var(--text-secondary, #9aa4b8);
+}
+
+.graphlog-slot-config legend {
+  font-size: 11px;
+  font-weight: 600;
+  padding: 0 4px;
+}
+
+.graphlog-slot-config label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 6px 0;
+}
+
+.graphlog-slot-config select,
+.graphlog-slot-config input[type='number'] {
+  flex: 1;
+  min-width: 0;
+  background: var(--bg-secondary, #1a2030);
+  color: var(--text-primary, #e6eaf2);
+  border: 1px solid var(--border-color, rgba(128, 140, 160, 0.25));
+  border-radius: 4px;
+  font-size: 12px;
+  padding: 3px 6px;
+}
+
+.graphlog-slot-auto {
+  user-select: none;
+}
+
+.graphlog-slot-range {
+  display: flex;
+  gap: 10px;
+}
+
+.graphlog-slot-range label {
+  flex: 1;
+}

--- a/crates/libretune-app/src/components/tuner-ui/GraphLog.css
+++ b/crates/libretune-app/src/components/tuner-ui/GraphLog.css
@@ -246,6 +246,13 @@
   min-width: 0;
 }
 
+.graphlog-cursor-time {
+  font-family: monospace;
+  font-size: 11px;
+  color: var(--accent-color, #4f8fe8);
+  margin-right: 6px;
+}
+
 .graphlog-latest-btn {
   font-size: 11px;
   font-weight: 600;

--- a/crates/libretune-app/src/components/tuner-ui/GraphLog.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/GraphLog.tsx
@@ -187,12 +187,14 @@ const PaneCanvas: React.FC<PaneCanvasProps> = ({
         }
       }
 
-      // Polyline
+      // Trace, drawn as raw sample-and-hold steps — this is measurement data,
+      // not a smoothed presentation graph.
       if (slot.channel && visible.length >= 2) {
         ctx.strokeStyle = slot.color;
-        ctx.lineWidth = 1.5;
+        ctx.lineWidth = 1;
         ctx.beginPath();
         let started = false;
+        let prevY = 0;
         for (const s of visible) {
           const v = s.values[slot.channel];
           if (v === undefined) {
@@ -205,10 +207,47 @@ const PaneCanvas: React.FC<PaneCanvasProps> = ({
             ctx.moveTo(x, y);
             started = true;
           } else {
+            ctx.lineTo(x, prevY);
             ctx.lineTo(x, y);
           }
+          prevY = y;
         }
         ctx.stroke();
+      }
+
+      // Peak marker: flag the highest value in the visible window so a pull's
+      // peak (e.g. 7500 rpm) is readable without hovering
+      if (slot.channel && visible.length >= 2) {
+        let peak: GraphSample | null = null;
+        let peakV = -Infinity;
+        for (const s of visible) {
+          const v = s.values[slot.channel];
+          if (v !== undefined && v > peakV) {
+            peakV = v;
+            peak = s;
+          }
+        }
+        if (peak && isFinite(peakV) && range > 0) {
+          const x = padL + plotW * (1 - (windowEnd - peak.t) / windowMs);
+          const y = padT + plotH * (1 - (peakV - min) / range);
+          ctx.fillStyle = slot.color;
+          ctx.globalAlpha = 0.75;
+          ctx.beginPath();
+          ctx.arc(x, y, 2.5, 0, Math.PI * 2);
+          ctx.fill();
+          const text = formatTick(peakV);
+          ctx.font = '11px monospace';
+          const tw = ctx.measureText(text).width;
+          const tx = Math.min(Math.max(x - tw / 2, padL + 2), padL + plotW - tw - 2);
+          const ty = y > padT + 16 ? y - 15 : y + 6;
+          ctx.fillStyle = bg;
+          ctx.fillRect(tx - 2, ty - 1, tw + 4, 13);
+          ctx.fillStyle = slot.color;
+          ctx.textAlign = 'left';
+          ctx.textBaseline = 'top';
+          ctx.fillText(text, tx, ty);
+          ctx.globalAlpha = 1;
+        }
       }
 
       // Channel label + latest value in the window
@@ -273,13 +312,13 @@ const PaneCanvas: React.FC<PaneCanvasProps> = ({
 
         // Value label beside the cursor, flipped near the right edge
         const text = formatTick(v);
-        ctx.font = 'bold 10px monospace';
+        ctx.font = 'bold 13px monospace';
         const tw = ctx.measureText(text).width;
         const onLeft = x > padL + plotW - tw - 14;
         const tx = onLeft ? x - 6 - tw : x + 6;
-        const ty = Math.min(Math.max(y - 6, padT + 2), padT + plotH - 12);
+        const ty = Math.min(Math.max(y - 8, padT + 2), padT + plotH - 16);
         ctx.fillStyle = bg;
-        ctx.fillRect(tx - 2, ty - 1, tw + 4, 12);
+        ctx.fillRect(tx - 2, ty - 1, tw + 4, 16);
         ctx.fillStyle = slot.color;
         ctx.textAlign = 'left';
         ctx.textBaseline = 'top';
@@ -382,14 +421,40 @@ export const GraphLog: React.FC<GraphLogProps> = ({
   const [configPane, setConfigPane] = useState<number | null>(null);
   const [size, setSize] = useState({ width: 800, height: 480 });
   const [hoverFrac, setHoverFrac] = useState<number | null>(null);
+  /** Right edge of the view in log time; null = follow the latest sample */
+  const [viewEnd, setViewEnd] = useState<number | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const zoomIn = useCallback(() => {
-    setTimeWindow(useGraphLogStore.getState().timeWindowSec * ZOOM_FACTOR);
-  }, [setTimeWindow]);
-  const zoomOut = useCallback(() => {
-    setTimeWindow(useGraphLogStore.getState().timeWindowSec / ZOOM_FACTOR);
-  }, [setTimeWindow]);
+  // Refs so the zoom handlers (bound once for hotkeys) see current values
+  const hoverFracRef = useRef<number | null>(null);
+  const viewEndRef = useRef<number | null>(null);
+  const samplesRef = useRef<GraphSample[]>(samples);
+  hoverFracRef.current = hoverFrac;
+  viewEndRef.current = viewEnd;
+  samplesRef.current = samples;
+
+  /** Zoom keeping the time under the hover cursor fixed; anchors the right
+   *  edge when the mouse isn't over the graphs. */
+  const zoomBy = useCallback(
+    (factor: number) => {
+      const oldWin = useGraphLogStore.getState().timeWindowSec * 1000;
+      const newWin = Math.min(600, Math.max(2, (oldWin / 1000) * factor)) * 1000;
+      const data = samplesRef.current;
+      const frac = hoverFracRef.current;
+      if (data.length > 0 && frac !== null) {
+        const lastT = data[data.length - 1].t;
+        const curEnd = viewEndRef.current ?? lastT;
+        const tCursor = curEnd - oldWin * (1 - frac);
+        const newEnd = tCursor + (1 - frac) * newWin;
+        setViewEnd(newEnd >= lastT ? null : Math.max(newEnd, data[0].t));
+      }
+      setTimeWindow(newWin / 1000);
+    },
+    [setTimeWindow],
+  );
+
+  const zoomIn = useCallback(() => zoomBy(ZOOM_FACTOR), [zoomBy]);
+  const zoomOut = useCallback(() => zoomBy(1 / ZOOM_FACTOR), [zoomBy]);
 
   // Q = zoom in, A = zoom out (ignored while typing in a form field)
   useEffect(() => {
@@ -426,12 +491,17 @@ export const GraphLog: React.FC<GraphLogProps> = ({
   }, []);
 
   const windowMs = timeWindowSec * 1000;
-  const windowEnd = samples.length > 0 ? samples[samples.length - 1].t : 0;
+  const latestT = samples.length > 0 ? samples[samples.length - 1].t : 0;
+  const windowEnd = viewEnd !== null ? Math.min(viewEnd, latestT) : latestT;
   const windowStart = windowEnd - windowMs;
+  const isFollowing = viewEnd === null;
   const visible = useMemo(() => {
     const startIdx = samples.findIndex((s) => s.t >= windowStart);
-    return startIdx < 0 ? [] : samples.slice(startIdx);
-  }, [samples, windowStart]);
+    if (startIdx < 0) return [];
+    let endIdx = samples.length;
+    while (endIdx > startIdx && samples[endIdx - 1].t > windowEnd) endIdx--;
+    return samples.slice(startIdx, endIdx);
+  }, [samples, windowStart, windowEnd]);
 
   const visiblePanes = activeTab.panes.filter((p) => !p.hidden);
   const timeAxisHeight = 22;
@@ -505,6 +575,16 @@ export const GraphLog: React.FC<GraphLogProps> = ({
           <Plus size={13} />
         </button>
         <div className="graphlog-window-select">
+          {!isFollowing && (
+            <button
+              type="button"
+              className="graphlog-latest-btn"
+              onClick={() => setViewEnd(null)}
+              title="Jump back to the newest data"
+            >
+              Latest
+            </button>
+          )}
           <button type="button" onClick={zoomIn} title="Zoom in (Q)">
             <ZoomIn size={14} />
           </button>

--- a/crates/libretune-app/src/components/tuner-ui/GraphLog.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/GraphLog.tsx
@@ -327,6 +327,8 @@ export const GraphLog: React.FC<GraphLogProps> = ({
 
   useEffect(() => {
     if (external) return;
+    // Fresh preview: drop any samples left over from a previous live session
+    liveBufferRef.current = [];
     const interval = window.setInterval(() => {
       const channels = useRealtimeStore.getState().channels;
       const values: Record<string, number> = {};

--- a/crates/libretune-app/src/components/tuner-ui/GraphLog.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/GraphLog.tsx
@@ -9,8 +9,8 @@
  * after Stop, or a loaded log in playback. Before the first recording it
  * shows an empty grid with a hint.
  */
-import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { Plus, X, Settings2 } from 'lucide-react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Plus, X, Settings2, ZoomIn, ZoomOut } from 'lucide-react';
 import { Dialog } from '../common';
 import {
   useGraphLogStore,
@@ -38,6 +38,19 @@ export interface GraphLogProps {
 
 const AXIS_TICKS = 5;
 const PANE_MIN_HEIGHT = 70;
+/** Horizontal padding reserved for the left/right axis labels */
+const PAD_L = 52;
+const PAD_R = 52;
+/** Zoom step per Q/A keypress or zoom button click */
+const ZOOM_FACTOR = 0.75;
+
+function formatWindow(sec: number): string {
+  if (sec < 10) return `${sec.toFixed(1)} s`;
+  if (sec < 60) return `${Math.round(sec)} s`;
+  const m = Math.floor(sec / 60);
+  const s = Math.round(sec % 60);
+  return s > 0 ? `${m}m ${s}s` : `${m} min`;
+}
 
 function formatTick(v: number): string {
   const abs = Math.abs(v);
@@ -93,6 +106,8 @@ interface PaneCanvasProps {
   width: number;
   height: number;
   cursorPosition?: number | null;
+  /** Hovered position 0..1 across the plot area, or null */
+  hoverFrac?: number | null;
   onOpenConfig: () => void;
 }
 
@@ -104,6 +119,7 @@ const PaneCanvas: React.FC<PaneCanvasProps> = ({
   width,
   height,
   cursorPosition,
+  hoverFrac = null,
   onOpenConfig,
 }) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -119,8 +135,8 @@ const PaneCanvas: React.FC<PaneCanvasProps> = ({
     canvas.height = height * dpr;
     ctx.scale(dpr, dpr);
 
-    const padL = 52;
-    const padR = 52;
+    const padL = PAD_L;
+    const padR = PAD_R;
     const padT = 6;
     const padB = 4;
     const plotW = Math.max(10, width - padL - padR);
@@ -217,7 +233,60 @@ const PaneCanvas: React.FC<PaneCanvasProps> = ({
       ctx.lineTo(x, padT + plotH);
       ctx.stroke();
     }
-  }, [pane, visible, windowMs, windowEnd, width, height, cursorPosition]);
+
+    // Hover cursor: vertical bar snapped to the nearest sample, with the
+    // value of each channel at that moment
+    if (hoverFrac !== null && visible.length > 0) {
+      const tHover = windowEnd - windowMs * (1 - hoverFrac);
+      let nearest = visible[0];
+      let bestDist = Math.abs(nearest.t - tHover);
+      for (const s of visible) {
+        const d = Math.abs(s.t - tHover);
+        if (d < bestDist) {
+          bestDist = d;
+          nearest = s;
+        }
+      }
+      const x = padL + plotW * (1 - (windowEnd - nearest.t) / windowMs);
+
+      ctx.strokeStyle = 'rgba(220,225,235,0.75)';
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.moveTo(x, padT);
+      ctx.lineTo(x, padT + plotH);
+      ctx.stroke();
+
+      for (const side of sides) {
+        const slot = pane[side];
+        if (!slot.channel) continue;
+        const v = nearest.values[slot.channel];
+        if (v === undefined) continue;
+        const { min, max } = slotBounds(slot, visible);
+        const range = max - min || 1;
+        const y = padT + plotH * (1 - (v - min) / range);
+
+        // Marker dot on the line
+        ctx.fillStyle = slot.color;
+        ctx.beginPath();
+        ctx.arc(x, y, 3, 0, Math.PI * 2);
+        ctx.fill();
+
+        // Value label beside the cursor, flipped near the right edge
+        const text = formatTick(v);
+        ctx.font = 'bold 10px monospace';
+        const tw = ctx.measureText(text).width;
+        const onLeft = x > padL + plotW - tw - 14;
+        const tx = onLeft ? x - 6 - tw : x + 6;
+        const ty = Math.min(Math.max(y - 6, padT + 2), padT + plotH - 12);
+        ctx.fillStyle = bg;
+        ctx.fillRect(tx - 2, ty - 1, tw + 4, 12);
+        ctx.fillStyle = slot.color;
+        ctx.textAlign = 'left';
+        ctx.textBaseline = 'top';
+        ctx.fillText(text, tx, ty);
+      }
+    }
+  }, [pane, visible, windowMs, windowEnd, width, height, cursorPosition, hoverFrac]);
 
   return (
     <div className="graphlog-pane" style={{ height }}>
@@ -312,7 +381,37 @@ export const GraphLog: React.FC<GraphLogProps> = ({
   const [renameValue, setRenameValue] = useState('');
   const [configPane, setConfigPane] = useState<number | null>(null);
   const [size, setSize] = useState({ width: 800, height: 480 });
+  const [hoverFrac, setHoverFrac] = useState<number | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+
+  const zoomIn = useCallback(() => {
+    setTimeWindow(useGraphLogStore.getState().timeWindowSec * ZOOM_FACTOR);
+  }, [setTimeWindow]);
+  const zoomOut = useCallback(() => {
+    setTimeWindow(useGraphLogStore.getState().timeWindowSec / ZOOM_FACTOR);
+  }, [setTimeWindow]);
+
+  // Q = zoom in, A = zoom out (ignored while typing in a form field)
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const tag = (e.target as HTMLElement | null)?.tagName;
+      if (tag === 'INPUT' || tag === 'SELECT' || tag === 'TEXTAREA') return;
+      if (e.ctrlKey || e.altKey || e.metaKey) return;
+      if (e.key === 'q' || e.key === 'Q') {
+        zoomIn();
+      } else if (e.key === 'a' || e.key === 'A') {
+        zoomOut();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [zoomIn, zoomOut]);
+
+  const handlePanesMouseMove = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    const frac = (e.clientX - rect.left - PAD_L) / Math.max(1, rect.width - PAD_L - PAD_R);
+    setHoverFrac(frac >= 0 && frac <= 1 ? frac : null);
+  }, []);
 
   // Track container size
   useEffect(() => {
@@ -406,23 +505,21 @@ export const GraphLog: React.FC<GraphLogProps> = ({
           <Plus size={13} />
         </button>
         <div className="graphlog-window-select">
-          <label>
-            Window
-            <select
-              value={timeWindowSec}
-              onChange={(e) => setTimeWindow(parseInt(e.target.value, 10))}
-            >
-              <option value={10}>10 s</option>
-              <option value={30}>30 s</option>
-              <option value={60}>1 min</option>
-              <option value={120}>2 min</option>
-              <option value={300}>5 min</option>
-            </select>
-          </label>
+          <button type="button" onClick={zoomIn} title="Zoom in (Q)">
+            <ZoomIn size={14} />
+          </button>
+          <span className="graphlog-window-label">{formatWindow(timeWindowSec)}</span>
+          <button type="button" onClick={zoomOut} title="Zoom out (A)">
+            <ZoomOut size={14} />
+          </button>
         </div>
       </div>
 
-      <div className="graphlog-panes">
+      <div
+        className="graphlog-panes"
+        onMouseMove={handlePanesMouseMove}
+        onMouseLeave={() => setHoverFrac(null)}
+      >
         {samples.length === 0 && (
           <div className="graphlog-empty-hint">Press Record to start logging</div>
         )}
@@ -438,6 +535,7 @@ export const GraphLog: React.FC<GraphLogProps> = ({
               width={size.width}
               height={paneHeight}
               cursorPosition={cursorPosition}
+              hoverFrac={hoverFrac}
               onOpenConfig={() => setConfigPane(paneIndex)}
             />
           );

--- a/crates/libretune-app/src/components/tuner-ui/GraphLog.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/GraphLog.tsx
@@ -188,29 +188,64 @@ const PaneCanvas: React.FC<PaneCanvasProps> = ({
       }
 
       // Trace, drawn as raw sample-and-hold steps — this is measurement data,
-      // not a smoothed presentation graph.
+      // not a smoothed presentation graph. When there are more samples than
+      // pixels, collapse each pixel column to its min/max span (oscilloscope
+      // style) so dense logs stay fast and peaks stay visible.
       if (slot.channel && visible.length >= 2) {
         ctx.strokeStyle = slot.color;
         ctx.lineWidth = 1;
         ctx.beginPath();
-        let started = false;
-        let prevY = 0;
-        for (const s of visible) {
-          const v = s.values[slot.channel];
-          if (v === undefined) {
-            started = false;
-            continue;
+        if (visible.length > plotW * 2) {
+          const colMin = new Float64Array(Math.ceil(plotW)).fill(Infinity);
+          const colMax = new Float64Array(Math.ceil(plotW)).fill(-Infinity);
+          for (const s of visible) {
+            const v = s.values[slot.channel];
+            if (v === undefined) continue;
+            const col = Math.min(
+              Math.ceil(plotW) - 1,
+              Math.max(0, Math.floor(plotW * (1 - (windowEnd - s.t) / windowMs))),
+            );
+            if (v < colMin[col]) colMin[col] = v;
+            if (v > colMax[col]) colMax[col] = v;
           }
-          const x = padL + plotW * (1 - (windowEnd - s.t) / windowMs);
-          const y = padT + plotH * (1 - (v - min) / range);
-          if (!started) {
-            ctx.moveTo(x, y);
-            started = true;
-          } else {
-            ctx.lineTo(x, prevY);
-            ctx.lineTo(x, y);
+          let prevYMid: number | null = null;
+          for (let col = 0; col < colMin.length; col++) {
+            if (colMin[col] === Infinity) {
+              prevYMid = null;
+              continue;
+            }
+            const x = padL + col;
+            const yLo = padT + plotH * (1 - (colMin[col] - min) / range);
+            const yHi = padT + plotH * (1 - (colMax[col] - min) / range);
+            // connect columns so sparse spikes don't float detached
+            if (prevYMid !== null) {
+              ctx.moveTo(x - 1, prevYMid);
+              ctx.lineTo(x, yHi);
+            }
+            ctx.moveTo(x, yHi);
+            ctx.lineTo(x, yLo + 0.5);
+            prevYMid = (yLo + yHi) / 2;
           }
-          prevY = y;
+        } else {
+          let started = false;
+          let prevY = 0;
+          for (const s of visible) {
+            const v = s.values[slot.channel];
+            if (v === undefined) {
+              started = false;
+              continue;
+            }
+            const x = padL + plotW * (1 - (windowEnd - s.t) / windowMs);
+            const y = padT + plotH * (1 - (v - min) / range);
+            if (!started) {
+              ctx.moveTo(x, y);
+              started = true;
+            } else {
+              ctx.lineTo(x, prevY);
+              ctx.lineTo(x, y);
+            }
+            prevY = y;
+          }
         }
         ctx.stroke();
       }

--- a/crates/libretune-app/src/components/tuner-ui/GraphLog.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/GraphLog.tsx
@@ -1,0 +1,519 @@
+/**
+ * Graph Log — TunerStudio/ECUMaster-style stacked strip charts.
+ *
+ * Renders the active graph-log tab as PANES_PER_TAB stacked panes sharing a
+ * time axis. Each pane plots one channel against the left axis and one against
+ * the right, each with its own fixed or auto scale.
+ *
+ * Data source: when a `samples` array is supplied (recording or log playback)
+ * it is drawn as-is; otherwise the component samples the realtime store itself
+ * so the view scrolls live without requiring a recording.
+ */
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { Plus, X, Settings2 } from 'lucide-react';
+import {
+  useGraphLogStore,
+  selectActiveTab,
+  ChannelSlot,
+  GraphPane,
+  AxisSide,
+} from '../../stores/graphLogStore';
+import { useRealtimeStore } from '../../stores/realtimeStore';
+import './GraphLog.css';
+
+export interface GraphSample {
+  /** Timestamp in milliseconds (epoch or log-relative — only deltas matter) */
+  t: number;
+  values: Record<string, number>;
+}
+
+export interface GraphLogProps {
+  /** Recorded/playback samples. When empty, the component live-samples the realtime store. */
+  samples?: GraphSample[];
+  /** Channels the user may assign to slots */
+  availableChannels: string[];
+  /** Cursor position 0..1 across the visible window (playback), or null */
+  cursorPosition?: number | null;
+}
+
+/** Live sampling rate for the self-fed buffer (ms) */
+const LIVE_SAMPLE_MS = 50;
+/** Maximum retained live history (ms) */
+const LIVE_RETENTION_MS = 5 * 60 * 1000;
+
+const AXIS_TICKS = 5;
+const PANE_MIN_HEIGHT = 70;
+
+function formatTick(v: number): string {
+  const abs = Math.abs(v);
+  if (abs >= 1000) return v.toFixed(0);
+  if (abs >= 10) return v.toFixed(1);
+  return v.toFixed(2);
+}
+
+function formatClock(ms: number): string {
+  const totalSec = Math.max(0, Math.floor(ms / 1000));
+  const m = Math.floor(totalSec / 60);
+  const s = totalSec % 60;
+  return `${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`;
+}
+
+/** Resolve slot bounds: fixed when configured, otherwise min/max of visible data. */
+function slotBounds(slot: ChannelSlot, visible: GraphSample[]): { min: number; max: number } {
+  if (!slot.auto) return { min: slot.min, max: slot.max };
+  let min = Infinity;
+  let max = -Infinity;
+  if (slot.channel) {
+    for (const s of visible) {
+      const v = s.values[slot.channel];
+      if (v === undefined) continue;
+      if (v < min) min = v;
+      if (v > max) max = v;
+    }
+  }
+  if (!isFinite(min) || !isFinite(max)) return { min: 0, max: 100 };
+  if (min === max) {
+    const pad = Math.abs(min) * 0.1 || 1;
+    return { min: min - pad, max: max + pad };
+  }
+  const pad = (max - min) * 0.05;
+  return { min: min - pad, max: max + pad };
+}
+
+interface PaneCanvasProps {
+  pane: GraphPane;
+  visible: GraphSample[];
+  windowMs: number;
+  windowEnd: number;
+  width: number;
+  height: number;
+  liveValues: Record<string, number>;
+  cursorPosition?: number | null;
+  onOpenConfig: () => void;
+}
+
+const PaneCanvas: React.FC<PaneCanvasProps> = ({
+  pane,
+  visible,
+  windowMs,
+  windowEnd,
+  width,
+  height,
+  liveValues,
+  cursorPosition,
+  onOpenConfig,
+}) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = width * dpr;
+    canvas.height = height * dpr;
+    ctx.scale(dpr, dpr);
+
+    const padL = 52;
+    const padR = 52;
+    const padT = 6;
+    const padB = 4;
+    const plotW = Math.max(10, width - padL - padR);
+    const plotH = Math.max(10, height - padT - padB);
+
+    const styles = getComputedStyle(canvas);
+    const bg = styles.getPropertyValue('--graphlog-pane-bg').trim() || '#141824';
+    const gridColor = styles.getPropertyValue('--graphlog-grid').trim() || 'rgba(128,140,160,0.15)';
+
+    ctx.fillStyle = bg;
+    ctx.fillRect(0, 0, width, height);
+
+    // Grid
+    ctx.strokeStyle = gridColor;
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    for (let i = 0; i <= AXIS_TICKS - 1; i++) {
+      const y = padT + (plotH * i) / (AXIS_TICKS - 1);
+      ctx.moveTo(padL, y);
+      ctx.lineTo(padL + plotW, y);
+    }
+    const vLines = 6;
+    for (let i = 0; i <= vLines; i++) {
+      const x = padL + (plotW * i) / vLines;
+      ctx.moveTo(x, padT);
+      ctx.lineTo(x, padT + plotH);
+    }
+    ctx.stroke();
+
+    const sides: AxisSide[] = ['left', 'right'];
+    for (const side of sides) {
+      const slot = pane[side];
+      const { min, max } = slotBounds(slot, visible);
+      const range = max - min || 1;
+
+      // Axis tick labels
+      ctx.fillStyle = slot.color;
+      ctx.font = '10px monospace';
+      ctx.textAlign = side === 'left' ? 'right' : 'left';
+      ctx.textBaseline = 'middle';
+      if (slot.channel) {
+        for (let i = 0; i < AXIS_TICKS; i++) {
+          const frac = i / (AXIS_TICKS - 1);
+          const y = padT + plotH * (1 - frac);
+          const v = min + range * frac;
+          const x = side === 'left' ? padL - 6 : padL + plotW + 6;
+          ctx.fillText(formatTick(v), x, y);
+        }
+      }
+
+      // Polyline
+      if (slot.channel && visible.length >= 2) {
+        ctx.strokeStyle = slot.color;
+        ctx.lineWidth = 1.5;
+        ctx.beginPath();
+        let started = false;
+        for (const s of visible) {
+          const v = s.values[slot.channel];
+          if (v === undefined) {
+            started = false;
+            continue;
+          }
+          const x = padL + plotW * (1 - (windowEnd - s.t) / windowMs);
+          const y = padT + plotH * (1 - (v - min) / range);
+          if (!started) {
+            ctx.moveTo(x, y);
+            started = true;
+          } else {
+            ctx.lineTo(x, y);
+          }
+        }
+        ctx.stroke();
+      }
+
+      // Channel label + current value
+      if (slot.channel) {
+        const current = liveValues[slot.channel];
+        const label = `${slot.channel}${current !== undefined ? `: ${formatTick(current)}` : ''}`;
+        ctx.font = 'bold 11px sans-serif';
+        ctx.textBaseline = 'top';
+        ctx.textAlign = side === 'left' ? 'left' : 'right';
+        const x = side === 'left' ? padL + 6 : padL + plotW - 6;
+        ctx.fillText(label, x, padT + 4);
+      }
+    }
+
+    // Playback cursor
+    if (cursorPosition !== null && cursorPosition !== undefined) {
+      const x = padL + plotW * cursorPosition;
+      ctx.strokeStyle = 'rgba(255,80,80,0.9)';
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.moveTo(x, padT);
+      ctx.lineTo(x, padT + plotH);
+      ctx.stroke();
+    }
+  }, [pane, visible, windowMs, windowEnd, width, height, liveValues, cursorPosition]);
+
+  return (
+    <div className="graphlog-pane" style={{ height }}>
+      <canvas ref={canvasRef} style={{ width, height }} />
+      <button
+        type="button"
+        className="graphlog-pane-config"
+        title="Configure pane channels and scales"
+        onClick={onOpenConfig}
+      >
+        <Settings2 size={13} />
+      </button>
+    </div>
+  );
+};
+
+interface SlotConfigProps {
+  label: string;
+  slot: ChannelSlot;
+  availableChannels: string[];
+  onChange: (patch: Partial<ChannelSlot>) => void;
+}
+
+const SlotConfig: React.FC<SlotConfigProps> = ({ label, slot, availableChannels, onChange }) => (
+  <fieldset className="graphlog-slot-config">
+    <legend style={{ color: slot.color }}>{label}</legend>
+    <label>
+      Channel
+      <select
+        value={slot.channel ?? ''}
+        onChange={(e) => onChange({ channel: e.target.value || null })}
+      >
+        <option value="">— none —</option>
+        {availableChannels.map((c) => (
+          <option key={c} value={c}>
+            {c}
+          </option>
+        ))}
+      </select>
+    </label>
+    <label className="graphlog-slot-auto">
+      <input
+        type="checkbox"
+        checked={slot.auto}
+        onChange={(e) => onChange({ auto: e.target.checked })}
+      />
+      Auto scale
+    </label>
+    <div className="graphlog-slot-range">
+      <label>
+        Min
+        <input
+          type="number"
+          step="any"
+          value={slot.min}
+          disabled={slot.auto}
+          onChange={(e) => {
+            const v = parseFloat(e.target.value);
+            if (!isNaN(v)) onChange({ min: v });
+          }}
+        />
+      </label>
+      <label>
+        Max
+        <input
+          type="number"
+          step="any"
+          value={slot.max}
+          disabled={slot.auto}
+          onChange={(e) => {
+            const v = parseFloat(e.target.value);
+            if (!isNaN(v)) onChange({ max: v });
+          }}
+        />
+      </label>
+    </div>
+  </fieldset>
+);
+
+export const GraphLog: React.FC<GraphLogProps> = ({
+  samples,
+  availableChannels,
+  cursorPosition = null,
+}) => {
+  const tabs = useGraphLogStore((s) => s.tabs);
+  const activeTab = useGraphLogStore(selectActiveTab);
+  const timeWindowSec = useGraphLogStore((s) => s.timeWindowSec);
+  const { addTab, removeTab, renameTab, setActiveTab, setTimeWindow, updateSlot } =
+    useGraphLogStore();
+
+  const [renamingTabId, setRenamingTabId] = useState<string | null>(null);
+  const [renameValue, setRenameValue] = useState('');
+  const [configPane, setConfigPane] = useState<number | null>(null);
+  const [size, setSize] = useState({ width: 800, height: 480 });
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Live self-sampling buffer, used when no external samples are provided.
+  const liveBufferRef = useRef<GraphSample[]>([]);
+  const [liveTick, setLiveTick] = useState(0);
+  const external = samples !== undefined && samples.length > 0;
+
+  const neededChannels = useMemo(() => {
+    const set = new Set<string>();
+    for (const pane of activeTab.panes) {
+      if (pane.left.channel) set.add(pane.left.channel);
+      if (pane.right.channel) set.add(pane.right.channel);
+    }
+    return Array.from(set);
+  }, [activeTab]);
+
+  useEffect(() => {
+    if (external) return;
+    const interval = window.setInterval(() => {
+      const channels = useRealtimeStore.getState().channels;
+      const values: Record<string, number> = {};
+      let any = false;
+      for (const name of neededChannels) {
+        const v = channels[name];
+        if (v !== undefined) {
+          values[name] = v;
+          any = true;
+        }
+      }
+      if (!any) return;
+      const buf = liveBufferRef.current;
+      const now = Date.now();
+      buf.push({ t: now, values });
+      const cutoff = now - LIVE_RETENTION_MS;
+      while (buf.length > 0 && buf[0].t < cutoff) buf.shift();
+      setLiveTick((n) => n + 1);
+    }, LIVE_SAMPLE_MS);
+    return () => window.clearInterval(interval);
+  }, [external, neededChannels]);
+
+  // Track container size
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const observer = new ResizeObserver((entries) => {
+      const rect = entries[0].contentRect;
+      setSize({ width: Math.max(300, rect.width), height: Math.max(200, rect.height) });
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  const data: GraphSample[] = external ? samples! : liveBufferRef.current;
+
+  const windowMs = timeWindowSec * 1000;
+  const windowEnd = data.length > 0 ? data[data.length - 1].t : Date.now();
+  const windowStart = windowEnd - windowMs;
+  const visible = useMemo(() => {
+    const startIdx = data.findIndex((s) => s.t >= windowStart);
+    return startIdx < 0 ? [] : data.slice(startIdx);
+  }, [data, windowStart, liveTick]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const liveValues = useRealtimeStore((s) => s.channels);
+
+  const visiblePanes = activeTab.panes.filter((p) => !p.hidden);
+  const timeAxisHeight = 22;
+  const paneHeight = Math.max(
+    PANE_MIN_HEIGHT,
+    Math.floor((size.height - timeAxisHeight) / Math.max(1, visiblePanes.length)),
+  );
+
+  const commitRename = () => {
+    if (renamingTabId) renameTab(renamingTabId, renameValue);
+    setRenamingTabId(null);
+  };
+
+  // Time axis labels (relative to window end)
+  const timeLabels = useMemo(() => {
+    const labels: Array<{ frac: number; text: string }> = [];
+    const steps = 6;
+    const base = data.length > 0 ? data[0].t : windowStart;
+    for (let i = 0; i <= steps; i++) {
+      const frac = i / steps;
+      const t = windowStart + windowMs * frac;
+      labels.push({ frac, text: formatClock(t - base) });
+    }
+    return labels;
+  }, [windowStart, windowMs, data]);
+
+  return (
+    <div className="graphlog" ref={containerRef}>
+      <div className="graphlog-tabbar">
+        {tabs.map((tab) => (
+          <div
+            key={tab.id}
+            className={`graphlog-tab${tab.id === activeTab.id ? ' active' : ''}`}
+            onClick={() => setActiveTab(tab.id)}
+            onDoubleClick={() => {
+              setRenamingTabId(tab.id);
+              setRenameValue(tab.name);
+            }}
+          >
+            {renamingTabId === tab.id ? (
+              <input
+                autoFocus
+                value={renameValue}
+                onChange={(e) => setRenameValue(e.target.value)}
+                onBlur={commitRename}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') commitRename();
+                  if (e.key === 'Escape') setRenamingTabId(null);
+                }}
+                onClick={(e) => e.stopPropagation()}
+              />
+            ) : (
+              <span>{tab.name}</span>
+            )}
+            {tabs.length > 1 && (
+              <button
+                type="button"
+                className="graphlog-tab-close"
+                title="Remove tab"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  removeTab(tab.id);
+                }}
+              >
+                <X size={11} />
+              </button>
+            )}
+          </div>
+        ))}
+        <button type="button" className="graphlog-tab-add" title="Add tab" onClick={addTab}>
+          <Plus size={13} />
+        </button>
+        <div className="graphlog-window-select">
+          <label>
+            Window
+            <select
+              value={timeWindowSec}
+              onChange={(e) => setTimeWindow(parseInt(e.target.value, 10))}
+            >
+              <option value={10}>10 s</option>
+              <option value={30}>30 s</option>
+              <option value={60}>1 min</option>
+              <option value={120}>2 min</option>
+              <option value={300}>5 min</option>
+            </select>
+          </label>
+        </div>
+      </div>
+
+      <div className="graphlog-panes">
+        {visiblePanes.map((pane) => {
+          const paneIndex = activeTab.panes.indexOf(pane);
+          return (
+            <PaneCanvas
+              key={paneIndex}
+              pane={pane}
+              visible={visible}
+              windowMs={windowMs}
+              windowEnd={windowEnd}
+              width={size.width}
+              height={paneHeight}
+              liveValues={liveValues}
+              cursorPosition={cursorPosition}
+              onOpenConfig={() => setConfigPane(paneIndex)}
+            />
+          );
+        })}
+        <div className="graphlog-timeaxis" style={{ height: timeAxisHeight }}>
+          {timeLabels.map((l) => (
+            <span key={l.frac} style={{ left: `calc(52px + (100% - 104px) * ${l.frac})` }}>
+              {l.text}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      {configPane !== null && (
+        <div className="graphlog-config-overlay" onClick={() => setConfigPane(null)}>
+          <div className="graphlog-config" onClick={(e) => e.stopPropagation()}>
+            <div className="graphlog-config-header">
+              <h3>Graph {configPane + 1} — channels &amp; scales</h3>
+              <button type="button" onClick={() => setConfigPane(null)} aria-label="Close">
+                <X size={14} />
+              </button>
+            </div>
+            <SlotConfig
+              label="Left axis"
+              slot={activeTab.panes[configPane].left}
+              availableChannels={availableChannels}
+              onChange={(patch) => updateSlot(activeTab.id, configPane, 'left', patch)}
+            />
+            <SlotConfig
+              label="Right axis"
+              slot={activeTab.panes[configPane].right}
+              availableChannels={availableChannels}
+              onChange={(patch) => updateSlot(activeTab.id, configPane, 'right', patch)}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default GraphLog;

--- a/crates/libretune-app/src/components/tuner-ui/GraphLog.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/GraphLog.tsx
@@ -1,16 +1,17 @@
 /**
  * Graph Log — TunerStudio/ECUMaster-style stacked strip charts.
  *
- * Renders the active graph-log tab as PANES_PER_TAB stacked panes sharing a
- * time axis. Each pane plots one channel against the left axis and one against
- * the right, each with its own fixed or auto scale.
+ * Renders the active graph-log tab as stacked panes sharing a time axis.
+ * Each pane plots one channel against the left axis and one against the
+ * right, each with its own fixed or auto scale.
  *
- * Data source: when a `samples` array is supplied (recording or log playback)
- * it is drawn as-is; otherwise the component samples the realtime store itself
- * so the view scrolls live without requiring a recording.
+ * The graph only draws recorded data: the session log while recording or
+ * after Stop, or a loaded log in playback. Before the first recording it
+ * shows an empty grid with a hint.
  */
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Plus, X, Settings2 } from 'lucide-react';
+import { Dialog } from '../common';
 import {
   useGraphLogStore,
   selectActiveTab,
@@ -18,7 +19,6 @@ import {
   GraphPane,
   AxisSide,
 } from '../../stores/graphLogStore';
-import { useRealtimeStore } from '../../stores/realtimeStore';
 import './GraphLog.css';
 
 export interface GraphSample {
@@ -28,18 +28,13 @@ export interface GraphSample {
 }
 
 export interface GraphLogProps {
-  /** Recorded/playback samples. When empty, the component live-samples the realtime store. */
-  samples?: GraphSample[];
+  /** Recorded session log or playback samples */
+  samples: GraphSample[];
   /** Channels the user may assign to slots */
   availableChannels: string[];
   /** Cursor position 0..1 across the visible window (playback), or null */
   cursorPosition?: number | null;
 }
-
-/** Live sampling rate for the self-fed buffer (ms) */
-const LIVE_SAMPLE_MS = 50;
-/** Maximum retained live history (ms) */
-const LIVE_RETENTION_MS = 5 * 60 * 1000;
 
 const AXIS_TICKS = 5;
 const PANE_MIN_HEIGHT = 70;
@@ -80,6 +75,16 @@ function slotBounds(slot: ChannelSlot, visible: GraphSample[]): { min: number; m
   return { min: min - pad, max: max + pad };
 }
 
+/** Last recorded value of a channel within the visible window */
+function lastValue(channel: string | null, visible: GraphSample[]): number | undefined {
+  if (!channel) return undefined;
+  for (let i = visible.length - 1; i >= 0; i--) {
+    const v = visible[i].values[channel];
+    if (v !== undefined) return v;
+  }
+  return undefined;
+}
+
 interface PaneCanvasProps {
   pane: GraphPane;
   visible: GraphSample[];
@@ -87,7 +92,6 @@ interface PaneCanvasProps {
   windowEnd: number;
   width: number;
   height: number;
-  liveValues: Record<string, number>;
   cursorPosition?: number | null;
   onOpenConfig: () => void;
 }
@@ -99,7 +103,6 @@ const PaneCanvas: React.FC<PaneCanvasProps> = ({
   windowEnd,
   width,
   height,
-  liveValues,
   cursorPosition,
   onOpenConfig,
 }) => {
@@ -192,9 +195,9 @@ const PaneCanvas: React.FC<PaneCanvasProps> = ({
         ctx.stroke();
       }
 
-      // Channel label + current value
+      // Channel label + latest value in the window
       if (slot.channel) {
-        const current = liveValues[slot.channel];
+        const current = lastValue(slot.channel, visible);
         const label = `${slot.channel}${current !== undefined ? `: ${formatTick(current)}` : ''}`;
         ctx.font = 'bold 11px sans-serif';
         ctx.textBaseline = 'top';
@@ -214,7 +217,7 @@ const PaneCanvas: React.FC<PaneCanvasProps> = ({
       ctx.lineTo(x, padT + plotH);
       ctx.stroke();
     }
-  }, [pane, visible, windowMs, windowEnd, width, height, liveValues, cursorPosition]);
+  }, [pane, visible, windowMs, windowEnd, width, height, cursorPosition]);
 
   return (
     <div className="graphlog-pane" style={{ height }}>
@@ -311,46 +314,6 @@ export const GraphLog: React.FC<GraphLogProps> = ({
   const [size, setSize] = useState({ width: 800, height: 480 });
   const containerRef = useRef<HTMLDivElement>(null);
 
-  // Live self-sampling buffer, used when no external samples are provided.
-  const liveBufferRef = useRef<GraphSample[]>([]);
-  const [liveTick, setLiveTick] = useState(0);
-  const external = samples !== undefined && samples.length > 0;
-
-  const neededChannels = useMemo(() => {
-    const set = new Set<string>();
-    for (const pane of activeTab.panes) {
-      if (pane.left.channel) set.add(pane.left.channel);
-      if (pane.right.channel) set.add(pane.right.channel);
-    }
-    return Array.from(set);
-  }, [activeTab]);
-
-  useEffect(() => {
-    if (external) return;
-    // Fresh preview: drop any samples left over from a previous live session
-    liveBufferRef.current = [];
-    const interval = window.setInterval(() => {
-      const channels = useRealtimeStore.getState().channels;
-      const values: Record<string, number> = {};
-      let any = false;
-      for (const name of neededChannels) {
-        const v = channels[name];
-        if (v !== undefined) {
-          values[name] = v;
-          any = true;
-        }
-      }
-      if (!any) return;
-      const buf = liveBufferRef.current;
-      const now = Date.now();
-      buf.push({ t: now, values });
-      const cutoff = now - LIVE_RETENTION_MS;
-      while (buf.length > 0 && buf[0].t < cutoff) buf.shift();
-      setLiveTick((n) => n + 1);
-    }, LIVE_SAMPLE_MS);
-    return () => window.clearInterval(interval);
-  }, [external, neededChannels]);
-
   // Track container size
   useEffect(() => {
     const el = containerRef.current;
@@ -363,17 +326,13 @@ export const GraphLog: React.FC<GraphLogProps> = ({
     return () => observer.disconnect();
   }, []);
 
-  const data: GraphSample[] = external ? samples! : liveBufferRef.current;
-
   const windowMs = timeWindowSec * 1000;
-  const windowEnd = data.length > 0 ? data[data.length - 1].t : Date.now();
+  const windowEnd = samples.length > 0 ? samples[samples.length - 1].t : 0;
   const windowStart = windowEnd - windowMs;
   const visible = useMemo(() => {
-    const startIdx = data.findIndex((s) => s.t >= windowStart);
-    return startIdx < 0 ? [] : data.slice(startIdx);
-  }, [data, windowStart, liveTick]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  const liveValues = useRealtimeStore((s) => s.channels);
+    const startIdx = samples.findIndex((s) => s.t >= windowStart);
+    return startIdx < 0 ? [] : samples.slice(startIdx);
+  }, [samples, windowStart]);
 
   const visiblePanes = activeTab.panes.filter((p) => !p.hidden);
   const timeAxisHeight = 22;
@@ -387,18 +346,18 @@ export const GraphLog: React.FC<GraphLogProps> = ({
     setRenamingTabId(null);
   };
 
-  // Time axis labels (relative to window end)
+  // Time axis labels (relative to the start of the log)
   const timeLabels = useMemo(() => {
     const labels: Array<{ frac: number; text: string }> = [];
     const steps = 6;
-    const base = data.length > 0 ? data[0].t : windowStart;
+    const base = samples.length > 0 ? samples[0].t : windowStart;
     for (let i = 0; i <= steps; i++) {
       const frac = i / steps;
       const t = windowStart + windowMs * frac;
       labels.push({ frac, text: formatClock(t - base) });
     }
     return labels;
-  }, [windowStart, windowMs, data]);
+  }, [windowStart, windowMs, samples]);
 
   return (
     <div className="graphlog" ref={containerRef}>
@@ -464,6 +423,9 @@ export const GraphLog: React.FC<GraphLogProps> = ({
       </div>
 
       <div className="graphlog-panes">
+        {samples.length === 0 && (
+          <div className="graphlog-empty-hint">Press Record to start logging</div>
+        )}
         {visiblePanes.map((pane) => {
           const paneIndex = activeTab.panes.indexOf(pane);
           return (
@@ -475,7 +437,6 @@ export const GraphLog: React.FC<GraphLogProps> = ({
               windowEnd={windowEnd}
               width={size.width}
               height={paneHeight}
-              liveValues={liveValues}
               cursorPosition={cursorPosition}
               onOpenConfig={() => setConfigPane(paneIndex)}
             />
@@ -490,30 +451,32 @@ export const GraphLog: React.FC<GraphLogProps> = ({
         </div>
       </div>
 
-      {configPane !== null && (
-        <div className="graphlog-config-overlay" onClick={() => setConfigPane(null)}>
-          <div className="graphlog-config" onClick={(e) => e.stopPropagation()}>
-            <div className="graphlog-config-header">
-              <h3>Graph {configPane + 1} — channels &amp; scales</h3>
-              <button type="button" onClick={() => setConfigPane(null)} aria-label="Close">
-                <X size={14} />
-              </button>
-            </div>
-            <SlotConfig
-              label="Left axis"
-              slot={activeTab.panes[configPane].left}
-              availableChannels={availableChannels}
-              onChange={(patch) => updateSlot(activeTab.id, configPane, 'left', patch)}
-            />
-            <SlotConfig
-              label="Right axis"
-              slot={activeTab.panes[configPane].right}
-              availableChannels={availableChannels}
-              onChange={(patch) => updateSlot(activeTab.id, configPane, 'right', patch)}
-            />
-          </div>
-        </div>
-      )}
+      <Dialog
+        open={configPane !== null}
+        onClose={() => setConfigPane(null)}
+        title={`Graph ${configPane !== null ? configPane + 1 : ''} — channels & scales`}
+        size="sm"
+        className="graphlog-config-dialog"
+      >
+        <Dialog.Body>
+          {configPane !== null && (
+            <>
+              <SlotConfig
+                label="Left axis"
+                slot={activeTab.panes[configPane].left}
+                availableChannels={availableChannels}
+                onChange={(patch) => updateSlot(activeTab.id, configPane, 'left', patch)}
+              />
+              <SlotConfig
+                label="Right axis"
+                slot={activeTab.panes[configPane].right}
+                availableChannels={availableChannels}
+                onChange={(patch) => updateSlot(activeTab.id, configPane, 'right', patch)}
+              />
+            </>
+          )}
+        </Dialog.Body>
+      </Dialog>
     </div>
   );
 };

--- a/crates/libretune-app/src/components/tuner-ui/GraphLog.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/GraphLog.tsx
@@ -98,6 +98,19 @@ function lastValue(channel: string | null, visible: GraphSample[]): number | und
   return undefined;
 }
 
+/** Binary search for the sample index nearest to time t */
+function nearestIndex(data: GraphSample[], t: number): number {
+  let lo = 0;
+  let hi = data.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (data[mid].t < t) lo = mid + 1;
+    else hi = mid;
+  }
+  if (lo > 0 && Math.abs(data[lo - 1].t - t) < Math.abs(data[lo].t - t)) return lo - 1;
+  return lo;
+}
+
 interface PaneCanvasProps {
   pane: GraphPane;
   visible: GraphSample[];
@@ -108,6 +121,8 @@ interface PaneCanvasProps {
   cursorPosition?: number | null;
   /** Hovered position 0..1 across the plot area, or null */
   hoverFrac?: number | null;
+  /** Persistent data cursor sample (arrow-key navigable), or null */
+  cursorSample?: GraphSample | null;
   onOpenConfig: () => void;
 }
 
@@ -120,6 +135,7 @@ const PaneCanvas: React.FC<PaneCanvasProps> = ({
   height,
   cursorPosition,
   hoverFrac = null,
+  cursorSample = null,
   onOpenConfig,
 }) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -308,23 +324,13 @@ const PaneCanvas: React.FC<PaneCanvasProps> = ({
       ctx.stroke();
     }
 
-    // Hover cursor: vertical bar snapped to the nearest sample, with the
-    // value of each channel at that moment
-    if (hoverFrac !== null && visible.length > 0) {
-      const tHover = windowEnd - windowMs * (1 - hoverFrac);
-      let nearest = visible[0];
-      let bestDist = Math.abs(nearest.t - tHover);
-      for (const s of visible) {
-        const d = Math.abs(s.t - tHover);
-        if (d < bestDist) {
-          bestDist = d;
-          nearest = s;
-        }
-      }
-      const x = padL + plotW * (1 - (windowEnd - nearest.t) / windowMs);
+    // Vertical marker at a sample with dots and value labels for both slots.
+    const drawSampleMarker = (sample: GraphSample, lineStyle: string, lineW: number) => {
+      const x = padL + plotW * (1 - (windowEnd - sample.t) / windowMs);
+      if (x < padL - 1 || x > padL + plotW + 1) return;
 
-      ctx.strokeStyle = 'rgba(220,225,235,0.75)';
-      ctx.lineWidth = 1;
+      ctx.strokeStyle = lineStyle;
+      ctx.lineWidth = lineW;
       ctx.beginPath();
       ctx.moveTo(x, padT);
       ctx.lineTo(x, padT + plotH);
@@ -333,7 +339,7 @@ const PaneCanvas: React.FC<PaneCanvasProps> = ({
       for (const side of sides) {
         const slot = pane[side];
         if (!slot.channel) continue;
-        const v = nearest.values[slot.channel];
+        const v = sample.values[slot.channel];
         if (v === undefined) continue;
         const { min, max } = slotBounds(slot, visible);
         const range = max - min || 1;
@@ -359,8 +365,20 @@ const PaneCanvas: React.FC<PaneCanvasProps> = ({
         ctx.textBaseline = 'top';
         ctx.fillText(text, tx, ty);
       }
+    };
+
+    // Persistent data cursor (arrow-key navigable)
+    if (cursorSample) {
+      drawSampleMarker(cursorSample, 'rgba(79,143,232,0.95)', 1.5);
     }
-  }, [pane, visible, windowMs, windowEnd, width, height, cursorPosition, hoverFrac]);
+
+    // Hover cursor: vertical bar snapped to the nearest sample
+    if (hoverFrac !== null && visible.length > 0) {
+      const tHover = windowEnd - windowMs * (1 - hoverFrac);
+      const nearest = visible[nearestIndex(visible, tHover)];
+      drawSampleMarker(nearest, 'rgba(220,225,235,0.6)', 1);
+    }
+  }, [pane, visible, windowMs, windowEnd, width, height, cursorPosition, hoverFrac, cursorSample]);
 
   return (
     <div className="graphlog-pane" style={{ height }}>
@@ -458,14 +476,18 @@ export const GraphLog: React.FC<GraphLogProps> = ({
   const [hoverFrac, setHoverFrac] = useState<number | null>(null);
   /** Right edge of the view in log time; null = follow the latest sample */
   const [viewEnd, setViewEnd] = useState<number | null>(null);
+  /** Persistent data cursor position in log time; arrow keys step it */
+  const [cursorT, setCursorT] = useState<number | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
   // Refs so the zoom handlers (bound once for hotkeys) see current values
   const hoverFracRef = useRef<number | null>(null);
   const viewEndRef = useRef<number | null>(null);
+  const cursorTRef = useRef<number | null>(null);
   const samplesRef = useRef<GraphSample[]>(samples);
   hoverFracRef.current = hoverFrac;
   viewEndRef.current = viewEnd;
+  cursorTRef.current = cursorT;
   samplesRef.current = samples;
 
   /** Zoom keeping the time under the hover cursor fixed; anchors the right
@@ -491,7 +513,30 @@ export const GraphLog: React.FC<GraphLogProps> = ({
   const zoomIn = useCallback(() => zoomBy(ZOOM_FACTOR), [zoomBy]);
   const zoomOut = useCallback(() => zoomBy(1 / ZOOM_FACTOR), [zoomBy]);
 
-  // Q = zoom in, A = zoom out (ignored while typing in a form field)
+  /** Step the data cursor by n samples, panning the view to keep it visible */
+  const stepCursor = useCallback((delta: number) => {
+    const data = samplesRef.current;
+    if (data.length === 0) return;
+    const cur = cursorTRef.current;
+    let idx = cur === null ? data.length - 1 : nearestIndex(data, cur);
+    if (cur !== null) idx += delta;
+    idx = Math.min(data.length - 1, Math.max(0, idx));
+    const t = data[idx].t;
+    setCursorT(t);
+
+    // Keep the cursor inside the view: nudge the window edge past it
+    const winMs = useGraphLogStore.getState().timeWindowSec * 1000;
+    const lastT = data[data.length - 1].t;
+    const end = viewEndRef.current ?? lastT;
+    if (t > end) {
+      setViewEnd(t >= lastT ? null : t);
+    } else if (t < end - winMs) {
+      setViewEnd(Math.min(t + winMs, lastT));
+    }
+  }, []);
+
+  // Q = zoom in, A = zoom out, arrows = step data cursor, Esc = clear cursor
+  // (all ignored while typing in a form field)
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       const tag = (e.target as HTMLElement | null)?.tagName;
@@ -501,11 +546,31 @@ export const GraphLog: React.FC<GraphLogProps> = ({
         zoomIn();
       } else if (e.key === 'a' || e.key === 'A') {
         zoomOut();
+      } else if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+        e.preventDefault();
+        const step = (e.shiftKey ? 10 : 1) * (e.key === 'ArrowLeft' ? -1 : 1);
+        stepCursor(step);
+      } else if (e.key === 'Escape') {
+        setCursorT(null);
       }
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [zoomIn, zoomOut]);
+  }, [zoomIn, zoomOut, stepCursor]);
+
+  /** Click on the graphs places the data cursor at the nearest sample */
+  const handlePanesClick = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    const data = samplesRef.current;
+    if (data.length === 0) return;
+    const rect = e.currentTarget.getBoundingClientRect();
+    const frac = (e.clientX - rect.left - PAD_L) / Math.max(1, rect.width - PAD_L - PAD_R);
+    if (frac < 0 || frac > 1) return;
+    const winMs = useGraphLogStore.getState().timeWindowSec * 1000;
+    const lastT = data[data.length - 1].t;
+    const end = viewEndRef.current ?? lastT;
+    const t = end - winMs * (1 - frac);
+    setCursorT(data[nearestIndex(data, t)].t);
+  }, []);
 
   const handlePanesMouseMove = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
     const rect = e.currentTarget.getBoundingClientRect();
@@ -537,6 +602,11 @@ export const GraphLog: React.FC<GraphLogProps> = ({
     while (endIdx > startIdx && samples[endIdx - 1].t > windowEnd) endIdx--;
     return samples.slice(startIdx, endIdx);
   }, [samples, windowStart, windowEnd]);
+
+  const cursorSample = useMemo(
+    () => (cursorT !== null && samples.length > 0 ? samples[nearestIndex(samples, cursorT)] : null),
+    [cursorT, samples],
+  );
 
   const visiblePanes = activeTab.panes.filter((p) => !p.hidden);
   const timeAxisHeight = 22;
@@ -610,6 +680,11 @@ export const GraphLog: React.FC<GraphLogProps> = ({
           <Plus size={13} />
         </button>
         <div className="graphlog-window-select">
+          {cursorSample && samples.length > 0 && (
+            <span className="graphlog-cursor-time" title="Data cursor (←/→ to step, Esc to clear)">
+              ▸ {formatClock(cursorSample.t - samples[0].t)}
+            </span>
+          )}
           {!isFollowing && (
             <button
               type="button"
@@ -634,6 +709,7 @@ export const GraphLog: React.FC<GraphLogProps> = ({
         className="graphlog-panes"
         onMouseMove={handlePanesMouseMove}
         onMouseLeave={() => setHoverFrac(null)}
+        onClick={handlePanesClick}
       >
         {samples.length === 0 && (
           <div className="graphlog-empty-hint">Press Record to start logging</div>
@@ -651,6 +727,7 @@ export const GraphLog: React.FC<GraphLogProps> = ({
               height={paneHeight}
               cursorPosition={cursorPosition}
               hoverFrac={hoverFrac}
+              cursorSample={cursorSample}
               onOpenConfig={() => setConfigPane(paneIndex)}
             />
           );

--- a/crates/libretune-app/src/stores/graphLogStore.ts
+++ b/crates/libretune-app/src/stores/graphLogStore.ts
@@ -77,15 +77,17 @@ let nextId = Date.now();
 const newTabId = () => `graphtab-${nextId++}`;
 
 /** Default pages mirroring the TunerStudio Fuel/Ignition presets.
- *  Channel names follow the rusEFI INI conventions; slots for channels a
- *  given INI doesn't define simply show no data until reassigned.
+ *  Channel names use the canonical lowercase alias names the realtime stream
+ *  and data logger add via apply_channel_aliases (rpm, map, lambda, …), which
+ *  work across rusEFI/Speeduino INIs. Slots for channels a given INI doesn't
+ *  provide simply show no data until reassigned.
  */
 const defaultTabs = (): GraphTab[] => [
   {
     id: newTabId(),
     name: 'Fuel',
     panes: [
-      makePane(0, makeSlot('left', 0, 'RPM', 0, 9000), makeSlot('right', 0, 'MAP', 0, 400)),
+      makePane(0, makeSlot('left', 0, 'rpm', 0, 9000), makeSlot('right', 0, 'map', 0, 400)),
       makePane(1, makeSlot('left', 1, 'lambda', 0.7, 1.3), makeSlot('right', 1, 'pulseWidth', 0, 25)),
       makePane(2, makeSlot('left', 2, 've', 0, 200), makeSlot('right', 2, 'tps', 0, 100)),
       makePane(3, makeSlot('left', 3, 'coolant', -40, 140), makeSlot('right', 3, 'iat', -40, 120)),
@@ -95,13 +97,21 @@ const defaultTabs = (): GraphTab[] => [
     id: newTabId(),
     name: 'Ignition',
     panes: [
-      makePane(0, makeSlot('left', 0, 'RPM', 0, 9000), makeSlot('right', 0, 'timing', -10, 60)),
-      makePane(1, makeSlot('left', 1, 'MAP', 0, 400), makeSlot('right', 1, 'tps', 0, 100)),
+      makePane(0, makeSlot('left', 0, 'rpm', 0, 9000), makeSlot('right', 0, 'advance', -10, 60)),
+      makePane(1, makeSlot('left', 1, 'map', 0, 400), makeSlot('right', 1, 'tps', 0, 100)),
       makePane(2),
       makePane(3),
     ],
   },
 ];
+
+/** Channel renames applied when migrating persisted state from v1 */
+const V1_CHANNEL_RENAMES: Record<string, string> = {
+  RPM: 'rpm',
+  MAP: 'map',
+  TPS: 'tps',
+  timing: 'advance',
+};
 
 interface GraphLogState {
   tabs: GraphTab[];
@@ -159,7 +169,7 @@ export const useGraphLogStore = create<GraphLogState>()(
       setActiveTab: (tabId) => set({ activeTabId: tabId }),
 
       setTimeWindow: (seconds) =>
-        set({ timeWindowSec: Math.min(300, Math.max(5, seconds)) }),
+        set({ timeWindowSec: Math.min(600, Math.max(2, seconds)) }),
 
       updateSlot: (tabId, paneIndex, side, patch) =>
         set((state) => ({
@@ -185,7 +195,25 @@ export const useGraphLogStore = create<GraphLogState>()(
     }),
     {
       name: 'libretune-graph-log',
-      version: 1,
+      version: 2,
+      migrate: (persisted, version) => {
+        const state = persisted as GraphLogState;
+        if (version < 2 && state?.tabs) {
+          // v1 defaults used uppercase channel names that don't exist in the
+          // recorded logs (canonical alias names are lowercase).
+          for (const tab of state.tabs) {
+            for (const pane of tab.panes) {
+              for (const side of ['left', 'right'] as const) {
+                const ch = pane[side].channel;
+                if (ch && V1_CHANNEL_RENAMES[ch]) {
+                  pane[side].channel = V1_CHANNEL_RENAMES[ch];
+                }
+              }
+            }
+          }
+        }
+        return state;
+      },
     },
   ),
 );

--- a/crates/libretune-app/src/stores/graphLogStore.ts
+++ b/crates/libretune-app/src/stores/graphLogStore.ts
@@ -1,0 +1,196 @@
+/**
+ * Zustand store for the Graph Log view (TunerStudio-style stacked strip charts).
+ *
+ * Layout model: the user has multiple renameable tabs; each tab holds a fixed
+ * number of stacked panes sharing one time axis; each pane plots up to two
+ * channels — one on the left axis, one on the right — with independent scales.
+ *
+ * Persisted to localStorage so tab layouts and scale overrides survive restarts.
+ */
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export const PANES_PER_TAB = 4;
+
+export type AxisSide = 'left' | 'right';
+
+export interface ChannelSlot {
+  /** Output channel name, or null when the slot is unassigned */
+  channel: string | null;
+  /** Fixed scale bounds (used when auto is false) */
+  min: number;
+  max: number;
+  /** Auto-scale to the visible data instead of the fixed bounds */
+  auto: boolean;
+  color: string;
+}
+
+export interface GraphPane {
+  left: ChannelSlot;
+  right: ChannelSlot;
+  hidden: boolean;
+}
+
+export interface GraphTab {
+  id: string;
+  name: string;
+  panes: GraphPane[];
+}
+
+/** Left/right line colors per pane, loosely matching the TunerStudio palette */
+export const PANE_COLORS: Array<{ left: string; right: string }> = [
+  { left: '#e05252', right: '#4f8fe8' },
+  { left: '#3dba6f', right: '#c069d8' },
+  { left: '#e0a030', right: '#7f7ff0' },
+  { left: '#d8d8d8', right: '#2fc4c4' },
+];
+
+const emptySlot = (side: AxisSide, paneIndex: number): ChannelSlot => ({
+  channel: null,
+  min: 0,
+  max: 100,
+  auto: true,
+  color: PANE_COLORS[paneIndex % PANE_COLORS.length][side],
+});
+
+const makeSlot = (
+  side: AxisSide,
+  paneIndex: number,
+  channel: string,
+  min?: number,
+  max?: number,
+): ChannelSlot => ({
+  channel,
+  min: min ?? 0,
+  max: max ?? 100,
+  auto: min === undefined || max === undefined,
+  color: PANE_COLORS[paneIndex % PANE_COLORS.length][side],
+});
+
+const makePane = (paneIndex: number, left?: ChannelSlot, right?: ChannelSlot): GraphPane => ({
+  left: left ?? emptySlot('left', paneIndex),
+  right: right ?? emptySlot('right', paneIndex),
+  hidden: false,
+});
+
+let nextId = Date.now();
+const newTabId = () => `graphtab-${nextId++}`;
+
+/** Default pages mirroring the TunerStudio Fuel/Ignition presets.
+ *  Channel names follow the rusEFI INI conventions; slots for channels a
+ *  given INI doesn't define simply show no data until reassigned.
+ */
+const defaultTabs = (): GraphTab[] => [
+  {
+    id: newTabId(),
+    name: 'Fuel',
+    panes: [
+      makePane(0, makeSlot('left', 0, 'RPM', 0, 9000), makeSlot('right', 0, 'MAP', 0, 400)),
+      makePane(1, makeSlot('left', 1, 'lambda', 0.7, 1.3), makeSlot('right', 1, 'pulseWidth', 0, 25)),
+      makePane(2, makeSlot('left', 2, 've', 0, 200), makeSlot('right', 2, 'tps', 0, 100)),
+      makePane(3, makeSlot('left', 3, 'coolant', -40, 140), makeSlot('right', 3, 'iat', -40, 120)),
+    ],
+  },
+  {
+    id: newTabId(),
+    name: 'Ignition',
+    panes: [
+      makePane(0, makeSlot('left', 0, 'RPM', 0, 9000), makeSlot('right', 0, 'timing', -10, 60)),
+      makePane(1, makeSlot('left', 1, 'MAP', 0, 400), makeSlot('right', 1, 'tps', 0, 100)),
+      makePane(2),
+      makePane(3),
+    ],
+  },
+];
+
+interface GraphLogState {
+  tabs: GraphTab[];
+  activeTabId: string;
+  /** Visible time window in seconds for live scrolling */
+  timeWindowSec: number;
+
+  addTab: () => void;
+  removeTab: (tabId: string) => void;
+  renameTab: (tabId: string, name: string) => void;
+  setActiveTab: (tabId: string) => void;
+  setTimeWindow: (seconds: number) => void;
+  updateSlot: (
+    tabId: string,
+    paneIndex: number,
+    side: AxisSide,
+    patch: Partial<ChannelSlot>,
+  ) => void;
+  setPaneHidden: (tabId: string, paneIndex: number, hidden: boolean) => void;
+}
+
+export const useGraphLogStore = create<GraphLogState>()(
+  persist(
+    (set) => ({
+      tabs: defaultTabs(),
+      activeTabId: '',
+      timeWindowSec: 30,
+
+      addTab: () =>
+        set((state) => {
+          const tab: GraphTab = {
+            id: newTabId(),
+            name: `Graph ${state.tabs.length + 1}`,
+            panes: [makePane(0), makePane(1), makePane(2), makePane(3)],
+          };
+          return { tabs: [...state.tabs, tab], activeTabId: tab.id };
+        }),
+
+      removeTab: (tabId) =>
+        set((state) => {
+          if (state.tabs.length <= 1) return state;
+          const tabs = state.tabs.filter((t) => t.id !== tabId);
+          const activeTabId =
+            state.activeTabId === tabId ? tabs[0].id : state.activeTabId;
+          return { tabs, activeTabId };
+        }),
+
+      renameTab: (tabId, name) =>
+        set((state) => ({
+          tabs: state.tabs.map((t) =>
+            t.id === tabId ? { ...t, name: name.trim() || t.name } : t,
+          ),
+        })),
+
+      setActiveTab: (tabId) => set({ activeTabId: tabId }),
+
+      setTimeWindow: (seconds) =>
+        set({ timeWindowSec: Math.min(300, Math.max(5, seconds)) }),
+
+      updateSlot: (tabId, paneIndex, side, patch) =>
+        set((state) => ({
+          tabs: state.tabs.map((t) => {
+            if (t.id !== tabId) return t;
+            const panes = t.panes.map((pane, i) =>
+              i === paneIndex ? { ...pane, [side]: { ...pane[side], ...patch } } : pane,
+            );
+            return { ...t, panes };
+          }),
+        })),
+
+      setPaneHidden: (tabId, paneIndex, hidden) =>
+        set((state) => ({
+          tabs: state.tabs.map((t) => {
+            if (t.id !== tabId) return t;
+            const panes = t.panes.map((pane, i) =>
+              i === paneIndex ? { ...pane, hidden } : pane,
+            );
+            return { ...t, panes };
+          }),
+        })),
+    }),
+    {
+      name: 'libretune-graph-log',
+      version: 1,
+    },
+  ),
+);
+
+/** Resolve the active tab, falling back to the first tab when the persisted
+ *  activeTabId no longer exists. */
+export const selectActiveTab = (state: GraphLogState): GraphTab =>
+  state.tabs.find((t) => t.id === state.activeTabId) ?? state.tabs[0];

--- a/crates/libretune-app/src/stores/graphLogStore.ts
+++ b/crates/libretune-app/src/stores/graphLogStore.ts
@@ -222,3 +222,64 @@ export const useGraphLogStore = create<GraphLogState>()(
  *  activeTabId no longer exists. */
 export const selectActiveTab = (state: GraphLogState): GraphTab =>
   state.tabs.find((t) => t.id === state.activeTabId) ?? state.tabs[0];
+
+/** Shape of an exported graph-log setup file (logging params travel with it) */
+export interface GraphLogSetupFile {
+  type: 'libretune-graphlog-setup';
+  version: 1;
+  tabs: GraphTab[];
+  timeWindowSec: number;
+  sampleRate?: number;
+}
+
+/** Serialize the current tabs + window into a setup file object. */
+export function exportGraphLogSetup(sampleRate?: number): GraphLogSetupFile {
+  const { tabs, timeWindowSec } = useGraphLogStore.getState();
+  return { type: 'libretune-graphlog-setup', version: 1, tabs, timeWindowSec, sampleRate };
+}
+
+/** Validate and apply an imported setup. Returns an error message, or null on
+ *  success. Slots are rebuilt through the constructors so missing/extra fields
+ *  from hand-edited files can't corrupt the store. */
+export function importGraphLogSetup(raw: unknown): string | null {
+  const data = raw as Partial<GraphLogSetupFile> | null;
+  if (!data || data.type !== 'libretune-graphlog-setup' || !Array.isArray(data.tabs)) {
+    return 'Not a valid graph log setup file';
+  }
+  if (data.tabs.length === 0) return 'Setup file contains no tabs';
+
+  const tabs: GraphTab[] = data.tabs.map((tab, tabIdx) => ({
+    id: newTabId(),
+    name: typeof tab?.name === 'string' && tab.name.trim() ? tab.name : `Graph ${tabIdx + 1}`,
+    panes: Array.from({ length: PANES_PER_TAB }, (_, paneIdx) => {
+      const pane = Array.isArray(tab?.panes) ? tab.panes[paneIdx] : undefined;
+      const rebuild = (side: AxisSide): ChannelSlot => {
+        const slot = pane?.[side];
+        if (!slot || typeof slot.channel !== 'string' || !slot.channel) {
+          return emptySlot(side, paneIdx);
+        }
+        const auto = slot.auto !== false;
+        const min = typeof slot.min === 'number' && isFinite(slot.min) ? slot.min : 0;
+        const max = typeof slot.max === 'number' && isFinite(slot.max) ? slot.max : 100;
+        return auto
+          ? { ...makeSlot(side, paneIdx, slot.channel), min, max, auto: true }
+          : makeSlot(side, paneIdx, slot.channel, min, max);
+      };
+      return {
+        left: rebuild('left'),
+        right: rebuild('right'),
+        hidden: pane?.hidden === true,
+      };
+    }),
+  }));
+
+  useGraphLogStore.setState({
+    tabs,
+    activeTabId: tabs[0].id,
+    timeWindowSec: Math.min(
+      600,
+      Math.max(2, typeof data.timeWindowSec === 'number' ? data.timeWindowSec : 30),
+    ),
+  });
+  return null;
+}

--- a/crates/libretune-core/src/datalog/recorder.rs
+++ b/crates/libretune-core/src/datalog/recorder.rs
@@ -49,12 +49,17 @@ impl DataLogger {
         self.sample_rate
     }
 
-    /// Start recording
+    /// Start (or resume) recording.
+    ///
+    /// Recording appends to the existing buffer: the timeline continues from
+    /// the last recorded entry, so stop/start cycles produce one continuous
+    /// log with no gaps. Use [`clear`](Self::clear) to begin a fresh log.
     pub fn start(&mut self) {
-        self.start_time = Some(Instant::now());
+        let now = Instant::now();
+        let elapsed = self.duration();
+        self.start_time = now.checked_sub(elapsed).or(Some(now));
         self.is_recording = true;
         self.last_sample = None;
-        self.buffer.clear();
     }
 
     /// Stop recording
@@ -150,5 +155,31 @@ mod tests {
 
         logger.stop();
         assert!(!logger.is_recording());
+    }
+
+    #[test]
+    fn test_restart_appends_with_continuous_timeline() {
+        let mut logger = DataLogger::new(vec!["rpm".into()]);
+        logger.set_sample_rate(200.0);
+
+        logger.start();
+        logger.record(vec![1000.0]);
+        logger.stop();
+        assert_eq!(logger.entry_count(), 1);
+        let first_ts = logger.duration();
+
+        // Restarting must keep the previous entries and continue the timeline
+        logger.start();
+        std::thread::sleep(Duration::from_millis(10));
+        logger.record(vec![2000.0]);
+        assert_eq!(logger.entry_count(), 2);
+        assert!(logger.duration() >= first_ts);
+
+        // Only clear() wipes the log
+        logger.clear();
+        assert_eq!(logger.entry_count(), 0);
+        logger.start();
+        logger.record(vec![3000.0]);
+        assert_eq!(logger.entry_count(), 1);
     }
 }


### PR DESCRIPTION
## Summary
- New **Graph Log** view in the Data Logging tab: renameable tabs, 4 stacked panes sharing a time axis, two channels per pane with independent fixed/auto left/right scales
- **Recording now actually works and appends**: the realtime stream feeds the data logger (it previously never called record()), and Record/Stop/Record extends one continuous log until Clear
- Interactions: Q/A zoom-to-cursor, hover value readout, peak markers, click-to-place data cursor steppable with arrow keys (Shift = x10)
- Robustness: channel-filtered log fetch + per-pixel min/max trace decimation (fixes webview OOM at 100 Hz), CSV export drops all-zero columns
- Setup export/import: graph tabs, scales and sample rate round-trip through a JSON file

## Test plan
- Manual testing in demo mode on Windows at 10-100 Hz sample rates (record/append/clear, zoom, cursors, CSV and setup round-trips)
- `cargo test -p libretune-core` (recorder append test added), `tsc --noEmit` clean, vitest suite green (one pre-existing flake unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)