### PR TITLE
fix: dashboard designer Backspace deletes gauge instead of editing po…

### DIFF
--- a/crates/libretune-app/src/components/dashboards/designer/PercentField.tsx
+++ b/crates/libretune-app/src/components/dashboards/designer/PercentField.tsx
@@ -1,0 +1,57 @@
+import { useEffect, useId, useRef, useState } from 'react';
+
+interface PercentFieldProps {
+  label: string;
+  /** Stored value as a 0..1 fraction (e.g. 0.02 for "2.0"). */
+  value: number;
+  onChange: (fraction: number) => void;
+}
+
+/**
+ * A percent-valued number input backed by a 0..1 fraction.
+ *
+ * A plain `value={(value * 100).toFixed(1)}` fights the user: every
+ * keystroke re-renders with the canonical formatted string, discarding
+ * in-progress edits (a trailing ".", a backspaced trailing zero, etc.) —
+ * so Backspace visually does nothing. This keeps a local text buffer while
+ * the field has focus, and only re-syncs from the external value on blur or
+ * when it changes while the field isn't focused (e.g. dragging on canvas).
+ */
+export default function PercentField({ label, value, onChange }: PercentFieldProps) {
+  const [text, setText] = useState(() => (value * 100).toFixed(1));
+  const focused = useRef(false);
+  const id = useId();
+
+  useEffect(() => {
+    if (!focused.current) {
+      setText((value * 100).toFixed(1));
+    }
+  }, [value]);
+
+  return (
+    <div className="property-group half">
+      <label htmlFor={id}>{label}</label>
+      <input
+        id={id}
+        type="text"
+        inputMode="decimal"
+        value={text}
+        onFocus={() => {
+          focused.current = true;
+        }}
+        onChange={(e) => {
+          const raw = e.target.value;
+          setText(raw);
+          const parsed = parseFloat(raw);
+          if (Number.isFinite(parsed)) {
+            onChange(parsed / 100);
+          }
+        }}
+        onBlur={() => {
+          focused.current = false;
+          setText((value * 100).toFixed(1));
+        }}
+      />
+    </div>
+  );
+}

--- a/crates/libretune-app/src/components/dashboards/designer/PropertyEditor.tsx
+++ b/crates/libretune-app/src/components/dashboards/designer/PropertyEditor.tsx
@@ -1,4 +1,5 @@
 import { DashComponent, TsGaugeConfig, TsIndicatorConfig, isGauge, isIndicator } from '../dashTypes';
