### PR TITLE
Fix controller command variable substitution (wideband tools)

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/constants_read.rs
+++ b/crates/libretune-app/src-tauri/src/commands/constants_read.rs
@@ -62,6 +62,7 @@ pub async fn get_constant(
         bit_options: constant.bit_options.clone(),
         help: constant.help.clone(),
         visibility_condition: constant.visibility_condition.clone(),
+        is_pc_variable: constant.is_pc_variable,
     })
 }
 

--- a/crates/libretune-app/src-tauri/src/commands/tune_io.rs
+++ b/crates/libretune-app/src-tauri/src/commands/tune_io.rs
@@ -161,6 +161,27 @@ fn parse_command_string(
     let mut result = Vec::new();
     let mut chars = s.chars().peekable();
 
+    // Consume a variable name and push its current value.
+    // Lookup chain matches what the UI shows: edited value, INI default, legacy map.
+    let substitute_var = |chars: &mut std::iter::Peekable<std::str::Chars>,
+                          result: &mut Vec<u8>| {
+        let mut var_name = String::new();
+        while let Some(&c) = chars.peek() {
+            if c.is_alphanumeric() || c == '_' {
+                var_name.push(chars.next().unwrap());
+            } else {
+                break;
+            }
+        }
+        let value = current_values
+            .get(&var_name)
+            .copied()
+            .or_else(|| def.default_values.get(&var_name).map(|v| *v as u8))
+            .or_else(|| def.pc_variables.get(&var_name).copied())
+            .unwrap_or(0);
+        result.push(value);
+    };
+
     while let Some(ch) = chars.next() {
         if ch == '\\' {
             // Escape sequence
@@ -185,28 +206,13 @@ fn parse_command_string(
                 Some('r') => result.push(b'\r'),
                 Some('t') => result.push(b'\t'),
                 Some('\\') => result.push(b'\\'),
+                // TS marks variables in controller commands as \$name
+                Some('$') => substitute_var(&mut chars, &mut result),
                 Some(c) => result.push(c as u8),
                 None => {}
             }
         } else if ch == '$' {
-            // Variable substitution
-            let mut var_name = String::new();
-            while let Some(&c) = chars.peek() {
-                if c.is_alphanumeric() || c == '_' {
-                    var_name.push(chars.next().unwrap());
-                } else {
-                    break;
-                }
-            }
-
-            // Same lookup chain the UI uses: edited value, INI default, legacy map
-            let value = current_values
-                .get(&var_name)
-                .copied()
-                .or_else(|| def.default_values.get(&var_name).map(|v| *v as u8))
-                .or_else(|| def.pc_variables.get(&var_name).copied())
-                .unwrap_or(0);
-            result.push(value);
+            substitute_var(&mut chars, &mut result);
         } else {
             result.push(ch as u8);
         }

--- a/crates/libretune-app/src-tauri/src/commands/tune_io.rs
+++ b/crates/libretune-app/src-tauri/src/commands/tune_io.rs
@@ -173,13 +173,15 @@ fn parse_command_string(
                 break;
             }
         }
+        // Same chain the UI displays: edited value, INI default, constant min.
+        // The legacy pc_variables map is parse-time zeros — only use it for
+        // names that aren't real constants.
         let value = current_values
             .get(&var_name)
             .copied()
             .or_else(|| def.default_values.get(&var_name).map(|v| *v as u8))
-            .or_else(|| def.pc_variables.get(&var_name).copied())
-            // Same last resort the UI display uses
             .or_else(|| def.constants.get(&var_name).map(|c| c.min as u8))
+            .or_else(|| def.pc_variables.get(&var_name).copied())
             .unwrap_or(0);
         result.push(value);
     };

--- a/crates/libretune-app/src-tauri/src/commands/tune_io.rs
+++ b/crates/libretune-app/src-tauri/src/commands/tune_io.rs
@@ -89,9 +89,18 @@ pub async fn resolve_controller_command(
     state: &AppState,
     command_name: &str,
 ) -> Result<Vec<u8>, String> {
+    // Current PcVariable values (dialog dropdowns) live in the tune cache,
+    // not in the definition's parse-time defaults
+    let mut current = std::collections::HashMap::new();
+    if let Some(cache) = state.tune_cache.lock().await.as_ref() {
+        for (name, value) in &cache.local_values {
+            current.insert(name.clone(), *value as u8);
+        }
+    }
+
     let def_guard = state.definition.lock().await;
     let def = def_guard.as_ref().ok_or("No INI definition loaded")?;
-    resolve_command_bytes(def, command_name, &mut std::collections::HashSet::new())
+    resolve_command_bytes(def, command_name, &current, &mut std::collections::HashSet::new())
 }
 
 /// Send pre-resolved controller command bytes to the connected ECU.
