### PR TITLE
Table editing: Page Up/Down cell adjust + bottom-left Y-axis origin option

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/app_settings.rs
+++ b/crates/libretune-app/src-tauri/src/commands/app_settings.rs
@@ -32,6 +32,11 @@ pub(crate) struct Settings {
     #[serde(default)]
     pub(crate) last_active_tab: Option<String>,
 
+    /// Render table Y axis with the origin at the bottom-left (ECUMaster
+    /// style: lowest load row at the bottom) instead of the top-left.
+    #[serde(default)]
+    pub(crate) table_y_axis_bottom: bool,
+
     // Heatmap color scheme settings
     #[serde(default = "default_heatmap_scheme")]
     pub(crate) heatmap_value_scheme: String, // Scheme for VE/timing tables

--- a/crates/libretune-app/src-tauri/src/commands/app_settings.rs
+++ b/crates/libretune-app/src-tauri/src/commands/app_settings.rs
@@ -32,8 +32,8 @@ pub(crate) struct Settings {
     #[serde(default)]
     pub(crate) last_active_tab: Option<String>,
 
-    /// Render table Y axis with the origin at the bottom-left (ECUMaster
-    /// style: lowest load row at the bottom) instead of the top-left.
+    /// Render table Y axis with the origin at the bottom-left (lowest load
+    /// row at the bottom) instead of the top-left.
     #[serde(default)]
     pub(crate) table_y_axis_bottom: bool,
 

--- a/crates/libretune-app/src-tauri/src/commands/settings.rs
+++ b/crates/libretune-app/src-tauri/src/commands/settings.rs
@@ -80,6 +80,9 @@ pub async fn update_setting(
         "onboarding_completed" => {
             settings.onboarding_completed = value.parse().map_err(|_| "Invalid boolean value")?
         }
+        "table_y_axis_bottom" => {
+            settings.table_y_axis_bottom = value.parse().map_err(|_| "Invalid boolean value")?
+        }
         // Session persistence
         "last_project_path" => {
             settings.last_project_path = if value.is_empty() { None } else { Some(value) }

--- a/crates/libretune-app/src/components/tables/TableEditor2D.tsx
+++ b/crates/libretune-app/src/components/tables/TableEditor2D.tsx
@@ -377,8 +377,8 @@ export default function TableEditor2D({
           'table.navigateLeft': ['ArrowLeft'],
           'table.navigateRight': ['ArrowRight'],
           'table.setEqual': ['='],
-          'table.increase': ['>', '.', 'q'],
-          'table.decrease': ['<', ',', '-', '_'],
+          'table.increase': ['>', '.', 'q', 'PageUp'],
+          'table.decrease': ['<', ',', '-', '_', 'PageDown'],
           'table.increaseMultiple': ['+'],
           'table.scale': ['*'],
           'table.interpolate': ['/'],
@@ -421,12 +421,12 @@ export default function TableEditor2D({
         handleSetEqual();
         return;
       }
-      if (matchesAction('table.increase') || ['>', '.', 'q'].includes(e.key)) {
+      if (matchesAction('table.increase') || ['>', '.', 'q', 'PageUp'].includes(e.key)) {
         e.preventDefault();
         handleIncrease(multiplier);
         return;
       }
-      if (matchesAction('table.decrease') || ['<', ',', '-', '_'].includes(e.key)) {
+      if (matchesAction('table.decrease') || ['<', ',', '-', '_', 'PageDown'].includes(e.key)) {
         e.preventDefault();
         handleDecrease(multiplier);
         return;

--- a/crates/libretune-app/src/components/tables/TableEditor2D.tsx
+++ b/crates/libretune-app/src/components/tables/TableEditor2D.tsx
@@ -377,8 +377,8 @@ export default function TableEditor2D({
           'table.navigateLeft': ['ArrowLeft'],
           'table.navigateRight': ['ArrowRight'],
           'table.setEqual': ['='],
-          'table.increase': ['>', '.', 'q', 'PageUp'],
-          'table.decrease': ['<', ',', '-', '_', 'PageDown'],
+          'table.increase': ['>', '.', 'q'],
+          'table.decrease': ['<', ',', '-', '_'],
           'table.increaseMultiple': ['+'],
           'table.scale': ['*'],
           'table.interpolate': ['/'],
@@ -421,12 +421,20 @@ export default function TableEditor2D({
         handleSetEqual();
         return;
       }
-      if (matchesAction('table.increase') || ['>', '.', 'q', 'PageUp'].includes(e.key)) {
+      // Page keys adjust by an absolute step (1 plain, 5 with Shift/Ctrl),
+      // unlike '>'/'<' which scale by a percentage.
+      if (e.key === 'PageUp' || e.key === 'PageDown') {
+        e.preventDefault();
+        const step = (isShift || isCtrl ? 5 : 1) * (e.key === 'PageUp' ? 1 : -1);
+        handleAdjustBy(step);
+        return;
+      }
+      if (matchesAction('table.increase') || ['>', '.', 'q'].includes(e.key)) {
         e.preventDefault();
         handleIncrease(multiplier);
         return;
       }
-      if (matchesAction('table.decrease') || ['<', ',', '-', '_', 'PageDown'].includes(e.key)) {
+      if (matchesAction('table.decrease') || ['<', ',', '-', '_'].includes(e.key)) {
         e.preventDefault();
         handleDecrease(multiplier);
         return;
@@ -626,6 +634,13 @@ export default function TableEditor2D({
   const handleContextMenuScale = (factor: number) => {
     setContextMenu({ visible: false, x: 0, y: 0, value: 0 });
     handleScale(factor);
+  };
+
+  /** Add a fixed amount to every selected cell (Page Up/Down) */
+  const handleAdjustBy = (amount: number) => {
+    selectedCellsCoords.forEach(([x, y]) => {
+      handleCellChange(x, y, localZValues[y][x] + amount, { suppressAlert: true });
+    });
   };
 
   const handleIncrease = (amount: number) => {

--- a/crates/libretune-app/src/components/tables/TableEditor2D.tsx
+++ b/crates/libretune-app/src/components/tables/TableEditor2D.tsx
@@ -423,12 +423,12 @@ export default function TableEditor2D({
         handleSetEqual();
         return;
       }
-      // Page keys adjust by an absolute step (1 plain, 5 with Shift/Ctrl),
-      // unlike '>'/'<' which scale by a percentage.
+      // Page keys adjust by an absolute step (0.1 plain, 1 with Shift,
+      // 0.05 with Ctrl), unlike '>'/'<' which scale by a percentage.
       if (e.key === 'PageUp' || e.key === 'PageDown') {
         e.preventDefault();
-        const step = (isShift || isCtrl ? 5 : 1) * (e.key === 'PageUp' ? 1 : -1);
-        handleAdjustBy(step);
+        const magnitude = isShift ? 1 : isCtrl ? 0.05 : 0.1;
+        handleAdjustBy(magnitude * (e.key === 'PageUp' ? 1 : -1));
         return;
       }
       if (matchesAction('table.increase') || ['>', '.', 'q'].includes(e.key)) {

--- a/crates/libretune-app/src/components/tables/TableEditor2D.tsx
+++ b/crates/libretune-app/src/components/tables/TableEditor2D.tsx
@@ -8,6 +8,7 @@ import TableContextMenu from './TableContextMenu';
 import RebinDialog from '../dialogs/RebinDialog';
 import CellEditDialog from '../dialogs/CellEditDialog';
 import { useHeatmapSettings } from '../../utils/useHeatmapSettings';
+import { useTableYAxisBottom } from '../../utils/useTableOrientation';
 import { useChannels } from '../../stores/realtimeStore';
 import { useToast } from '../../contexts/ToastContext';
 import { getHotkeyManager } from '../../services/hotkeyService';
@@ -201,6 +202,7 @@ export default function TableEditor2D({
   
   // Get heatmap scheme from user settings
   const { settings: heatmapSettings } = useHeatmapSettings();
+  const yAxisBottom = useTableYAxisBottom();
 
   const selectedCellsCoords = useMemo(() => {
     if (!selectionRange) return [];
@@ -528,12 +530,15 @@ export default function TableEditor2D({
     let newX = currentX;
     let newY = currentY;
 
+    // With the bottom-left origin, visually "up" is the next data row
+    const upDelta = yAxisBottom ? 1 : -1;
+
     switch (key) {
       case 'ArrowUp':
-        newY = Math.max(0, currentY - 1);
+        newY = Math.min(y_bins.length - 1, Math.max(0, currentY + upDelta));
         break;
       case 'ArrowDown':
-        newY = Math.min(y_bins.length - 1, currentY + 1);
+        newY = Math.min(y_bins.length - 1, Math.max(0, currentY - upDelta));
         break;
       case 'ArrowLeft':
         newX = Math.max(0, currentX - 1);
@@ -1186,6 +1191,7 @@ export default function TableEditor2D({
           showColorShade={showColorShade}
           heatmapScheme={heatmapSettings.valueScheme}
           compact={embedded}
+          yAxisBottom={yAxisBottom}
         />
         {hasEmbeddedTableLiveReadout(table_name, x_output_channel, y_output_channel) && (
           <TableLiveReadout

--- a/crates/libretune-app/src/components/tables/TableEditor2D.tsx
+++ b/crates/libretune-app/src/components/tables/TableEditor2D.tsx
@@ -636,32 +636,27 @@ export default function TableEditor2D({
     handleScale(factor);
   };
 
-  /** Add a fixed amount to every selected cell (Page Up/Down) */
-  const handleAdjustBy = (amount: number) => {
+  /** Apply a transform to every selected cell in ONE state update.
+   *  Going through handleCellChange per cell loses all but the last cell
+   *  (each call clones the same stale localZValues) and collapses the
+   *  selection to a single cell. */
+  const applyToSelection = (fn: (value: number) => number) => {
+    if (selectedCellsCoords.length === 0) return;
+    const newValues = localZValues.map(row => [...row]);
     selectedCellsCoords.forEach(([x, y]) => {
-      handleCellChange(x, y, localZValues[y][x] + amount, { suppressAlert: true });
+      newValues[y][x] = fn(newValues[y][x]);
     });
+    setLocalZValues(newValues);
+    pushHistory(newValues, localXBins, localYBins);
+    onValuesChange?.(newValues);
   };
 
-  const handleIncrease = (amount: number) => {
-    const values = selectedCellsCoords.map(([x, y]) => {
-      return { x, y, value: localZValues[y][x] };
-    });
-    
-    values.forEach(({ x, y, value }) => {
-      handleCellChange(x, y, value * (1 + amount), { suppressAlert: true });
-    });
-  };
+  /** Add a fixed amount to every selected cell (Page Up/Down) */
+  const handleAdjustBy = (amount: number) => applyToSelection((v) => v + amount);
 
-  const handleDecrease = (amount: number) => {
-    const values = selectedCellsCoords.map(([x, y]) => {
-      return { x, y, value: localZValues[y][x] };
-    });
-    
-    values.forEach(({ x, y, value }) => {
-      handleCellChange(x, y, value * (1 - amount), { suppressAlert: true });
-    });
-  };
+  const handleIncrease = (amount: number) => applyToSelection((v) => v * (1 + amount));
+
+  const handleDecrease = (amount: number) => applyToSelection((v) => v * (1 - amount));
 
   const handleScale = async (factor: number) => {
     const previousValues = localZValues.map((row) => [...row]);

--- a/crates/libretune-app/src/components/tables/TableGrid.tsx
+++ b/crates/libretune-app/src/components/tables/TableGrid.tsx
@@ -244,9 +244,12 @@ export default function TableGrid({
     if (dragAnchor && gridRef.current) {
       const rect = gridRef.current.getBoundingClientRect();
       const x = Math.floor((e.clientX - rect.left) / (rect.width / x_size));
-      const y = Math.floor((e.clientY - rect.top) / (rect.height / y_size));
-      
-      if (x >= 0 && x < x_size && y >= 0 && y < y_size) {
+      const visualY = Math.floor((e.clientY - rect.top) / (rect.height / y_size));
+      // Pixel math yields the visual row; map back to the data row when the
+      // grid renders bottom-up.
+      const y = yAxisBottom ? y_size - 1 - visualY : visualY;
+
+      if (x >= 0 && x < x_size && visualY >= 0 && visualY < y_size) {
         onSelectionChange({ start: dragAnchor, end: [x, y] });
       }
     }
@@ -261,7 +264,8 @@ export default function TableGrid({
       if (lockedCells?.has(cellKey)) return null;
 
       const left = (x / x_size) * 100;
-      const top = (y / y_size) * 100;
+      const displayY = yAxisBottom ? y_size - 1 - y : y;
+      const top = (displayY / y_size) * 100;
 
       return `${left},${top}`;
     }).filter(Boolean) as string[];
@@ -271,7 +275,8 @@ export default function TableGrid({
       if (lockedCells?.has(cellKey)) return null;
 
       const left = (x / x_size) * 100;
-      const top = (y / y_size) * 100;
+      const displayY = yAxisBottom ? y_size - 1 - y : y;
+      const top = (displayY / y_size) * 100;
 
       return (
         <div

--- a/crates/libretune-app/src/components/tables/TableGrid.tsx
+++ b/crates/libretune-app/src/components/tables/TableGrid.tsx
@@ -24,6 +24,8 @@ interface TableGridProps {
   liveCursorX?: number; // Current X-axis value (e.g., RPM)
   liveCursorY?: number; // Current Y-axis value (e.g., MAP/TPS)
   showLiveCursor?: boolean;
+  /** Render rows bottom-up so the origin is at the bottom-left (display only) */
+  yAxisBottom?: boolean;
   // Heatmap color props
   showColorShade?: boolean; // Whether to show heatmap colors
   heatmapScheme?: HeatmapScheme | string[]; // Scheme name or custom color stops
@@ -50,6 +52,7 @@ export default function TableGrid({
   showColorShade = true,
   heatmapScheme = 'tunerstudio',
   compact = false,
+  yAxisBottom = false,
 }: TableGridProps) {
   const gridRef = useRef<HTMLDivElement>(null);
   const [editingCell, setEditingCell] = useState<[number, number] | null>(null);
@@ -347,8 +350,10 @@ export default function TableGrid({
         );
       })}
 
-      {/* Data rows: each row = y-axis label + data cells */}
-      {z_values.map((row, y) => {
+      {/* Data rows: each row = y-axis label + data cells.
+          Display order only — all coordinates stay in data space. */}
+      {(yAxisBottom ? [...z_values.keys()].reverse() : [...z_values.keys()]).map((y) => {
+        const row = z_values[y];
         const isEditingYAxis = editingAxis?.axis === 'y' && editingAxis.index === y;
         const isYHeaderSelected = selectionRange && 
           y >= Math.min(selectionRange.start[1], selectionRange.end[1]) && 
@@ -444,7 +449,7 @@ export default function TableGrid({
           className="live-cursor-overlay"
           style={{
             '--cursor-x': liveCursorPosition.x,
-            '--cursor-y': liveCursorPosition.y,
+            '--cursor-y': yAxisBottom ? y_size - 1 - liveCursorPosition.y : liveCursorPosition.y,
             '--cols': x_size,
             '--rows': y_size,
           } as React.CSSProperties}

--- a/crates/libretune-app/src/components/tuner-ui/GraphLog.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/GraphLog.tsx
@@ -1,5 +1,5 @@
 /**
- * Graph Log — TunerStudio/ECUMaster-style stacked strip charts.
+ * Graph Log — stacked strip charts for viewing recorded channels.
  *
  * Renders the active graph-log tab as stacked panes sharing a time axis.
  * Each pane plots one channel against the left axis and one against the

--- a/crates/libretune-app/src/components/tuner-ui/TableEditor.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/TableEditor.tsx
@@ -608,11 +608,13 @@ export function TableEditor({
         break;
       case '>':
       case '.':
+      case 'PageUp':
         e.preventDefault();
         adjustValues(delta * multiplier);
         break;
       case '<':
       case ',':
+      case 'PageDown':
         e.preventDefault();
         adjustValues(-delta * multiplier);
         break;

--- a/crates/libretune-app/src/components/tuner-ui/TableEditor.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/TableEditor.tsx
@@ -627,14 +627,14 @@ export function TableEditor({
         e.preventDefault();
         adjustValues(-delta * multiplier);
         break;
-      // Page keys use fixed steps: 1 plain, 5 coarse (Shift or Ctrl)
+      // Page keys use fixed steps: 0.1 plain, 1 with Shift, 0.05 with Ctrl
       case 'PageUp':
         e.preventDefault();
-        adjustValues(e.shiftKey || e.ctrlKey ? 5 : 1);
+        adjustValues(e.shiftKey ? 1 : e.ctrlKey ? 0.05 : 0.1);
         break;
       case 'PageDown':
         e.preventDefault();
-        adjustValues(e.shiftKey || e.ctrlKey ? -5 : -1);
+        adjustValues(e.shiftKey ? -1 : e.ctrlKey ? -0.05 : -0.1);
         break;
       case '+':
         e.preventDefault();

--- a/crates/libretune-app/src/components/tuner-ui/TableEditor.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/TableEditor.tsx
@@ -608,15 +608,22 @@ export function TableEditor({
         break;
       case '>':
       case '.':
-      case 'PageUp':
         e.preventDefault();
         adjustValues(delta * multiplier);
         break;
       case '<':
       case ',':
-      case 'PageDown':
         e.preventDefault();
         adjustValues(-delta * multiplier);
+        break;
+      // Page keys use fixed steps: 1 plain, 5 coarse (Shift or Ctrl)
+      case 'PageUp':
+        e.preventDefault();
+        adjustValues(e.shiftKey || e.ctrlKey ? 5 : 1);
+        break;
+      case 'PageDown':
+        e.preventDefault();
+        adjustValues(e.shiftKey || e.ctrlKey ? -5 : -1);
         break;
       case '+':
         e.preventDefault();

--- a/crates/libretune-app/src/components/tuner-ui/TableEditor.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/TableEditor.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useRef, useEffect, KeyboardEvent, useMemo } from 'react';
 import { useChannels } from '../../stores/realtimeStore';
 import { useHeatmapSettings } from '../../utils/useHeatmapSettings';
+import { useTableYAxisBottom } from '../../utils/useTableOrientation';
 import './TableEditor.css';
 import TableEditor3D from '../tables/TableEditor3D';
 import TableToolbar from './table-editor/TableToolbar';
@@ -110,6 +111,9 @@ export function TableEditor({
 
   // Heatmap settings from user preferences
   const { settings: heatmapSettings, getColor: getHeatmapColor } = useHeatmapSettings();
+
+  // Y-axis origin at bottom-left (ECUMaster style) — display-only flip
+  const yAxisBottom = useTableYAxisBottom();
 
   const heatmapScheme = useMemo(() => {
     if (heatmapSettings.valueScheme === 'custom' && heatmapSettings.customValueStops?.length) {
@@ -572,21 +576,28 @@ export function TableEditor({
     const multiplier = e.ctrlKey ? 5 : 1;
     const delta = e.shiftKey ? 1 : 0.1;
 
+    // With the bottom-left origin, visually "up" is the next data row
+    const upDelta = yAxisBottom ? 1 : -1;
+
     switch (e.key) {
-      case 'ArrowUp':
+      case 'ArrowUp': {
         e.preventDefault();
-        if (row > 0) {
-          const newPos = { row: row - 1, col };
+        const upRow = row + upDelta;
+        if (upRow >= 0 && upRow < data.zValues.length) {
+          const newPos = { row: upRow, col };
           setSelection({ start: e.shiftKey ? selection.start : newPos, end: newPos });
         }
         break;
-      case 'ArrowDown':
+      }
+      case 'ArrowDown': {
         e.preventDefault();
-        if (row < data.zValues.length - 1) {
-          const newPos = { row: row + 1, col };
+        const downRow = row - upDelta;
+        if (downRow >= 0 && downRow < data.zValues.length) {
+          const newPos = { row: downRow, col };
           setSelection({ start: e.shiftKey ? selection.start : newPos, end: newPos });
         }
         break;
+      }
       case 'ArrowLeft':
         e.preventDefault();
         if (col > 0) {
@@ -706,7 +717,7 @@ export function TableEditor({
     selection, editingCell, data, finishEdit, getSelectedCells, setEqual,
     adjustValues, scaleValues, interpolate, interpolateHorizontal, interpolateVertical,
     smooth, copySelection, pasteSelection, selectAll, resetToOriginal, floodFill,
-    undo, redo, handleCellDoubleClick, followMode, setFollowMode
+    undo, redo, handleCellDoubleClick, followMode, setFollowMode, yAxisBottom
   ]);
 
   // Focus input when editing
@@ -894,9 +905,10 @@ export function TableEditor({
             </tr>
           </thead>
           <tbody>
-            {data.yAxis.map((y, rowIndex) => (
+            {/* Display order only — rowIndex stays in data space */}
+            {(yAxisBottom ? [...data.yAxis.keys()].reverse() : [...data.yAxis.keys()]).map((rowIndex) => (
               <tr key={rowIndex}>
-                <th className="table-y-header">{y}</th>
+                <th className="table-y-header">{data.yAxis[rowIndex]}</th>
                 {data.xAxis.map((_, colIndex) => {
                   const value = data.zValues[rowIndex][colIndex];
                   const isSelected = isCellSelected(rowIndex, colIndex);

--- a/crates/libretune-app/src/components/tuner-ui/TableEditor.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/TableEditor.tsx
@@ -112,7 +112,7 @@ export function TableEditor({
   // Heatmap settings from user preferences
   const { settings: heatmapSettings, getColor: getHeatmapColor } = useHeatmapSettings();
 
-  // Y-axis origin at bottom-left (ECUMaster style) — display-only flip
+  // Y-axis origin at bottom-left — display-only flip
   const yAxisBottom = useTableYAxisBottom();
 
   const heatmapScheme = useMemo(() => {

--- a/crates/libretune-app/src/components/tuner-ui/dialogs/SettingsDialog.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/dialogs/SettingsDialog.tsx
@@ -51,6 +51,7 @@ export function SettingsDialog({ isOpen, onClose, theme, onThemeChange, onSettin
   const [localUnits, setLocalUnits] = useState('metric');
   const [autoBurnOnClose, setAutoBurnOnClose] = useState(false);
   const [demoMode, setDemoMode] = useState(false);
+  const [tableYAxisBottom, setTableYAxisBottom] = useState(false);
   const [demoLoading, setDemoLoading] = useState(false);
   const [indicatorColumnCount, setIndicatorColumnCount] = useState('auto');
   const [indicatorFillEmpty, setIndicatorFillEmpty] = useState(false);
@@ -125,6 +126,7 @@ export function SettingsDialog({ isOpen, onClose, theme, onThemeChange, onSettin
           }
         }
         if (settings.auto_burn_on_close !== undefined) setAutoBurnOnClose(!!settings.auto_burn_on_close);
+        if (settings.table_y_axis_bottom !== undefined) setTableYAxisBottom(!!settings.table_y_axis_bottom);
         if (settings.indicator_column_count !== undefined) setIndicatorColumnCount(settings.indicator_column_count);
         if (settings.indicator_fill_empty !== undefined) setIndicatorFillEmpty(!!settings.indicator_fill_empty);
         if (settings.indicator_text_fit !== undefined) setIndicatorTextFit(settings.indicator_text_fit);
@@ -549,6 +551,23 @@ export function SettingsDialog({ isOpen, onClose, theme, onThemeChange, onSettin
               Demo Mode (simulate ECU)
             </label>
             <span className="dialog-form-note">Simulate ECU data for testing (runtime-only)</span>
+          </div>
+
+          <div className="dialog-form-group">
+            <label>
+              <input
+                type="checkbox"
+                checked={tableYAxisBottom}
+                onChange={(e) => {
+                  const enabled = e.target.checked;
+                  setTableYAxisBottom(enabled);
+                  invoke('update_setting', { key: 'table_y_axis_bottom', value: String(enabled) })
+                    .catch((err) => console.error('Failed to save table Y axis setting:', err));
+                }}
+              />
+              Table Y axis zero at bottom
+            </label>
+            <span className="dialog-form-note">Show the lowest load row at the bottom of tables (ECUMaster style)</span>
           </div>
 
           <FormField

--- a/crates/libretune-app/src/components/tuner-ui/dialogs/SettingsDialog.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/dialogs/SettingsDialog.tsx
@@ -567,7 +567,7 @@ export function SettingsDialog({ isOpen, onClose, theme, onThemeChange, onSettin
               />
               Table Y axis zero at bottom
             </label>
-            <span className="dialog-form-note">Show the lowest load row at the bottom of tables (ECUMaster style)</span>
+            <span className="dialog-form-note">Show the lowest load row at the bottom of tables</span>
           </div>
 
           <FormField

--- a/crates/libretune-app/src/utils/useTableOrientation.ts
+++ b/crates/libretune-app/src/utils/useTableOrientation.ts
@@ -2,8 +2,8 @@
  * Table Y-axis orientation setting.
  *
  * When enabled (Settings → "Table Y axis zero at bottom"), table editors
- * render rows so the origin sits at the bottom-left like ECUMaster — the
- * lowest load row at the bottom, increasing upward. Display-only: data
+ * render rows so the origin sits at the bottom-left — the lowest load row
+ * at the bottom, increasing upward. Display-only: data
  * coordinates, selection, and clipboard behavior are unchanged.
  */
 import { useEffect, useState } from 'react';

--- a/crates/libretune-app/src/utils/useTableOrientation.ts
+++ b/crates/libretune-app/src/utils/useTableOrientation.ts
@@ -1,0 +1,47 @@
+/**
+ * Table Y-axis orientation setting.
+ *
+ * When enabled (Settings → "Table Y axis zero at bottom"), table editors
+ * render rows so the origin sits at the bottom-left like ECUMaster — the
+ * lowest load row at the bottom, increasing upward. Display-only: data
+ * coordinates, selection, and clipboard behavior are unchanged.
+ */
+import { useEffect, useState } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import { listen, UnlistenFn } from '@tauri-apps/api/event';
+
+export function useTableYAxisBottom(): boolean {
+  const [bottom, setBottom] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+    let unlisten: UnlistenFn | null = null;
+
+    const load = () => {
+      invoke<{ table_y_axis_bottom?: boolean }>('get_settings')
+        .then((s) => {
+          if (mounted) setBottom(!!s?.table_y_axis_bottom);
+        })
+        .catch(() => {});
+    };
+
+    load();
+
+    (async () => {
+      try {
+        unlisten = await listen<string>('settings:changed', (event) => {
+          if (event.payload === 'table_y_axis_bottom') load();
+        });
+      } catch {
+        // Not running under Tauri (tests) — setting stays at its default.
+      }
+    })();
+
+    return () => {
+      mounted = false;
+      if (unlisten) unlisten();
+    };
+  }, []);
+
+  return bottom;
+}


### PR DESCRIPTION
## Summary
- **Page Up/Down** adjust the selected table cells by a fixed step (0.1 plain, 1 with Shift, 0.05 with Ctrl) in both table editors; also fixes a bug where multi-cell increase/decrease only applied to the last selected cell (per-cell updates on stale state)
- **Settings toggle "Table Y axis zero at bottom"**: renders table rows bottom-up (lowest load row at the bottom, increasing upward). Display-only - data coordinates, selection, clipboard and cell ops unchanged; arrow keys, drag selection, history trail and the live ECU cursor all follow the visual orientation; applies instantly and persists

## Test plan
- Manual testing on Windows: single/multi-cell selections with page keys and modifiers; axis flip verified in both editors including arrow navigation, drag selection, and follow-mode cursor
- `tsc --noEmit` clean, `cargo check` clean, vitest green (one pre-existing unrelated flake)

Note: built on top of the graph log branch - once PR for the graph log merges, this diff reduces to the table-editing commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)