+import PercentField from './PercentField';
 
 interface Props {
   component: DashComponent;
@@ -142,44 +143,28 @@ export default function PropertyEditor({ component, onChange }: Props) {
         <div className="property-section">
           <h4>Position & Size</h4>
           <div className="property-row">
-            <div className="property-group half">
-              <label>X (%)</label>
-              <input
-                type="number"
-                step={0.01}
-                value={((gauge.relative_x ?? 0) * 100).toFixed(1)}
-                onChange={(e) => updateGauge({ relative_x: parseFloat(e.target.value) / 100 })}
-              />
-            </div>
-            <div className="property-group half">
-              <label>Y (%)</label>
-              <input
-                type="number"
-                step={0.01}
-                value={((gauge.relative_y ?? 0) * 100).toFixed(1)}
-                onChange={(e) => updateGauge({ relative_y: parseFloat(e.target.value) / 100 })}
-              />
-            </div>
+            <PercentField
+              label="X (%)"
+              value={gauge.relative_x ?? 0}
+              onChange={(v) => updateGauge({ relative_x: v })}
+            />
+            <PercentField
+              label="Y (%)"
+              value={gauge.relative_y ?? 0}
+              onChange={(v) => updateGauge({ relative_y: v })}
+            />
           </div>
           <div className="property-row">
-            <div className="property-group half">
-              <label>Width (%)</label>
-              <input
-                type="number"
-                step={0.01}
-                value={((gauge.relative_width ?? 0.25) * 100).toFixed(1)}
-                onChange={(e) => updateGauge({ relative_width: parseFloat(e.target.value) / 100 })}
-              />
-            </div>
-            <div className="property-group half">
-              <label>Height (%)</label>
-              <input
-                type="number"
-                step={0.01}
-                value={((gauge.relative_height ?? 0.25) * 100).toFixed(1)}
-                onChange={(e) => updateGauge({ relative_height: parseFloat(e.target.value) / 100 })}
-              />
-            </div>
+            <PercentField
+              label="Width (%)"
+              value={gauge.relative_width ?? 0.25}
+              onChange={(v) => updateGauge({ relative_width: v })}
+            />
+            <PercentField
+              label="Height (%)"
+              value={gauge.relative_height ?? 0.25}
+              onChange={(v) => updateGauge({ relative_height: v })}
+            />
           </div>
         </div>
 
@@ -292,44 +277,28 @@ export default function PropertyEditor({ component, onChange }: Props) {
         <div className="property-section">
           <h4>Position & Size</h4>
           <div className="property-row">
-            <div className="property-group half">
-              <label>X (%)</label>
-              <input
-                type="number"
-                step={0.01}
-                value={((indicator.relative_x ?? 0) * 100).toFixed(1)}
-                onChange={(e) => updateIndicator({ relative_x: parseFloat(e.target.value) / 100 })}
-              />
-            </div>
-            <div className="property-group half">
-              <label>Y (%)</label>
-              <input
-                type="number"
-                step={0.01}
-                value={((indicator.relative_y ?? 0) * 100).toFixed(1)}
-                onChange={(e) => updateIndicator({ relative_y: parseFloat(e.target.value) / 100 })}
-              />
-            </div>
+            <PercentField
+              label="X (%)"
+              value={indicator.relative_x ?? 0}
+              onChange={(v) => updateIndicator({ relative_x: v })}
+            />
+            <PercentField
+              label="Y (%)"
+              value={indicator.relative_y ?? 0}
+              onChange={(v) => updateIndicator({ relative_y: v })}
+            />
           </div>
           <div className="property-row">
-            <div className="property-group half">
-              <label>Width (%)</label>
-              <input
-                type="number"
-                step={0.01}
-                value={((indicator.relative_width ?? 0.1) * 100).toFixed(1)}
-                onChange={(e) => updateIndicator({ relative_width: parseFloat(e.target.value) / 100 })}
-              />
-            </div>
-            <div className="property-group half">
-              <label>Height (%)</label>
-              <input
-                type="number"
-                step={0.01}
-                value={((indicator.relative_height ?? 0.05) * 100).toFixed(1)}
-                onChange={(e) => updateIndicator({ relative_height: parseFloat(e.target.value) / 100 })}
-              />
-            </div>
+            <PercentField
+              label="Width (%)"
+              value={indicator.relative_width ?? 0.1}
+              onChange={(v) => updateIndicator({ relative_width: v })}
+            />
+            <PercentField
+              label="Height (%)"
+              value={indicator.relative_height ?? 0.05}
+              onChange={(v) => updateIndicator({ relative_height: v })}
+            />
           </div>
         </div>
       </div>

--- a/crates/libretune-app/src/components/dashboards/designer/__tests__/PercentField.test.tsx
+++ b/crates/libretune-app/src/components/dashboards/designer/__tests__/PercentField.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import PercentField from '../PercentField';
+
+describe('PercentField', () => {
+  it('renders the fraction as a formatted percentage', () => {
+    render(<PercentField label="X (%)" value={0.02} onChange={vi.fn()} />);
+    expect(screen.getByLabelText('X (%)')).toHaveValue('2.0');
+  });
+
+  it('lets backspace shorten the displayed text instead of snapping back', () => {
+    render(<PercentField label="X (%)" value={2 / 100} onChange={vi.fn()} />);
+    const input = screen.getByLabelText('X (%)') as HTMLInputElement;
+
+    fireEvent.focus(input);
+    // Simulate the user backspacing the trailing "0" off "2.0" -> "2."
+    fireEvent.change(input, { target: { value: '2.' } });
+
+    expect(input.value).toBe('2.');
+  });
+
+  it('propagates a valid parsed fraction while typing', () => {
+    const onChange = vi.fn();
+    render(<PercentField label="X (%)" value={0} onChange={onChange} />);
+    const input = screen.getByLabelText('X (%)');
+
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: '15' } });
+
+    expect(onChange).toHaveBeenCalledWith(0.15);
+  });
+
+  it('does not call onChange for an in-progress non-numeric value', () => {
+    const onChange = vi.fn();
+    render(<PercentField label="X (%)" value={0.02} onChange={onChange} />);
+    const input = screen.getByLabelText('X (%)');
+
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: '' } });
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('reformats to the canonical value on blur', () => {
+    render(<PercentField label="X (%)" value={2 / 100} onChange={vi.fn()} />);
+    const input = screen.getByLabelText('X (%)') as HTMLInputElement;
+
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: '2.' } });
+    expect(input.value).toBe('2.');
+
+    fireEvent.blur(input);
+    expect(input.value).toBe('2.0');
+  });
+
+  it('updates the displayed value when the prop changes while unfocused (e.g. canvas drag)', () => {
+    const { rerender } = render(<PercentField label="X (%)" value={0.02} onChange={vi.fn()} />);
+    rerender(<PercentField label="X (%)" value={0.5} onChange={vi.fn()} />);
+    expect(screen.getByLabelText('X (%)')).toHaveValue('50.0');
+  });
+});

