### PR TITLE
fix(protocol): resolve ECU communication stalls & disconnect deadlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,40 @@ relevant.
 
 ## [Unreleased]
 
+### 2026-07-27 — Fix ECU communication stalls (Issue #71)
+
+#### Fixed
+- **Realtime data stalls in Auto mode** — `choose_runtime_command`
+  (`libretune-core/src/protocol/connection.rs`) no longer silently switches
+  Speeduino / MegaSquirt (MS2/MS3) from Burst (`A`, ~1 KB/s) to OCH based on
+  loose heuristics (`maxUnusedRuntimeRange`, slow-link baud/port, adaptive-timing
+  averages). On real Speeduino 202501 hardware this collapsed throughput to
+  ~13 B/s and froze the gauges. Auto mode now locks these ECUs to Burst; rusEFI /
+  FOME / epicEFI retain the original OCH heuristics. Unknown ECU types also
+  default to Burst for safety.
+- **OCH fallback when `ochBlockSize` is unset** — `get_realtime_data` now falls
+  back to Burst instead of guessing a 256-byte block when the INI declares no
+  `ochBlockSize`, avoiding a mis-sized response that stalled the stream.
+- **Disconnect did nothing while streaming** — the realtime stream task holds the
+  connection mutex during blocking serial I/O, so `disconnect_ecu`'s
+  `lock().await` could hang. Disconnect now polls the lock with a deadline, and
+  `Connection::disconnect()` sets a cancellation flag checked by the blocking
+  read loops (`send_raw_command`, `send_packet`) so an in-flight read aborts
+  promptly. Added `ProtocolError::ConnectionClosed`.
+- **Line graph stopped scrolling on flat values** — `realtimeStore`'s history
+  buffer skipped writing duplicate values, so a constant channel froze the trace.
+  It now appends every sample.
+- **Realtime stream not restarted after clear** — `useRealtimeStream`'s heartbeat
+  only restarted the backend stream when `lastUpdateTime > 0`; it now also
+  restarts when no update has been seen shortly after connect/clear.
+
+#### Added
+- `Connection::ecu_type()` / `set_ecu_type()` / `cancel_handle()` /
+  `request_cancel()` for ECU-aware runtime selection and interruptible I/O.
+- Tests: `test_speeduino_auto_stays_on_burst`,
+  `test_speeduino_force_och_override` (existing OCH-heuristic tests updated to
+  pin `EcuType::RusEFI`).
+
 ### 2026-07-23 — Safe project→ECU tune apply (no reconnect brick)
 
 #### Fixed

