### PR TITLE
Add live WBO status panel to the wideband tools dialog

### DIFF
--- a/crates/libretune-app/src/components/dialogs/PanelComponents.tsx
+++ b/crates/libretune-app/src/components/dialogs/PanelComponents.tsx
@@ -10,6 +10,7 @@ import { listen } from '@tauri-apps/api/event';
 import { Activity, Grid3X3, AlertTriangle } from 'lucide-react';
 import CurveEditor, { SimpleGaugeInfo } from '../curves/CurveEditor';
 import TableEditor2D from '../tables/TableEditor2D';
+import WidebandLiveStatus from '../hardware/WidebandLiveStatus';
 import {
   type DialogComponent,
   type DialogDefinition,
@@ -307,7 +308,7 @@ export const RecursivePanel = memo(function RecursivePanel({
     const multiColumn = fieldCount >= 8;
     const commandGrid = isCommandButtonPanel(definition.components);
     const testOtherPanel = /^testother$/i.test(name);
-    return (
+    const dialogPanel = (
       <div
         className={`nested-panel${multiColumn ? ' nested-panel--multi' : ''}${commandGrid ? ' nested-panel--compact-commands' : ''}${testOtherPanel ? ' nested-panel--test-other' : ''}`}
         data-panel={name}
@@ -322,6 +323,17 @@ export const RecursivePanel = memo(function RecursivePanel({
         </div>
       </div>
     );
+
+    // rusEFI wideband tools: attach live WBO readouts beside the controls
+    if (/^canReWidebandNewTools$/i.test(name)) {
+      return (
+        <div className="wbo-tools-row">
+          {dialogPanel}
+          <WidebandLiveStatus />
+        </div>
+      );
+    }
+    return dialogPanel;
   }
 
   // Render as portEditor - placeholder for programmable outputs configuration

--- a/crates/libretune-app/src/components/hardware/WidebandLiveStatus.css
+++ b/crates/libretune-app/src/components/hardware/WidebandLiveStatus.css
@@ -1,0 +1,79 @@
+.wbo-tools-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.wbo-live {
+  flex: 0 0 320px;
+  border: 1px solid var(--border-color, rgba(128, 140, 160, 0.25));
+  border-radius: 8px;
+  padding: 14px;
+  background: var(--bg-secondary, #1a2030);
+}
+
+.wbo-live-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary, #9aa4b8);
+  margin-bottom: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.wbo-live-status {
+  text-align: center;
+  font-size: 18px;
+  font-weight: 700;
+  padding: 10px;
+  border-radius: 6px;
+  margin-bottom: 12px;
+  background: var(--bg-primary, #10141f);
+  color: var(--text-secondary, #9aa4b8);
+}
+
+.wbo-live-status--done { color: #3dba6f; }
+.wbo-live-status--busy { color: #e0a030; animation: wbo-pulse 1s ease-in-out infinite; }
+.wbo-live-status--failed { color: #e05252; }
+
+@keyframes wbo-pulse {
+  50% { opacity: 0.5; }
+}
+
+.wbo-live-tiles {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+
+.wbo-live-tile {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 10px;
+  border-radius: 6px;
+  background: var(--bg-primary, #10141f);
+}
+
+.wbo-live-tile--wide {
+  margin-top: 8px;
+}
+
+.wbo-live-tile-label {
+  font-size: 11px;
+  color: var(--text-secondary, #9aa4b8);
+}
+
+.wbo-live-tile-value {
+  font-family: monospace;
+  font-size: 26px;
+  font-weight: 700;
+  color: var(--text-primary, #e6eaf2);
+  font-variant-numeric: tabular-nums;
+}
+
+.wbo-live-tile-value small {
+  font-size: 13px;
+  color: var(--text-secondary, #9aa4b8);
+  font-weight: 400;
+}

--- a/crates/libretune-app/src/components/hardware/WidebandLiveStatus.tsx
+++ b/crates/libretune-app/src/components/hardware/WidebandLiveStatus.tsx
@@ -1,0 +1,64 @@
+import { useChannels } from '../../stores/realtimeStore';
+import './WidebandLiveStatus.css';
+
+const CMD_STATUS: Record<number, { label: string; cls: string }> = {
+  0: { label: 'Idle', cls: 'idle' },
+  1: { label: 'Done', cls: 'done' },
+  2: { label: 'Writing…', cls: 'busy' },
+  3: { label: 'Failed', cls: 'failed' },
+};
+
+/** Infer the configured sensor type from the heater's ESR regulation target
+ *  (LSU 4.9 regulates to ~300 ohm, LSU 4.2 to ~80-100 ohm). Only meaningful
+ *  once the sensor is heated. */
+function inferSensorType(esr: number | undefined, tempC: number | undefined): string {
+  if (esr === undefined || tempC === undefined) return '—';
+  if (tempC < 500) return 'sensor cold';
+  if (esr >= 180 && esr <= 450) return 'LSU 4.9';
+  if (esr >= 40 && esr < 160) return 'LSU 4.2';
+  return '?';
+}
+
+export default function WidebandLiveStatus() {
+  const v = useChannels([
+    'lambda', 'wb1tempC', 'wb1esr', 'wb1heaterDuty', 'wb1pumpDuty',
+    'wb1stateCode', 'canReWidebandCmdStatus',
+  ]);
+
+  const status = CMD_STATUS[Math.round(v['canReWidebandCmdStatus'] ?? -1)];
+  const fmt = (x: number | undefined, digits = 0) =>
+    x === undefined ? '—' : x.toFixed(digits);
+
+  const tiles: Array<[string, string, string?]> = [
+    ['λ', fmt(v['lambda'], 2)],
+    ['Sensor temp', fmt(v['wb1tempC']), '°C'],
+    ['ESR', fmt(v['wb1esr']), 'Ω'],
+    ['Heater', fmt(v['wb1heaterDuty']), '%'],
+    ['Pump', fmt(v['wb1pumpDuty']), '%'],
+    ['State code', fmt(v['wb1stateCode'])],
+  ];
+
+  return (
+    <div className="wbo-live">
+      <div className="wbo-live-title">WBO Live</div>
+      <div className={`wbo-live-status wbo-live-status--${status?.cls ?? 'unknown'}`}>
+        {status?.label ?? 'No data'}
+      </div>
+      <div className="wbo-live-tiles">
+        {tiles.map(([label, value, unit]) => (
+          <div key={label} className="wbo-live-tile">
+            <span className="wbo-live-tile-label">{label}</span>
+            <span className="wbo-live-tile-value">
+              {value}
+              {unit && <small> {unit}</small>}
+            </span>
+          </div>
+        ))}
+      </div>
+      <div className="wbo-live-tile wbo-live-tile--wide">
+        <span className="wbo-live-tile-label">Configured as (from ESR)</span>
+        <span className="wbo-live-tile-value">{inferSensorType(v['wb1esr'], v['wb1tempC'])}</span>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
- Big live readouts beside the wideband controls: lambda, sensor temp, ESR, heater/pump duty, state code
- Colored command status (Idle / Writing / Done / Failed) - previously invisible since the INI indicator panel fails to load
- Shows the configured sensor type inferred from the heater ESR regulation target (LSU 4.9 ~300 ohm vs 4.2 ~80-100 ohm), since the protocol has no readback

Tested against real hardware (uaefi + rusEFI WBO).