### PR TITLE
Tune loading and persistence fixes

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/table_update.rs
+++ b/crates/libretune-app/src-tauri/src/commands/table_update.rs
@@ -70,6 +70,13 @@ pub async fn update_table_data(
                 if end <= page_data.len() {
                     page_data[start..end].copy_from_slice(&raw_data);
                 }
+
+                // Offline reads prefer the parsed msq constants over page data,
+                // so keep them in sync or edits revert on reload
+                tune.constants.insert(
+                    table.map.clone(),
+                    libretune_core::tune::TuneValue::Array(flat_values.clone()),
+                );
             }
 
             // Mark tune as modified

--- a/crates/libretune-app/src-tauri/src/commands/tune_io.rs
+++ b/crates/libretune-app/src-tauri/src/commands/tune_io.rs
@@ -24,9 +24,20 @@ pub async fn list_tune_files() -> Result<Vec<String>, String> {
         .map_err(|e| format!("Failed to read projects directory: {}", e))?;
 
     for entry in entries.flatten() {
-        if let Some(name) = entry.file_name().to_str() {
+        let path = entry.path();
+        if path.is_dir() {
+            // Tunes live inside project folders (e.g. <project>/CurrentTune.msq)
+            if let Ok(sub) = std::fs::read_dir(&path) {
+                for sub_entry in sub.flatten() {
+                    let sub_path = sub_entry.path();
+                    if sub_path.extension().is_some_and(|e| e == "msq") {
+                        tunes.push(sub_path.to_string_lossy().to_string());
+                    }
+                }
+            }
+        } else if let Some(name) = entry.file_name().to_str() {
             if name.ends_with(".msq") || name.ends_with(".json") {
-                tunes.push(entry.path().to_string_lossy().to_string());
+                tunes.push(path.to_string_lossy().to_string());
             }
         }
     }

--- a/crates/libretune-app/src/App.tsx
+++ b/crates/libretune-app/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback } from "react";
+import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { AlertTriangle } from "lucide-react";
 import { invoke } from "@tauri-apps/api/core";
@@ -1008,6 +1008,18 @@ function AppContent() {
     }
   }
 