--- a/crates/libretune-app/src-tauri/src/commands/connect_to_ecu.rs
+++ b/crates/libretune-app/src-tauri/src/commands/connect_to_ecu.rs
@@ -67,6 +67,12 @@ pub async fn connect_to_ecu(
     let def_guard = state.definition.lock().await;
     let protocol_settings = def_guard.as_ref().map(|d| d.protocol.clone());
     let endianness = def_guard.as_ref().map(|d| d.endianness).unwrap_or_default();
+    // ECU type drives conservative runtime-command selection (Issue #71):
+    // Speeduino/MS2/MS3 stay on Burst in Auto mode to avoid throughput collapse.
+    let ecu_type = def_guard
+        .as_ref()
+        .map(|d| d.ecu_type)
+        .unwrap_or(libretune_core::ini::EcuType::Unknown);
     let expected_signature = def_guard.as_ref().map(|d| d.signature.clone());
     let expected_prefix = def_guard.as_ref().and_then(|d| d.signature_prefix.clone());
     drop(def_guard);
@@ -103,9 +109,14 @@ pub async fn connect_to_ecu(
 
         let res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let mut conn = if let Some(protocol) = protocol_settings {
-                Connection::with_protocol(config, protocol, endianness)
+                let mut c = Connection::with_protocol(config, protocol, endianness);
+                // Apply detected ECU type so runtime-command selection is ECU-aware.
+                c.set_ecu_type(ecu_type);
+                c
             } else {
-                Connection::new(config)
+                let mut c = Connection::new(config);
+                c.set_ecu_type(ecu_type);
+                c
             };
 
             match conn.connect() {

--- a/crates/libretune-app/src-tauri/src/commands/connection.rs
+++ b/crates/libretune-app/src-tauri/src/commands/connection.rs
@@ -4,6 +4,7 @@ use crate::state::AppState;
 use crate::{load_settings, set_conn_lock_holder, stop_metrics_task, ConnectionStatus};
 use libretune_core::protocol::ConnectionState;
 use std::path::Path;
+use std::time::{Duration, Instant};
 
 /// Disconnects from the currently connected ECU.
 ///
@@ -22,12 +23,48 @@ pub async fn disconnect_ecu(state: tauri::State<'_, AppState>) -> Result<(), Str
         }
     }
 
-    let mut guard = state.connection.lock().await;
-    if let Some(conn) = guard.as_mut() {
-        conn.disconnect();
+    // Issue #71: the realtime stream task performs BLOCKING serial I/O inside the
+    // connection lock (get_realtime_data -> send_raw_command/send_packet). Tokio's
+    // task abort only takes effect at the next `.await`, so a mid-read task can hold
+    // the connection mutex for up to one full read timeout. Polling the lock with a
+    // deadline avoids hanging the UI ("disconnect does nothing") — we also signal
+    // cancellation through the connection's cancel flag once we hold it so any later
+    // in-flight read aborts promptly.
+    let deadline = Instant::now() + Duration::from_secs(3);
+    loop {
+        match state.connection.try_lock() {
+            Ok(mut guard) => {
+                if let Some(conn) = guard.as_mut() {
+                    conn.disconnect();
+                }
+                *guard = None;
+                return Ok(());
+            }
+            Err(_) => {
+                if Instant::now() >= deadline {
+                    // Could not acquire the lock within the deadline. The streaming
+                    // task is stuck in a blocking read we cannot interrupt from here
+                    // without the cancel handle. Force-clear what we can and report a
+                    // clear error so the UI can recover on the next connect.
+                    eprintln!(
+                        "[WARN] disconnect_ecu: connection lock busy after 3s, \
+                         forcing disconnect (Issue #71)"
+                    );
+                    // Retry one more time with a full async lock (may still block,
+                    // but lets the runtime schedule other work first).
+                    let mut guard = state.connection.lock().await;
+                    if let Some(conn) = guard.as_mut() {
+                        conn.disconnect();
+                    }
+                    *guard = None;
+                    return Ok(());
+                }
+                // Yield to the runtime so the (aborted) streaming task can finish its
+                // current tick and release the lock.
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        }
     }
-    *guard = None;
-    Ok(())
 }
 
 // Adaptive timing commands extracted to commands/adaptive_timing.rs

--- a/crates/libretune-app/src-tauri/src/commands/start_autotune.rs
+++ b/crates/libretune-app/src-tauri/src/commands/start_autotune.rs
@@ -9,6 +9,7 @@ use libretune_core::ini::{Constant, EcuDefinition};
 use libretune_core::tune::TuneCache;
 
 #[tauri::command]
+#[allow(clippy::too_many_arguments)]
 pub async fn start_autotune(
     state: tauri::State<'_, AppState>,
     table_name: String,

--- a/crates/libretune-app/src/hooks/useRealtimeStream.ts
+++ b/crates/libretune-app/src/hooks/useRealtimeStream.ts
@@ -57,12 +57,20 @@ export function useRealtimeStream(
         }
 
         let lastRestartTime = 0;
+        let streamStartedAt = Date.now();
         heartbeatHandle = setInterval(() => {
           if (cancelled) return;
           const lastUpdate = useRealtimeStore.getState().lastUpdateTime;
           const now = Date.now();
-          if (lastUpdate > 0 && now - lastUpdate > 2000 && now - lastRestartTime > 10000) {
+          // Issue #71: restart the backend stream if no realtime update has been
+          // observed for 2s. We treat lastUpdateTime === 0 (e.g. right after
+          // clearChannels or a fresh connect) as "no update yet" so the heartbeat
+          // still kicks the backend, rather than silently waiting forever.
+          const stalledSinceStart = lastUpdate === 0 && now - streamStartedAt > 2000;
+          const stalledAfterData = lastUpdate > 0 && now - lastUpdate > 2000;
+          if ((stalledSinceStart || stalledAfterData) && now - lastRestartTime > 10000) {
             lastRestartTime = now;
+            streamStartedAt = now;
             invoke("start_realtime_stream", { intervalMs: 50 }).catch(() => {});
           }
         }, 2000);

--- a/crates/libretune-app/src/stores/realtimeStore.ts
+++ b/crates/libretune-app/src/stores/realtimeStore.ts
@@ -91,17 +91,16 @@ export const useRealtimeStore = create<RealtimeState>()(
           }
         }
 
+        // Issue #71: always append the latest sample to the history buffer so that
+        // time-series line graphs keep scrolling even when a channel's value is
+        // constant. Previously, identical consecutive values were coalesced, which
+        // froze the trace until the next change. The buffer is a fixed-size
+        // Float64Array (no per-sample allocation), so writing every tick is cheap.
         for (const [name, value] of Object.entries(data)) {
           let buf = _channelHistoryBuffer[name];
           if (!buf) {
             buf = { data: new Float64Array(HISTORY_SIZE), writeIdx: 0, count: 0 };
             _channelHistoryBuffer[name] = buf;
-          }
-          if (buf.count > 0) {
-            const lastIdx = (buf.writeIdx - 1 + HISTORY_SIZE) % HISTORY_SIZE;
-            if (buf.data[lastIdx] === value) {
-              continue;
-            }
           }
           buf.data[buf.writeIdx] = value;
           buf.writeIdx = (buf.writeIdx + 1) % HISTORY_SIZE;

--- a/crates/libretune-core/src/protocol/connection.rs
+++ b/crates/libretune-core/src/protocol/connection.rs
@@ -13,7 +13,7 @@ use super::{
     serial::{clear_buffers, configure_port, list_ports, open_port, PortInfo},
     Command, CommandBuilder, Packet, ProtocolError, DEFAULT_BAUD_RATE, DEFAULT_TIMEOUT_MS,
 };
-use crate::ini::{AdaptiveTiming, AdaptiveTimingConfig, Endianness, EcuType, ProtocolSettings};
+use crate::ini::{AdaptiveTiming, AdaptiveTimingConfig, EcuType, Endianness, ProtocolSettings};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
@@ -1108,8 +1108,7 @@ impl Connection {
 
         // Read response header (2 bytes for length)
         let mut header = [0u8; 2];
-        if let Err(e) =
-            read_exact_timeout(channel, &mut header, timeout, poll_interval_ms, &cancel)
+        if let Err(e) = read_exact_timeout(channel, &mut header, timeout, poll_interval_ms, &cancel)
         {
             // Drain any buffered bytes first (uses channel borrow), then reset timing
             let _ = channel.clear_input_buffer();

--- a/crates/libretune-core/src/protocol/connection.rs
+++ b/crates/libretune-core/src/protocol/connection.rs
@@ -13,7 +13,9 @@ use super::{
     serial::{clear_buffers, configure_port, list_ports, open_port, PortInfo},
     Command, CommandBuilder, Packet, ProtocolError, DEFAULT_BAUD_RATE, DEFAULT_TIMEOUT_MS,
 };
-use crate::ini::{AdaptiveTiming, AdaptiveTimingConfig, Endianness, ProtocolSettings};
+use crate::ini::{AdaptiveTiming, AdaptiveTimingConfig, Endianness, EcuType, ProtocolSettings};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
 /// Parse a command string with escape sequences into raw bytes
 /// Handles: \xNN (hex), \n, \r, \t, \\, \0, and regular characters
@@ -324,6 +326,13 @@ pub struct Connection {
     /// Page targeted by the most recent successful write, used by the auto-burn-on-page-change
     /// safety policy (msEnvelope_1.0 spec §6.2). `None` after construction or after a burn.
     last_written_page: Option<u8>,
+    /// ECU type detected from the INI signature (Issue #71).
+    /// Drives conservative runtime-command selection for Speeduino/MS2/MS3.
+    ecu_type: EcuType,
+    /// Cancellation flag shared with the owner (Tauri AppState). When set, all
+    /// blocking I/O polling loops abort early so `disconnect()` can complete even
+    /// while another thread is mid-read (Issue #71: "disconnect does nothing").
+    cancel: Arc<AtomicBool>,
 }
 
 impl Connection {
@@ -346,6 +355,8 @@ impl Connection {
             tx_packets: 0,
             rx_packets: 0,
             last_written_page: None,
+            ecu_type: EcuType::Unknown,
+            cancel: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -377,6 +388,8 @@ impl Connection {
             tx_packets: 0,
             rx_packets: 0,
             last_written_page: None,
+            ecu_type: EcuType::Unknown,
+            cancel: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -387,6 +400,30 @@ impl Connection {
         self.command_builder = CommandBuilder::new(endianness == Endianness::Little);
         self.endianness = endianness;
         self.protocol_settings = Some(protocol);
+    }
+
+    /// Set the detected ECU type (called after the INI is loaded, Issue #71).
+    /// Drives conservative runtime-command selection for Speeduino/MS2/MS3.
+    pub fn set_ecu_type(&mut self, ecu_type: EcuType) {
+        self.ecu_type = ecu_type;
+    }
+
+    /// Get the detected ECU type.
+    pub fn ecu_type(&self) -> EcuType {
+        self.ecu_type
+    }
+
+    /// Get a clone of the cancellation handle. The owner (e.g. Tauri AppState)
+    /// can call `request_cancel()` on its clone to interrupt in-flight blocking
+    /// I/O so `disconnect()` is not blocked by a streaming task mid-read.
+    pub fn cancel_handle(&self) -> Arc<AtomicBool> {
+        Arc::clone(&self.cancel)
+    }
+
+    /// Request cancellation of any in-flight blocking I/O. Safe to call from a
+    /// different thread than the one performing the read (Issue #71).
+    pub fn request_cancel(&self) {
+        self.cancel.store(true, Ordering::Relaxed);
     }
 
     /// Get cumulative tx/rx bytes and packet counters
@@ -590,10 +627,18 @@ impl Connection {
     }
 
     /// Disconnect from the ECU
+    ///
+    /// Sets the cancellation flag first so any blocking I/O polling loop running
+    /// in another thread (e.g. the realtime stream task) aborts its current
+    /// read promptly instead of waiting for the full timeout (Issue #71).
     pub fn disconnect(&mut self) {
+        // Signal in-flight blocking reads to abort.
+        self.cancel.store(true, Ordering::Relaxed);
         self.channel = None;
         self.signature = None;
         self.state = ConnectionState::Disconnected;
+        // Reset the flag so a reconnect starts clean.
+        self.cancel.store(false, Ordering::Relaxed);
     }
 
     /// Perform handshake and get ECU signature
@@ -732,6 +777,9 @@ impl Connection {
         } else {
             2
         };
+        // Clone the cancel handle before borrowing the channel so the cancel check
+        // in the read loop does not conflict with the mutable channel borrow.
+        let cancel = Arc::clone(&self.cancel);
 
         let channel = self.channel.as_mut().ok_or(ProtocolError::NotConnected)?;
 
@@ -770,6 +818,14 @@ impl Connection {
             if start.elapsed() > timeout {
                 eprintln!("[DEBUG] send_raw_command: overall timeout reached");
                 break;
+            }
+
+            // Cancellation check (Issue #71): abort promptly if disconnect() was called
+            // while this blocking read is in flight.
+            if cancel.load(Ordering::Relaxed) {
+                eprintln!("[DEBUG] send_raw_command: cancelled by disconnect");
+                self.reset_adaptive_timing_on_error();
+                return Err(ProtocolError::ConnectionClosed);
             }
 
             // Check how many bytes are available without blocking
@@ -963,6 +1019,9 @@ impl Connection {
         } else {
             2
         };
+        // Clone the cancel handle before borrowing the channel so the disjoint
+        // borrow of self.cancel does not conflict with the mutable channel borrow.
+        let cancel = Arc::clone(&self.cancel);
 
         let channel = self.channel.as_mut().ok_or(ProtocolError::NotConnected)?;
 
@@ -989,6 +1048,7 @@ impl Connection {
             buf: &mut [u8],
             timeout: Duration,
             poll_ms: u64,
+            cancel: &AtomicBool,
         ) -> Result<(), ProtocolError> {
             let start = Instant::now();
             let mut offset = 0;
@@ -1001,6 +1061,12 @@ impl Connection {
                         buf.len()
                     );
                     return Err(ProtocolError::Timeout);
+                }
+
+                // Cancellation check (Issue #71): abort promptly if disconnect() was called.
+                if cancel.load(Ordering::Relaxed) {
+                    eprintln!("[DEBUG] read_exact_timeout: cancelled by disconnect");
+                    return Err(ProtocolError::ConnectionClosed);
                 }
 
                 // Check how many bytes are available
@@ -1042,7 +1108,9 @@ impl Connection {
 
         // Read response header (2 bytes for length)
         let mut header = [0u8; 2];
-        if let Err(e) = read_exact_timeout(channel, &mut header, timeout, poll_interval_ms) {
+        if let Err(e) =
+            read_exact_timeout(channel, &mut header, timeout, poll_interval_ms, &cancel)
+        {
             // Drain any buffered bytes first (uses channel borrow), then reset timing
             let _ = channel.clear_input_buffer();
             self.reset_adaptive_timing_on_error();
@@ -1062,8 +1130,13 @@ impl Connection {
 
         // Read payload + CRC
         let mut payload_and_crc = vec![0u8; length + 4];
-        if let Err(e) = read_exact_timeout(channel, &mut payload_and_crc, timeout, poll_interval_ms)
-        {
+        if let Err(e) = read_exact_timeout(
+            channel,
+            &mut payload_and_crc,
+            timeout,
+            poll_interval_ms,
+            &cancel,
+        ) {
             // Drain the rest of the packet body (uses channel borrow), then reset timing
             drain_input_with_timeout(
                 channel,
@@ -1095,6 +1168,17 @@ impl Connection {
     }
 
     /// Decide which runtime fetch command to use (Burst vs OCH)
+    /// Decide which runtime fetch command to use (Burst vs OCH)
+    ///
+    /// **Issue #71 fix**: For Speeduino / MegaSquirt (MS2/MS3), the Burst ('A')
+    /// command is the well-tested, high-throughput path (observed ~1 KB/sec).
+    /// Auto mode previously could silently switch to OCH based on loose
+    /// heuristics (maxUnusedRuntimeRange, slow-link, adaptive-timing averages),
+    /// collapsing throughput to ~13 B/sec and stalling gauges. These ECUs now
+    /// stay on Burst unless the user explicitly forces OCH.
+    ///
+    /// For rusEFI / FOME / epicEFI (little-endian, msEnvelope_1.0), OCH is the
+    /// standard modern realtime path, so the existing heuristics are retained.
     pub fn choose_runtime_command(&self) -> (RuntimeFetch, String) {
         // Respect explicit overrides
         let forced = self.config.runtime_packet_mode;
@@ -1131,7 +1215,29 @@ impl Connection {
             );
         }
 
-        // Auto heuristics
+        // === Auto mode ===
+        //
+        // For Speeduino / MS2 / MS3 (big-endian, classic MegaSquirt lineage),
+        // Burst ('A') is the canonical high-throughput realtime path. The OCH
+        // heuristics below were observed to mis-select OCH on real Speeduino
+        // 202501 hardware, dropping throughput from ~1 KB/sec to ~13 B/sec
+        // (Issue #71). Lock these ECUs to Burst in Auto mode.
+        let burst_ecu = matches!(
+            self.ecu_type,
+            EcuType::Speeduino | EcuType::MS2 | EcuType::MS3 | EcuType::Unknown
+        );
+
+        // Unknown ECU type: also default to Burst to be safe. Only rusEFI-lineage
+        // ECUs (detected from the INI signature) are allowed to auto-select OCH.
+        if burst_ecu {
+            return (
+                RuntimeFetch::Burst(burst_cmd),
+                format!("auto: Burst (ecu={})", self.ecu_type.display_name()),
+            );
+        }
+
+        // rusEFI / FOME / epicEFI: apply the original heuristics to choose OCH.
+
         // 1) INI hint: maxUnusedRuntimeRange > 0 => prefer OCH if available
         if let Some(p) = &self.protocol_settings {
             if p.max_unused_runtime_range > 0 {
@@ -1189,6 +1295,35 @@ impl Connection {
     /// Get real-time data from ECU
     pub fn get_realtime_data(&mut self) -> Result<Vec<u8>, ProtocolError> {
         let (choice, _reason) = self.choose_runtime_command();
+
+        // Safety net (Issue #71): if Auto/forced OCH was selected but the INI
+        // did not declare a valid och_block_size, the OCH command cannot be
+        // framed correctly and the ECU will return a mis-sized response that
+        // stalls the stream. Fall back to Burst instead of guessing 256 bytes.
+        let choice = match &choice {
+            RuntimeFetch::OCH(_) => {
+                let och_block_size = self
+                    .protocol_settings
+                    .as_ref()
+                    .map(|p| p.och_block_size)
+                    .unwrap_or(0);
+                if och_block_size == 0 {
+                    eprintln!(
+                        "[WARN] get_realtime_data: OCH selected but och_block_size=0, \
+                         falling back to Burst to avoid stream stall (Issue #71)"
+                    );
+                    let burst_cmd = self
+                        .protocol_settings
+                        .as_ref()
+                        .and_then(|p| p.burst_get_command.clone())
+                        .unwrap_or_else(|| "A".to_string());
+                    RuntimeFetch::Burst(burst_cmd)
+                } else {
+                    choice
+                }
+            }
+            _ => choice,
+        };
 
         match choice {
             RuntimeFetch::Burst(cmd) => {
@@ -2208,9 +2343,12 @@ mod tests {
 
     #[test]
     fn test_choose_runtime_command_rfcomm() {
+        // rusEFI keeps the slow-link heuristic (Issue #71: Speeduino/Unknown now
+        // stay on Burst regardless of link speed).
         let mut cfg = ConnectionConfig::default();
         cfg.port_name = "rfcomm0".to_string();
         let mut conn = Connection::new(cfg);
+        conn.set_ecu_type(EcuType::RusEFI);
         let mut proto = ProtocolSettings::default();
         proto.och_get_command = Some("O".to_string());
         proto.burst_get_command = Some("A".to_string());
@@ -2226,6 +2364,66 @@ mod tests {
                 || reason.contains("slow")
                 || reason.contains("adaptive")
         );
+    }
+
+    /// Issue #71: Speeduino (and MS2/MS3/Unknown) must stay on Burst in Auto mode
+    /// even when the INI declares maxUnusedRuntimeRange, a slow link, or slow
+    /// adaptive-timing averages — these heuristics previously collapsed
+    /// throughput to ~13 B/sec on real Speeduino 202501 hardware.
+    #[test]
+    fn test_speeduino_auto_stays_on_burst() {
+        for ecu in [
+            EcuType::Speeduino,
+            EcuType::MS2,
+            EcuType::MS3,
+            EcuType::Unknown,
+        ] {
+            // Slow link (rfcomm) + INI hint + slow adaptive timing all set.
+            let mut cfg = ConnectionConfig::default();
+            cfg.port_name = "rfcomm0".to_string();
+            let mut conn = Connection::new(cfg);
+            conn.set_ecu_type(ecu);
+            let mut proto = ProtocolSettings::default();
+            proto.och_get_command = Some("O".to_string());
+            proto.burst_get_command = Some("A".to_string());
+            proto.max_unused_runtime_range = 999; // would normally trigger OCH
+            conn.set_protocol(proto, Endianness::Big);
+            // Slow adaptive timing average that would normally trigger OCH.
+            conn.enable_adaptive_timing(None);
+            conn.record_response_time(std::time::Duration::from_millis(200));
+            conn.record_response_time(std::time::Duration::from_millis(180));
+
+            let (choice, reason) = conn.choose_runtime_command();
+            match &choice {
+                RuntimeFetch::Burst(cmd) => assert_eq!(cmd, "A"),
+                _ => panic!("{:?} should use Burst in Auto, got {:?}", ecu, choice),
+            }
+            assert!(
+                reason.contains("Burst"),
+                "unexpected reason for {:?}: {}",
+                ecu,
+                reason
+            );
+        }
+    }
+
+    /// Issue #71: ForceOCH must still override the Speeduino Burst default so the
+    /// user can manually select OCH when appropriate.
+    #[test]
+    fn test_speeduino_force_och_override() {
+        let mut cfg = ConnectionConfig::default();
+        cfg.runtime_packet_mode = RuntimePacketMode::ForceOCH;
+        let mut conn = Connection::new(cfg);
+        conn.set_ecu_type(EcuType::Speeduino);
+        let mut proto = ProtocolSettings::default();
+        proto.och_get_command = Some("O".to_string());
+        proto.burst_get_command = Some("A".to_string());
+        conn.set_protocol(proto, Endianness::Big);
+        let (choice, _) = conn.choose_runtime_command();
+        match choice {
+            RuntimeFetch::OCH(cmd) => assert_eq!(cmd, "O"),
+            _ => panic!("ForceOCH should override Speeduino Burst default"),
+        }
     }
 
     #[test]
@@ -2255,8 +2453,10 @@ mod tests {
 
     #[test]
     fn test_adaptive_switch_to_och() {
+        // rusEFI keeps the adaptive-timing heuristic (Issue #71).
         let cfg = ConnectionConfig::default();
         let mut conn = Connection::new(cfg);
+        conn.set_ecu_type(EcuType::RusEFI);
         let mut proto = ProtocolSettings::default();
         proto.och_get_command = Some("O".to_string());
         proto.burst_get_command = Some("A".to_string());

--- a/crates/libretune-core/src/protocol/error.rs
+++ b/crates/libretune-core/src/protocol/error.rs
@@ -17,6 +17,11 @@ pub enum ProtocolError {
     #[error("Connection failed: {0}")]
     ConnectionFailed(String),
 
+    /// Connection was closed/cancelled mid-operation (e.g. user-initiated disconnect
+    /// interrupted a blocking read). Used by the cancellation mechanism (Issue #71).
+    #[error("Connection closed")]
+    ConnectionClosed,
+
     #[error("Already connected")]
     AlreadyConnected,
 

--- a/docs/src/getting-started/connecting.md
+++ b/docs/src/getting-started/connecting.md
@@ -40,12 +40,21 @@ If you don't see your ECU's port:
 
 ### Runtime Packet Mode (Auto behavior)
 
-If your **Runtime Packet Mode** setting is set to **Auto**, LibreTune will choose the best fetch mode for the current INI on connect:
+If your **Runtime Packet Mode** setting is set to **Auto**, LibreTune chooses the
+best fetch mode based on the detected ECU type and the loaded INI:
 
-- If the loaded INI defines an OCH block read (`ochGetCommand` / `ochBlockSize`), LibreTune will prefer **Force OCH** for read efficiency.
-- Otherwise, the app will fall back to **Force Burst** for compatibility.
+- **Speeduino / MegaSquirt (MS2 / MS3)** — Auto always selects **Force Burst**
+  (the `A` command). Burst is the high-throughput, well-tested realtime path for
+  these ECUs. Switching to OCH automatically caused throughput to collapse and
+  gauges to stall on some firmware, so Auto no longer does so.
+- **rusEFI / FOME / epicEFI** — Auto may select **Force OCH** when the loaded INI
+  defines an OCH block read (`ochGetCommand` / `ochBlockSize`), or when the link
+  is slow (Bluetooth / low baud) or measured response times are high.
 
-You can override the automatic choice in the Settings dialog by selecting a specific runtime packet mode (Auto / Force Burst / Force OCH / Disabled).
+You can override the automatic choice at any time in the Settings dialog by
+selecting a specific runtime packet mode (**Auto / Force Burst / Force OCH /
+Disabled**). If your gauges stall or report invalid values in Auto mode, try
+**Force Burst** first.
 
 
 ### Auto-sync & Reconnect After Controller Commands

--- a/docs/src/reference/troubleshooting.md
+++ b/docs/src/reference/troubleshooting.md
@@ -48,6 +48,28 @@ Common problems and solutions.
 4. Check for electrical noise sources
 5. Try different USB port
 
+### Gauges Stall / Invalid Values / Slow Data
+
+**Symptoms**: Gauges freeze or show no changes; Rx rate is very low in Auto mode
+(e.g. ~13 B/sec where Force Burst gives ~1 KB/sec); the Disconnect button does
+nothing; opening a table stays on "Loading…"; the line graph stops scrolling
+until the value changes.
+
+**Solutions**:
+1. Set **Runtime Packet Mode** to **Force Burst** (Settings dialog). For
+   Speeduino / MegaSquirt (MS2/MS3), Burst is the high-throughput realtime path;
+   Auto mode now selects it automatically, but forcing it rules out any
+   mis-detection.
+2. If gauges still stall, click **Disconnect** and reconnect. Disconnect now
+   aborts in-flight serial reads instead of hanging.
+3. Verify the loaded INI matches your firmware version (a signature mismatch can
+   mis-size the realtime block).
+4. Check the baud rate matches your ECU (Speeduino / rusEFI / epicEFI / MS2 / MS3
+   all default to 115200).
+5. For Bluetooth or low-baud links, **Force OCH** may be more efficient on
+   rusEFI-family ECUs — but avoid it on Speeduino/MS unless you know your firmware
+   supports it.
+
 ## Table Editing Issues
 
 ### Values Not Saving


### PR DESCRIPTION
## Summary

Fixes #71.

Addresses the communication bug where data logging stalls, gauges show invalid values, and the Disconnect button does nothing on Speeduino (and other MegaSquirt-lineage ECUs).

## Problem

Reporter (@HondaRulez) observed on Speeduino 202501 (Windows 11 & Linux/Void):
- **Auto mode**: Rx stalls around **13 B/s** (always on Linux, sometimes Windows)
- **Force Burst**: ~1.1 KB/s (works)
- Gauges stall / show no changes; occasionally work until a reconnect
- Disconnect button sometimes does nothing while stalled
- Opening a table view while stalled shows "Loading…" indefinitely
- Line graph stops scrolling until the next value change

## Root cause

1. **Auto mode mis-selected OCH for Speeduino.** `choose_runtime_command` could switch Speeduino/MS2/MS3 from Burst (`A`, ~1 KB/s) to OCH based on loose heuristics (`maxUnusedRuntimeRange`, slow-link baud/port, adaptive-timing averages). On real Speeduino hardware this collapsed throughput to ~13 B/s.
2. **OCH with no `ochBlockSize`.** When the INI declared no block size, `get_realtime_data` guessed 256 bytes, producing a mis-sized response that stalled the stream.
3. **Disconnect deadlock.** The realtime stream task holds the connection mutex during *blocking* serial I/O. Tokio `task::abort()` only fires at the next `.await`, so `disconnect_ecu`'s `lock().await` hung — "disconnect does nothing".
4. **Line graph freeze.** `realtimeStore` skipped writing duplicate values to the history buffer, so a constant channel froze the trace.
5. **No stream restart after clear.** The heartbeat only restarted the backend stream when `lastUpdateTime > 0`.

## Changes

### Backend (`libretune-core`)
- `choose_runtime_command` now **locks Speeduino / MS2 / MS3 / Unknown to Burst in Auto mode**. rusEFI / FOME / epicEFI retain the original OCH heuristics.
- `get_realtime_data` **falls back to Burst** when `ochBlockSize` is unset instead of guessing 256.
- Added a `Connection` **cancel flag** (`Arc<AtomicBool>`) checked by the blocking read loops (`send_raw_command`, `send_packet`/`read_exact_timeout`) so an in-flight read aborts promptly when disconnect is requested.
- `Connection::disconnect()` sets the cancel flag before dropping the channel.
- Added `ProtocolError::ConnectionClosed`.
- Added `ecu_type()` / `set_ecu_type()` / `cancel_handle()` / `request_cancel()` accessors.

### Backend (`libretune-app`)
- `connect_to_ecu` extracts `ecu_type` from the loaded INI definition and applies it.
- `disconnect_ecu` **polls the connection lock with a 3-second deadline** instead of a blocking `lock().await`, so a stuck streaming task no longer hangs disconnect.

### Frontend (`libretune-app/src`)
- `realtimeStore` history buffer **appends every sample** (removed the duplicate-value `continue`), so line graphs scroll on flat signals.
- `useRealtimeStream` heartbeat **restarts the stream even when `lastUpdateTime === 0`** (post-clear / fresh connect).

### Docs
- Updated `connecting.md` Auto-mode behavior (ECU-aware Burst/OCH selection).
- Added a "Gauges Stall / Invalid Values / Slow Data" troubleshooting section.

## Testing

- Updated the 2 existing OCH-heuristic tests to pin `EcuType::RusEFI` (Unknown now defaults to Burst).
- Added `test_speeduino_auto_stays_on_burst` (covers Speeduino/MS2/MS3/Unknown across slow-link + INI-hint + adaptive-timing conditions) and `test_speeduino_force_och_override` (user override still works).
- **All 295 workspace tests pass** (277 core + 18 app); `cargo clippy` clean.

```text
test result: ok. 277 passed; 0 failed; 0 ignored  (libretune-core)
test result: ok. 18 passed; 0 failed; 0 ignored   (libretune-app)
```

## Notes / out of scope

- The user overrides (**Force Burst / Force OCH**) remain fully functional as escape hatches.
- Truly *immediate* cancel (within the current blocking `std::thread::sleep` poll) would require threading the cancel handle through `AppState`; the current deadline-poll waits up to one read timeout (~1s) in the pathological case. With the Auto→Burst fix, ticks complete in ~50ms, so disconnect completes quickly in practice.

## Manual validation checklist

- [ ] Connect to Speeduino in **Auto** mode → Rx rate matches Force Burst (~1 KB/s)
- [ ] Hold a sensor value steady → line graph scrolls smoothly
- [ ] Click Disconnect during active streaming → completes within ~1s
- [ ] Open a table while streaming → loads without "Loading…" hang