### PR TITLE
fix(gauges): stop lambda line graph from waving after disconnect

### DIFF
--- a/crates/libretune-app/src/PopOutWindow.tsx
+++ b/crates/libretune-app/src/PopOutWindow.tsx
@@ -59,12 +59,37 @@ export default function PopOutWindow() {
   const [constantValues, setConstantValues] = useState<Record<string, number>>({});
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [isConnected, setIsConnected] = useState(false);
 
   // Debug: log on mount
   useEffect(() => {
     console.log('[PopOutWindow] Component mounted');
     console.log('[PopOutWindow] hash:', window.location.hash);
     console.log('[PopOutWindow] href:', window.location.href);
+  }, []);
+
+  // Track connection status so the popped-out dashboard behaves the same as
+  // the main window (e.g. time-series gauges scroll only while connected).
+  useEffect(() => {
+    let cancelled = false;
+
+    const poll = async () => {
+      try {
+        const status = await invoke<{ state: string }>('get_connection_status');
+        if (!cancelled) {
+          setIsConnected(status.state === 'Connected');
+        }
+      } catch (e) {
+        console.error('[PopOutWindow] Failed to fetch connection status:', e);
+      }
+    };
+
+    poll();
+    const interval = setInterval(poll, 1000);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
   }, []);
 
   // Parse URL params and load data
@@ -311,7 +336,7 @@ export default function PopOutWindow() {
 
     switch (popOutData.type) {
       case 'dashboard':
-        return <TsDashboard />;
+        return <TsDashboard isConnected={isConnected} />;
       
       case 'table':
         // Show loading while fetching data

--- a/crates/libretune-app/src/components/dashboards/TsDashboard.tsx
+++ b/crates/libretune-app/src/components/dashboards/TsDashboard.tsx
@@ -488,6 +488,7 @@ export default function TsDashboard({ initialDashPath, isConnected = false }: Ts
         sweepValues={sweepValues}
         gaugeDemoActive={gaugeDemoActive}
         demoValues={demoValues}
+        isConnected={isConnected}
         wrapperRef={dashboardWrapperRef}
         onContextMenu={handleContextMenu}
       />

--- a/crates/libretune-app/src/components/dashboards/components/DashboardCanvas.tsx
+++ b/crates/libretune-app/src/components/dashboards/components/DashboardCanvas.tsx
@@ -33,6 +33,7 @@ interface Props {
   sweepValues: Record<string, number>;
   gaugeDemoActive: boolean;
   demoValues: Record<string, number>;
+  isConnected: boolean;
   wrapperRef: React.RefObject<HTMLDivElement>;
   onContextMenu: (e: React.MouseEvent, gaugeId: string | null) => void;
 }
@@ -60,6 +61,7 @@ export default function DashboardCanvas({
   sweepValues,
   gaugeDemoActive,
   demoValues,
+  isConnected,
   wrapperRef,
   onContextMenu,
 }: Props) {
@@ -183,6 +185,7 @@ export default function DashboardCanvas({
                     embeddedImages={embeddedImages}
                     legacyMode={legacyMode}
                     overrideStore={sweepActive || gaugeDemoActive}
+                    isConnected={isConnected}
                   />
                 </div>
               </ConditionalWrapper>
@@ -225,6 +228,7 @@ export default function DashboardCanvas({
             sweepValues={sweepValues}
             gaugeDemoActive={gaugeDemoActive}
             demoValues={demoValues}
+            isConnected={isConnected}
             onContextMenu={onContextMenu}
           />
         ))}
@@ -256,6 +260,7 @@ function ExtraClusterLayer({
   sweepValues,
   gaugeDemoActive,
   demoValues,
+  isConnected,
   onContextMenu,
 }: {
   cluster: GaugeCluster;
@@ -266,6 +271,7 @@ function ExtraClusterLayer({
   sweepValues: Record<string, number>;
   gaugeDemoActive: boolean;
   demoValues: Record<string, number>;
+  isConnected: boolean;
   onContextMenu: (e: React.MouseEvent, gaugeId: string | null) => void;
 }) {
   const visible = useEnabledCondition(cluster.enabled_condition ?? null);
@@ -301,6 +307,7 @@ function ExtraClusterLayer({
                   embeddedImages={embeddedImages}
                   legacyMode={legacyMode}
                   overrideStore={sweepActive || gaugeDemoActive}
+                  isConnected={isConnected}
                 />
               </div>
             </ConditionalWrapper>

--- a/crates/libretune-app/src/components/gauges/TsGauge.tsx
+++ b/crates/libretune-app/src/components/gauges/TsGauge.tsx
@@ -29,12 +29,14 @@ interface TsGaugeProps {
   legacyMode?: boolean;
   /** When true, the value prop takes priority over the store subscription (sweep/demo mode) */
   overrideStore?: boolean;
+  /** Whether the ECU/stream is connected. Time-series painters only continuous-render while connected. */
+  isConnected?: boolean;
 }
 
 /**
  * Internal TsGauge component - wrapped in React.memo below
  */
-function TsGaugeInner({ config, value, embeddedImages, legacyMode = false, overrideStore = false }: TsGaugeProps) {
+function TsGaugeInner({ config, value, embeddedImages, legacyMode = false, overrideStore = false, isConnected = false }: TsGaugeProps) {
   const [fontsReady, setFontsReady] = useState(false);
   const [imagesReady, setImagesReady] = useState(false);
 
@@ -213,8 +215,9 @@ function TsGaugeInner({ config, value, embeddedImages, legacyMode = false, overr
   );
 
   // Time-series painters must keep repainting so the trace scrolls left even
-  // when the channel value is constant (Issue #71).
-  const continuousRender = ['LineGraph', 'Histogram', 'MultiChannelTrend'].includes(
+  // when the channel value is constant (Issue #71). Only enable this while the
+  // ECU/stream is connected; disconnected gauges should be still (Issue #83).
+  const continuousRender = isConnected && ['LineGraph', 'Histogram', 'MultiChannelTrend'].includes(
     config.gauge_painter,
   );
 
@@ -254,7 +257,8 @@ const TsGauge = React.memo(TsGaugeInner, (prevProps, nextProps) => {
     prevProps.config === nextProps.config &&
     prevProps.embeddedImages === nextProps.embeddedImages &&
     prevProps.legacyMode === nextProps.legacyMode &&
-    prevProps.overrideStore === nextProps.overrideStore
+    prevProps.overrideStore === nextProps.overrideStore &&
+    prevProps.isConnected === nextProps.isConnected
   );
 });
 

--- a/crates/libretune-app/src/components/gauges/painters/__tests__/lineGraph.test.ts
+++ b/crates/libretune-app/src/components/gauges/painters/__tests__/lineGraph.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { lineGraphPainter } from '../lineGraph';
+import { getChannelHistoryBuffer, useRealtimeStore } from '../../../../stores/realtimeStore';
+import type { TsGaugeConfig, TsColor } from '../../../dashboards/dashTypes';
+
+const mockCtx = (): CanvasRenderingContext2D =>
+  ({
+    setTransform: vi.fn(),
+    scale: vi.fn(),
+    clearRect: vi.fn(),
+    fillRect: vi.fn(),
+    beginPath: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    closePath: vi.fn(),
+    stroke: vi.fn(),
+    fill: vi.fn(),
+    fillText: vi.fn(),
+    strokeText: vi.fn(),
+    measureText: () => ({ width: 0 }),
+    quadraticCurveTo: vi.fn(),
+    createLinearGradient: () => ({ addColorStop: vi.fn() }),
+    arc: vi.fn(),
+    setLineDash: vi.fn(),
+    shadowColor: '',
+    shadowBlur: 0,
+    shadowOffsetY: 0,
+    lineWidth: 1,
+    lineCap: 'butt',
+    lineJoin: 'miter',
+    fillStyle: '',
+    strokeStyle: '',
+    textAlign: 'left',
+    textBaseline: 'top',
+    font: '',
+  } as unknown as CanvasRenderingContext2D);
+
+const baseConfig: TsGaugeConfig = {
+  id: 'lambda_hist',
+  title: 'LAMBDA TREND',
+  units: 'λ',
+  output_channel: 'lambda',
+  min: 0.7,
+  max: 1.3,
+  value: 1.0,
+  gauge_painter: 'LineGraph',
+  gauge_style: '',
+  relative_x: 0,
+  relative_y: 0,
+  relative_width: 1,
+  relative_height: 1,
+  min_vp: null,
+  max_vp: null,
+  default_min: null,
+  default_max: null,
+  peg_limits: false,
+  low_warning: null,
+  high_warning: null,
+  low_critical: null,
+  high_critical: null,
+  low_warning_vp: null,
+  high_warning_vp: null,
+  low_critical_vp: null,
+  high_critical_vp: null,
+  back_color: { alpha: 255, red: 28, green: 32, blue: 40 },
+  font_color: { alpha: 255, red: 34, green: 197, blue: 94 },
+  needle_color: { alpha: 255, red: 34, green: 197, blue: 94 },
+  trim_color: { alpha: 255, red: 148, green: 163, blue: 184 },
+  warn_color: { alpha: 255, red: 234, green: 179, blue: 8 },
+  critical_color: { alpha: 255, red: 239, green: 68, blue: 68 },
+  value_digits: 3,
+  label_digits: 0,
+  font_family: 'Arial',
+  font_size_adjustment: 0,
+  italic_font: false,
+  sweep_angle: 270,
+  start_angle: 225,
+  face_angle: 0,
+  sweep_begin_degree: 0,
+  counter_clockwise: false,
+  major_ticks: 10,
+  minor_ticks: 5,
+  border_width: 0,
+  shortest_size: 0,
+  shape_locked_to_aspect: false,
+  antialiasing_on: true,
+  background_image_file_name: null,
+  needle_image_file_name: null,
+  show_history: true,
+  history_value: 0,
+  history_delay: 0,
+  needle_smoothing: 0,
+  short_click_action: null,
+  long_click_action: null,
+  display_value_at_180: false,
+};
+
+describe('lineGraphPainter', () => {
+  beforeEach(() => {
+    useRealtimeStore.getState().clearChannels();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does not call Math.random when no channel history exists', () => {
+    const randomSpy = vi.spyOn(Math, 'random').mockImplementation(() => 0.5);
+
+    const ctx = mockCtx();
+    lineGraphPainter({
+      ctx,
+      width: 200,
+      height: 100,
+      value: 1.0,
+      peakValue: 1.0,
+      config: baseConfig,
+      legacyMode: false,
+      bgImage: null,
+      needleImage: null,
+      getValueColor: () => baseConfig.font_color as TsColor,
+      getFontSpec: (size) => `${size}px Arial`,
+      getFontFamily: () => 'Arial',
+      getEmbeddedImage: () => null,
+    });
+
+    expect(randomSpy).not.toHaveBeenCalled();
+  });
+
+  it('renders a deterministic flat line when history is empty', () => {
+    const ctx = mockCtx();
+    const lineToCalls: { x: number; y: number }[] = [];
+    (ctx.lineTo as any).mockImplementation((x: number, y: number) => {
+      lineToCalls.push({ x, y });
+    });
+
+    lineGraphPainter({
+      ctx,
+      width: 200,
+      height: 100,
+      value: 1.0,
+      peakValue: 1.0,
+      config: baseConfig,
+      legacyMode: false,
+      bgImage: null,
+      needleImage: null,
+      getValueColor: () => baseConfig.font_color as TsColor,
+      getFontSpec: (size) => `${size}px Arial`,
+      getFontFamily: () => 'Arial',
+      getEmbeddedImage: () => null,
+    });
+
+    // With empty history the painter should emit trace points.
+    expect(lineToCalls.length).toBeGreaterThan(0);
+
+    // With numPoints=50 the line trace contributes 50 identical line-to calls,
+    // plus one closing baseline point for the filled area. Verify the trace is
+    // deterministic by counting the dominant y value.
+    const ys = lineToCalls.map((p) => p.y);
+    const counts = new Map<number, number>();
+    for (const y of ys) {
+      counts.set(y, (counts.get(y) ?? 0) + 1);
+    }
+    const largestCount = Math.max(...counts.values());
+    expect(largestCount).toBeGreaterThanOrEqual(50);
+  });
+
+  it('uses actual history when available', () => {
+    // Seed the history buffer for the lambda channel.
+    useRealtimeStore.getState().updateChannels({ lambda: 0.75 });
+    useRealtimeStore.getState().updateChannels({ lambda: 0.9 });
+    useRealtimeStore.getState().updateChannels({ lambda: 1.1 });
+
+    const history = getChannelHistoryBuffer('lambda');
+    expect(history.length).toBeGreaterThan(0);
+
+    const ctx = mockCtx();
+    const lineToCalls: { x: number; y: number }[] = [];
+    (ctx.lineTo as any).mockImplementation((x: number, y: number) => {
+      lineToCalls.push({ x, y });
+    });
+
+    lineGraphPainter({
+      ctx,
+      width: 200,
+      height: 100,
+      value: 1.0,
+      peakValue: 1.0,
+      config: baseConfig,
+      legacyMode: false,
+      bgImage: null,
+      needleImage: null,
+      getValueColor: () => baseConfig.font_color as TsColor,
+      getFontSpec: (size) => `${size}px Arial`,
+      getFontFamily: () => 'Arial',
+      getEmbeddedImage: () => null,
+    });
+
+    // With history we should get at least as many line points as history entries.
+    expect(lineToCalls.length).toBeGreaterThanOrEqual(history.length);
+  });
+});

--- a/crates/libretune-app/src/components/gauges/painters/lineGraph.ts
+++ b/crates/libretune-app/src/components/gauges/painters/lineGraph.ts
@@ -77,17 +77,16 @@ export const lineGraphPainter: Painter = (pctx) => {
       });
     }
   } else {
-    // No history available - show simulated data for demo
+    // No history available — render a flat line at the current/default value
+    // so disconnected gauges are steady instead of showing a random waving trace
+    // (Issue #83). The deterministic shape gives immediate visual feedback while
+    // still resembling a line graph.
     const numPoints = 50;
     const valuePercent = (value - config.min) / (config.max - config.min);
+    const clampedPercent = Math.max(0, Math.min(1, valuePercent));
 
     for (let i = 0; i < numPoints; i++) {
       const t = i / (numPoints - 1);
-      // Simulate some variation leading up to current value
-      const noise = Math.sin(t * 20) * 0.05 + Math.sin(t * 7) * 0.03;
-      const historicalPercent = valuePercent + (1 - t) * (Math.random() * 0.2 - 0.1) + noise * (1 - t);
-      const clampedPercent = Math.max(0, Math.min(1, historicalPercent));
-
       points.push({
         x: padding + t * graphWidth,
         y: graphY + graphHeight - clampedPercent * graphHeight,


### PR DESCRIPTION
Fixes #83.

## Problem
On the Dash/Tuning view, the lambda (and other line-graph) gauges kept waving with random values even after disconnect and during gauge sweep. This happened because the LineGraph painter's no-history fallback used Math.random() to generate a fake trace, and time-series painters were set to continuous-render unconditionally.

## Changes
- lineGraphPainter: replaced the random no-history fallback with a flat line at the current/default value.
- TsGauge: added an isConnected prop and gated continuousRender for LineGraph, Histogram, and MultiChannelTrend on it.
- DashboardCanvas / TsDashboard: plumbed isConnected through to all gauges, including extra clusters.
- PopOutWindow: polls connection status so popped-out dashboards behave the same as the main window.
- Added a regression test for lineGraphPainter verifying Math.random is not called and the fallback trace is deterministic.

## Verification
- 
px vitest run src/components/gauges/painters/__tests__/lineGraph.test.ts src/components/dashboards → 16 passed
- 
px tsc --noEmit → clean
- Manual check: connected gauges scroll; disconnected gauges are steady.
