### PR TITLE
fix: run legacy-protocol timing test before CRC test in speeduino_test

### DIFF
--- a/crates/libretune-core/examples/speeduino_test.rs
+++ b/crates/libretune-core/examples/speeduino_test.rs
@@ -157,6 +157,21 @@ fn main() {
         test_legacy_command(&mut port, b'S', "Signature (rusEFI)", timeout_ms);
     }
 
+    // Dynamic timing test — must run before the CRC section below. On
+    // firmware supporting msEnvelope, a single CRC-framed command switches
+    // the controller into that mode permanently until the next power
+    // cycle, so any later request using the legacy raw-ASCII commands this
+    // test relies on gets a framed reply back instead and fails.
+    if !fast_mode && test_legacy {
+        println!();
+        println!("═══════════════════════════════════════════════════════════════");
+        println!();
+        println!("⏱  Testing dynamic timing (finding minimum working delay)...");
+        println!();
+
+        test_dynamic_timing(&mut port, timeout_ms);
+    }
+
     // Test CRC protocol
     if test_crc {
         println!();
@@ -173,17 +188,6 @@ fn main() {
 
         // Test 'S' command with CRC wrapper
         test_crc_command(&mut port, &[b'S'], "Signature (CRC)", timeout_ms);
-    }
-
-    // Dynamic timing test
-    if !fast_mode && test_legacy {
-        println!();
-        println!("═══════════════════════════════════════════════════════════════");
-        println!();
-        println!("⏱  Testing dynamic timing (finding minimum working delay)...");
-        println!();
-
-        test_dynamic_timing(&mut port, timeout_ms);
     }
 
     println!();


### PR DESCRIPTION
On firmware supporting msEnvelope (e.g. Speeduino 202501), sending one CRC-framed command switches the controller into that mode permanently until the next power cycle. The dynamic timing test still sends raw legacy ASCII commands and expects a legacy reply, so running it after the CRC protocol section made it fail every time with framed garbage bytes instead of the expected signature.

## Related Issues
Closes #76

## Changes Made
- Moved the dynamic timing test to run before the CRC protocol section, so nothing legacy-dependent runs after the irreversible mode switch.

## Testing
- [x] I have tested these changes locally
- [x] New and existing tests pass (`cargo test`)
- [x] Verified against real Speeduino 202501 firmware on real hardware — before the fix, the timing test failed at every delay tested with framed garbage bytes; after reordering, all three sections (legacy, timing, CRC) pass in one run

## Checklist
- [x] Code compiles without errors
- [x] No new clippy warnings
- [x] Code is formatted (`cargo fmt`)
- [x] TypeScript compiles without errors
- [x] Documentation updated if needed (n/a)
- [x] Commit messages follow conventional format
