### PR TITLE
Table live-cursor improvements: follow by default, accurate marker, fading trace

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/app_settings.rs
+++ b/crates/libretune-app/src-tauri/src/commands/app_settings.rs
@@ -45,6 +45,10 @@ pub(crate) struct Settings {
     #[serde(default)]
     pub(crate) table_trail_color: String,
 
+    /// Seconds before trail points expire (0 = never)
+    #[serde(default = "default_trail_fade_sec")]
+    pub(crate) table_trail_fade_sec: f64,
+
     // Heatmap color scheme settings
     #[serde(default = "default_heatmap_scheme")]
     pub(crate) heatmap_value_scheme: String, // Scheme for VE/timing tables
@@ -122,6 +126,10 @@ pub(crate) fn default_runtime_packet_mode() -> String {
 
 fn default_heatmap_scheme() -> String {
     "tunerstudio".to_string()
+}
+
+fn default_trail_fade_sec() -> f64 {
+    8.0
 }
 
 fn default_true() -> bool {

--- a/crates/libretune-app/src-tauri/src/commands/app_settings.rs
+++ b/crates/libretune-app/src-tauri/src/commands/app_settings.rs
@@ -37,6 +37,14 @@ pub(crate) struct Settings {
     #[serde(default)]
     pub(crate) table_y_axis_bottom: bool,
 
+    /// Custom color for the live cursor marker (empty = theme default)
+    #[serde(default)]
+    pub(crate) table_cursor_color: String,
+
+    /// Custom color for the operating-point trail (empty = default blue)
+    #[serde(default)]
+    pub(crate) table_trail_color: String,
+
     // Heatmap color scheme settings
     #[serde(default = "default_heatmap_scheme")]
     pub(crate) heatmap_value_scheme: String, // Scheme for VE/timing tables

--- a/crates/libretune-app/src-tauri/src/commands/settings.rs
+++ b/crates/libretune-app/src-tauri/src/commands/settings.rs
@@ -83,6 +83,8 @@ pub async fn update_setting(
         "table_y_axis_bottom" => {
             settings.table_y_axis_bottom = value.parse().map_err(|_| "Invalid boolean value")?
         }
+        "table_cursor_color" => settings.table_cursor_color = value,
+        "table_trail_color" => settings.table_trail_color = value,
         // Session persistence
         "last_project_path" => {
             settings.last_project_path = if value.is_empty() { None } else { Some(value) }

--- a/crates/libretune-app/src-tauri/src/commands/settings.rs
+++ b/crates/libretune-app/src-tauri/src/commands/settings.rs
@@ -85,6 +85,9 @@ pub async fn update_setting(
         }
         "table_cursor_color" => settings.table_cursor_color = value,
         "table_trail_color" => settings.table_trail_color = value,
+        "table_trail_fade_sec" => {
+            settings.table_trail_fade_sec = value.parse().map_err(|_| "Invalid number")?
+        }
         // Session persistence
         "last_project_path" => {
             settings.last_project_path = if value.is_empty() { None } else { Some(value) }

--- a/crates/libretune-app/src/App.css
+++ b/crates/libretune-app/src/App.css
@@ -1063,9 +1063,7 @@ body {
   position: absolute;
   width: 48px;
   height: 48px;
-  /* Position calculated from CSS variables */
-  left: calc((var(--cursor-x) / var(--cols)) * 100%);
-  top: calc((var(--cursor-y) / var(--rows)) * 100%);
+  /* left/top set inline from measured cell metrics */
   transform: translate(-50%, -50%);
   
   /* TS-style yellow/green crosshair */

--- a/crates/libretune-app/src/App.css
+++ b/crates/libretune-app/src/App.css
@@ -1057,6 +1057,11 @@ body {
   bottom: 0;
   pointer-events: none;
   z-index: 100;
+  transition: opacity 0.8s ease-out;
+}
+
+.live-cursor-overlay--faded {
+  opacity: 0;
 }
 
 .live-cursor-marker {

--- a/crates/libretune-app/src/App.tsx
+++ b/crates/libretune-app/src/App.tsx
@@ -32,6 +32,7 @@ import { useIniDefaultsLoader } from "./hooks/useIniDefaultsLoader";
 import { useTableCurveRefresh } from "./hooks/useTableCurveRefresh";
 import { useGlobalShortcuts } from "./hooks/useGlobalShortcuts";
 import { useEcuEventListeners } from "./hooks/useEcuEventListeners";
+import { useTableAccentColorVars } from "./utils/useTableOrientation";
 import { useAutoConnect, type ConnectOptions } from "./hooks/useAutoConnect";
 import { useReconnectHandler } from "./hooks/useReconnectHandler";
 import { useTuneModified } from "./hooks/useTuneModified";
@@ -577,6 +578,9 @@ function AppContent() {
     setSaveDialogOpen,
     setBurnDialogOpen,
   });
+
+  // User-configured cursor/trail colors → root CSS vars
+  useTableAccentColorVars();
 
   // App-level event listeners: window title, active-tab persistence,
   // reconnect:request, ini:changed, demo:changed (extracted to hook).

--- a/crates/libretune-app/src/components/tables/TableEditor2D.tsx
+++ b/crates/libretune-app/src/components/tables/TableEditor2D.tsx
@@ -153,7 +153,7 @@ export default function TableEditor2D({
   const [lockedCells, setLockedCells] = useState<Set<string>>(new Set());
   const [historyTrail, setHistoryTrail] = useState<[number, number][]>([]);
   const [showColorShade, setShowColorShade] = useState(true);
-  const [showHistoryTrail, setShowHistoryTrail] = useState(false);
+  const [showHistoryTrail, setShowHistoryTrail] = useState(true);
   const [show3D, setShow3D] = useState(false);
   
   // History Stack

--- a/crates/libretune-app/src/components/tables/TableEditor2D.tsx
+++ b/crates/libretune-app/src/components/tables/TableEditor2D.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { ArrowLeft, Save, Zap, ExternalLink, AlertTriangle, Palette, MapPin, Crosshair, Box } from 'lucide-react';
 import TableToolbar from './TableToolbar';
@@ -337,15 +337,40 @@ export default function TableEditor2D({
     setHistoryIndex(prev => Math.min(prev + 1, 49));
   }, [historyIndex]);
 
+  // Trail of recent live operating points (trace)
+  const realtimeRef = useRef(realtimeData);
+  realtimeRef.current = realtimeData;
   useEffect(() => {
+    if (!followMode) {
+      setHistoryTrail([]);
+      return;
+    }
+    const nearest = (value: number, bins: number[]) => {
+      let best = 0;
+      let diff = Infinity;
+      bins.forEach((b, i) => {
+        const d = Math.abs(b - value);
+        if (d < diff) {
+          diff = d;
+          best = i;
+        }
+      });
+      return best;
+    };
     const interval = setInterval(() => {
-      if (followMode && activeCell) {
-        const trail = [...historyTrail.slice(-50), activeCell];
-        setHistoryTrail(trail);
-      }
-    }, 500);
+      const data = realtimeRef.current;
+      const xv = x_output_channel ? data?.[x_output_channel] : data?.rpm;
+      const yv = y_output_channel ? data?.[y_output_channel] : data?.map;
+      if (xv === undefined || yv === undefined) return;
+      const cell: [number, number] = [nearest(xv, localXBins), nearest(yv, localYBins)];
+      setHistoryTrail((prev) => {
+        const last = prev[prev.length - 1];
+        if (last && last[0] === cell[0] && last[1] === cell[1]) return prev;
+        return [...prev.slice(-49), cell];
+      });
+    }, 250);
     return () => clearInterval(interval);
-  }, [followMode, activeCell]);
+  }, [followMode, x_output_channel, y_output_channel, localXBins, localYBins]);
 
   // Keyboard event handling for TS-style hotkeys
   useEffect(() => {

--- a/crates/libretune-app/src/components/tables/TableEditor2D.tsx
+++ b/crates/libretune-app/src/components/tables/TableEditor2D.tsx
@@ -9,7 +9,7 @@ import RebinDialog from '../dialogs/RebinDialog';
 import CellEditDialog from '../dialogs/CellEditDialog';
 import LambdaPreviewTable from './LambdaPreviewTable';
 import { useHeatmapSettings } from '../../utils/useHeatmapSettings';
-import { useTableYAxisBottom } from '../../utils/useTableOrientation';
+import { useTableYAxisBottom, useTrailFadeSec } from '../../utils/useTableOrientation';
 import { useChannels } from '../../stores/realtimeStore';
 import { useToast } from '../../contexts/ToastContext';
 import { getHotkeyManager } from '../../services/hotkeyService';
@@ -204,6 +204,7 @@ export default function TableEditor2D({
   // Get heatmap scheme from user settings
   const { settings: heatmapSettings } = useHeatmapSettings();
   const yAxisBottom = useTableYAxisBottom();
+  const trailFadeSec = useTrailFadeSec();
 
   // Show the read-only lambda companion only for actual target-AFR tables
   // (not blend/bias tables whose values aren't AFR).
@@ -357,7 +358,7 @@ export default function TableEditor2D({
       });
       return best;
     };
-    const TRAIL_TTL_MS = 8000;
+    const ttlMs = trailFadeSec > 0 ? trailFadeSec * 1000 : Infinity;
     const interval = setInterval(() => {
       const data = realtimeRef.current;
       const xv = x_output_channel ? data?.[x_output_channel] : data?.rpm;
@@ -366,7 +367,7 @@ export default function TableEditor2D({
       const now = Date.now();
       const cell: [number, number] = [nearest(xv, localXBins), nearest(yv, localYBins)];
       setHistoryTrail((prev) => {
-        const kept = prev.filter(([, , t]) => now - t < TRAIL_TTL_MS);
+        const kept = prev.filter(([, , t]) => now - t < ttlMs);
         const last = kept[kept.length - 1];
         if (last && last[0] === cell[0] && last[1] === cell[1]) {
           return kept.length === prev.length ? prev : kept;
@@ -375,7 +376,7 @@ export default function TableEditor2D({
       });
     }, 250);
     return () => clearInterval(interval);
-  }, [followMode, x_output_channel, y_output_channel, localXBins, localYBins]);
+  }, [followMode, x_output_channel, y_output_channel, localXBins, localYBins, trailFadeSec]);
 
   // Keyboard event handling for TS-style hotkeys
   useEffect(() => {

--- a/crates/libretune-app/src/components/tables/TableEditor2D.tsx
+++ b/crates/libretune-app/src/components/tables/TableEditor2D.tsx
@@ -151,7 +151,7 @@ export default function TableEditor2D({
   
   const [selectionRange, setSelectionRange] = useState<SelectionRange | null>(null);
   const [lockedCells, setLockedCells] = useState<Set<string>>(new Set());
-  const [historyTrail, setHistoryTrail] = useState<[number, number][]>([]);
+  const [historyTrail, setHistoryTrail] = useState<[number, number, number][]>([]);
   const [showColorShade, setShowColorShade] = useState(true);
   const [showHistoryTrail, setShowHistoryTrail] = useState(true);
   const [show3D, setShow3D] = useState(false);
@@ -357,16 +357,21 @@ export default function TableEditor2D({
       });
       return best;
     };
+    const TRAIL_TTL_MS = 8000;
     const interval = setInterval(() => {
       const data = realtimeRef.current;
       const xv = x_output_channel ? data?.[x_output_channel] : data?.rpm;
       const yv = y_output_channel ? data?.[y_output_channel] : data?.map;
       if (xv === undefined || yv === undefined) return;
+      const now = Date.now();
       const cell: [number, number] = [nearest(xv, localXBins), nearest(yv, localYBins)];
       setHistoryTrail((prev) => {
-        const last = prev[prev.length - 1];
-        if (last && last[0] === cell[0] && last[1] === cell[1]) return prev;
-        return [...prev.slice(-49), cell];
+        const kept = prev.filter(([, , t]) => now - t < TRAIL_TTL_MS);
+        const last = kept[kept.length - 1];
+        if (last && last[0] === cell[0] && last[1] === cell[1]) {
+          return kept.length === prev.length ? prev : kept;
+        }
+        return [...kept.slice(-49), [cell[0], cell[1], now]];
       });
     }, 250);
     return () => clearInterval(interval);
@@ -1210,7 +1215,7 @@ export default function TableEditor2D({
           selectionRange={selectionRange}
           onSelectionChange={handleSelectionChange}
           onCellDoubleClick={handleCellDoubleClick}
-          historyTrail={showHistoryTrail ? historyTrail : []}
+          historyTrail={showHistoryTrail ? historyTrail.map(([x, y]) => [x, y] as [number, number]) : []}
           lockedCells={lockedCells}
           onCellLock={handleCellLock}
           // Live cursor - maps realtime values to table position

--- a/crates/libretune-app/src/components/tables/TableEditor2D.tsx
+++ b/crates/libretune-app/src/components/tables/TableEditor2D.tsx
@@ -192,7 +192,7 @@ export default function TableEditor2D({
     value: 0,
   });
 
-  const [followMode, setFollowMode] = useState(false);
+  const [followMode, setFollowMode] = useState(true);
   const [activeCell, setActiveCell] = useState<[number, number] | null>(null);
 
   const { showToast } = useToast();

--- a/crates/libretune-app/src/components/tables/TableGrid.tsx
+++ b/crates/libretune-app/src/components/tables/TableGrid.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useState, useRef, useMemo, useCallback } from 'react';
+import { Fragment, useState, useRef, useMemo, useCallback, useLayoutEffect } from 'react';
 import { valueToHeatmapColor, HeatmapScheme } from '../../utils/heatmapColors';
 
 export interface SelectionRange {
@@ -256,49 +256,55 @@ export default function TableGrid({
   };
 
 
+  // Pixel metrics of the data-cell area (the CSS-var percent math was offset
+  // by the axis label column/header row and missed cell centering)
+  const [cellMetrics, setCellMetrics] = useState<{ l: number; t: number; w: number; h: number } | null>(null);
+  useLayoutEffect(() => {
+    const grid = gridRef.current;
+    if (!grid) return;
+    const measure = () => {
+      const cell = grid.querySelector('.table-cell') as HTMLElement | null;
+      if (cell) {
+        setCellMetrics({ l: cell.offsetLeft, t: cell.offsetTop, w: cell.offsetWidth, h: cell.offsetHeight });
+      }
+    };
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(grid);
+    return () => observer.disconnect();
+  }, [x_size, y_size, compact]);
+
+  const cellCenter = (x: number, y: number) => {
+    if (!cellMetrics) return null;
+    const displayY = yAxisBottom ? y_size - 1 - y : y;
+    return {
+      cx: cellMetrics.l + (x + 0.5) * cellMetrics.w,
+      cy: cellMetrics.t + (displayY + 0.5) * cellMetrics.h,
+    };
+  };
+
   const renderHistoryTrail = () => {
-    if (!historyTrail || historyTrail.length === 0) return null;
+    if (!historyTrail || historyTrail.length === 0 || !cellMetrics) return null;
 
-    const points = historyTrail.map(([x, y]) => {
-      const cellKey = `${x},${y}`;
-      if (lockedCells?.has(cellKey)) return null;
+    const centers = historyTrail
+      .filter(([x, y]) => !lockedCells?.has(`${x},${y}`))
+      .map(([x, y]) => cellCenter(x, y))
+      .filter((c): c is { cx: number; cy: number } => c !== null);
 
-      const left = (x / x_size) * 100;
-      const displayY = yAxisBottom ? y_size - 1 - y : y;
-      const top = (displayY / y_size) * 100;
-
-      return `${left},${top}`;
-    }).filter(Boolean) as string[];
-
-    const pointElements = historyTrail.map(([x, y], i) => {
-      const cellKey = `${x},${y}`;
-      if (lockedCells?.has(cellKey)) return null;
-
-      const left = (x / x_size) * 100;
-      const displayY = yAxisBottom ? y_size - 1 - y : y;
-      const top = (displayY / y_size) * 100;
-
-      return (
-        <div
-          key={`trail-${i}`}
-          className="history-trail-point"
-          style={{ left: `${left}%`, top: `${top}%` }}
-        />
-      );
-    }).filter(Boolean);
-
-    if (points.length === 0) return null;
+    if (centers.length === 0) return null;
 
     return (
       <svg className="history-trail-svg">
         <polyline
-          points={points.join(' ')}
+          points={centers.map((c) => `${c.cx},${c.cy}`).join(' ')}
           fill="none"
           stroke="#4A90E2"
           strokeWidth="2"
           strokeOpacity="0.7"
         />
-        {pointElements}
+        {centers.map((c, i) => (
+          <circle key={i} cx={c.cx} cy={c.cy} r="3" fill="#4A90E2" fillOpacity="0.8" />
+        ))}
       </svg>
     );
   };
@@ -449,19 +455,14 @@ export default function TableGrid({
       {renderHistoryTrail()}
       
       {/* Live Cursor Overlay - shows current ECU operating point */}
-      {liveCursorPosition && (
-        <div 
-          className="live-cursor-overlay"
-          style={{
-            '--cursor-x': liveCursorPosition.x,
-            '--cursor-y': yAxisBottom ? y_size - 1 - liveCursorPosition.y : liveCursorPosition.y,
-            '--cols': x_size,
-            '--rows': y_size,
-          } as React.CSSProperties}
-        >
-          <div className="live-cursor-marker" />
-        </div>
-      )}
+      {liveCursorPosition && cellMetrics && (() => {
+        const c = cellCenter(liveCursorPosition.x, liveCursorPosition.y);
+        return c && (
+          <div className="live-cursor-overlay">
+            <div className="live-cursor-marker" style={{ left: c.cx, top: c.cy }} />
+          </div>
+        );
+      })()}
     </div>
   );
 }

--- a/crates/libretune-app/src/components/tables/TableGrid.tsx
+++ b/crates/libretune-app/src/components/tables/TableGrid.tsx
@@ -68,11 +68,6 @@ export default function TableGrid({
   const y_size = y_bins.length;
 
   // Calculate live cursor position (fractional cell indices)
-  // Fade the cursor after the operating point sits still for a while
-  const [cursorFaded, setCursorFaded] = useState(false);
-  const lastCursorRef = useRef<{ x: number; y: number } | null>(null);
-  const fadeTimerRef = useRef<number | null>(null);
-
   const liveCursorPosition = useMemo(() => {
     if (!showLiveCursor || liveCursorX === undefined || liveCursorY === undefined) {
       return null;
@@ -110,23 +105,6 @@ export default function TableGrid({
 
     return { x: xPos, y: yPos };
   }, [showLiveCursor, liveCursorX, liveCursorY, x_bins, y_bins]);
-
-  useLayoutEffect(() => {
-    const pos = liveCursorPosition;
-    if (!pos) return;
-    const last = lastCursorRef.current;
-    // Quarter-cell threshold so sensor jitter doesn't keep the cursor alive
-    const moved = !last || Math.abs(last.x - pos.x) > 0.25 || Math.abs(last.y - pos.y) > 0.25;
-    if (!moved) return;
-    lastCursorRef.current = pos;
-    setCursorFaded(false);
-    if (fadeTimerRef.current) window.clearTimeout(fadeTimerRef.current);
-    fadeTimerRef.current = window.setTimeout(() => setCursorFaded(true), 3000);
-  }, [liveCursorPosition]);
-
-  useLayoutEffect(() => () => {
-    if (fadeTimerRef.current) window.clearTimeout(fadeTimerRef.current);
-  }, []);
 
   const getCellColor = useCallback((value: number, x: number, y: number) => {
     const cellKey = `${x},${y}`;
@@ -480,7 +458,7 @@ export default function TableGrid({
       {liveCursorPosition && cellMetrics && (() => {
         const c = cellCenter(liveCursorPosition.x, liveCursorPosition.y);
         return c && (
-          <div className={`live-cursor-overlay${cursorFaded ? ' live-cursor-overlay--faded' : ''}`}>
+          <div className="live-cursor-overlay">
             <div className="live-cursor-marker" style={{ left: c.cx, top: c.cy }} />
           </div>
         );

--- a/crates/libretune-app/src/components/tables/TableGrid.tsx
+++ b/crates/libretune-app/src/components/tables/TableGrid.tsx
@@ -1,5 +1,5 @@
 import { Fragment, useState, useRef, useMemo, useCallback, useLayoutEffect } from 'react';
-import { valueToHeatmapColor, HeatmapScheme } from '../../utils/heatmapColors';
+import { valueToHeatmapColor, contrastTextColor, HeatmapScheme } from '../../utils/heatmapColors';
 
 export interface SelectionRange {
   start: [number, number];
@@ -125,7 +125,7 @@ export default function TableGrid({
 
     // Use centralized heatmap utility
     const color = valueToHeatmapColor(value, minVal, maxVal, heatmapScheme);
-    return { background: color };
+    return { background: color, color: contrastTextColor(color) };
   }, [lockedCells, showColorShade, z_values, heatmapScheme]);
 
   const handleKeyDown = (e: KeyboardEvent, x: number, y: number) => {

--- a/crates/libretune-app/src/components/tables/TableGrid.tsx
+++ b/crates/libretune-app/src/components/tables/TableGrid.tsx
@@ -298,12 +298,12 @@ export default function TableGrid({
         <polyline
           points={centers.map((c) => `${c.cx},${c.cy}`).join(' ')}
           fill="none"
-          stroke="#4A90E2"
+          style={{ stroke: 'var(--cursor-trail, #4A90E2)' }}
           strokeWidth="2"
           strokeOpacity="0.7"
         />
         {centers.map((c, i) => (
-          <circle key={i} cx={c.cx} cy={c.cy} r="3" fill="#4A90E2" fillOpacity="0.8" />
+          <circle key={i} cx={c.cx} cy={c.cy} r="3" style={{ fill: 'var(--cursor-trail, #4A90E2)' }} fillOpacity="0.8" />
         ))}
       </svg>
     );

--- a/crates/libretune-app/src/components/tables/TableGrid.tsx
+++ b/crates/libretune-app/src/components/tables/TableGrid.tsx
@@ -115,7 +115,8 @@ export default function TableGrid({
     const pos = liveCursorPosition;
     if (!pos) return;
     const last = lastCursorRef.current;
-    const moved = !last || Math.abs(last.x - pos.x) > 0.05 || Math.abs(last.y - pos.y) > 0.05;
+    // Quarter-cell threshold so sensor jitter doesn't keep the cursor alive
+    const moved = !last || Math.abs(last.x - pos.x) > 0.25 || Math.abs(last.y - pos.y) > 0.25;
     if (!moved) return;
     lastCursorRef.current = pos;
     setCursorFaded(false);

--- a/crates/libretune-app/src/components/tables/TableGrid.tsx
+++ b/crates/libretune-app/src/components/tables/TableGrid.tsx
@@ -68,6 +68,11 @@ export default function TableGrid({
   const y_size = y_bins.length;
 
   // Calculate live cursor position (fractional cell indices)
+  // Fade the cursor after the operating point sits still for a while
+  const [cursorFaded, setCursorFaded] = useState(false);
+  const lastCursorRef = useRef<{ x: number; y: number } | null>(null);
+  const fadeTimerRef = useRef<number | null>(null);
+
   const liveCursorPosition = useMemo(() => {
     if (!showLiveCursor || liveCursorX === undefined || liveCursorY === undefined) {
       return null;
@@ -105,6 +110,22 @@ export default function TableGrid({
 
     return { x: xPos, y: yPos };
   }, [showLiveCursor, liveCursorX, liveCursorY, x_bins, y_bins]);
+
+  useLayoutEffect(() => {
+    const pos = liveCursorPosition;
+    if (!pos) return;
+    const last = lastCursorRef.current;
+    const moved = !last || Math.abs(last.x - pos.x) > 0.05 || Math.abs(last.y - pos.y) > 0.05;
+    if (!moved) return;
+    lastCursorRef.current = pos;
+    setCursorFaded(false);
+    if (fadeTimerRef.current) window.clearTimeout(fadeTimerRef.current);
+    fadeTimerRef.current = window.setTimeout(() => setCursorFaded(true), 3000);
+  }, [liveCursorPosition]);
+
+  useLayoutEffect(() => () => {
+    if (fadeTimerRef.current) window.clearTimeout(fadeTimerRef.current);
+  }, []);
 
   const getCellColor = useCallback((value: number, x: number, y: number) => {
     const cellKey = `${x},${y}`;
@@ -458,7 +479,7 @@ export default function TableGrid({
       {liveCursorPosition && cellMetrics && (() => {
         const c = cellCenter(liveCursorPosition.x, liveCursorPosition.y);
         return c && (
-          <div className="live-cursor-overlay">
+          <div className={`live-cursor-overlay${cursorFaded ? ' live-cursor-overlay--faded' : ''}`}>
             <div className="live-cursor-marker" style={{ left: c.cx, top: c.cy }} />
           </div>
         );

--- a/crates/libretune-app/src/components/tuner-ui/TableEditor.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/TableEditor.tsx
@@ -88,8 +88,8 @@ export function TableEditor({
   const tableRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   
-  // Follow mode state
-  const [followMode, setFollowMode] = useState(false);
+  // Follow mode state (on by default so open tables track the live cursor)
+  const [followMode, setFollowMode] = useState(true);
   const [historyTrail, setHistoryTrail] = useState<Array<{ row: number; col: number; time: number }>>([]);
   const TRAIL_DURATION_MS = 3000; // 3 second trail
   

--- a/crates/libretune-app/src/components/tuner-ui/TableEditor.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/TableEditor.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback, useRef, useEffect, KeyboardEvent, useMemo } from
 import { useChannels } from '../../stores/realtimeStore';
 import { useHeatmapSettings } from '../../utils/useHeatmapSettings';
 import { contrastTextColor } from '../../utils/heatmapColors';
-import { useTableYAxisBottom } from '../../utils/useTableOrientation';
+import { useTableYAxisBottom, useTrailFadeSec } from '../../utils/useTableOrientation';
 import './TableEditor.css';
 import TableEditor3D from '../tables/TableEditor3D';
 import TableToolbar from './table-editor/TableToolbar';
@@ -92,7 +92,8 @@ export function TableEditor({
   // Follow mode state (on by default so open tables track the live cursor)
   const [followMode, setFollowMode] = useState(true);
   const [historyTrail, setHistoryTrail] = useState<Array<{ row: number; col: number; time: number }>>([]);
-  const TRAIL_DURATION_MS = 3000; // 3 second trail
+  const trailFadeSec = useTrailFadeSec();
+  const TRAIL_DURATION_MS = trailFadeSec > 0 ? trailFadeSec * 1000 : Infinity;
   
   // Context menu state
   const [contextMenu, setContextMenu] = useState<ContextMenuState>({ x: 0, y: 0, visible: false });

--- a/crates/libretune-app/src/components/tuner-ui/TableEditor.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/TableEditor.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useRef, useEffect, KeyboardEvent, useMemo } from 'react';
 import { useChannels } from '../../stores/realtimeStore';
 import { useHeatmapSettings } from '../../utils/useHeatmapSettings';
+import { contrastTextColor } from '../../utils/heatmapColors';
 import { useTableYAxisBottom } from '../../utils/useTableOrientation';
 import './TableEditor.css';
 import TableEditor3D from '../tables/TableEditor3D';
@@ -925,8 +926,9 @@ export function TableEditor({
                     <td
                       key={colIndex}
                       className={`table-cell ${isSelected ? 'selected' : ''} ${isLive ? 'live' : ''} ${isInTrail ? 'trail' : ''}`}
-                      style={{ 
+                      style={{
                         backgroundColor: getValueColor(value),
+                        color: contrastTextColor(getValueColor(value)),
                         ...(isInTrail && { '--trail-opacity': trailOpacity } as React.CSSProperties)
                       }}
                       onMouseDown={(e) => handleCellMouseDown(rowIndex, colIndex, e)}

--- a/crates/libretune-app/src/components/tuner-ui/dialogs/SettingsDialog.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/dialogs/SettingsDialog.tsx
@@ -54,6 +54,7 @@ export function SettingsDialog({ isOpen, onClose, theme, onThemeChange, onSettin
   const [tableYAxisBottom, setTableYAxisBottom] = useState(false);
   const [tableCursorColor, setTableCursorColor] = useState('');
   const [tableTrailColor, setTableTrailColor] = useState('');
+  const [tableTrailFadeSec, setTableTrailFadeSec] = useState(8);
   const [demoLoading, setDemoLoading] = useState(false);
   const [indicatorColumnCount, setIndicatorColumnCount] = useState('auto');
   const [indicatorFillEmpty, setIndicatorFillEmpty] = useState(false);
@@ -98,7 +99,7 @@ export function SettingsDialog({ isOpen, onClose, theme, onThemeChange, onSettin
   const [autoConnect, setAutoConnect] = useState(false);
   
   // Settings dialog tabs
-  const [currentTab, setCurrentTab] = useState<'general' | 'definitions' | 'hotkeys'>('general');
+  const [currentTab, setCurrentTab] = useState<'general' | 'appearance' | 'definitions' | 'hotkeys'>('general');
 
   // ECU Definitions tab state
   const [iniList, setIniList] = useState<{id: string; name: string; signature: string; path: string; imported: boolean; source: string}[]>([]);
@@ -131,6 +132,7 @@ export function SettingsDialog({ isOpen, onClose, theme, onThemeChange, onSettin
         if (settings.table_y_axis_bottom !== undefined) setTableYAxisBottom(!!settings.table_y_axis_bottom);
         if (settings.table_cursor_color) setTableCursorColor(settings.table_cursor_color);
         if (settings.table_trail_color) setTableTrailColor(settings.table_trail_color);
+        if (settings.table_trail_fade_sec !== undefined) setTableTrailFadeSec(settings.table_trail_fade_sec);
         if (settings.indicator_column_count !== undefined) setIndicatorColumnCount(settings.indicator_column_count);
         if (settings.indicator_fill_empty !== undefined) setIndicatorFillEmpty(!!settings.indicator_fill_empty);
         if (settings.indicator_text_fit !== undefined) setIndicatorTextFit(settings.indicator_text_fit);
@@ -374,6 +376,16 @@ export function SettingsDialog({ isOpen, onClose, theme, onThemeChange, onSettin
           >
             General
           </button>
+          <button
+            className={`dialog-tab ${currentTab === 'appearance' ? 'active' : ''}`}
+            onClick={() => setCurrentTab('appearance')}
+            role="tab"
+            id="appearance-tab"
+            aria-selected={currentTab === 'appearance'}
+            aria-controls="appearance-panel"
+          >
+            Appearance
+          </button>
           <button 
             className={`dialog-tab ${currentTab === 'definitions' ? 'active' : ''}`}
             onClick={() => {
@@ -403,15 +415,6 @@ export function SettingsDialog({ isOpen, onClose, theme, onThemeChange, onSettin
         <div className="dialog-content">
           {currentTab === 'general' && (
             <div className="dialog-tab-content" id="general-panel" role="tabpanel" aria-labelledby="general-tab">
-              <FormField label="Theme">
-                {() => (
-                  <ThemePicker 
-                    selectedTheme={localTheme as ThemeName} 
-                    onChange={(theme) => setLocalTheme(theme)}
-                  />
-                )}
-              </FormField>
-
               <FormField label="Language">
                 {(id) => (
                   <select
@@ -557,48 +560,6 @@ export function SettingsDialog({ isOpen, onClose, theme, onThemeChange, onSettin
             <span className="dialog-form-note">Simulate ECU data for testing (runtime-only)</span>
           </div>
 
-          <div className="dialog-form-group">
-            <label>
-              <input
-                type="checkbox"
-                checked={tableYAxisBottom}
-                onChange={(e) => {
-                  const enabled = e.target.checked;
-                  setTableYAxisBottom(enabled);
-                  invoke('update_setting', { key: 'table_y_axis_bottom', value: String(enabled) })
-                    .catch((err) => console.error('Failed to save table Y axis setting:', err));
-                }}
-              />
-              Table Y axis zero at bottom
-            </label>
-            <span className="dialog-form-note">Show the lowest load row at the bottom of tables</span>
-          </div>
-
-          <div className="dialog-form-group">
-            <label style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-              <input
-                type="color"
-                value={tableCursorColor || '#00ff00'}
-                onChange={(e) => {
-                  setTableCursorColor(e.target.value);
-                  invoke('update_setting', { key: 'table_cursor_color', value: e.target.value }).catch(() => {});
-                }}
-              />
-              Live cursor color
-              <input
-                type="color"
-                value={tableTrailColor || '#4A90E2'}
-                onChange={(e) => {
-                  setTableTrailColor(e.target.value);
-                  invoke('update_setting', { key: 'table_trail_color', value: e.target.value }).catch(() => {});
-                }}
-                style={{ marginLeft: 16 }}
-              />
-              Trail color
-            </label>
-            <span className="dialog-form-note">Colors of the operating-point marker and its trace on tables</span>
-          </div>
-
           <FormField
             label="Default Runtime Packet Mode"
             help={<>
@@ -705,56 +666,6 @@ export function SettingsDialog({ isOpen, onClose, theme, onThemeChange, onSettin
               </div>
             </>
           )}
-
-          <h3 style={{ marginTop: '1.5rem', marginBottom: '0.5rem' }}>Heatmap Colors</h3>
-          
-          <FormField label="Value Tables (VE, Timing)">
-            {(id) => (
-              <select
-                id={id}
-                value={heatmapValueScheme}
-                onChange={(e) => setHeatmapValueScheme(e.target.value as HeatmapScheme)}
-              >
-                {availableSchemes.filter(s => s.id !== 'custom').map(scheme => (
-                  <option key={scheme.id} value={scheme.id}>
-                    {scheme.name} {scheme.colorblindSafe && '(colorblind-safe)'}
-                  </option>
-                ))}
-              </select>
-            )}
-          </FormField>
-
-          <FormField label="Change Display (AFR Correction)">
-            {(id) => (
-              <select
-                id={id}
-                value={heatmapChangeScheme}
-                onChange={(e) => setHeatmapChangeScheme(e.target.value as HeatmapScheme)}
-              >
-                {availableSchemes.filter(s => s.id !== 'custom').map(scheme => (
-                  <option key={scheme.id} value={scheme.id}>
-                    {scheme.name} {scheme.colorblindSafe && '(colorblind-safe)'}
-                  </option>
-                ))}
-              </select>
-            )}
-          </FormField>
-
-          <FormField label="Coverage Display (Hit Weighting)">
-            {(id) => (
-              <select
-                id={id}
-                value={heatmapCoverageScheme}
-                onChange={(e) => setHeatmapCoverageScheme(e.target.value as HeatmapScheme)}
-              >
-                {availableSchemes.filter(s => s.id !== 'custom').map(scheme => (
-                  <option key={scheme.id} value={scheme.id}>
-                    {scheme.name} {scheme.colorblindSafe && '(colorblind-safe)'}
-                  </option>
-                ))}
-              </select>
-            )}
-          </FormField>
 
           <h3 style={{ marginTop: '1.5rem', marginBottom: '0.5rem' }}>Dashboard</h3>
           
@@ -981,6 +892,131 @@ export function SettingsDialog({ isOpen, onClose, theme, onThemeChange, onSettin
               />
             )}
           </FormField>
+            </div>
+          )}
+
+          {currentTab === 'appearance' && (
+            <div className="dialog-tab-content" id="appearance-panel" role="tabpanel" aria-labelledby="appearance-tab">
+              <FormField label="Theme">
+                {() => (
+                  <ThemePicker
+                    selectedTheme={localTheme as ThemeName}
+                    onChange={(theme) => setLocalTheme(theme)}
+                  />
+                )}
+              </FormField>
+
+              <h3 style={{ marginTop: '1.5rem', marginBottom: '0.5rem' }}>Heatmap Colors</h3>
+
+              <FormField label="Value Tables (VE, Timing)">
+                {(id) => (
+                  <select
+                    id={id}
+                    value={heatmapValueScheme}
+                    onChange={(e) => setHeatmapValueScheme(e.target.value as HeatmapScheme)}
+                  >
+                    {availableSchemes.filter(s => s.id !== 'custom').map(scheme => (
+                      <option key={scheme.id} value={scheme.id}>
+                        {scheme.name} {scheme.colorblindSafe && '(colorblind-safe)'}
+                      </option>
+                    ))}
+                  </select>
+                )}
+              </FormField>
+
+              <FormField label="Change Display (AFR Correction)">
+                {(id) => (
+                  <select
+                    id={id}
+                    value={heatmapChangeScheme}
+                    onChange={(e) => setHeatmapChangeScheme(e.target.value as HeatmapScheme)}
+                  >
+                    {availableSchemes.filter(s => s.id !== 'custom').map(scheme => (
+                      <option key={scheme.id} value={scheme.id}>
+                        {scheme.name} {scheme.colorblindSafe && '(colorblind-safe)'}
+                      </option>
+                    ))}
+                  </select>
+                )}
+              </FormField>
+
+              <FormField label="Coverage Display (Hit Weighting)">
+                {(id) => (
+                  <select
+                    id={id}
+                    value={heatmapCoverageScheme}
+                    onChange={(e) => setHeatmapCoverageScheme(e.target.value as HeatmapScheme)}
+                  >
+                    {availableSchemes.filter(s => s.id !== 'custom').map(scheme => (
+                      <option key={scheme.id} value={scheme.id}>
+                        {scheme.name} {scheme.colorblindSafe && '(colorblind-safe)'}
+                      </option>
+                    ))}
+                  </select>
+                )}
+              </FormField>
+
+              <h3 style={{ marginTop: '1.5rem', marginBottom: '0.5rem' }}>Table Display</h3>
+
+              <div className="dialog-form-group">
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={tableYAxisBottom}
+                    onChange={(e) => {
+                      const enabled = e.target.checked;
+                      setTableYAxisBottom(enabled);
+                      invoke('update_setting', { key: 'table_y_axis_bottom', value: String(enabled) }).catch(() => {});
+                    }}
+                  />
+                  Table Y axis zero at bottom
+                </label>
+                <span className="dialog-form-note">Show the lowest load row at the bottom of tables</span>
+              </div>
+
+              <div className="dialog-form-group">
+                <label style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                  <input
+                    type="color"
+                    value={tableCursorColor || '#00ff00'}
+                    onChange={(e) => {
+                      setTableCursorColor(e.target.value);
+                      invoke('update_setting', { key: 'table_cursor_color', value: e.target.value }).catch(() => {});
+                    }}
+                  />
+                  Live cursor color
+                  <input
+                    type="color"
+                    value={tableTrailColor || '#4A90E2'}
+                    onChange={(e) => {
+                      setTableTrailColor(e.target.value);
+                      invoke('update_setting', { key: 'table_trail_color', value: e.target.value }).catch(() => {});
+                    }}
+                    style={{ marginLeft: 16 }}
+                  />
+                  Trail color
+                </label>
+                <span className="dialog-form-note">Colors of the operating-point marker and its trace on tables</span>
+              </div>
+
+              <div className="dialog-form-group">
+                <label style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                  <input
+                    type="number"
+                    min={0}
+                    step={1}
+                    value={tableTrailFadeSec}
+                    onChange={(e) => {
+                      const v = Math.max(0, parseFloat(e.target.value) || 0);
+                      setTableTrailFadeSec(v);
+                      invoke('update_setting', { key: 'table_trail_fade_sec', value: String(v) }).catch(() => {});
+                    }}
+                    style={{ width: 70 }}
+                  />
+                  Trail fade time (seconds)
+                </label>
+                <span className="dialog-form-note">How long trace points stay on the table; 0 keeps them forever</span>
+              </div>
             </div>
           )}
 

--- a/crates/libretune-app/src/components/tuner-ui/dialogs/SettingsDialog.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/dialogs/SettingsDialog.tsx
@@ -52,6 +52,8 @@ export function SettingsDialog({ isOpen, onClose, theme, onThemeChange, onSettin
   const [autoBurnOnClose, setAutoBurnOnClose] = useState(false);
   const [demoMode, setDemoMode] = useState(false);
   const [tableYAxisBottom, setTableYAxisBottom] = useState(false);
+  const [tableCursorColor, setTableCursorColor] = useState('');
+  const [tableTrailColor, setTableTrailColor] = useState('');
   const [demoLoading, setDemoLoading] = useState(false);
   const [indicatorColumnCount, setIndicatorColumnCount] = useState('auto');
   const [indicatorFillEmpty, setIndicatorFillEmpty] = useState(false);
@@ -127,6 +129,8 @@ export function SettingsDialog({ isOpen, onClose, theme, onThemeChange, onSettin
         }
         if (settings.auto_burn_on_close !== undefined) setAutoBurnOnClose(!!settings.auto_burn_on_close);
         if (settings.table_y_axis_bottom !== undefined) setTableYAxisBottom(!!settings.table_y_axis_bottom);
+        if (settings.table_cursor_color) setTableCursorColor(settings.table_cursor_color);
+        if (settings.table_trail_color) setTableTrailColor(settings.table_trail_color);
         if (settings.indicator_column_count !== undefined) setIndicatorColumnCount(settings.indicator_column_count);
         if (settings.indicator_fill_empty !== undefined) setIndicatorFillEmpty(!!settings.indicator_fill_empty);
         if (settings.indicator_text_fit !== undefined) setIndicatorTextFit(settings.indicator_text_fit);
@@ -568,6 +572,31 @@ export function SettingsDialog({ isOpen, onClose, theme, onThemeChange, onSettin
               Table Y axis zero at bottom
             </label>
             <span className="dialog-form-note">Show the lowest load row at the bottom of tables</span>
+          </div>
+
+          <div className="dialog-form-group">
+            <label style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              <input
+                type="color"
+                value={tableCursorColor || '#00ff00'}
+                onChange={(e) => {
+                  setTableCursorColor(e.target.value);
+                  invoke('update_setting', { key: 'table_cursor_color', value: e.target.value }).catch(() => {});
+                }}
+              />
+              Live cursor color
+              <input
+                type="color"
+                value={tableTrailColor || '#4A90E2'}
+                onChange={(e) => {
+                  setTableTrailColor(e.target.value);
+                  invoke('update_setting', { key: 'table_trail_color', value: e.target.value }).catch(() => {});
+                }}
+                style={{ marginLeft: 16 }}
+              />
+              Trail color
+            </label>
+            <span className="dialog-form-note">Colors of the operating-point marker and its trace on tables</span>
           </div>
 
           <FormField

--- a/crates/libretune-app/src/utils/heatmapColors.ts
+++ b/crates/libretune-app/src/utils/heatmapColors.ts
@@ -244,6 +244,28 @@ export function getGradientColor(stops: string[], position: number): RGBColor {
  * @param scheme - Color scheme to use (or custom stops array)
  * @returns CSS color string
  */
+/** Black or white text depending on background luminance. Accepts #rrggbb or
+ *  rgb(...) strings; returns undefined for anything else (CSS default wins). */
+export function contrastTextColor(background: string): string | undefined {
+  let r: number, g: number, b: number;
+  const hex = /^#([0-9a-f]{6})$/i.exec(background.trim());
+  const rgb = /^rgba?\((\d+)\s*,\s*(\d+)\s*,\s*(\d+)/i.exec(background.trim());
+  if (hex) {
+    const n = parseInt(hex[1], 16);
+    r = (n >> 16) & 255;
+    g = (n >> 8) & 255;
+    b = n & 255;
+  } else if (rgb) {
+    r = +rgb[1];
+    g = +rgb[2];
+    b = +rgb[3];
+  } else {
+    return undefined;
+  }
+  const lum = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+  return lum > 0.55 ? '#111418' : '#ffffff';
+}
+
 export function valueToHeatmapColor(
   value: number,
   min: number,

--- a/crates/libretune-app/src/utils/heatmapColors.ts
+++ b/crates/libretune-app/src/utils/heatmapColors.ts
@@ -12,6 +12,7 @@
 /** Available heatmap color scheme presets */
 export type HeatmapScheme =
   | 'tunerstudio'  // Classic: Blue → Cyan → Green → Yellow → Orange → Red
+  | 'pastel'       // Soft: Green → Yellow → Orange → Red, low saturation
   | 'thermal'      // Black → Purple → Red → Orange → Yellow → White
   | 'viridis'      // Colorblind-safe: Purple → Blue → Teal → Green → Yellow
   | 'plasma'       // Colorblind-safe: Purple → Pink → Orange → Yellow
@@ -55,6 +56,18 @@ export const HEATMAP_SCHEMES: Record<Exclude<HeatmapScheme, 'custom'>, HeatmapSc
       '#FFFF00', // Yellow
       '#FF8000', // Orange
       '#FF0000', // Red (hot/high)
+    ],
+  },
+  pastel: {
+    name: 'Pastel',
+    description: 'Soft green-to-red gradient, easy on the eyes',
+    colorblindSafe: false,
+    stops: [
+      '#66c96d', // soft green (low)
+      '#a9d94f',
+      '#e8e14b', // soft yellow
+      '#f0a944', // soft orange
+      '#e96c6c', // soft red (high)
     ],
   },
   thermal: {
@@ -294,6 +307,7 @@ export function getSchemeDefinition(scheme: HeatmapScheme): HeatmapSchemeDefinit
 export function getAvailableSchemes(): Array<{ id: HeatmapScheme; name: string; colorblindSafe: boolean }> {
   return [
     { id: 'tunerstudio', name: 'TunerStudio Classic', colorblindSafe: false },
+    { id: 'pastel', name: 'Pastel', colorblindSafe: false },
     { id: 'thermal', name: 'Thermal', colorblindSafe: false },
     { id: 'viridis', name: 'Viridis', colorblindSafe: true },
     { id: 'plasma', name: 'Plasma', colorblindSafe: true },

--- a/crates/libretune-app/src/utils/useTableOrientation.ts
+++ b/crates/libretune-app/src/utils/useTableOrientation.ts
@@ -10,6 +10,39 @@ import { useEffect, useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { listen, UnlistenFn } from '@tauri-apps/api/event';
 
+/** Apply user cursor/trail colors as root CSS vars (call once in App).
+ *  Empty settings leave the theme defaults untouched. */
+export function useTableAccentColorVars(): void {
+  useEffect(() => {
+    const apply = (cursor?: string, trail?: string) => {
+      const root = document.documentElement.style;
+      if (cursor) root.setProperty('--cursor-live', cursor);
+      else root.removeProperty('--cursor-live');
+      if (trail) root.setProperty('--cursor-trail', trail);
+      else root.removeProperty('--cursor-trail');
+    };
+    const load = () => {
+      invoke<{ table_cursor_color?: string; table_trail_color?: string }>('get_settings')
+        .then((s) => apply(s?.table_cursor_color, s?.table_trail_color))
+        .catch(() => {});
+    };
+    load();
+    let unlisten: UnlistenFn | null = null;
+    (async () => {
+      try {
+        unlisten = await listen<string>('settings:changed', (e) => {
+          if (e.payload === 'table_cursor_color' || e.payload === 'table_trail_color') load();
+        });
+      } catch {
+        // Not running under Tauri
+      }
+    })();
+    return () => {
+      if (unlisten) unlisten();
+    };
+  }, []);
+}
+
 export function useTableYAxisBottom(): boolean {
   const [bottom, setBottom] = useState(false);
 

--- a/crates/libretune-app/src/utils/useTableOrientation.ts
+++ b/crates/libretune-app/src/utils/useTableOrientation.ts
@@ -43,6 +43,33 @@ export function useTableAccentColorVars(): void {
   }, []);
 }
 
+/** Trail point lifetime in seconds (0 = never expire) */
+export function useTrailFadeSec(): number {
+  const [sec, setSec] = useState(8);
+  useEffect(() => {
+    const load = () => {
+      invoke<{ table_trail_fade_sec?: number }>('get_settings')
+        .then((s) => setSec(s?.table_trail_fade_sec ?? 8))
+        .catch(() => {});
+    };
+    load();
+    let unlisten: UnlistenFn | null = null;
+    (async () => {
+      try {
+        unlisten = await listen<string>('settings:changed', (e) => {
+          if (e.payload === 'table_trail_fade_sec') load();
+        });
+      } catch {
+        // Not running under Tauri
+      }
+    })();
+    return () => {
+      if (unlisten) unlisten();
+    };
+  }, []);
+  return sec;
+}
+
 export function useTableYAxisBottom(): boolean {
   const [bottom, setBottom] = useState(false);
 


### PR DESCRIPTION
- Follow mode and history trail on by default when opening tables
- Cursor marker and trail now position from measured cell metrics (previously offset by the axis labels and missing cell centering; trail SVG used percent values as pixel units)
- Trail records the live operating point (was recording the selected cell) and expires after a configurable time (Settings, 0 = forever)
- New Pastel heatmap scheme; cell text color picks black/white by background luminance
- Configurable cursor/trail colors; new Appearance settings tab grouping theme, heatmap and table display options
- "Display Settings" pulled into a separate tab

Tested on Windows against a rusEFI ECU with trigger simulator.