### PR TITLE
fix(tables): stop VE table scrollbar-twitch oscillation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,30 @@ relevant.
 
 ## [Unreleased]
 
+### 2026-07-29 — Fix VE table scrollbar-twitch oscillation
+
+The VE table (the only table rendered in "fit viewport" mode, where cell
+sizes are computed to fill the available panel space) visibly jittered a few
+times per second, with scrollbars flashing on and off around it. This was a
+measure → overflow → scrollbar → re-measure feedback loop: the fit math
+targeted `clientWidth`/`clientHeight` (which exclude the scrollbar) but
+ignored the grid container's 2px border, so the fitted grid overshot the host
+by ~2px, toggling the scrollbars every animation frame.
+
+#### Fixed
+- **`TableGrid.tsx`** — the `fitViewport` `measure()` now subtracts the grid
+  container's 2px border from the available width/height before computing
+  column/row sizes, so the fit no longer produces an overflowing grid.
+- **`TableEditor2D.css`** — added `scrollbar-gutter: stable both-edges` to
+  `.table-grid-fit-host` so `clientWidth`/`clientHeight` stay constant when
+  scrollbars appear/disappear. This breaks the feedback loop as a defence in
+  depth, even if a tiny overshoot is ever reintroduced.
+
+#### Docs
+- Added a "VE Table Flickers / Twitches" entry to the Troubleshooting
+  reference (`docs/src/reference/troubleshooting.md`) describing the symptom,
+  cause, and fix.
+
 ### 2026-07-29 — Comment overhaul (Rust tests + frontend logic)
 
 Overhaul of code comments across the test suite and frontend logic. **No

--- a/crates/libretune-app/src/components/tables/TableEditor2D.css
+++ b/crates/libretune-app/src/components/tables/TableEditor2D.css
@@ -73,6 +73,12 @@
   width: 100%;
   height: 100%;
   overflow: auto;
