### PR TITLE
fix(protocol): resolve remaining Issue #71 stalls and line-graph scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ relevant.
   ~13 B/s and froze the gauges. Auto mode now locks these ECUs to Burst; rusEFI /
   FOME / epicEFI retain the original OCH heuristics. Unknown ECU types also
   default to Burst for safety.
+- **Frontend Auto mode still forced OCH** — `App.tsx` preemptively converted
+  "Auto" to "ForceOCH" whenever the INI declared `ochBlockSize > 0`, bypassing
+  the backend's ECU-aware selection and re-creating the stall on Speeduino. Auto
+  is now passed through untouched so the backend can lock Speeduino/MS2/MS3 to
+  Burst.
 - **OCH fallback when `ochBlockSize` is unset** — `get_realtime_data` now falls
   back to Burst instead of guessing a 256-byte block when the INI declares no
   `ochBlockSize`, avoiding a mis-sized response that stalled the stream.
@@ -35,7 +40,10 @@ relevant.
   promptly. Added `ProtocolError::ConnectionClosed`.
 - **Line graph stopped scrolling on flat values** — `realtimeStore`'s history
   buffer skipped writing duplicate values, so a constant channel froze the trace.
-  It now appends every sample.
+  It now appends every sample. Additionally, `useGaugeRenderer` kept the rAF
+  loop idle once the animated value converged; LineGraph/Histogram/MultiChannelTrend
+  gauges now keep rendering at a throttled rate so the time-series trace keeps
+  scrolling on steady sources.
 - **Realtime stream not restarted after clear** — `useRealtimeStream`'s heartbeat
   only restarted the backend stream when `lastUpdateTime > 0`; it now also
   restarts when no update has been seen shortly after connect/clear.

