### PR TITLE
ci: bump deprecated Node.js 20 actions to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  
 
 jobs:
   rust-check:
@@ -17,7 +18,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -31,7 +32,7 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libgtk-3-dev libudev-dev
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -56,7 +57,7 @@ jobs:
     name: Security Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -101,12 +102,12 @@ jobs:
       run:
         working-directory: crates/libretune-app
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: crates/libretune-app/package-lock.json
 
@@ -126,7 +127,7 @@ jobs:
     name: Format Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -139,7 +140,7 @@ jobs:
     name: AppImage Structure Validation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -150,9 +151,9 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libgtk-3-dev libudev-dev libfuse2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: crates/libretune-app/package-lock.json
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,7 +20,7 @@ jobs:
       has_changes: ${{ steps.check.outputs.has_changes }}
       date_stamp: ${{ steps.date.outputs.date }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0  # Need full history to check commits
 
@@ -46,7 +46,7 @@ jobs:
     if: needs.check-changes.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -57,7 +57,7 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libgtk-3-dev libudev-dev
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -72,9 +72,9 @@ jobs:
         run: cargo test --workspace
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: crates/libretune-app/package-lock.json
 
@@ -91,7 +91,7 @@ jobs:
     needs: [check-changes, test]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -108,9 +108,9 @@ jobs:
             libudev-dev
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: crates/libretune-app/package-lock.json
 
@@ -172,15 +172,15 @@ jobs:
     needs: [check-changes, test]
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: crates/libretune-app/package-lock.json
 
@@ -225,15 +225,15 @@ jobs:
     needs: [check-changes, test]
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: crates/libretune-app/package-lock.json
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,8 @@ jobs:
     outputs:
       tag_name: ${{ steps.get_version.outputs.VERSION || 'manual' }}
     steps:
-      - uses: actions/checkout@v4
-      
+      - uses: actions/checkout@v5
+
       - name: Get version from tag
         id: get_version
         if: startsWith(github.ref, 'refs/tags/')
@@ -30,7 +30,7 @@ jobs:
     needs: create-release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -47,9 +47,9 @@ jobs:
             libudev-dev
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: crates/libretune-app/package-lock.json
 
@@ -104,15 +104,15 @@ jobs:
     needs: create-release
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: crates/libretune-app/package-lock.json
 
@@ -164,15 +164,15 @@ jobs:
     needs: create-release
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: crates/libretune-app/package-lock.json
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,22 @@ relevant.
 
 ## [Unreleased]
 
+### 2026-07-27 — CI: drop deprecated Node.js 20 actions
+
+#### Fixed
+- **CI failing on the Node.js 20 deprecation** — GitHub Actions deprecated the
+  Node.js 20 runtime (the runner now force-migrates Node-20 actions to Node 24
+  and emits a warning that fails the check job). Bumped the affected first-party
+  actions from `@v4` (Node 20) to `@v5` (Node 24) across `ci.yml`, `nightly.yml`,
+  and `release.yml`: `actions/checkout`, `actions/cache`, `actions/setup-node`.
+  See
+  https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+
+#### Changed
+- **Frontend build Node version aligned to 24** — the `setup-node` `node-version`
+  in all workflows is now `'24'` (current LTS), replacing `'22'`, so the runner
+  Node and the action runtime match.
+
 ### 2026-07-23 — Safe project→ECU tune apply (no reconnect brick)
 
 #### Fixed


### PR DESCRIPTION
## Summary

Fixes the CI failure caused by the GitHub Actions **Node.js 20 deprecation** — the runner now force-migrates Node-20 actions to Node 24 and emits a warning that fails the check job.

> \Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/cache@v4, actions/checkout@v4.\

Ref: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## Changes

Bumped the affected first-party actions from \@v4\ (Node 20) **\u2192 \@v5\** (Node 24) across all three workflow files:

| Action | Before | After |
| --- | --- | --- |
| \ctions/checkout\ | \@v4\ | \@v5\ |
| \ctions/cache\ | \@v4\ | \@v5\ |
| \ctions/setup-node\ | \@v4\ | \@v5\ |

Files: \.github/workflows/ci.yml\, \
ightly.yml\, \elease.yml\

Also aligned the \setup-node\ \
ode-version\ to \'24'\ (current LTS) in all workflows so the runner Node and the action runtime match.

\ctions/upload-artifact@v6\ and \dtolnay/rust-toolchain@stable\ were already on supported runtimes and are untouched.

## Why \5\

These actions\ \4\ majors are built on the Node.js 20 runtime, which GitHub deprecated on the hosted runners. \5\ switches them to the Node.js 24 runtime, resolving the deprecation warning natively rather than via the forced migration.

## Checklist

- [x] \ci.yml\ updated
- [x] \
ightly.yml\ updated (same issue, would fail on next run)
- [x] \elease.yml\ updated (same issue, would fail on next tag)
- [x] CHANGELOG entry added

## Testing

No code changes — workflow-only. The deprecation warning will be gone on the next CI run, and the actions will execute natively on Node 24.