### PR TITLE
fix: dashboard designer canvas clipping and Layers panel truncation

### DIFF
--- a/crates/libretune-app/src/components/dashboards/DashboardDesigner.css
+++ b/crates/libretune-app/src/components/dashboards/DashboardDesigner.css
@@ -101,6 +101,12 @@
 .designer-content {
   display: flex;
   flex: 1;
+  /* Flex items default to min-height: auto, which on some engines (notably
+     WebKitGTK, used on Linux) refuses to shrink this item below its
+     content's natural height — silently defeating the overflow-y: auto
+     below. Chromium/WebView2 (Windows) tends to tolerate this; WebKitGTK
+     does not. Force it explicitly so scrolling actually engages everywhere. */
+  min-height: 0;
   /* .designer-canvas below enforces a 400px min-height; if the toolbar and
      window size leave less vertical room than that, this row must scroll
      instead of silently clipping the bottom of the canvas (and any gauges

--- a/crates/libretune-app/src/components/dashboards/DashboardDesigner.css
+++ b/crates/libretune-app/src/components/dashboards/DashboardDesigner.css
@@ -101,7 +101,12 @@
 .designer-content {
   display: flex;
   flex: 1;
-  overflow: hidden;
+  /* .designer-canvas below enforces a 400px min-height; if the toolbar and
+     window size leave less vertical room than that, this row must scroll
+     instead of silently clipping the bottom of the canvas (and any gauges
+     placed there) with no way to reach it. */
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 /* Canvas area */
@@ -455,11 +460,19 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  /* Grid items default to min-width: auto, which lets content fight the
+     column's 1fr track and defeats this ellipsis. Force it to actually
+     shrink instead of overflowing the panel. */
+  min-width: 0;
 }
 .layer-row .layer-kind {
   font-size: 0.65rem;
   opacity: 0.55;
   font-family: monospace;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 5.5em;
 }
 .layer-row button {
   background: transparent;


### PR DESCRIPTION
## Related Issues
Closes #70

## Changes Made
- `.designer-content` used `overflow: hidden`. The canvas enforces a 400px min-height, so when the toolbar/window leave less vertical room than that, the bottom of the canvas (and any gauges placed there) got clipped with no way to scroll down and reach it. Now scrolls vertically instead.
- `.layer-row`'s name column had `text-overflow: ellipsis` but it never actually engaged, since grid items default to `min-width: auto` and the browser refused to shrink the column below its content's natural width — it overflowed the 280px panel instead of truncating. Added `min-width: 0` so the existing ellipsis works, and added the same truncation to `.layer-kind` (e.g. "HorizontalBarGauge"), which had zero overflow handling and was the main thing blowing out row width.

## Testing
- [x] I have tested these changes locally
- [x] New and existing tests pass (`cargo test`, `npm run test:run`)
- [x] The UI works correctly with these changes

## Checklist
- [x] Code compiles without errors
- [x] No new clippy warnings
- [x] Code is formatted (`cargo fmt`)
- [x] TypeScript compiles without errors
- [x] Documentation updated if needed (n/a)
- [x] Commit messages follow conventional format