+  /* Reserve scrollbar gutter on both axes so scrollbars appearing/disappearing
+     don't change clientWidth/clientHeight. Without this, the fitViewport
+     ResizeObserver measure() oscillates: grid overflows by ~2px (container
+     border) -> scrollbar appears -> clientWidth shrinks -> refit smaller ->
+     scrollbar vanishes -> clientWidth snaps back -> overflow again -> loop. */
+  scrollbar-gutter: stable both-edges;
 }
 
 .table-editor-2d .table-grid-container--fit-ve {

--- a/crates/libretune-app/src/components/tables/TableGrid.tsx
+++ b/crates/libretune-app/src/components/tables/TableGrid.tsx
@@ -359,6 +359,15 @@ export default function TableGrid({
       const availH = host.clientHeight;
       if (availW < 32 || availH < 32 || x_size < 1 || y_size < 1) return;
 
+      // The grid container has a 1px border on every side (2px total per
+      // axis). If we fit columns/rows to the raw clientWidth/clientHeight,
+      // the border pushes the grid 2px past the host -> a scrollbar appears
+      // -> clientWidth shrinks -> ResizeObserver refits -> scrollbar vanishes
+      // -> clientWidth snaps back -> overflow again. That oscillation is the
+      // visible "twitch". Subtract the border so the fit never overflows.
+      const fitW = availW - 2;
+      const fitH = availH - 2;
+
       const minCol = 22;
       const minRow = 16;
       const minAxis = 28;
@@ -366,16 +375,16 @@ export default function TableGrid({
       const preferredRow = 32;
       const preferredAxis = compact ? 52 : 44;
 
-      let col = Math.floor((availW - minAxis) / x_size);
+      let col = Math.floor((fitW - minAxis) / x_size);
       col = Math.max(minCol, Math.min(preferredCol, col));
-      let axis = Math.floor(availW - col * x_size);
+      let axis = Math.floor(fitW - col * x_size);
       axis = Math.max(minAxis, Math.min(preferredAxis, axis));
-      if (axis + col * x_size > availW) {
-        col = Math.max(minCol, Math.floor((availW - minAxis) / x_size));
-        axis = Math.max(minAxis, availW - col * x_size);
+      if (axis + col * x_size > fitW) {
+        col = Math.max(minCol, Math.floor((fitW - minAxis) / x_size));
+        axis = Math.max(minAxis, fitW - col * x_size);
       }
 
-      let row = Math.floor(availH / (y_size + 1));
+      let row = Math.floor(fitH / (y_size + 1));
       row = Math.max(minRow, Math.min(preferredRow, row));
 
       setFitPx((prev) =>

--- a/docs/src/reference/troubleshooting.md
+++ b/docs/src/reference/troubleshooting.md
@@ -101,6 +101,26 @@ until the value changes.
 2. Verify table is editable (not read-only)
 3. Check INI defines table as writable
 
+### VE Table Flickers / Twitches
+
+**Symptoms**: The VE table grid visibly jitters a few times per second;
+horizontal/vertical scrollbars flash on and off around the table; resizing
+the window or the panel makes it stop or get worse.
+
+**Cause**: The VE table is the only table rendered in "fit viewport" mode
+(it sizes its cells to fill the available panel space). A measure → overflow →
+scrollbar → re-measure feedback loop caused the grid to overshoot its host
+by ~2px (the grid container's border), which toggled the scrollbars on and
+off every animation frame.
+
+**Solutions**:
+1. This is fixed in current builds — the fit math now accounts for the grid
+   border, and the host reserves a stable scrollbar gutter so `clientWidth`/
+   `clientHeight` can't change when scrollbars toggle.
+2. If you still see it on an older build, update to the latest nightly.
+3. If it recurs on a *non*-VE table (which use fixed cell sizing), it is a
+   different issue — please report it with the table name.
+
 ## AutoTune Issues
 
 ### No Recommendations


### PR DESCRIPTION
## Summary

The VE table visibly **twitched/jittered a few times per second**, with the horizontal/vertical scrollbars flashing on and off around the grid. Resizing the panel or window would make it stop or get worse.

## Root cause

The VE table is the only table rendered in **"fit viewport" mode** — its cell sizes are computed at runtime to fill the available panel space (gated by `table_name` matching `/^vetable(\d+)?tbl$/i` in `TableEditor2D.tsx`). That mode had a **measure → overflow → scrollbar → re-measure feedback loop**:

1. A `ResizeObserver` on `.table-grid-fit-host` reads `clientWidth`/`clientHeight` (which **exclude** the scrollbar) and computes column/row sizes to fill that space.
2. **Bug:** the fit math targeted that raw `clientWidth`/`clientHeight` but ignored the grid container's `1px` border on every side (2px per axis total, with `box-sizing: border-box`).
3. So the fitted grid landed ~2px **over** the host width → a scrollbar appeared.
4. The scrollbar stole ~15px from `clientWidth` → `ResizeObserver` fired → `measure()` recomputed smaller columns → grid fit → scrollbar disappeared → `clientWidth` snapped back → next frame overshot again → **loop**.

A 32×32 table amplifies the effect because the constant 2px border overshoot gets divided across 32 columns, producing a visible per-cell swing.

## Fix

Two complementary changes:

- **`TableGrid.tsx`** — in the `fitViewport` `measure()`, subtract the grid container's 2px border (`const fitW = availW - 2; const fitH = availH - 2;`) before computing column/row sizes, so the fit no longer produces an overflowing grid in the first place.
- **`TableEditor2D.css`** — added `scrollbar-gutter: stable both-edges` to `.table-grid-fit-host` so `clientWidth`/`clientHeight` stay constant when scrollbars appear/disappear. This is **defence in depth**: it breaks the feedback loop even if a tiny overshoot is ever reintroduced.

## Why not just CSS or just JS?

The JS fix alone handles the current 2px border overshoot, but the loop is fundamentally fragile — any future change that reintroduces a sub-pixel overshoot would bring the twitch back. `scrollbar-gutter: stable` makes the measurement invariant to scrollbar presence, which is the real structural fix. Both together are belt-and-suspenders.

## Docs

- Added a **"VE Table Flickers / Twitches"** entry to `docs/src/reference/troubleshooting.md` describing the symptom, cause, and fix.
- Added a dated block to `CHANGELOG.md` under `[Unreleased]`.

## Testing

- `npm run typecheck` — clean (no TS errors in `TableGrid.tsx`).
- Verified the app launches and opens a rusEFI project (`TestProject2`) with the VE table rendering without the oscillation.

## Files changed

- `crates/libretune-app/src/components/tables/TableGrid.tsx`
- `crates/libretune-app/src/components/tables/TableEditor2D.css`
- `docs/src/reference/troubleshooting.md`
- `CHANGELOG.md`

> Note: the `public/manual/*` files in the working tree were left out — they are auto-generated outputs of the `docs:sync` script (run by `npm run dev`) and will be regenerated on the next build.
