### PR TITLE
Add lambda companion view to the Target AFR table

### DIFF
--- a/crates/libretune-app/src/components/tables/LambdaPreviewTable.css
+++ b/crates/libretune-app/src/components/tables/LambdaPreviewTable.css
@@ -1,0 +1,60 @@
+.lambda-preview {
+  flex: 0 0 auto;
+  max-width: 40%;
+  overflow: auto;
+  border: 1px solid var(--border-color, rgba(128, 140, 160, 0.25));
+  border-radius: 6px;
+  padding: 6px;
+  background: var(--bg-secondary, #1a2030);
+  align-self: flex-start;
+}
+
+.lambda-preview-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.lambda-preview-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary, #9aa4b8);
+}
+
+.lambda-preview-header select {
+  background: var(--bg-primary, #10141f);
+  color: var(--text-primary, #e6eaf2);
+  border: 1px solid var(--border-color, rgba(128, 140, 160, 0.25));
+  border-radius: 4px;
+  font-size: 11px;
+  padding: 2px 4px;
+}
+
+.lambda-preview-grid {
+  display: grid;
+  gap: 1px;
+  font-family: monospace;
+  font-size: 10px;
+}
+
+.lambda-preview-corner {
+  background: transparent;
+}
+
+.lambda-preview-axis {
+  padding: 2px 4px;
+  text-align: right;
+  color: var(--text-secondary, #9aa4b8);
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.lambda-preview-cell {
+  padding: 2px 4px;
+  text-align: right;
+  color: var(--text-primary, #e6eaf2);
+  background: var(--bg-primary, #10141f);
+  white-space: nowrap;
+}

--- a/crates/libretune-app/src/components/tables/LambdaPreviewTable.css
+++ b/crates/libretune-app/src/components/tables/LambdaPreviewTable.css
@@ -6,7 +6,10 @@
   border-radius: 6px;
   padding: 10px;
   background: var(--bg-secondary, #1a2030);
-  align-self: flex-start;
+  /* Stretch to the main table's height so both grids line up */
+  align-self: stretch;
+  display: flex;
+  flex-direction: column;
 }
 
 .lambda-preview-header {
@@ -37,6 +40,16 @@
   gap: 1px;
   font-family: monospace;
   font-size: 13px;
+  /* Fill the stretched panel, distributing rows to match the main table */
+  flex: 1;
+  grid-auto-rows: 1fr;
+  min-height: 0;
+}
+
+.lambda-preview-grid > div {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
 }
 
 .lambda-preview-corner {

--- a/crates/libretune-app/src/components/tables/LambdaPreviewTable.css
+++ b/crates/libretune-app/src/components/tables/LambdaPreviewTable.css
@@ -6,10 +6,11 @@
   border-radius: 6px;
   padding: 10px;
   background: var(--bg-secondary, #1a2030);
-  /* Stretch to the main table's height so both grids line up */
-  align-self: stretch;
+  /* Height is pinned to the main table grid via ResizeObserver */
+  align-self: flex-start;
   display: flex;
   flex-direction: column;
+  box-sizing: border-box;
 }
 
 .lambda-preview-header {
@@ -40,10 +41,11 @@
   gap: 1px;
   font-family: monospace;
   font-size: 13px;
-  /* Fill the stretched panel, distributing rows to match the main table */
+  /* Fill the pinned panel, distributing rows to match the main table */
   flex: 1;
-  grid-auto-rows: 1fr;
+  grid-auto-rows: minmax(0, 1fr);
   min-height: 0;
+  overflow: hidden;
 }
 
 .lambda-preview-grid > div {

--- a/crates/libretune-app/src/components/tables/LambdaPreviewTable.css
+++ b/crates/libretune-app/src/components/tables/LambdaPreviewTable.css
@@ -1,10 +1,10 @@
 .lambda-preview {
   flex: 0 0 auto;
-  max-width: 40%;
+  max-width: 48%;
   overflow: auto;
   border: 1px solid var(--border-color, rgba(128, 140, 160, 0.25));
   border-radius: 6px;
-  padding: 6px;
+  padding: 10px;
   background: var(--bg-secondary, #1a2030);
   align-self: flex-start;
 }
@@ -36,7 +36,7 @@
   display: grid;
   gap: 1px;
   font-family: monospace;
-  font-size: 10px;
+  font-size: 13px;
 }
 
 .lambda-preview-corner {
@@ -44,7 +44,7 @@
 }
 
 .lambda-preview-axis {
-  padding: 2px 4px;
+  padding: 3px 6px;
   text-align: right;
   color: var(--text-secondary, #9aa4b8);
   font-weight: 600;
@@ -52,9 +52,40 @@
 }
 
 .lambda-preview-cell {
-  padding: 2px 4px;
+  padding: 3px 6px;
   text-align: right;
   color: var(--text-primary, #e6eaf2);
   background: var(--bg-primary, #10141f);
   white-space: nowrap;
+}
+
+/* ---- Live gauges ---- */
+.lambda-preview-gauges {
+  display: flex;
+  gap: 10px;
+  margin: 0 auto;
+}
+
+.lambda-preview-gauge {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  padding: 3px 10px;
+  border: 1px solid var(--border-color, rgba(128, 140, 160, 0.25));
+  border-radius: 5px;
+  background: var(--bg-primary, #10141f);
+}
+
+.lambda-preview-gauge-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-secondary, #9aa4b8);
+}
+
+.lambda-preview-gauge-value {
+  font-family: monospace;
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--accent-color, #4f8fe8);
+  font-variant-numeric: tabular-nums;
 }

--- a/crates/libretune-app/src/components/tables/LambdaPreviewTable.tsx
+++ b/crates/libretune-app/src/components/tables/LambdaPreviewTable.tsx
@@ -4,8 +4,9 @@
  * Mirrors the AFR table's values converted to lambda for a selectable fuel
  * blend (E0…E100). Purely a viewing aid: no editing, no effect on the tune.
  */
-import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
+import { Fragment, useEffect, useMemo, useRef, useState, type CSSProperties } from 'react';
 import { useChannels } from '../../stores/realtimeStore';
+import { useHeatmapSettings } from '../../utils/useHeatmapSettings';
 import './LambdaPreviewTable.css';
 
 /** Live λ and AFR readouts, isolated so realtime updates only re-render
@@ -97,6 +98,19 @@ export default function LambdaPreviewTable({
     return yAxisBottom ? order.reverse() : order;
   }, [zValues.length, yAxisBottom]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Muted heatmap: same scheme as the main table, blended into the dark
+  // background so the companion doesn't compete visually.
+  const { getColor: getHeatmapColor } = useHeatmapSettings();
+  const [minVal, maxVal] = useMemo(() => {
+    const flat = zValues.flat();
+    return flat.length > 0 ? [Math.min(...flat), Math.max(...flat)] : [0, 1];
+  }, [zValues]);
+  const cellStyle = (afr: number): CSSProperties => {
+    if (minVal === maxVal) return {};
+    const heat = getHeatmapColor(afr, minVal, maxVal, 'value');
+    return { background: `color-mix(in srgb, ${heat} 35%, var(--bg-primary, #10141f))` };
+  };
+
   const handleFuelChange = (id: string) => {
     setFuelId(id);
     try {
@@ -137,7 +151,7 @@ export default function LambdaPreviewTable({
           <Fragment key={`row-${y}`}>
             <div className="lambda-preview-axis">{yBins[y]}</div>
             {zValues[y]?.map((afr, x) => (
-              <div key={`${x}-${y}`} className="lambda-preview-cell">
+              <div key={`${x}-${y}`} className="lambda-preview-cell" style={cellStyle(afr)}>
                 {(afr / fuel.stoich).toFixed(2)}
               </div>
             ))}

--- a/crates/libretune-app/src/components/tables/LambdaPreviewTable.tsx
+++ b/crates/libretune-app/src/components/tables/LambdaPreviewTable.tsx
@@ -15,6 +15,15 @@ function LiveLambdaAfrGauges() {
   const lambda = values['lambda'];
   const afr = values['afr'];
 
+  // The ECU's effective stoich ratio is AFR/λ; the ethanol blend follows
+  // from where that sits between E0 (14.7:1) and E100 (9.0:1), linearly.
+  let fuelBlend: string = '—';
+  if (lambda !== undefined && afr !== undefined && lambda > 0.01) {
+    const stoich = afr / lambda;
+    const ethanol = ((14.7 - stoich) / (14.7 - 9.0)) * 100;
+    fuelBlend = `E${Math.round(Math.min(100, Math.max(0, ethanol)))}`;
+  }
+
   return (
     <div className="lambda-preview-gauges">
       <div className="lambda-preview-gauge">
@@ -28,6 +37,10 @@ function LiveLambdaAfrGauges() {
         <span className="lambda-preview-gauge-value">
           {afr !== undefined ? afr.toFixed(1) : '—'}
         </span>
+      </div>
+      <div className="lambda-preview-gauge" title="Ethanol blend derived from AFR ÷ λ (effective stoich ratio)">
+        <span className="lambda-preview-gauge-label">Fuel</span>
+        <span className="lambda-preview-gauge-value">{fuelBlend}</span>
       </div>
     </div>
   );

--- a/crates/libretune-app/src/components/tables/LambdaPreviewTable.tsx
+++ b/crates/libretune-app/src/components/tables/LambdaPreviewTable.tsx
@@ -1,0 +1,94 @@
+/**
+ * LambdaPreviewTable — read-only companion for Target AFR tables.
+ *
+ * Mirrors the AFR table's values converted to lambda for a selectable fuel
+ * blend (E0…E100). Purely a viewing aid: no editing, no effect on the tune.
+ */
+import { Fragment, useMemo, useState } from 'react';
+import './LambdaPreviewTable.css';
+
+/** Stoichiometric AFR per ethanol blend (linear gasoline/ethanol mix) */
+const FUEL_STOICH: Array<{ id: string; label: string; stoich: number }> = [
+  { id: 'e0', label: 'E0', stoich: 14.7 },
+  { id: 'e10', label: 'E10', stoich: 14.13 },
+  { id: 'e30', label: 'E30', stoich: 12.99 },
+  { id: 'e85', label: 'E85', stoich: 9.85 },
+  { id: 'e100', label: 'E100', stoich: 9.0 },
+];
+
+const STORAGE_KEY = 'libretune-lambda-preview-fuel';
+
+interface LambdaPreviewTableProps {
+  /** AFR values [row][col] — mirrored live from the editable table */
+  zValues: number[][];
+  xBins: number[];
+  yBins: number[];
+  /** Match the main table's row orientation */
+  yAxisBottom?: boolean;
+}
+
+export default function LambdaPreviewTable({
+  zValues,
+  xBins,
+  yBins,
+  yAxisBottom = false,
+}: LambdaPreviewTableProps) {
+  const [fuelId, setFuelId] = useState<string>(
+    () => localStorage.getItem(STORAGE_KEY) ?? 'e0',
+  );
+  const fuel = FUEL_STOICH.find((f) => f.id === fuelId) ?? FUEL_STOICH[0];
+
+  const rowOrder = useMemo(() => {
+    const order = zValues.map((_, i) => i);
+    return yAxisBottom ? order.reverse() : order;
+  }, [zValues.length, yAxisBottom]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleFuelChange = (id: string) => {
+    setFuelId(id);
+    try {
+      localStorage.setItem(STORAGE_KEY, id);
+    } catch {
+      // localStorage unavailable — selection just won't persist
+    }
+  };
+
+  return (
+    <div className="lambda-preview">
+      <div className="lambda-preview-header">
+        <span className="lambda-preview-title">λ view</span>
+        <select
+          value={fuel.id}
+          onChange={(e) => handleFuelChange(e.target.value)}
+          title={`Stoichiometric AFR ${fuel.stoich}:1`}
+        >
+          {FUEL_STOICH.map((f) => (
+            <option key={f.id} value={f.id}>
+              {f.label} ({f.stoich}:1)
+            </option>
+          ))}
+        </select>
+      </div>
+      <div
+        className="lambda-preview-grid"
+        style={{ gridTemplateColumns: `auto repeat(${xBins.length}, 1fr)` }}
+      >
+        <div className="lambda-preview-corner" />
+        {xBins.map((x, i) => (
+          <div key={`x-${i}`} className="lambda-preview-axis">
+            {x}
+          </div>
+        ))}
+        {rowOrder.map((y) => (
+          <Fragment key={`row-${y}`}>
+            <div className="lambda-preview-axis">{yBins[y]}</div>
+            {zValues[y]?.map((afr, x) => (
+              <div key={`${x}-${y}`} className="lambda-preview-cell">
+                {(afr / fuel.stoich).toFixed(2)}
+              </div>
+            ))}
+          </Fragment>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/crates/libretune-app/src/components/tables/LambdaPreviewTable.tsx
+++ b/crates/libretune-app/src/components/tables/LambdaPreviewTable.tsx
@@ -5,7 +5,33 @@
  * blend (E0…E100). Purely a viewing aid: no editing, no effect on the tune.
  */
 import { Fragment, useMemo, useState } from 'react';
+import { useChannels } from '../../stores/realtimeStore';
 import './LambdaPreviewTable.css';
+
+/** Live λ and AFR readouts, isolated so realtime updates only re-render
+ *  the gauges and not the whole preview grid. */
+function LiveLambdaAfrGauges() {
+  const values = useChannels(['lambda', 'afr']);
+  const lambda = values['lambda'];
+  const afr = values['afr'];
+
+  return (
+    <div className="lambda-preview-gauges">
+      <div className="lambda-preview-gauge">
+        <span className="lambda-preview-gauge-label">λ</span>
+        <span className="lambda-preview-gauge-value">
+          {lambda !== undefined ? lambda.toFixed(2) : '—'}
+        </span>
+      </div>
+      <div className="lambda-preview-gauge">
+        <span className="lambda-preview-gauge-label">AFR</span>
+        <span className="lambda-preview-gauge-value">
+          {afr !== undefined ? afr.toFixed(1) : '—'}
+        </span>
+      </div>
+    </div>
+  );
+}
 
 /** Stoichiometric AFR per ethanol blend (linear gasoline/ethanol mix) */
 const FUEL_STOICH: Array<{ id: string; label: string; stoich: number }> = [
@@ -56,6 +82,7 @@ export default function LambdaPreviewTable({
     <div className="lambda-preview">
       <div className="lambda-preview-header">
         <span className="lambda-preview-title">λ view</span>
+        <LiveLambdaAfrGauges />
         <select
           value={fuel.id}
           onChange={(e) => handleFuelChange(e.target.value)}

--- a/crates/libretune-app/src/components/tables/LambdaPreviewTable.tsx
+++ b/crates/libretune-app/src/components/tables/LambdaPreviewTable.tsx
@@ -4,7 +4,7 @@
  * Mirrors the AFR table's values converted to lambda for a selectable fuel
  * blend (E0…E100). Purely a viewing aid: no editing, no effect on the tune.
  */
-import { Fragment, useMemo, useState } from 'react';
+import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
 import { useChannels } from '../../stores/realtimeStore';
 import './LambdaPreviewTable.css';
 
@@ -39,7 +39,7 @@ function LiveLambdaAfrGauges() {
         </span>
       </div>
       <div className="lambda-preview-gauge" title="Ethanol blend derived from AFR ÷ λ (effective stoich ratio)">
-        <span className="lambda-preview-gauge-label">Fuel</span>
+        <span className="lambda-preview-gauge-label">calculated fuel</span>
         <span className="lambda-preview-gauge-value">{fuelBlend}</span>
       </div>
     </div>
@@ -77,6 +77,21 @@ export default function LambdaPreviewTable({
   );
   const fuel = FUEL_STOICH.find((f) => f.id === fuelId) ?? FUEL_STOICH[0];
 
+  // Pin the panel's height to the main table grid so both read as one unit.
+  const panelRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const panel = panelRef.current;
+    const mainGrid = panel?.parentElement?.querySelector('.table-grid-container');
+    if (!panel || !mainGrid) return;
+    const sync = () => {
+      panel.style.height = `${(mainGrid as HTMLElement).offsetHeight}px`;
+    };
+    sync();
+    const observer = new ResizeObserver(sync);
+    observer.observe(mainGrid);
+    return () => observer.disconnect();
+  }, []);
+
   const rowOrder = useMemo(() => {
     const order = zValues.map((_, i) => i);
     return yAxisBottom ? order.reverse() : order;
@@ -92,7 +107,7 @@ export default function LambdaPreviewTable({
   };
 
   return (
-    <div className="lambda-preview">
+    <div className="lambda-preview" ref={panelRef}>
       <div className="lambda-preview-header">
         <span className="lambda-preview-title">λ view</span>
         <LiveLambdaAfrGauges />

--- a/crates/libretune-app/src/components/tables/TableEditor2D.css
+++ b/crates/libretune-app/src/components/tables/TableEditor2D.css
@@ -33,6 +33,15 @@
   align-items: flex-start;
 }
 
+/* Lambda companion sits to the right of the AFR grid */
+.editor-content.editor-content--with-lambda {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 12px;
+}
+
 .table-editor-2d.embedded .editor-content.editor-content--with-live {
   flex: 0 0 auto;
   flex-direction: row;

--- a/crates/libretune-app/src/components/tables/TableEditor2D.tsx
+++ b/crates/libretune-app/src/components/tables/TableEditor2D.tsx
@@ -7,6 +7,7 @@ import TableEditor3D from './TableEditor3D';
 import TableContextMenu from './TableContextMenu';
 import RebinDialog from '../dialogs/RebinDialog';
 import CellEditDialog from '../dialogs/CellEditDialog';
+import LambdaPreviewTable from './LambdaPreviewTable';
 import { useHeatmapSettings } from '../../utils/useHeatmapSettings';
 import { useTableYAxisBottom } from '../../utils/useTableOrientation';
 import { useChannels } from '../../stores/realtimeStore';
@@ -203,6 +204,10 @@ export default function TableEditor2D({
   // Get heatmap scheme from user settings
   const { settings: heatmapSettings } = useHeatmapSettings();
   const yAxisBottom = useTableYAxisBottom();
+
+  // Show the read-only lambda companion only for actual target-AFR tables
+  // (not blend/bias tables whose values aren't AFR).
+  const isAfrTargetTable = table_name.toLowerCase().startsWith('afrtable');
 
   const selectedCellsCoords = useMemo(() => {
     if (!selectionRange) return [];
@@ -1157,8 +1162,8 @@ export default function TableEditor2D({
           heatmapScheme={heatmapSettings.valueScheme}
         />
       ) : (
-      <div 
-        className={`editor-content${hasEmbeddedTableLiveReadout(table_name, x_output_channel, y_output_channel) ? ' editor-content--with-live' : ''}`}
+      <div
+        className={`editor-content${hasEmbeddedTableLiveReadout(table_name, x_output_channel, y_output_channel) ? ' editor-content--with-live' : ''}${isAfrTargetTable ? ' editor-content--with-lambda' : ''}`}
         onContextMenu={e => {
           const target = e.target as HTMLElement;
           if (target.classList.contains('table-cell')) {
@@ -1193,6 +1198,14 @@ export default function TableEditor2D({
           compact={embedded}
           yAxisBottom={yAxisBottom}
         />
+        {isAfrTargetTable && (
+          <LambdaPreviewTable
+            zValues={localZValues}
+            xBins={localXBins}
+            yBins={localYBins}
+            yAxisBottom={yAxisBottom}
+          />
+        )}
         {hasEmbeddedTableLiveReadout(table_name, x_output_channel, y_output_channel) && (
           <TableLiveReadout
             tableName={table_name}


### PR DESCRIPTION
## Summary
- Read-only **lambda companion table** beside the Target AFR table: mirrors the AFR values converted to lambda, updating live as cells are edited
- **Fuel blend dropdown** (E0/E10/E30/E85/E100) selects the stoich ratio for the conversion; choice persists
- **Three live gauges**: current lambda, current AFR, and "calculated fuel" - the ethanol blend derived from AFR / lambda mapped between gasoline (14.7:1) and ethanol (9.0:1)
- Panel height pins to the main grid via ResizeObserver so both tables align exactly; muted heatmap coloring (main table's scheme at 35% intensity); follows the Y-axis origin setting

## Test plan
- Manual testing on Windows in demo mode: live gauges, fuel dropdown conversions, live cell-edit mirroring, height alignment across resizes, flipped-axis ordering
- `tsc --noEmit` clean

Note: stacked on the table-editing PR - once that merges, this diff reduces to the lambda-companion commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)