@@ -106,6 +115,7 @@ pub async fn send_controller_command_bytes(state: &AppState, bytes: &[u8]) -> Re
 fn resolve_command_bytes(
     def: &EcuDefinition,
     command_name: &str,
+    current_values: &std::collections::HashMap<String, u8>,
     visited: &mut std::collections::HashSet<String>,
 ) -> Result<Vec<u8>, String> {
     // Prevent infinite recursion
@@ -128,12 +138,12 @@ fn resolve_command_bytes(
         match part {
             CommandPart::Raw(raw_str) => {
                 // Parse hex escapes and variable substitution
-                let bytes = parse_command_string(def, raw_str)?;
+                let bytes = parse_command_string(def, raw_str, current_values)?;
                 result.extend(bytes);
             }
             CommandPart::Reference(ref_name) => {
                 // Recursively resolve referenced command
-                let ref_bytes = resolve_command_bytes(def, ref_name, visited)?;
+                let ref_bytes = resolve_command_bytes(def, ref_name, current_values, visited)?;
                 result.extend(ref_bytes);
             }
         }
@@ -143,7 +153,11 @@ fn resolve_command_bytes(
 }
 
 /// Parse a command string with hex escapes (\x00) and variable substitution ($tsCanId)
-fn parse_command_string(def: &EcuDefinition, s: &str) -> Result<Vec<u8>, String> {
+fn parse_command_string(
+    def: &EcuDefinition,
+    s: &str,
+    current_values: &std::collections::HashMap<String, u8>,
+) -> Result<Vec<u8>, String> {
     let mut result = Vec::new();
     let mut chars = s.chars().peekable();
 
@@ -185,13 +199,14 @@ fn parse_command_string(def: &EcuDefinition, s: &str) -> Result<Vec<u8>, String>
                 }
             }
 
-            // Look up variable value
-            if let Some(&value) = def.pc_variables.get(&var_name) {
-                result.push(value);
-            } else {
-                // Variable not found - push 0 as default
-                result.push(0);
-            }
+            // Same lookup chain the UI uses: edited value, INI default, legacy map
+            let value = current_values
+                .get(&var_name)
+                .copied()
+                .or_else(|| def.default_values.get(&var_name).map(|v| *v as u8))
+                .or_else(|| def.pc_variables.get(&var_name).copied())
+                .unwrap_or(0);
+            result.push(value);
         } else {
             result.push(ch as u8);
         }

--- a/crates/libretune-app/src-tauri/src/commands/tune_io.rs
+++ b/crates/libretune-app/src-tauri/src/commands/tune_io.rs
@@ -100,7 +100,12 @@ pub async fn resolve_controller_command(
 
     let def_guard = state.definition.lock().await;
     let def = def_guard.as_ref().ok_or("No INI definition loaded")?;
-    resolve_command_bytes(def, command_name, &current, &mut std::collections::HashSet::new())
+    resolve_command_bytes(
+        def,
+        command_name,
+        &current,
+        &mut std::collections::HashSet::new(),
+    )
 }
 
 /// Send pre-resolved controller command bytes to the connected ECU.

--- a/crates/libretune-app/src-tauri/src/commands/tune_io.rs
+++ b/crates/libretune-app/src-tauri/src/commands/tune_io.rs
@@ -178,6 +178,8 @@ fn parse_command_string(
             .copied()
             .or_else(|| def.default_values.get(&var_name).map(|v| *v as u8))
             .or_else(|| def.pc_variables.get(&var_name).copied())
+            // Same last resort the UI display uses
+            .or_else(|| def.constants.get(&var_name).map(|c| c.min as u8))
             .unwrap_or(0);
         result.push(value);
     };

--- a/crates/libretune-app/src-tauri/src/commands/types.rs
+++ b/crates/libretune-app/src-tauri/src/commands/types.rs
@@ -89,6 +89,7 @@ pub(crate) struct ConstantInfo {
     pub bit_options: Vec<String>,
     pub help: Option<String>,
     pub visibility_condition: Option<String>, // Expression for when field should be visible
+    pub is_pc_variable: bool,
 }
 /// Sync response with progress information
 #[derive(Serialize)]

--- a/crates/libretune-app/src/components/dialogs/fields/DialogField.tsx
+++ b/crates/libretune-app/src/components/dialogs/fields/DialogField.tsx
@@ -47,7 +47,21 @@ export default function DialogField({
         invoke<number>('get_constant_value', { name })
           .then((v) => {
             console.log(`[DialogField] Got value for '${name}':`, v);
-            setSelectedBit(Math.round(v));
+            let bit = Math.round(v);
+            // PcVariables stuck on an INVALID option display as the first
+            // valid option; write that value back so controller commands
+            // send what the dropdown shows.
+            const opts = c.bit_options || [];
+            if (c.is_pc_variable && opts[bit]?.trim().toUpperCase() === 'INVALID') {
+              const firstValid = opts.findIndex(
+                (o) => o?.trim().toUpperCase() !== 'INVALID',
+              );
+              if (firstValid >= 0) {
+                bit = firstValid;
+                invoke('update_constant', { name, value: firstValid }).catch(() => {});
+              }
+            }
+            setSelectedBit(bit);
           })
           .catch((e) => {
             console.error(`[DialogField] Failed to get value for '${name}':`, e);

--- a/crates/libretune-app/src/components/dialogs/types.ts
+++ b/crates/libretune-app/src/components/dialogs/types.ts
@@ -41,6 +41,7 @@ export interface Constant {
   help?: string;
   visibility_condition?: string;  // Expression for when field should be visible
   display_offset?: number;  // For bits type: offset to add to displayed value (e.g., +1 for [4:7+1])
+  is_pc_variable?: boolean;
 }
 
 export interface TableInfo {


### PR DESCRIPTION
Wideband dialog commands (ping / set index / set sensor type) never worked - the ECU received garbage. Four stacked issues, verified against real hardware with a serial byte log:

- `\$name` (TS escaped-dollar syntax) was parsed as a literal `$` plus ASCII text instead of substituting the variable value
- Substitution read the definition's static pc_variables map instead of current edited values
- Lookup fallbacks now mirror the UI display chain (edited value, INI default, constant min)
- Bits PcVariables stuck on an INVALID option displayed the first valid option without storing it; the stored value now snaps to the displayed one (PcVariables only, never tune data)

Verified: ping returns FW version and set sensor type round-trips to the WBO (cross-checked in TunerStudio).