--- a/crates/libretune-app/src/App.tsx
+++ b/crates/libretune-app/src/App.tsx
@@ -781,20 +781,12 @@ function AppContent() {
         : availablePorts[0];
 
       // Connect and get mismatch info directly (no async race)
-      let runtimeMode = connectionRuntimePacketMode || defaultRuntimePacketMode;
-
-      // If runtime mode is Auto, try to detect best mode from INI capabilities
-      if (runtimeMode === 'Auto') {
-        try {
-          // Attempt to query backend capabilities directly. If a definition isn't loaded
-          // the command will error and we'll fall back to a safe default.
-          const caps = await invoke<{ supports_och: boolean }>('get_protocol_capabilities');
-          runtimeMode = caps && caps.supports_och ? 'ForceOCH' : 'ForceBurst';
-        } catch (e) {
-          console.warn('Runtime mode auto-detect failed, defaulting to ForceBurst:', e);
-          runtimeMode = 'ForceBurst';
-        }
-      }
+      // Issue #71 follow-up: the backend's choose_runtime_command already
+      // implements ECU-aware Auto selection (Speeduino/MS2/MS3/Unknown stay on
+      // Burst; rusEFI/FOME/epicEFI use OCH heuristics). Preemptively forcing
+      // OCH here based only on INI och_block_size bypassed that safeguard and
+      // collapsed Speeduino throughput to ~14 B/s. Pass Auto through untouched.
+      const runtimeMode = connectionRuntimePacketMode || defaultRuntimePacketMode;
 
       const result = await invoke<ConnectResult>("connect_to_ecu", { 
         portName: portToUse, 

--- a/crates/libretune-app/src/__tests__/App.integration.test.tsx
+++ b/crates/libretune-app/src/__tests__/App.integration.test.tsx
@@ -227,7 +227,7 @@ describe('App integration (toolbar connection-info)', () => {
     expect(screen.queryByText('INI Signature Mismatch')).toBeNull();
   });
 
-  it('auto-selects runtime packet mode (Auto → ForceOCH when INI supports OCH)', async () => {
+  it('passes Auto runtime packet mode through to the backend (Issue #71)', async () => {
     let connectArgs: any = null;
 
     (invoke as unknown as any).mockImplementation((cmd: string, args?: any) => {
@@ -239,7 +239,8 @@ describe('App integration (toolbar connection-info)', () => {
         case 'get_protocol_defaults':
           return Promise.resolve({ default_baud_rate: 115200, timeout_ms: 2000 });
         case 'get_protocol_capabilities':
-          // Simulate INI that supports OCH
+          // The frontend no longer consults this for Auto mode; the backend
+          // choose_runtime_command is ECU-aware and selects appropriately.
           return Promise.resolve({ supports_och: true });
         case 'connect_to_ecu':
           connectArgs = args;
@@ -281,9 +282,10 @@ describe('App integration (toolbar connection-info)', () => {
     const dialogConnect = await screen.findByText('Connect');
     dialogConnect.click();
 
-    // Wait for connect_to_ecu to be called and assert runtimePacketMode chosen
+    // Wait for connect_to_ecu to be called and assert Auto is left untouched
+    // so the backend's ECU-aware choose_runtime_command can decide.
     await waitFor(() => expect(connectArgs).not.toBeNull());
-    expect(connectArgs.runtimePacketMode).toBe('ForceOCH');
+    expect(connectArgs.runtimePacketMode).toBe('Auto');
 
   });
 });

--- a/crates/libretune-app/src/components/gauges/TsGauge.tsx
+++ b/crates/libretune-app/src/components/gauges/TsGauge.tsx
@@ -212,12 +212,19 @@ function TsGaugeInner({ config, value, embeddedImages, legacyMode = false, overr
     [config, legacyMode, getEmbeddedImage, getValueColor, getFontSpec, getFontFamily],
   );
 
+  // Time-series painters must keep repainting so the trace scrolls left even
+  // when the channel value is constant (Issue #71).
+  const continuousRender = ['LineGraph', 'Histogram', 'MultiChannelTrend'].includes(
+    config.gauge_painter,
+  );
+
   const { canvasRef, displayValueRef } = useGaugeRenderer({
     config,
     value,
     overrideStore,
     enabled: fontsReady && imagesReady,
     paint,
+    continuousRender,
   });
 
   return (

--- a/crates/libretune-app/src/components/gauges/useGaugeRenderer.ts
+++ b/crates/libretune-app/src/components/gauges/useGaugeRenderer.ts
@@ -53,6 +53,14 @@ export interface UseGaugeRendererOptions {
   enabled: boolean;
   /** Per-frame painter — called with the current display value. */
   paint: GaugePaintFn;
+  /**
+   * When true, the rAF loop keeps running at a throttled rate even after the
+   * animated value has converged. Required for time-series painters (LineGraph,
+   * Histogram, MultiChannelTrend) so the trace keeps scrolling when the channel
+   * value is steady — the underlying history buffer receives a new sample every
+   * tick, but the visual only updates if we keep repainting.
+   */
+  continuousRender?: boolean;
 }
 
 export interface UseGaugeRendererResult {
@@ -76,7 +84,7 @@ export interface UseGaugeRendererResult {
 }
 
 export function useGaugeRenderer(opts: UseGaugeRendererOptions): UseGaugeRendererResult {
-  const { config, value, overrideStore, enabled, paint } = opts;
+  const { config, value, overrideStore, enabled, paint, continuousRender } = opts;
 
   const canvasRef = useRef<HTMLCanvasElement>(null);
 
@@ -250,8 +258,19 @@ export function useGaugeRenderer(opts: UseGaugeRendererOptions): UseGaugeRendere
         peakValueRef.current = target;
       }
       const diff = target - displayValueRef.current;
+      const keepAlive = continuousRender && !overrideStoreRef.current && channel;
       if (Math.abs(diff) > epsilon) {
         displayValueRef.current = displayValueRef.current + diff * ANIMATION_LERP;
+        if (timestamp - lastDrawTimeRef.current >= DRAW_INTERVAL_MS) {
+          drawFrame();
+          lastDrawTimeRef.current = timestamp;
+        }
+        rafIdRef.current = requestAnimationFrame(animate);
+      } else if (keepAlive) {
+        // Time-series painters need continuous redraws so the trace scrolls
+        // even when the channel value is constant. Snap to target and throttle
+        // drawing to the configured frame interval to avoid burning CPU.
+        displayValueRef.current = target;
         if (timestamp - lastDrawTimeRef.current >= DRAW_INTERVAL_MS) {
           drawFrame();
           lastDrawTimeRef.current = timestamp;
@@ -314,6 +333,7 @@ export function useGaugeRenderer(opts: UseGaugeRendererOptions): UseGaugeRendere
     config.max,
     config.peg_limits,
     config.antialiasing_on,
+    continuousRender,
   ]);
 
   return { canvasRef, displayValueRef, peakValueRef };

--- a/crates/libretune-app/src/setupTests.ts
+++ b/crates/libretune-app/src/setupTests.ts
@@ -1,5 +1,21 @@
 import '@testing-library/jest-dom';
 
+// Provide a minimal localStorage stub for jsdom environments where it is missing.
+if (typeof globalThis.localStorage === 'undefined') {
+  const store: Record<string, string> = {};
+  globalThis.localStorage = {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = String(value); },
+    removeItem: (key: string) => { delete store[key]; },
+    clear: () => { Object.keys(store).forEach((k) => { delete store[k]; }); },
+    key: (index: number) => Object.keys(store)[index] ?? null,
+    length: 0,
+  } as Storage;
+  Object.defineProperty(globalThis.localStorage, 'length', {
+    get: () => Object.keys(store).length,
+  });
+}
+
 // Provide a minimal ResizeObserver stub for jsdom (not available in JSDOM)
 if (typeof globalThis.ResizeObserver === 'undefined') {
   globalThis.ResizeObserver = class ResizeObserver {

--- a/crates/libretune-core/src/protocol/connection.rs
+++ b/crates/libretune-core/src/protocol/connection.rs
@@ -1326,7 +1326,16 @@ impl Connection {
 
         match choice {
             RuntimeFetch::Burst(cmd) => {
-                if self.use_modern_protocol {
+                // Issue #71 follow-up: Speeduino / MS2 / MS3 / Unknown must use the
+                // legacy raw-ASCII Burst path even if the handshake or INI somehow
+                // left use_modern_protocol enabled. These ECUs do not accept a
+                // CRC-framed Burst request. rusEFI/FOME/epicEFI keep CRC framing
+                // when modern protocol is active.
+                let force_raw_burst = matches!(
+                    self.ecu_type,
+                    EcuType::Speeduino | EcuType::MS2 | EcuType::MS3 | EcuType::Unknown
+                );
+                if self.use_modern_protocol && !force_raw_burst {
                     let expected_len = self
                         .protocol_settings
                         .as_ref()


### PR DESCRIPTION
## Summary

Follow-up fix for #71. After #78 was merged, @HondaRulez reported that Auto mode still stalls at ~14 B/s on connect and that line graphs still do not scroll on steady sources (Linux). This PR addresses both remaining issues.

## What changed

### Backend (`libretune-core`)

- **Hardened Burst path for Speeduino/MS2/MS3/Unknown**: `get_realtime_data` now forces the legacy raw-ASCII Burst path for these ECU types even if `use_modern_protocol` is enabled. They do not accept CRC-framed Burst requests, so this removes another path that could collapse throughput.

### Frontend (`libretune-app`)

- **Stop forcing OCH from Auto mode**: `App.tsx` was converting "Auto" to "ForceOCH" whenever the INI declared `ochBlockSize > 0`. This bypassed the backend's ECU-aware selection and sent Speeduino down the slow OCH path. Auto is now passed through untouched so the backend can lock Speeduino/MS2/MS3 to Burst.
- **Keep time-series gauges rendering on steady values**: `useGaugeRenderer` went idle once the animated value converged, so LineGraph/Histogram/MultiChannelTrend froze when a channel stayed constant. Added a `continuousRender` option that keeps the rAF loop running at a throttled rate for those painters.

### Test / QA

- Updated `App.integration.test.tsx` to assert that Auto mode is passed through to the backend.
- Added a `localStorage` stub in `setupTests.ts` to fix jsdom test failures.
- Updated `CHANGELOG.md`.

## Test results

- `cargo test -p libretune-core --lib` — 277 passed
- `cargo test -p libretune-core --test protocol` — 10 passed
- `cargo clippy -p libretune-core -p libretune-app -- -D warnings` — clean
- `cargo fmt --check` — clean
- `npm run typecheck` — clean
- `npm run test:run` — 85 passed

> Note: `cargo test --workspace` exhausts the Windows linker (`LNK1102: out of memory`) on this machine, so crate-level tests were run instead.

## Related

Closes #71
