### PR TITLE
Fix/ve table fit viewport

### DIFF
--- a/crates/libretune-app/src/components/tables/TableEditor2D.css
+++ b/crates/libretune-app/src/components/tables/TableEditor2D.css
@@ -54,6 +54,34 @@
   max-width: 100%;
 }
 
+/* veTableTbl only: give the grid a real viewport to fit into */
+.table-editor-2d.table-editor-2d--ve-fit.embedded .editor-content,
+.table-editor-2d.table-editor-2d--ve-fit.embedded .editor-content.editor-content--with-live {
+  flex: 1 1 auto;
+  align-self: stretch;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.table-editor-2d .table-grid-fit-host {
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 0;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+}
+
+.table-editor-2d .table-grid-container--fit-ve {
+  /* Still content-sized; host is the scroll/measure box */
+  width: max-content;
+  height: max-content;
+  max-width: none;
+}
+
 .table-editor-2d.embedded .editor-content.editor-content--with-live .table-grid-container {
   flex: 0 0 auto;
 }

--- a/crates/libretune-app/src/components/tables/TableEditor2D.tsx
+++ b/crates/libretune-app/src/components/tables/TableEditor2D.tsx
@@ -209,6 +209,8 @@ export default function TableEditor2D({
   // Show the read-only lambda companion only for actual target-AFR tables
   // (not blend/bias tables whose values aren't AFR).
   const isAfrTargetTable = table_name.toLowerCase().startsWith('afrtable');
+  // Primary VE table only (32x32 on many firmwares) — do not change other tables.
+  const fitVeViewport = table_name.toLowerCase() === 'vetabletbl';
 
   const selectedCellsCoords = useMemo(() => {
     if (!selectionRange) return [];
@@ -1069,7 +1071,9 @@ export default function TableEditor2D({
   }
 
   return (
-    <div className={`table-editor-2d ${embedded ? 'embedded' : 'standalone'}`}>
+    <div
+      className={`table-editor-2d ${embedded ? 'embedded' : 'standalone'}${fitVeViewport ? ' table-editor-2d--ve-fit' : ''}`}
+    >
       {/* Embedded mode: compact title bar with pop-out button */}
       {embedded && (
         <div className="embedded-header">
@@ -1228,6 +1232,7 @@ export default function TableEditor2D({
           heatmapScheme={heatmapSettings.valueScheme}
           compact={embedded}
           yAxisBottom={yAxisBottom}
+          fitViewport={fitVeViewport}
         />
         {isAfrTargetTable && (
           <LambdaPreviewTable

--- a/crates/libretune-app/src/components/tables/TableEditor2D.tsx
+++ b/crates/libretune-app/src/components/tables/TableEditor2D.tsx
@@ -209,8 +209,8 @@ export default function TableEditor2D({
   // Show the read-only lambda companion only for actual target-AFR tables
   // (not blend/bias tables whose values aren't AFR).
   const isAfrTargetTable = table_name.toLowerCase().startsWith('afrtable');
-  // Primary VE table only (32x32 on many firmwares) — do not change other tables.
-  const fitVeViewport = table_name.toLowerCase() === 'vetabletbl';
+  // VE tables only (veTableTbl / veTable1Tbl…veTable4Tbl) — not MAF, blend, or other maps.
+  const fitVeViewport = /^vetable(\d+)?tbl$/i.test(table_name);
 
   const selectedCellsCoords = useMemo(() => {
     if (!selectionRange) return [];

--- a/crates/libretune-app/src/components/tables/TableGrid.tsx
+++ b/crates/libretune-app/src/components/tables/TableGrid.tsx
@@ -1,4 +1,12 @@
-import { Fragment, useState, useRef, useMemo, useCallback, useLayoutEffect } from 'react';
+import {
+  Fragment,
+  useState,
+  useRef,
+  useMemo,
+  useCallback,
+  useLayoutEffect,
+  type CSSProperties,
+} from 'react';
 import { valueToHeatmapColor, contrastTextColor, HeatmapScheme } from '../../utils/heatmapColors';
 
 export interface SelectionRange {
@@ -31,6 +39,11 @@ interface TableGridProps {
   heatmapScheme?: HeatmapScheme | string[]; // Scheme name or custom color stops
   /** Embedded/dialog tables: fixed compact layout (GP#1–4, etc.) */
   compact?: boolean;
+  /**
+   * VE main table only: shrink cell geometry to fit the parent viewport.
+   * Other tables must keep fixed rem sizing.
+   */
+  fitViewport?: boolean;
 }
 
 export default function TableGrid({
@@ -53,8 +66,11 @@ export default function TableGrid({
   heatmapScheme = 'tunerstudio',
   compact = false,
   yAxisBottom = false,
+  fitViewport = false,
 }: TableGridProps) {
+  const hostRef = useRef<HTMLDivElement>(null);
   const gridRef = useRef<HTMLDivElement>(null);
+  const [fitPx, setFitPx] = useState<{ axis: number; col: number; row: number } | null>(null);
   const [editingCell, setEditingCell] = useState<[number, number] | null>(null);
   const [editValue, setEditValue] = useState<string>('');
   // cellDrag stores the anchor point of the selection
@@ -309,18 +325,71 @@ export default function TableGrid({
     );
   };
 
-  // Fixed column widths — tuning tables must not stretch with the panel
-  const axisCol = compact ? '3.25rem' : '2.75rem';
-  const dataCol = compact ? '3.5rem' : '3rem';
-  const gridTemplateColumns = `${axisCol} repeat(${x_size}, ${dataCol})`;
+  // Fixed column widths — tuning tables must not stretch with the panel.
+  // Exception: fitViewport (veTableTbl only) sizes cells from the parent box.
+  useLayoutEffect(() => {
+    if (!fitViewport) {
+      setFitPx(null);
+      return;
+    }
+    const host = hostRef.current;
+    if (!host) return;
 
-  return (
-    <div 
+    const measure = () => {
+      const availW = host.clientWidth;
+      const availH = host.clientHeight;
+      if (availW < 32 || availH < 32 || x_size < 1 || y_size < 1) return;
+
+      const minCol = 22;
+      const minRow = 16;
+      const minAxis = 28;
+      const preferredCol = compact ? 56 : 48;
+      const preferredRow = 32;
+      const preferredAxis = compact ? 52 : 44;
+
+      let col = Math.floor((availW - minAxis) / x_size);
+      col = Math.max(minCol, Math.min(preferredCol, col));
+      let axis = Math.floor(availW - col * x_size);
+      axis = Math.max(minAxis, Math.min(preferredAxis, axis));
+      if (axis + col * x_size > availW) {
+        col = Math.max(minCol, Math.floor((availW - minAxis) / x_size));
+        axis = Math.max(minAxis, availW - col * x_size);
+      }
+
+      let row = Math.floor(availH / (y_size + 1));
+      row = Math.max(minRow, Math.min(preferredRow, row));
+
+      setFitPx((prev) =>
+        prev && prev.axis === axis && prev.col === col && prev.row === row
+          ? prev
+          : { axis, col, row },
+      );
+    };
+
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(host);
+    return () => ro.disconnect();
+  }, [fitViewport, x_size, y_size, compact]);
+
+  const axisCol = fitPx ? `${fitPx.axis}px` : compact ? '3.25rem' : '2.75rem';
+  const dataCol = fitPx ? `${fitPx.col}px` : compact ? '3.5rem' : '3rem';
+  const gridTemplateColumns = `${axisCol} repeat(${x_size}, ${dataCol})`;
+  const gridStyle: CSSProperties = fitPx
+    ? {
+        gridTemplateColumns,
+        ['--table-row-h' as string]: `${fitPx.row}px`,
+        fontSize: `${Math.max(9, Math.min(13, Math.floor(fitPx.col * 0.32)))}px`,
+      }
+    : { gridTemplateColumns };
+
+  const grid = (
+    <div
       ref={gridRef}
-      className={`table-grid-container${compact ? ' table-grid-container--compact' : ''}`}
+      className={`table-grid-container${compact ? ' table-grid-container--compact' : ''}${fitViewport ? ' table-grid-container--fit-ve' : ''}`}
       onMouseUp={handleMouseUp}
       onMouseMove={handleCellMouseMove}
-      style={{ gridTemplateColumns }}
+      style={gridStyle}
     >
       {/* Corner cell (row 0, col 0) */}
       <div className="axis-corner" />
@@ -463,6 +532,16 @@ export default function TableGrid({
           </div>
         );
       })()}
+    </div>
+  );
+
+  if (!fitViewport) {
+    return grid;
+  }
+
+  return (
+    <div ref={hostRef} className="table-grid-fit-host">
+      {grid}
     </div>
   );
 }


### PR DESCRIPTION
Fit large VE tables to the dialog so a 32×32 map is usable; other tables unchanged.

- Shrinks cells to the available viewport for` veTableTbl` /` veTable1–4Tbl` only
- Leaves spark, AFR, MAF, etc. on fixed sizing