### PR TITLE
fix(dashboards): fall back to gauge.min instead of stale gauge.value …

### DIFF
--- a/crates/libretune-app/src/components/dashboards/components/DashboardCanvas.tsx
+++ b/crates/libretune-app/src/components/dashboards/components/DashboardCanvas.tsx
@@ -4,6 +4,7 @@ import { DashFile, GaugeCluster, TsGaugeConfig, isGauge, isIndicator } from '../
 import TsGauge from '../../gauges/TsGauge';
 import LiveTsIndicator from './LiveTsIndicator';
 import { buildDefaultGauge } from '../utils/defaultGauge';
+import { resolveGaugeValue } from '../utils/resolveGaugeValue';
 import { useEnabledCondition } from '../hooks/useEnabledCondition';
 
 interface ChannelInfo {
@@ -156,11 +157,7 @@ export default function DashboardCanvas({
         {cluster.components.map((component, index) => {
           if (isGauge(component)) {
             const gauge = component.Gauge;
-            const value = sweepActive
-              ? (sweepValues[gauge.output_channel] ?? gauge.min)
-              : gaugeDemoActive
-                ? (demoValues[gauge.output_channel] ?? gauge.value)
-                : gauge.value;
+            const value = resolveGaugeValue(gauge, { sweepActive, sweepValues, gaugeDemoActive, demoValues });
 
             const gaugeStyle: React.CSSProperties = {
               left: `${toPercent(gauge.relative_x)}%`,
@@ -282,11 +279,7 @@ function ExtraClusterLayer({
       {cluster.components.map((component, index) => {
         if (isGauge(component)) {
           const gauge = component.Gauge;
-          const value = sweepActive
-            ? (sweepValues[gauge.output_channel] ?? gauge.min)
-            : gaugeDemoActive
-              ? (demoValues[gauge.output_channel] ?? gauge.value)
-              : gauge.value;
+          const value = resolveGaugeValue(gauge, { sweepActive, sweepValues, gaugeDemoActive, demoValues });
           const style: React.CSSProperties = {
             left: `${toPercent(gauge.relative_x)}%`,
             top: `${toPercent(gauge.relative_y)}%`,

--- a/crates/libretune-app/src/components/dashboards/utils/__tests__/resolveGaugeValue.test.ts
+++ b/crates/libretune-app/src/components/dashboards/utils/__tests__/resolveGaugeValue.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { resolveGaugeValue } from '../resolveGaugeValue';
+
+const gauge = { output_channel: 'rpm', min: 0, value: 6.833777777777774 };
+
+describe('resolveGaugeValue', () => {
+  it('falls back to gauge.min, not the stale design-time gauge.value, when there is no active preview', () => {
+    const result = resolveGaugeValue(gauge, {
+      sweepActive: false,
+      sweepValues: {},
+      gaugeDemoActive: false,
+      demoValues: {},
+    });
+    expect(result).toBe(0);
+  });
+
+  it('uses the sweep value when sweep is active', () => {
+    const result = resolveGaugeValue(gauge, {
+      sweepActive: true,
+      sweepValues: { rpm: 3500 },
+      gaugeDemoActive: false,
+      demoValues: {},
+    });
+    expect(result).toBe(3500);
+  });
+
+  it('falls back to gauge.min (not gauge.value) when sweep is active but this channel has no sweep value yet', () => {
+    const result = resolveGaugeValue(gauge, {
+      sweepActive: true,
+      sweepValues: {},
+      gaugeDemoActive: false,
+      demoValues: {},
+    });
+    expect(result).toBe(0);
+  });
+
+  it('uses the demo value when demo mode is active', () => {
+    const result = resolveGaugeValue(gauge, {
+      sweepActive: false,
+      sweepValues: {},
+      gaugeDemoActive: true,
+      demoValues: { rpm: 4200 },
+    });
+    expect(result).toBe(4200);
+  });
+
+  it('falls back to gauge.value (the design-time preview) when demo mode is active but this channel has no demo value yet', () => {
+    const result = resolveGaugeValue(gauge, {
+      sweepActive: false,
+      sweepValues: {},
+      gaugeDemoActive: true,
+      demoValues: {},
+    });
+    expect(result).toBe(gauge.value);
+  });
+
+  it('prefers sweep over demo when both are somehow active', () => {
+    const result = resolveGaugeValue(gauge, {
+      sweepActive: true,
+      sweepValues: { rpm: 1000 },
+      gaugeDemoActive: true,
+      demoValues: { rpm: 2000 },
+    });
+    expect(result).toBe(1000);
+  });
+});

--- a/crates/libretune-app/src/components/dashboards/utils/resolveGaugeValue.ts
+++ b/crates/libretune-app/src/components/dashboards/utils/resolveGaugeValue.ts
@@ -1,0 +1,33 @@
+import { TsGaugeConfig } from '../dashTypes';
+
+interface ResolveGaugeValueArgs {
+  sweepActive: boolean;
+  sweepValues: Record<string, number>;
+  gaugeDemoActive: boolean;
+  demoValues: Record<string, number>;
+}
+
+/**
+ * Picks the value a gauge should render with, outside of its own live
+ * store subscription (sweep/demo preview modes, or the fallback for when
+ * there's no live data at all).
+ *
+ * `gauge.value` is a static, design-time preview number saved with the
+ * dashboard file — not live data. Using it as the live/no-data fallback
+ * meant a disconnected gauge (or one that just remounted, e.g. after
+ * switching tabs) could show a plausible-looking but entirely fake
+ * reading with no indication it wasn't real (Issue #73). `gauge.min`
+ * matches the convention already used one branch up for sweep mode.
+ */
+export function resolveGaugeValue(
+  gauge: Pick<TsGaugeConfig, 'output_channel' | 'min' | 'value'>,
+  { sweepActive, sweepValues, gaugeDemoActive, demoValues }: ResolveGaugeValueArgs,
+): number {
+  if (sweepActive) {
+    return sweepValues[gauge.output_channel] ?? gauge.min;
+  }
+  if (gaugeDemoActive) {
+    return demoValues[gauge.output_channel] ?? gauge.value;
+  }
+  return gauge.min;
+}


### PR DESCRIPTION
## Description
`gauge.value` is a static, design-time preview number saved with the dashboard
file — not live data. Using it as the no-live-data fallback meant a
disconnected gauge (or one that just remounted, e.g. after switching tabs)
could show a plausible-looking but entirely fake reading with no indication
it wasn't real.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues
Closes #73

## Changes Made
- Extracted the gauge value-picking logic out of `DashboardCanvas` into a new
  `resolveGaugeValue()` helper
- Changed the no-live-data fallback from `gauge.value` (stale design-time
  preview) to `gauge.min`, matching the convention already used for sweep mode
- Added unit tests covering sweep/demo/fallback precedence

## Testing
- [x] I have tested these changes locally
- [x] New and existing tests pass (`npm test` — 89/89, including 6 new tests
      for `resolveGaugeValue`; no Rust changes in this PR)
- [x] The UI works correctly with these changes

## Checklist
- [x] Code compiles without errors
- [x] No new clippy warnings (`cargo clippy`)
- [x] Code is formatted (`cargo fmt`)
- [x] TypeScript compiles without errors (`npx tsc --noEmit`)
- [ ] Documentation updated if needed
- [x] Commit messages follow conventional format

## Screenshots (if applicable)
N/A — internal fallback-value logic change, no visual difference in normal operation.