--- a/crates/libretune-app/src/components/dashboards/designer/__tests__/useDesignerKeyboard.test.ts
+++ b/crates/libretune-app/src/components/dashboards/designer/__tests__/useDesignerKeyboard.test.ts
@@ -1,0 +1,71 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useDesignerKeyboard } from '../useDesignerKeyboard';
+
+function fireKeyDown(target: EventTarget, key: string, opts: Partial<KeyboardEventInit> = {}) {
+  const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true, ...opts });
+  target.dispatchEvent(event);
+  return event;
+}
+
+function renderDesignerKeyboard() {
+  const handlers = {
+    onDelete: vi.fn(),
+    onUndo: vi.fn(),
+    onRedo: vi.fn(),
+    onCopy: vi.fn(),
+    onPaste: vi.fn(),
+    onSave: vi.fn(),
+    onDeselect: vi.fn(),
+  };
+  renderHook(() => useDesignerKeyboard(handlers));
+  return handlers;
+}
+
+describe('useDesignerKeyboard', () => {
+  it('deletes the selection on Backspace when focus is on the window/canvas', () => {
+    const handlers = renderDesignerKeyboard();
+    fireKeyDown(window, 'Backspace');
+    expect(handlers.onDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not delete the selection on Backspace while typing in a text input', () => {
+    const input = document.createElement('input');
+    input.type = 'text';
+    document.body.appendChild(input);
+
+    const handlers = renderDesignerKeyboard();
+    fireKeyDown(input, 'Backspace');
+
+    expect(handlers.onDelete).not.toHaveBeenCalled();
+    document.body.removeChild(input);
+  });
+
+  it('does not delete the selection on Delete while typing in a textarea', () => {
+    const textarea = document.createElement('textarea');
+    document.body.appendChild(textarea);
+
+    const handlers = renderDesignerKeyboard();
+    fireKeyDown(textarea, 'Delete');
+
+    expect(handlers.onDelete).not.toHaveBeenCalled();
+    document.body.removeChild(textarea);
+  });
+
+  it('still fires Ctrl+S (save) when focus is on the canvas, not a field', () => {
+    const handlers = renderDesignerKeyboard();
+    fireKeyDown(window, 's', { ctrlKey: true });
+    expect(handlers.onSave).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not hijack Ctrl+S while typing in a field (lets the browser/field handle it)', () => {
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+
+    const handlers = renderDesignerKeyboard();
+    fireKeyDown(input, 's', { ctrlKey: true });
+
+    expect(handlers.onSave).not.toHaveBeenCalled();
+    document.body.removeChild(input);
+  });
+});

--- a/crates/libretune-app/src/components/dashboards/designer/useDesignerKeyboard.ts
+++ b/crates/libretune-app/src/components/dashboards/designer/useDesignerKeyboard.ts
@@ -10,6 +10,14 @@ interface UseDesignerKeyboardArgs {
   onDeselect: () => void;
 }
 
+/** True while the user is typing into a form field, so designer shortcuts shouldn't fire. */
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  if (target.isContentEditable) return true;
+  const tag = target.tagName;
+  return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
+}
+
 /**
  * Window-level keyboard shortcuts for the dashboard designer.
  *  - Delete / Backspace: delete selected
@@ -17,6 +25,9 @@ interface UseDesignerKeyboardArgs {
  *  - Ctrl/Cmd+C / V: copy / paste
  *  - Ctrl/Cmd+S: save
  *  - Esc: clear selection
+ *
+ * Disabled while a form field (e.g. a property editor input) has focus, so
+ * e.g. Backspace-ing a position value doesn't delete the selected gauge.
  */
 export function useDesignerKeyboard({
   onDelete,
@@ -29,6 +40,8 @@ export function useDesignerKeyboard({
 }: UseDesignerKeyboardArgs): void {
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      if (isEditableTarget(e.target)) return;
+
       if (e.key === 'Delete' || e.key === 'Backspace') {
         onDelete();
       } else if (e.ctrlKey || e.metaKey) {


### PR DESCRIPTION
…sition (#69)

Two independent bugs were compounding in the same fields:

- useDesignerKeyboard: the window-level keydown handler deleted the selected component on Backspace/Delete regardless of what had focus, so backspacing in a property panel input deleted the whole gauge instead of editing text. Now skips designer shortcuts entirely while a form field is focused.

- PropertyEditor's X/Y/Width/Height inputs re-rendered their value as `(n * 100).toFixed(1)` on every keystroke, discarding in-progress edits (a trailing ".", a backspaced trailing zero) even after the deletion bug above is fixed. Extracted a PercentField component that buffers the raw text locally while focused and only reformats on blur or on external changes (e.g. dragging the gauge on canvas).

Closes #69

## Description
Brief description of the changes in this PR.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues
Closes #(issue number)

## Changes Made
- Change 1
- Change 2
- Change 3

## Testing
- [x] I have tested these changes locally
- [x] New and existing tests pass (`cargo test`)
- [x] The UI works correctly with these changes

## Checklist
- [x] Code compiles without errors
- [x] No new clippy warnings (`cargo clippy`)
- [x] Code is formatted (`cargo fmt`)
- [x] TypeScript compiles without errors (`npx tsc --noEmit`)
- [x] Documentation updated if needed
- [x] Commit messages follow conventional format

## Screenshots (if applicable)
Add screenshots showing the changes, especially for UI updates.
