### PR TITLE
Fix/tune cache lock ordering deadlocks

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/console.rs
+++ b/crates/libretune-app/src-tauri/src/commands/console.rs
@@ -33,18 +33,24 @@ pub async fn send_console_command(
     _app: tauri::AppHandle,
     command: String,
 ) -> Result<String, String> {
-    let mut conn_guard = state.connection.lock().await;
-    let conn = conn_guard.as_mut().ok_or("Not connected to ECU")?;
+    // Snapshot the ECU type and drop the definition lock before the blocking
+    // conn.send_console_command() call below — holding it across ECU I/O
+    // starves every other command that needs the definition (e.g. load_tune).
+    let ecu_type = {
+        let def_guard = state.definition.lock().await;
+        let def = def_guard.as_ref().ok_or("No INI definition loaded")?;
+        def.ecu_type
+    };
 
-    let def_guard = state.definition.lock().await;
-    let def = def_guard.as_ref().ok_or("No INI definition loaded")?;
-
-    if !def.ecu_type.supports_console() {
+    if !ecu_type.supports_console() {
         return Err(format!(
             "ECU type {:?} does not support text-based console",
-            def.ecu_type
+            ecu_type
         ));
     }
+
+    let mut conn_guard = state.connection.lock().await;
+    let conn = conn_guard.as_mut().ok_or("Not connected to ECU")?;
 
     let response = conn
         .send_console_command(&libretune_core::protocol::ConsoleCommand::new(&command))

--- a/crates/libretune-app/src-tauri/src/commands/constant_update.rs
+++ b/crates/libretune-app/src-tauri/src/commands/constant_update.rs
@@ -8,16 +8,27 @@ pub async fn update_constant(
     name: String,
     value: f64,
 ) -> Result<(), String> {
-    let mut conn_guard = state.connection.lock().await;
+    // Snapshot only what we need from the definition, then drop the lock before
+    // doing any ECU I/O below. Holding `state.definition` across a blocking
+    // conn.read_memory()/write_memory() call starves every other command that
+    // needs the definition (e.g. load_tune) if the ECU I/O stalls.
     let def_guard = state.definition.lock().await;
-    let mut cache_guard = state.tune_cache.lock().await;
-
     let def = def_guard.as_ref().ok_or("Definition not loaded")?;
-
     let constant = def
         .constants
         .get(&name)
-        .ok_or_else(|| format!("Constant {} not found", name))?;
+        .ok_or_else(|| format!("Constant {} not found", name))?
+        .clone();
+    let endianness = def.endianness;
+    let default_page_bytes = def
+        .page_sizes
+        .get(constant.page as usize)
+        .copied()
+        .unwrap_or(256) as usize;
+    drop(def_guard);
+
+    let mut conn_guard = state.connection.lock().await;
+    let mut cache_guard = state.tune_cache.lock().await;
 
     // PC variables are stored locally, not on ECU
     if constant.is_pc_variable {
@@ -120,15 +131,10 @@ pub async fn update_constant(
         let mut tune_guard = state.current_tune.lock().await;
         if let Some(tune) = tune_guard.as_mut() {
             // Update page data
-            let page_data = tune.pages.entry(constant.page).or_insert_with(|| {
-                vec![
-                    0u8;
-                    def.page_sizes
-                        .get(constant.page as usize)
-                        .copied()
-                        .unwrap_or(256) as usize
-                ]
-            });
+            let page_data = tune
+                .pages
+                .entry(constant.page)
+                .or_insert_with(|| vec![0u8; default_page_bytes]);
             let start = read_offset as usize;
             let end = start + existing_bytes.len();
             if end <= page_data.len() {
@@ -168,7 +174,7 @@ pub async fn update_constant(
     let mut raw_data = vec![0u8; constant.size_bytes()];
     constant
         .data_type
-        .write_to_bytes(&mut raw_data, 0, raw_val, def.endianness);
+        .write_to_bytes(&mut raw_data, 0, raw_val, endianness);
 
     // Always write to TuneCache if available (enables offline editing)
     if let Some(cache) = cache_guard.as_mut() {
@@ -177,16 +183,10 @@ pub async fn update_constant(
             let mut tune_guard = state.current_tune.lock().await;
             if let Some(tune) = tune_guard.as_mut() {
                 // Get or create page data
-                let page_data = tune.pages.entry(constant.page).or_insert_with(|| {
-                    // Create empty page if it doesn't exist
-                    vec![
-                        0u8;
-                        def.page_sizes
-                            .get(constant.page as usize)
-                            .copied()
-                            .unwrap_or(256) as usize
-                    ]
-                });
+                let page_data = tune
+                    .pages
+                    .entry(constant.page)
+                    .or_insert_with(|| vec![0u8; default_page_bytes]);
 
                 // Update the page data
                 let start = constant.offset as usize;

--- a/crates/libretune-app/src-tauri/src/commands/constants_read.rs
+++ b/crates/libretune-app/src-tauri/src/commands/constants_read.rs
@@ -356,10 +356,7 @@ pub async fn get_constant_value(
         };
 
         let raw_data = conn.read_memory(params).map_err(|e| e.to_string())?;
-        if let Some(raw_val) = constant
-            .data_type
-            .read_from_bytes(&raw_data, 0, endianness)
-        {
+        if let Some(raw_val) = constant.data_type.read_from_bytes(&raw_data, 0, endianness) {
             return Ok(constant.raw_to_display(raw_val));
         }
         return Ok(0.0);
@@ -368,10 +365,7 @@ pub async fn get_constant_value(
     // If offline, read from cache (MSQ data)
     if let Some(cache) = cache_guard.as_ref() {
         if let Some(raw_data) = cache.read_bytes(constant.page, constant.offset, length) {
-            if let Some(raw_val) = constant
-                .data_type
-                .read_from_bytes(raw_data, 0, endianness)
-            {
+            if let Some(raw_val) = constant.data_type.read_from_bytes(raw_data, 0, endianness) {
                 return Ok(constant.raw_to_display(raw_val));
             }
         }

--- a/crates/libretune-app/src-tauri/src/commands/constants_read.rs
+++ b/crates/libretune-app/src-tauri/src/commands/constants_read.rs
@@ -77,17 +77,21 @@ pub async fn get_constant_string_value(
     state: tauri::State<'_, AppState>,
     name: String,
 ) -> Result<String, String> {
-    let mut conn_guard = state.connection.lock().await;
+    // Snapshot the constant and drop the definition lock before any ECU I/O
+    // below — holding it across a blocking conn.read_memory() call starves
+    // every other command that needs the definition (e.g. load_tune).
     let def_guard = state.definition.lock().await;
-    let tune_guard = state.current_tune.lock().await;
-
     let def = def_guard.as_ref().ok_or("Definition not loaded")?;
-    let conn = conn_guard.as_mut();
-
     let constant = def
         .constants
         .get(&name)
-        .ok_or_else(|| format!("Constant {} not found", name))?;
+        .ok_or_else(|| format!("Constant {} not found", name))?
+        .clone();
+    drop(def_guard);
+
+    let mut conn_guard = state.connection.lock().await;
+    let tune_guard = state.current_tune.lock().await;
+    let conn = conn_guard.as_mut();
 
     // For string type, read the raw bytes and convert to UTF-8 string
     if constant.data_type != DataType::String {
@@ -146,18 +150,25 @@ pub async fn get_constant_value(
     state: tauri::State<'_, AppState>,
     name: String,
 ) -> Result<f64, String> {
-    let mut conn_guard = state.connection.lock().await;
+    // Snapshot the constant (and its INI default, for the PC-variable path)
+    // and drop the definition lock before any ECU I/O below — holding it
+    // across a blocking conn.read_memory() call starves every other command
+    // that needs the definition (e.g. load_tune).
     let def_guard = state.definition.lock().await;
-    let cache_guard = state.tune_cache.lock().await;
-    let tune_guard = state.current_tune.lock().await;
-
     let def = def_guard.as_ref().ok_or("Definition not loaded")?;
-    let conn = conn_guard.as_mut();
-
     let constant = def
         .constants
         .get(&name)
-        .ok_or_else(|| format!("Constant {} not found", name))?;
+        .ok_or_else(|| format!("Constant {} not found", name))?
+        .clone();
+    let default_value = def.default_values.get(&name).copied();
+    let endianness = def.endianness;
+    drop(def_guard);
+
+    let mut conn_guard = state.connection.lock().await;
+    let cache_guard = state.tune_cache.lock().await;
+    let tune_guard = state.current_tune.lock().await;
+    let conn = conn_guard.as_mut();
 
     // PC variables are stored locally, not on ECU
     if constant.is_pc_variable {
@@ -168,7 +179,7 @@ pub async fn get_constant_value(
             }
         }
         // Fall back to default value from INI
-        if let Some(&default_val) = def.default_values.get(&name) {
+        if let Some(default_val) = default_value {
             return Ok(default_val);
         }
         // Last resort: use min value or 0
@@ -347,7 +358,7 @@ pub async fn get_constant_value(
         let raw_data = conn.read_memory(params).map_err(|e| e.to_string())?;
         if let Some(raw_val) = constant
             .data_type
-            .read_from_bytes(&raw_data, 0, def.endianness)
+            .read_from_bytes(&raw_data, 0, endianness)
         {
             return Ok(constant.raw_to_display(raw_val));
         }
@@ -359,7 +370,7 @@ pub async fn get_constant_value(
         if let Some(raw_data) = cache.read_bytes(constant.page, constant.offset, length) {
             if let Some(raw_val) = constant
                 .data_type
-                .read_from_bytes(raw_data, 0, def.endianness)
+                .read_from_bytes(raw_data, 0, endianness)
             {
                 return Ok(constant.raw_to_display(raw_val));
             }

--- a/crates/libretune-app/src-tauri/src/commands/curve_ops.rs
+++ b/crates/libretune-app/src-tauri/src/commands/curve_ops.rs
@@ -213,8 +213,11 @@ pub async fn get_curve_data(
     }
 
     // Get tune and connection
-    let tune_guard = state.current_tune.lock().await;
+    // Lock order: connection before current_tune, matching the convention used
+    // by every write path (get_constant_value, update_constant, etc.) — the
+    // reverse order deadlocks against those.
     let mut conn_guard = state.connection.lock().await;
+    let tune_guard = state.current_tune.lock().await;
     let mut conn = conn_guard.as_mut();
 
     let x_bins = read_const_from_source(&x_const, tune_guard.as_ref(), &mut conn, endianness)?;

--- a/crates/libretune-app/src-tauri/src/commands/diagnostic_loggers.rs
+++ b/crates/libretune-app/src-tauri/src/commands/diagnostic_loggers.rs
@@ -66,11 +66,18 @@ pub async fn start_tooth_logger(
     state: tauri::State<'_, AppState>,
     app: tauri::AppHandle,
 ) -> Result<ToothLogResult, String> {
-    let mut conn_guard = state.connection.lock().await;
-    let def_guard = state.definition.lock().await;
+    // Just confirming a definition is loaded — drop the lock immediately
+    // rather than holding it across the blocking ECU read below, which would
+    // starve every other command that needs the definition (e.g. load_tune).
+    {
+        let def_guard = state.definition.lock().await;
+        if def_guard.is_none() {
+            return Err("Definition not loaded".to_string());
+        }
+    }
 
+    let mut conn_guard = state.connection.lock().await;
     let conn = conn_guard.as_mut().ok_or("Not connected to ECU")?;
-    let _def = def_guard.as_ref().ok_or("Definition not loaded")?;
 
     // Detect ECU type from signature
     let signature = conn.signature().unwrap_or_default().to_lowercase();
@@ -274,11 +281,18 @@ pub async fn start_composite_logger(
     state: tauri::State<'_, AppState>,
     app: tauri::AppHandle,
 ) -> Result<CompositeLogResult, String> {
-    let mut conn_guard = state.connection.lock().await;
-    let def_guard = state.definition.lock().await;
+    // Just confirming a definition is loaded — drop the lock immediately
+    // rather than holding it across the blocking ECU read below, which would
+    // starve every other command that needs the definition (e.g. load_tune).
+    {
+        let def_guard = state.definition.lock().await;
+        if def_guard.is_none() {
+            return Err("Definition not loaded".to_string());
+        }
+    }
 
+    let mut conn_guard = state.connection.lock().await;
     let conn = conn_guard.as_mut().ok_or("Not connected to ECU")?;
-    let _def = def_guard.as_ref().ok_or("Definition not loaded")?;
 
     let signature = conn.signature().unwrap_or_default().to_lowercase();
 

--- a/crates/libretune-app/src-tauri/src/commands/get_table_data.rs
+++ b/crates/libretune-app/src-tauri/src/commands/get_table_data.rs
@@ -194,9 +194,14 @@ pub async fn get_table_data(
     }
 
     // Get tune, cache and connection
-    let tune_guard = state.current_tune.lock().await;
-    let cache_guard = state.tune_cache.lock().await;
+    // Lock order: connection, then tune_cache, then current_tune — matching the
+    // convention used by every write path (get_constant_value, update_constant,
+    // table/curve edits, sync_ecu_data). Acquiring connection last (as this used
+    // to) deadlocks against those. Acquiring tune_cache before current_tune
+    // matches get_all_constant_values, avoiding that separate AB-BA cycle too.
     let mut conn_guard = state.connection.lock().await;
+    let cache_guard = state.tune_cache.lock().await;
+    let tune_guard = state.current_tune.lock().await;
     let mut conn = conn_guard.as_mut();
 
     let x_bins = read_const_from_source(

--- a/crates/libretune-app/src-tauri/src/commands/load_pages.rs
+++ b/crates/libretune-app/src-tauri/src/commands/load_pages.rs
@@ -12,8 +12,10 @@ pub async fn load_all_pages(
     // Get pages to load and their sizes
     let pages_to_load: Vec<(u8, u16)>;
     {
-        let cache_guard = state.tune_cache.lock().await;
+        // Lock order: definition before tune_cache, matching the convention used
+        // everywhere else these two are held together (avoids an AB-BA deadlock).
         let def_guard = state.definition.lock().await;
+        let cache_guard = state.tune_cache.lock().await;
 
         let cache = cache_guard.as_ref().ok_or("TuneCache not initialized")?;
         let def = def_guard.as_ref().ok_or("Definition not loaded")?;

--- a/crates/libretune-app/src-tauri/src/commands/project_mgmt.rs
+++ b/crates/libretune-app/src-tauri/src/commands/project_mgmt.rs
@@ -11,6 +11,10 @@ use crate::{ConnectionSettingsResponse, CurrentProjectInfo};
 /// Returns: Nothing on success
 #[tauri::command]
 pub async fn close_project(state: tauri::State<'_, AppState>) -> Result<(), String> {
+    // Lock order: definition before current_project, matching apply_base_map —
+    // avoids an AB-BA deadlock against it.
+    let mut def_guard = state.definition.lock().await;
+
     // Get and close the project
     let mut proj_guard = state.current_project.lock().await;
     if let Some(project) = proj_guard.take() {
@@ -20,7 +24,6 @@ pub async fn close_project(state: tauri::State<'_, AppState>) -> Result<(), Stri
     }
 
     // Clear definition
-    let mut def_guard = state.definition.lock().await;
     *def_guard = None;
 
     // Clear tune

--- a/crates/libretune-app/src-tauri/src/commands/project_tune_sync.rs
+++ b/crates/libretune-app/src-tauri/src/commands/project_tune_sync.rs
@@ -99,8 +99,10 @@ pub async fn write_project_tune_to_ecu(
     _app: tauri::AppHandle,
     state: tauri::State<'_, AppState>,
 ) -> Result<(), String> {
-    let project_guard = state.current_project.lock().await;
+    // Lock order: definition before current_project, matching apply_base_map —
+    // avoids an AB-BA deadlock against it.
     let def_guard = state.definition.lock().await;
+    let project_guard = state.current_project.lock().await;
 
     let project = project_guard.as_ref().ok_or("No project open")?;
     let _def = def_guard.as_ref().ok_or("Definition not loaded")?;

--- a/crates/libretune-app/src-tauri/src/commands/save_tune.rs
+++ b/crates/libretune-app/src-tauri/src/commands/save_tune.rs
@@ -9,10 +9,13 @@ pub async fn save_tune(
     state: tauri::State<'_, AppState>,
     path: Option<String>,
 ) -> Result<String, String> {
+    // Lock order: definition, then tune_cache, then current_tune — matching the
+    // convention used everywhere else these are held together (avoids an AB-BA
+    // deadlock against e.g. get_table_data/get_all_constant_values).
+    let def_guard = state.definition.lock().await;
+    let cache_guard = state.tune_cache.lock().await;
     let mut tune_guard = state.current_tune.lock().await;
     let path_guard = state.current_tune_path.lock().await;
-    let cache_guard = state.tune_cache.lock().await;
-    let def_guard = state.definition.lock().await;
 
     let tune = tune_guard.as_mut().ok_or("No tune loaded")?;
     let def = def_guard.as_ref().ok_or("Definition not loaded")?;

--- a/crates/libretune-app/src-tauri/src/commands/tune_compare.rs
+++ b/crates/libretune-app/src-tauri/src/commands/tune_compare.rs
@@ -23,14 +23,18 @@ pub async fn merge_from_tune(
     let source =
         TuneFile::load(&source_path).map_err(|e| format!("Failed to load source tune: {}", e))?;
 
+    // Lock order: definition, then tune_cache, then current_tune — matching the
+    // convention used everywhere else these are held together (avoids an AB-BA
+    // deadlock against e.g. get_table_data/get_all_constant_values). Acquired
+    // upfront even though cache/def are only used conditionally below.
+    let def_guard = state.definition.lock().await;
+    let mut cache_guard = state.tune_cache.lock().await;
     let mut tune_guard = state.current_tune.lock().await;
     let tune = tune_guard.as_mut().ok_or("No tune loaded")?;
 
     let merged = TuneDiff::merge_selected(tune, &source, &constant_names);
 
     if merged > 0 {
-        let mut cache_guard = state.tune_cache.lock().await;
-        let def_guard = state.definition.lock().await;
         if let (Some(cache), Some(def)) = (cache_guard.as_mut(), def_guard.as_ref()) {
             for name in &constant_names {
                 if let Some(value) = source.constants.get(name) {


### PR DESCRIPTION
## Description
AppState shares a handful of coarse `tokio::sync::Mutex` fields (`definition`,
`connection`, `tune_cache`, `current_tune`, `current_project`) across many
independently-written command handlers, with no enforced acquisition order
and no consistent rule about dropping a lock before doing blocking ECU serial
I/O. This produced two distinct, reproduced failure modes: a permanently
stuck `load_tune`, and a stuck `get_table_data` after connecting to a live
ECU and switching tabs.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues
N/A — found and reproduced during hands-on debugging, not tied to an
existing filed issue.

## Changes Made
- **Lock held across blocking I/O** (starves any other command needing that
  lock for the ECU read/write's duration): fixed in `update_constant`,
  `get_constant_value`, `get_constant_string_value`, `send_console_command`,
  `start_tooth_logger`, `start_composite_logger` — clone what's needed and
  drop the lock before touching the connection.
- **Lock-ordering (AB-BA) deadlocks**, where two commands acquired the same
  locks in opposite order and could deadlock if run concurrently (routine on
  tune load / tab switch): fixed in `get_table_data`, `get_curve_data`,
  `save_tune`, `merge_from_tune`, `load_all_pages`, `close_project`,
  `write_project_tune_to_ecu` — aligned all to one consistent order:
  connection, then definition, then tune_cache, then current_tune, then
  current_project.

## Testing
- [x] I have tested these changes locally, including manually reproducing
      the original stuck-table/deadlock scenario against a live ECU
      connection (connect → load tune → open table → switch tabs →
      disconnect) and confirming it no longer hangs
- [x] New and existing tests pass (`cargo test` — 18/18, including the
      pre-existing `test_no_deadlock_between_execute_controller_and_realtime_snapshot`)
- [x] The UI works correctly with these changes

## Checklist
- [x] Code compiles without errors
- [x] No new clippy warnings (`cargo clippy`)
- [x] Code is formatted (`cargo fmt`)
- [x] TypeScript compiles without errors (`npx tsc --noEmit`) — no frontend
      changes in this PR
- [ ] Documentation updated if needed
- [x] Commit messages follow conventional format

## Screenshots (if applicable)
N/A — internal concurrency fix, no visual/UI change.