+  // Refresh open views whenever the backend loads a tune (any entry point)
+  const refreshOpenTabsRef = useRef<() => Promise<void>>(async () => {});
+  refreshOpenTabsRef.current = refreshOpenTabs;
+  useEffect(() => {
+    if (!isTauri) return;
+    let unlisten: (() => void) | null = null;
+    listen("tune:loaded", () => { refreshOpenTabsRef.current(); })
+      .then((un) => { unlisten = un; })
+      .catch(() => {});
+    return () => { if (unlisten) unlisten(); };
+  }, []);
+
   /** Re-fetch open table/curve tabs so they reflect the current tune */
   async function refreshOpenTabs() {
     const updated = { ...tabContents };
@@ -1036,10 +1048,9 @@ function AppContent() {
     try {
       showLoading("Loading tune file...");
       await invoke("load_tune", { path: tunePath });
-      // Refresh constants and open views so the UI reflects the loaded tune
+      // Refresh constants so the UI reflects the loaded tune
+      // (open views refresh via the backend's tune:loaded event)
       await fetchConstants();
-      await refreshOpenTabs();
-      window.dispatchEvent(new Event("lt:tune-loaded"));
       showToast("Tune file loaded successfully", "success");
     } catch (e) {
       showToast("Failed to load tune: " + e, "error");

--- a/crates/libretune-app/src/App.tsx
+++ b/crates/libretune-app/src/App.tsx
@@ -1008,14 +1008,38 @@ function AppContent() {
     }
   }
 
+  /** Re-fetch open table/curve tabs so they reflect the current tune */
+  async function refreshOpenTabs() {
+    const updated = { ...tabContents };
+    let changed = false;
+    for (const [id, content] of Object.entries(tabContents)) {
+      try {
+        if (content.type === "table") {
+          const data = await invoke<BackendTableData>("get_table_data", { tableName: id });
+          updated[id] = { type: "table", data: toTunerTableData(data) };
+          changed = true;
+        } else if (content.type === "curve") {
+          const data = await invoke<BackendCurveData>("get_curve_data", { curveName: id });
+          updated[id] = { ...content, data: toCurveData(data) };
+          changed = true;
+        }
+      } catch {
+        // keep the tab's previous data
+      }
+    }
+    if (changed) setTabContents(updated);
+  }
+
   /** Import an existing tune file (.msq) into the currently open project */
   async function handleImportTuneIntoProject(tunePath: string) {
     if (!currentProject) return;
     try {
       showLoading("Loading tune file...");
       await invoke("load_tune", { path: tunePath });
-      // Refresh constants so UI reflects the loaded tune
+      // Refresh constants and open views so the UI reflects the loaded tune
       await fetchConstants();
+      await refreshOpenTabs();
+      window.dispatchEvent(new Event("lt:tune-loaded"));
       showToast("Tune file loaded successfully", "success");
     } catch (e) {
       showToast("Failed to load tune: " + e, "error");

--- a/crates/libretune-app/src/components/dialogs/PanelComponents.tsx
+++ b/crates/libretune-app/src/components/dialogs/PanelComponents.tsx
@@ -212,8 +212,8 @@ export const RecursivePanel = memo(function RecursivePanel({
         onValuesChange={(values) => {
           // Save changes to backend
           invoke('update_table_data', {
-            table_name: tableData.name,
-            z_values: values,
+            tableName: tableData.name,
+            zValues: values,
           }).then(() => {
             onUpdate?.();
           }).catch((err) => {

--- a/crates/libretune-app/src/components/dialogs/PanelComponents.tsx
+++ b/crates/libretune-app/src/components/dialogs/PanelComponents.tsx
@@ -54,6 +54,14 @@ export const RecursivePanel = memo(function RecursivePanel({
   const [gaugeConfig, setGaugeConfig] = useState<SimpleGaugeInfo | null>(null);
   const [portEditor, setPortEditor] = useState<PortEditorConfig | null>(null);
   const [panelType, setPanelType] = useState<'loading' | 'dialog' | 'indicatorPanel' | 'readoutPanel' | 'table' | 'curve' | 'portEditor' | 'unknown'>('loading');
+  const [reloadTick, setReloadTick] = useState(0);
+
+  // Re-fetch when a new tune is loaded
+  useEffect(() => {
+    const onTuneLoaded = () => setReloadTick((t) => t + 1);
+    window.addEventListener('lt:tune-loaded', onTuneLoaded);
+    return () => window.removeEventListener('lt:tune-loaded', onTuneLoaded);
+  }, []);
 
   useLayoutEffect(() => {
     let cancelled = false;
@@ -188,7 +196,7 @@ export const RecursivePanel = memo(function RecursivePanel({
     return () => {
       cancelled = true;
     };
-  }, [name]);
+  }, [name, reloadTick]);
 
   if (panelType === 'loading') {
     return <div className="panel-loading">Loading {name}...</div>;
@@ -198,6 +206,7 @@ export const RecursivePanel = memo(function RecursivePanel({
   if (panelType === 'table' && tableInfo && tableData) {
     return (
       <TableEditor2D
+        key={`${name}-${reloadTick}`}
         title={tableInfo.title || name}
         table_name={tableData.name}
         x_axis_name={tableData.x_axis_name || 'X'}

--- a/crates/libretune-app/src/components/dialogs/PanelComponents.tsx
+++ b/crates/libretune-app/src/components/dialogs/PanelComponents.tsx
@@ -6,6 +6,7 @@
 
 import { useState, useEffect, useLayoutEffect, useRef, memo, useMemo, useCallback } from 'react';
 import { invoke } from '@tauri-apps/api/core';
+import { listen } from '@tauri-apps/api/event';
 import { Activity, Grid3X3, AlertTriangle } from 'lucide-react';
 import CurveEditor, { SimpleGaugeInfo } from '../curves/CurveEditor';
 import TableEditor2D from '../tables/TableEditor2D';
@@ -56,11 +57,13 @@ export const RecursivePanel = memo(function RecursivePanel({
   const [panelType, setPanelType] = useState<'loading' | 'dialog' | 'indicatorPanel' | 'readoutPanel' | 'table' | 'curve' | 'portEditor' | 'unknown'>('loading');
   const [reloadTick, setReloadTick] = useState(0);
 
-  // Re-fetch when a new tune is loaded
+  // Re-fetch when a new tune is loaded (backend emits on every load path)
   useEffect(() => {
-    const onTuneLoaded = () => setReloadTick((t) => t + 1);
-    window.addEventListener('lt:tune-loaded', onTuneLoaded);
-    return () => window.removeEventListener('lt:tune-loaded', onTuneLoaded);
+    let unlisten: (() => void) | null = null;
+    listen('tune:loaded', () => setReloadTick((t) => t + 1))
+      .then((un) => { unlisten = un; })
+      .catch(() => {});
+    return () => { if (unlisten) unlisten(); };
   }, []);
 
   useLayoutEffect(() => {

--- a/crates/libretune-app/src/components/tables/TableEditor2D.tsx
+++ b/crates/libretune-app/src/components/tables/TableEditor2D.tsx
@@ -903,8 +903,8 @@ export default function TableEditor2D({
         pushHistory(newValues, localXBins, localYBins);
         // Persist to backend without triggering n*m alerts
         invoke('update_table_data', {
-          table_name,
-          z_values: newValues
+          tableName: table_name,
+          zValues: newValues
         });
         
         // Update selection to cover pasted area
@@ -937,8 +937,8 @@ export default function TableEditor2D({
       
       // Update backend
       invoke('update_table_data', {
-        table_name,
-        z_values: snapshot.z,
+        tableName: table_name,
+        zValues: snapshot.z,
         // Backend update for axis not yet available via simple set command
         // but local state is reverted
       });
@@ -959,8 +959,8 @@ export default function TableEditor2D({
       onValuesChange?.(snapshot.z);
 
       invoke('update_table_data', {
-        table_name,
-        z_values: snapshot.z
+        tableName: table_name,
+        zValues: snapshot.z
       });
     }
   };
@@ -986,8 +986,8 @@ export default function TableEditor2D({
 
   const handleSave = () => {
     invoke('update_table_data', {
-      table_name,
-      z_values: localZValues
+      tableName: table_name,
+      zValues: localZValues
     }).then(() => {
     });
   };

--- a/crates/libretune-core/src/project/repository.rs
+++ b/crates/libretune-core/src/project/repository.rs
@@ -174,35 +174,29 @@ impl IniRepository {
     fn extract_ini_info(content: &str) -> io::Result<(String, String)> {
         let mut name = String::new();
         let mut signature = String::new();
-        let mut in_megatune = false;
+        // Newer rusEFI INIs put the signature in [TunerStudio] instead of [MegaTune]
+        let mut in_section = false;
 
         for line in content.lines() {
             let line = line.trim();
 
             if line.starts_with('[') {
-                // Check for [MegaTune] section start (case-insensitive)
-                // Handle trailing comments: [MegaTune] ; comment
-                let header_part = line.split(';').next().unwrap_or("").trim();
-                in_megatune = header_part
-                    .trim_matches(|c| c == '[' || c == ']')
-                    .eq_ignore_ascii_case("MegaTune");
+                let header = line.split(';').next().unwrap_or("").trim();
+                let header = header.trim_matches(|c| c == '[' || c == ']');
+                in_section = header.eq_ignore_ascii_case("MegaTune")
+                    || header.eq_ignore_ascii_case("TunerStudio");
                 continue;
             }
 
-            if !in_megatune {
+            if !in_section {
                 continue;
             }
 
-            // Look for signature in [MegaTune] section
-            if line.to_lowercase().starts_with("signature") {
-                if let Some((_, val)) = line.split_once('=') {
+            if let Some((key, val)) = line.split_once('=') {
+                let key = key.trim();
+                if signature.is_empty() && key.eq_ignore_ascii_case("signature") {
                     signature = Self::extract_quoted_value(val);
-                }
-            }
-
-            // Look for nEmu in [MegaTune] section for display name
-            if line.to_lowercase().starts_with("nemu") {
-                if let Some((_, val)) = line.split_once('=') {
+                } else if name.is_empty() && key.eq_ignore_ascii_case("nEmu") {
                     name = Self::extract_quoted_value(val);
                 }
             }
@@ -211,7 +205,7 @@ impl IniRepository {
         if signature.is_empty() {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
-                "Could not find signature in [MegaTune] section of INI file",
+                "Could not find signature in [MegaTune] or [TunerStudio] section of INI file",
             ));
         }
 
@@ -298,6 +292,14 @@ impl IniRepository {
 mod tests {
     use super::*;
     use std::env::temp_dir;
+
+    #[test]
+    fn extract_ini_info_accepts_signature_in_tunerstudio_section() {
+        let ini = "[MegaTune]\n  MTversion = 2.25\n[TunerStudio]\n  queryCommand = \"S\"\n  signature= \"rusEFI master.2026.02.20.uaefi.4211171972\" ; comment\n";
+        let (name, sig) = IniRepository::extract_ini_info(ini).unwrap();
+        assert_eq!(sig, "rusEFI master.2026.02.20.uaefi.4211171972");
+        assert_eq!(name, sig);
+    }
 
     #[test]
     fn test_ini_repository() {


### PR DESCRIPTION
Four related fixes around tune files, found while daily-driving with a rusEFI uaefi build:

- **INI import**: accept `signature` in `[TunerStudio]` (newer rusEFI releases moved it out of `[MegaTune]`)
- **Table edit persistence**: saves silently never reached the backend (snake_case invoke args Tauri rejects), and offline reads preferred stale msq constants over updated page bytes - edits reverted on reload
- **Refresh on tune load**: open table/curve tabs and embedded dialog tables now refresh when the backend emits tune:loaded, instead of showing stale values until reopened
- **Load Tune dialog**: scan project subfolders for .msq files (the list was always empty since tunes live at `<project>/CurrentTune.msq`)

Each fix is a separate commit. Tested on Windows against the 2026-02 uaefi release.