### PR TITLE
feat: AI Assistant (docked side panel, read loop) + settings fix + default dashboard + docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,6 +146,15 @@ The project aims to provide professional ECU tuning workflow and functionality w
 - Template structure: name, description, ECU type, INI pattern, default connection settings
 - Frontend: Template picker in NewProjectDialog with 3-mode flow (select template → configure or scratch)
 
+### 12. AI Assistant (Bring-Your-Own-LLM)
+- Core: `crates/libretune-core/src/agent/` (orchestrator, tools, context, summarize, safety, tiers)
+- LLM providers: `crates/libretune-core/src/llm/` (Provider trait + native OpenAI/Anthropic/Google impls over reqwest)
+- Backend commands: `crates/libretune-app/src-tauri/src/commands/agent.rs` (agent_status, agent_send_message, agent_apply_proposals)
+- Frontend: `crates/libretune-app/src/components/agent/` (AgentSidePanel, ChatPanel, ProposalQueue)
+- Features: docked side panel (resizable, pop-out-able), multi-turn read loop (ReadToolExecutor), per-item review queue with safety-tier badges, authority clamping, INI validation
+- Safety: the model only ever PROPOSES; nothing burns automatically. Gated by an "at your own risk" enablement (RiskAcknowledgement shared primitive). Settings reset risk-ack on provider/key change.
+- Gap closures motivated by this feature: extended validate_action_set (min/max, cell bounds, DataType range, bits enum); TableRole enum + infer_table_roles(); summarize_tune_context(); constant safety tiering.
+
 ## Development Commands
 
 ### Backend (Rust)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,74 @@ relevant.
 
 ## [Unreleased]
 
+### 2026-07-31 — AI Assistant (bring-your-own-LLM) + UX fixes
+
+Adds a bring-your-own-LLM assistant that acts as a co-pilot for tuning and ECU
+configuration. The model only ever *proposes* changes; every proposal is
+validated against the INI, clamped to authority limits, and staged in a review
+queue for explicit user approval. Nothing burns to the ECU automatically.
+
+#### Added — AI Assistant
+- **Core library** (`crates/libretune-core/src/`):
+  - `agent/` module: `orchestrator` (multi-turn read→respond loop via a
+    `ReadToolExecutor` trait), `tools` (tool catalogue), `context`,
+    `summarize` (coverage + AFR error + anomalies aggregation), `safety`
+    (authority clamping), `tiers` (constant safety tiering:
+    Safe / Caution / Dangerous).
+  - `llm/` module: `Provider` trait + native OpenAI / Anthropic / Google
+    implementations over the existing `reqwest` client (no vendor SDK crates).
+  - `TableRole` enum + `EcuDefinition::infer_table_roles()` — machine-readable
+    table roles (Ve / Ignition / AfrTarget / WarmupEnrichment / Other) derived
+    from the INI's `[VeAnalyze]` / `[WueAnalyze]` config, so the assistant knows
+    what a table *does* without guessing from its name.
+  - Extended `ActionPlayer::validate_action_set` beyond existence checks: now
+    validates `Constant.min/max` bounds, `DataType` raw storage range, table
+    cell-index bounds (`x_size`/`y_size`), and bits-type enum values.
+- **Tauri app** (`crates/libretune-app/src-tauri/src/`):
+  - `commands/agent.rs`: `agent_status`, `agent_send_message` (multi-turn loop
+    with a `LiveReadExecutor` that reads tables/constants against live state),
+    `agent_apply_proposals` (re-validates; stages, never burns).
+  - AI settings wired through the 3-layer settings pattern (all keys present in
+    `update_setting` — avoids the latent `auto_commit_on_save` bug): provider,
+    base URL, API key, model, capability tier; enablement gated on a risk
+    acknowledgement that resets on provider/key change.
+- **Frontend** (`crates/libretune-app/src/components/`):
+  - `AgentSidePanel` — docked, non-modal, resizable right-hand panel (header
+    with pop-out + collapse buttons, collapsible review queue). Pop-out to its
+    own window via the existing `WebviewWindow` hash-routing system (`agent`
+    type in `PopOutWindow.tsx`; `agent:dock` event to restore).
+  - `ChatPanel` + `ProposalQueue` — conversational transcript + per-item review
+    surface with safety-tier badges and clamp notices.
+  - `common/RiskAcknowledgement` — reusable risk-ack primitive (lifted from the
+    firmware-update pattern).
+  - Tools → AI Assistant menu entry (a toggle reflecting panel visibility).
+
+#### Changed
+- **Settings dialog Apply/OK buttons** — split the old single "Apply"
+  (which saved *and* closed) into Windows-convention **Apply** (save, stay
+  open, show per-setting status) and **OK** (save and close). Each setting now
+  saves independently so one failure no longer silently aborts the rest — this
+  was the root cause of AI provider info not persisting.
+- **Default dashboard** is now **Telemetry Live** (was Basic), with Basic as
+  the fallback if Telemetry Live is absent.
+
+#### Docs
+- New feature guide `docs/src/features/ai-assistant.md` (usage, providers,
+  safety model, troubleshooting, privacy).
+- New technical reference `docs/src/technical/ai-assistant.md` (module layout,
+  agent-loop diagram, Provider/ReadToolExecutor traits, tool catalogue).
+- Added AI Assistant section to the settings guide.
+- Added AI Assistant entries to the technical README and SUMMARY.md.
+- Added two AI FAQ entries ("Can it tune my car for me?", "Do I need
+  OpenAI?").
+- Synced all of the above to the in-app manual (`public/manual/` + `toc.json`).
+- Added section 12 to `AGENTS.md` documenting the feature for future agents.
+
+#### Verification
+- `cargo test -p libretune-core`: all tests pass (lib + integration).
+- `cargo clippy -p libretune-core --lib`: clean.
+- `npm run typecheck`: clean.
+
 ### 2026-07-29 — Fix VE table scrollbar-twitch oscillation
 
 The VE table (the only table rendered in "fit viewport" mode, where cell

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2401,6 +2401,7 @@ dependencies = [
 name = "libretune-app"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "byteorder",
  "chrono",
  "dirs 5.0.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2422,6 +2422,7 @@ name = "libretune-core"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "base64 0.22.1",
  "byteorder",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ tokio-serial = "5.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
+# Async trait support (for the LLM Provider trait in libretune-core)
+async-trait = "0.1"
+
 # Error handling
 thiserror = "2.0"
 anyhow = "1.0"

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Data logger with configurable sample rates, playback controls, CSV import/export
 Project-based workflow with restore points, Git-based tune versioning, CSV export/import, TunerStudio project import, INI version tracking with automatic tune migration, and change annotations. Online INI search from Speeduino and rusEFI GitHub repos.
 
 ### Additional
+- **AI Assistant**: Bring-your-own-LLM co-pilot (OpenAI / Anthropic / Google / local Ollama) that reads your tables, diagnoses problems, and *proposes* validated, authority-clamped changes for explicit review — nothing burns automatically. Docked side panel, pop-out-able.
 - **Multi-monitor**: Pop out any tab to its own window with bidirectional sync
 - **Unit preferences**: Temperature (°C/°F/K), pressure (kPa/PSI/bar/inHg), AFR/Lambda
 - **Performance calculator**: Estimated HP/torque curves and acceleration times
@@ -155,6 +156,8 @@ libretune/
 │   │       ├── autotune/       # AutoTune algorithms
 │   │       ├── tune/           # Tune file management
 │   │       ├── dash/           # Dashboard format (incl. layout.rs defaults)
+│   │       ├── agent/          # AI assistant orchestrator, tools, safety tiers
+│   │       ├── llm/            # LLM provider trait + OpenAI/Anthropic/Google impls
 │   │       └── project/        # Project, restore points, Git versioning
 │   └── libretune-app/          # Tauri desktop application
 │       ├── src/                # React frontend (TypeScript)

--- a/crates/libretune-app/public/manual/SUMMARY.md
+++ b/crates/libretune-app/public/manual/SUMMARY.md
@@ -37,6 +37,7 @@
 - [Tools](./features/tools.md)
 - [Pop-out Windows](./features/popout-windows.md)
 - [ECU Console](./features/ecu-console.md)
+- [AI Assistant](./features/ai-assistant.md)
 - [Tune Migration](./features/tune-migration.md)
 - [Hardware Configuration](./technical/port-editor.md)
 - [Action Scripting](./reference/action-scripting.md)
@@ -68,6 +69,7 @@
 - [Lua Scripting](./technical/lua-scripting.md)
 - [Plugin System](./technical/plugin-system.md)
 - [Port Editor](./technical/port-editor.md)
+- [AI Assistant](./technical/ai-assistant.md)
 
 # FAQ
 

--- a/crates/libretune-app/public/manual/changelog.md
+++ b/crates/libretune-app/public/manual/changelog.md
@@ -32,6 +32,7 @@ All notable changes to LibreTune will be documented in this file.
 - **Change Annotations** — Annotate individual tune changes with notes explaining the purpose of each modification.
 - **WASM Plugin System** — Secure, sandboxed plugin architecture using WebAssembly. Plugins declare permissions and run without external dependencies.
 - **Dashboard Validation** — Automated validation of dashboard configurations against INI channel definitions.
+- **AI Assistant** — Bring-your-own-LLM co-pilot that helps tune and configure your ECU. Supports OpenAI, Anthropic, and Google providers (plus any OpenAI-compatible local endpoint like Ollama). The assistant only ever *proposes* changes — every proposal is validated against the INI, clamped to authority limits, and staged in a review queue for explicit user approval. Nothing burns automatically. Lives in a docked side panel (resizable, pop-out-able). Gated behind an "at your own risk" enablement.
 - Git-based tune versioning with commit history, branches, and auto-commit settings
 - Comprehensive documentation system (API docs + user manual)
 - TuneHistoryPanel for viewing and managing tune history
@@ -49,6 +50,7 @@ All notable changes to LibreTune will be documented in this file.
 - CSV export/import for tune data
 - Reset tune to defaults
 - Runtime Packet Mode setting (Auto / Force Burst / Force OCH / Disabled)
+- Backend logging now controlled via `RUST_LOG` using `tracing` (`info` default); ECU protocol debug output can be re-enabled with `RUST_LOG=libretune_core::protocol=debug`
 
 ### Changed
 - Replaced template-based "New Project" flow with file-centric "Open Tune File" workflow

--- a/crates/libretune-app/public/manual/faq.md
+++ b/crates/libretune-app/public/manual/faq.md
@@ -22,6 +22,21 @@ Yes. Use **File → Import TS Project** to import your TunerStudio project folde
 
 Yes. LibreTune uses the same INI format as TunerStudio. Your existing INI files should work without modification.
 
+### Can the AI Assistant tune my car for me?
+
+No — and that's deliberate. The AI Assistant is a **co-pilot**: it can read your
+tables, diagnose problems, and *propose* changes, but it never applies or burns
+anything automatically. Every proposal flows to a review queue where you accept
+or reject each change before it's staged to the working tune. Burning to the ECU
+is always a separate manual step. See [AI Assistant](./features/ai-assistant.md)
+for the full safety model.
+
+### Do I need an OpenAI account to use the AI Assistant?
+
+No. The assistant is **bring-your-own-LLM**. You can use OpenAI, Anthropic,
+Google, or run a local model (e.g. via Ollama) so your data never leaves your
+machine. See [Providers](./features/ai-assistant.md#providers).
+
 ## Connection Issues
 
 ### My ECU doesn't appear in the port list

--- a/crates/libretune-app/public/manual/features/ai-assistant.md
+++ b/crates/libretune-app/public/manual/features/ai-assistant.md
@@ -1,0 +1,180 @@
+# AI Assistant
+
+LibreTune includes an optional **AI Assistant** that can help you tune and
+configure your ECU. It is a **bring-your-own-LLM** feature: you supply the
+provider, API key, and model (OpenAI, Anthropic, Google, or any
+OpenAI-compatible local endpoint such as Ollama), and the assistant acts as a
+co-pilot.
+
+> ⚠️ **At your own risk.** The assistant can propose changes that affect
+> engine behavior. It only ever *proposes*; nothing is applied or burned
+> automatically. See [Safety Model](#safety-model) below.
+
+## Overview
+
+The assistant lives in a **docked side panel** on the right side of the window
+(similar to VS Code's chat), so you can chat with it while still viewing and
+editing tables and dashboards. It can also be **popped out** into its own
+window for multi-monitor setups.
+
+What the assistant can do:
+
+- **Explain** tables, constants, and gauges in plain English.
+- **Diagnose** problems from tune data and table health.
+- **Propose ECU configuration changes** (feature enablement, scalar constants).
+- **Propose tune edits** to individual cells or bulk regions.
+- **Read tables live** and analyze them in the same conversation — when it says
+  "let me look at your VE table," it actually reads the data and comes back with
+  an analysis.
+
+The assistant is **not** a closed-loop controller. It does not run every
+realtime tick — that remains the job of the algorithmic [AutoTune](./autotune.md)
+engine. Think of it as a smart strategy and explanation layer on top of the
+existing tools.
+
+## Enabling the Assistant
+
+1. Open **Tools → Settings**.
+2. Scroll to the **AI Assistant (at your own risk)** section.
+3. Read the risk warning and check the acknowledgement box.
+4. Fill in the provider details (see [Providers](#providers)).
+5. Choose a **Capability Tier** (see below).
+6. Check **Enable AI Assistant**.
+7. Click **Apply** (saves without closing) or **OK** (saves and closes).
+
+> **Note:** Each setting saves independently. If one setting fails to save
+> (for example, enabling without a risk acknowledgement), the others still save
+> and the failure is shown in the dialog footer.
+
+### Capability Tiers
+
+| Tier | What it allows |
+|------|----------------|
+| **Read / diagnose only** | Explain and analyze. Cannot propose changes. Start here until you trust the assistant. |
+| **Propose ECU configuration changes** | Propose constant changes (feature toggles, scalars). |
+| **Propose tune edits** | Propose table-cell edits and bulk operations. |
+
+## Using the Assistant
+
+1. Open **Tools → AI Assistant** (a toggle — click again to hide the panel).
+2. Type a message in the chat input. Examples:
+   - "Can you review my ignition table?"
+   - "How does my VE table look? Any glaring issues?"
+   - "Enable launch control."
+   - "Explain the fuelAlgorithm setting."
+3. The assistant may **read data first** (it will say "Let me pull up…"), then
+   reply with an analysis. This is normal — it's gathering context.
+4. If the assistant wants to make changes, it emits a **proposal** that appears
+   in the **Review queue** at the bottom of the panel.
+5. Each proposed item shows:
+   - **What** it wants to change (table cell, constant, bulk operation).
+   - **Why** it wants to change it (the assistant's reasoning).
+   - **Safety tier** (Safe / Caution / Dangerous) for configuration changes.
+   - **Validation status** — whether the proposal is within the INI's declared bounds.
+   - **Clamp notice** — if a tuning proposal exceeded the authority limit.
+6. Accept or reject each item, or click **Accept all valid**.
+7. Click **Stage accepted changes** to apply them to the working tune.
+8. **Burn** the tune to the ECU separately, only when you are satisfied.
+
+### The Side Panel
+
+- **Resizable** — drag the left edge to resize (280–640px).
+- **Collapsible review queue** — click the queue header to collapse/expand it.
+  It auto-expands when new proposals arrive.
+- **Pop-out** — click the external-link icon in the panel header to open the
+  assistant in its own window. Use that window's **Dock** button to bring it
+  back to the docked panel.
+
+## Providers
+
+LibreTune speaks each provider's **native protocol** (not just an
+OpenAI-compatible shim):
+
+| Provider | Setting value | Notes |
+|----------|---------------|-------|
+| **OpenAI** | `openai` | Also works with any OpenAI-compatible endpoint: OpenRouter, Ollama (`/v1`), LM Studio, vLLM. |
+| **Anthropic** | `anthropic` | Claude models (`claude-3-5-sonnet-…`, etc.). |
+| **Google** | `google` | Gemini models (`gemini-1.5-pro`, etc.). |
+
+### Provider Settings
+
+- **Base URL** — leave empty for the provider default. For a local model, point
+  at its endpoint, e.g. `http://localhost:11434/v1` for Ollama.
+- **API key** — your provider key. Optional for local/no-auth endpoints.
+- **Model** — e.g. `gpt-4o`, `claude-3-5-sonnet-20241022`, `gemini-1.5-pro`.
+  The model **must support tool/function calling** for the assistant to work.
+
+### Local Models (Recommended for Privacy)
+
+Because you bring your own model, you control where your data goes. For maximum
+privacy, run a local model with [Ollama](https://ollama.com):
+
+1. Install Ollama and pull a tool-capable model (e.g. `ollama pull llama3.1`).
+2. In settings, set **Provider** = OpenAI, **Base URL** = `http://localhost:11434/v1`.
+3. Leave the API key empty.
+4. Set **Model** to the model name you pulled.
+
+Tune data never leaves your machine.
+
+## Safety Model
+
+The assistant is deliberately constrained at multiple layers:
+
+| Layer | What it does |
+|-------|--------------|
+| **Propose only** | The model emits tool calls that become a proposal list. It has no apply/burn command. |
+| **INI validation** | Every proposal is checked against the loaded INI: table/constant existence, cell-index bounds, `min`/`max`, `DataType` storage range, and bits-type enum values. |
+| **Authority clamping** | Tune edits are clamped to the same per-cell and percentage limits used by AutoTune (`AutoTuneAuthorityLimits`). |
+| **Human approval** | Accepted proposals are staged; they do not burn automatically. |
+| **Dangerous-constant flagging** | Constants that affect pins, triggers, output inversion, or hard limits are marked **Dangerous** and require explicit per-item confirmation. |
+| **No ECU burn** | The assistant has no burn command. You must click Burn yourself. |
+| **Read-loop bounded** | Multi-turn read interactions are capped (6 rounds) to prevent runaway cost. |
+
+### How proposals are validated
+
+When the assistant proposes a value, the validator checks three things:
+
+1. **Display-unit bounds** — the INI declares `min` and `max` for every
+   constant. A proposed value outside that range is rejected with an error.
+2. **Storage-type range** — even before scaling, the raw value must fit the
+   underlying type (e.g. a `U16` must be 0–65535). This catches values the
+   display bounds might miss when `scale ≠ 1`.
+3. **Bits-type enumeration** — for feature toggles, the value must be a valid
+   index into the constant's declared options.
+
+## Tips for Good Results
+
+- **Start with the Read tier** until you understand how the assistant reasons.
+- **Ask it to read first**: "Read my VE table and tell me which cells have good
+  data coverage" gives it context before it proposes edits.
+- **Be specific**: "Lean out the 3000 RPM / 80 kPa cell by 2%" is safer than
+  "fix my tune."
+- **Review every clamp**: if a value was authority-clamped, the original
+  requested value and reason are shown in the review queue.
+- **Compare with AutoTune**: for VE tables, the algorithmic AutoTune engine
+  remains the ground truth. Use the assistant for strategy, then cross-check
+  its proposals.
+
+## Troubleshooting
+
+| Problem | Likely cause / fix |
+|---------|-------------------|
+| "AI assistant is not enabled" | Enable it in Settings and acknowledge the risk warning. |
+| "AI assistant risk acknowledgement is missing" | Check the acknowledgement box in the AI Assistant settings section. |
+| "Authentication failed" | Check your API key. |
+| "Could not parse provider response" | The model may not support tool/function calling. Use a model that does (e.g. `gpt-4o`, `claude-3-5-sonnet`). |
+| Proposals fail validation | The model asked for an out-of-bounds value or a non-existent table/constant. Reject it and rephrase your request. |
+| Assistant does not propose changes | You may be in Read tier, or the model chose not to call a tool. Ask more specifically, or raise the capability tier. |
+| Assistant stalls after "let me look at…" | This should not happen — the read loop executes reads and feeds results back. If it does, the model may be returning no tool calls; check the provider/model supports tool calling. |
+| Settings don't save when I hit Apply | Look at the footer of the settings dialog — it shows which setting failed (hover for details). |
+
+## Privacy & Data Handling
+
+- **Hosted providers** (OpenAI, Anthropic, Google): tune data and ECU context
+  are sent over HTTPS to that provider. Do not use them with sensitive data
+  unless you trust their policies.
+- **Local providers** (Ollama, LM Studio, vLLM): data stays on your machine.
+- **API key storage**: the key is stored locally in LibreTune's settings file
+  (plaintext in v1). OS-keychain storage is planned as a follow-up.
+- Changing the provider or API key resets the risk acknowledgement, so you
+  re-confirm before the assistant is re-enabled.

--- a/crates/libretune-app/public/manual/getting-started/settings.md
+++ b/crates/libretune-app/public/manual/getting-started/settings.md
@@ -225,6 +225,53 @@ Available placeholders:
 
 ---
 
+## AI Assistant
+
+The **AI Assistant** is a bring-your-own-LLM co-pilot that can help you tune and
+configure your ECU. See [AI Assistant](../features/ai-assistant.md) for full
+usage details.
+
+> ⚠️ **At your own risk.** The assistant only ever *proposes* changes; nothing
+> is applied or burned automatically.
+
+### Enabling
+
+1. Scroll to the **AI Assistant (at your own risk)** section.
+2. Read the risk warning and check the acknowledgement box.
+3. Configure the provider (see below).
+4. Check **Enable AI Assistant**.
+5. Click **Apply** (save without closing) or **OK** (save and close).
+
+### Provider
+
+- **OpenAI** — hosted OpenAI, or any OpenAI-compatible endpoint (OpenRouter,
+  Ollama, LM Studio, vLLM).
+- **Anthropic** — Claude models.
+- **Google** — Gemini models.
+
+### Base URL
+
+Leave empty for the provider default. For a local model, set this to the local
+endpoint, e.g. `http://localhost:11434/v1` for Ollama.
+
+### API Key
+
+Your provider key. Optional for local/no-auth endpoints. Stored locally in the
+settings file.
+
+### Model
+
+A tool/function-calling-capable model (e.g. `gpt-4o`,
+`claude-3-5-sonnet-20241022`, `gemini-1.5-pro`).
+
+### Capability Tier
+
+- **Read / diagnose only** — explain and analyze; cannot propose changes.
+- **Propose ECU configuration changes** — propose constant changes.
+- **Propose tune edits** — propose table-cell and bulk edits.
+
+---
+
 ## AutoTune Settings
 
 Default values for AutoTune parameters.

--- a/crates/libretune-app/public/manual/technical/README.md
+++ b/crates/libretune-app/public/manual/technical/README.md
@@ -21,6 +21,7 @@ This section provides in-depth technical documentation for LibreTune's core algo
 ### Core Systems
 - **[Version Control](./version-control.md)** - Git integration, tune fingerprinting, and migration detection
 - **[Lua Scripting](./lua-scripting.md)** - Sandboxed runtime, API reference, and security model
+- **[AI Assistant](./ai-assistant.md)** - Bring-your-own-LLM agent loop, provider trait, validation extensions
 
 ## Philosophy
 

--- a/crates/libretune-app/public/manual/technical/ai-assistant.md
+++ b/crates/libretune-app/public/manual/technical/ai-assistant.md
@@ -1,0 +1,162 @@
+# AI Assistant Architecture
+
+This document describes the technical architecture of LibreTune's bring-your-own-LLM
+AI Assistant. It is intended for developers contributing to or extending the feature.
+
+## Design Principles
+
+1. **Bring your own model** — LibreTune never hosts a model. The user supplies the
+   provider, key, and model. This keeps the feature dependency-free and private.
+2. **Propose, never apply** — the assistant's only output is a validated, clamped
+   *proposal*. Application and burn are always separate, user-triggered steps.
+3. **Reuse existing primitives** — the assistant is a thin layer over the existing
+   `Action` enum, `validate_action_set`, AutoTune engines, and INI metadata. It does
+   not duplicate safety logic.
+4. **Provider-agnostic** — a single `Provider` trait abstracts all LLM backends. The
+   orchestrator never sees provider-specific JSON.
+
+## Module Layout
+
+```
+crates/libretune-core/src/
+├── agent/
+│   ├── mod.rs           # module root + re-exports
+│   ├── orchestrator.rs  # multi-turn agent loop + ReadToolExecutor trait
+│   ├── tools.rs         # tool catalogue (JSON-schema tool definitions)
+│   ├── context.rs       # context-gathering helpers (constants, tables)
+│   ├── summarize.rs     # summarize_tune_context() aggregation
+│   ├── safety.rs        # authority-limit clamping
+│   └── tiers.rs         # constant safety tiering (Safe/Caution/Dangerous)
+└── llm/
+    ├── mod.rs           # module root
+    ├── types.rs         # ChatRequest/ChatResponse/Message/ToolCall/LlmError
+    ├── provider.rs      # Provider trait + factory
+    ├── client.rs        # LlmClient (top-level entry point)
+    └── providers/
+        ├── openai.rs    # OpenAI Chat Completions (native protocol)
+        ├── anthropic.rs # Anthropic Messages API (native protocol)
+        └── google.rs    # Google Gemini generateContent (native protocol)
+```
+
+The Tauri layer wraps these in `crates/libretune-app/src-tauri/src/commands/agent.rs`
+(commands: `agent_status`, `agent_send_message`, `agent_apply_proposals`).
+
+## The Agent Loop
+
+One user turn runs a **multi-turn loop** inside `orchestrator::run_turn`:
+
+```
+user message
+     │
+     ▼
+┌─────────────────────────────────────────────┐
+│  build ChatRequest (system + history + msg) │
+│  + tool catalogue                            │
+└──────────────────────┬──────────────────────┘
+                       ▼
+              call Provider::chat
+                       │
+        ┌──────────────┴───────────────┐
+        ▼                              ▼
+  read tool calls?              propose tool calls?
+        │                              │
+        ▼                              ▼
+  execute via                 map → Action[]
+  ReadToolExecutor            validate_action_set
+        │                     clamp to authority
+        ▼                     accumulate into Proposal
+  append tool-result                   │
+  messages to history                  │
+        │                              │
+        ▼                              ▼
+  loop back ─────────────►  (no reads left? → done)
+                                   │
+                                   ▼
+                            return Proposal
+```
+
+The loop is bounded by `MAX_READ_ROUNDS` (6) to cap cost and prevent runaway
+conversations. Read results are fed back as tool-result messages so the model can
+reason over actual table/constant data before emitting its final reply.
+
+## The Provider Trait
+
+```rust
+#[async_trait]
+pub trait Provider: Send + Sync {
+    fn name(&self) -> &str;
+    async fn chat(&self, req: &ChatRequest) -> Result<ChatResponse, LlmError>;
+}
+```
+
+Each concrete provider translates the generic `ChatRequest` to its wire format
+(OpenAI `tools[]`, Anthropic `tool_use` blocks, Gemini `functionDeclarations`),
+calls its endpoint via the shared `reqwest` client, and parses the response back
+into a generic `ChatResponse`. Adding a new provider requires only implementing
+this trait — no orchestrator changes.
+
+## The ReadToolExecutor Trait
+
+```rust
+#[async_trait]
+pub trait ReadToolExecutor: Send + Sync {
+    fn handles(&self, tool_name: &str) -> bool;
+    async fn execute(&self, tool_name: &str, arguments: &str) -> String;
+}
+```
+
+The core library defines this contract; the Tauri layer implements it as
+`LiveReadExecutor`, which reaches `AppState` via `tauri::Manager::state()` and
+reads tables/constants against the loaded definition and tune. This split keeps
+the loop unit-testable without a live provider or ECU.
+
+## Tool Catalogue
+
+Defined in `agent/tools.rs`. The model may call:
+
+| Tool | Type | Purpose |
+|------|------|---------|
+| `list_tables` | read | Discover table names + roles + dimensions |
+| `read_table` | read | Get a table's values, axis bins, units |
+| `read_constant` | read | Get a constant's value, min/max, options |
+| `list_features` | read | List feature-toggle (bits) constants |
+| `summarize_tune_context` | read | Aggregated coverage + AFR error + anomalies |
+| `tune_health_check` | read | Per-region health scores |
+| `propose_table_edit` | propose | Stage a single-cell edit (reviewed + clamped) |
+| `propose_bulk_operation` | propose | Stage scale/smooth/interpolate (reviewed) |
+| `propose_constant_change` | propose | Stage a constant change (tier-flagged) |
+
+## TableRole Inference
+
+`EcuDefinition::infer_table_roles()` attaches a machine-readable `TableRole`
+enum (`Ve`, `Ignition`, `AfrTarget`, `WarmupEnrichment`, `Other`) to every
+`TableDefinition`, derived from the INI's `[VeAnalyze]` and `[WueAnalyze]`
+sections. This lets the assistant know what a table *does* without guessing from
+its name.
+
+## Validation Extensions
+
+The assistant motivated extending `ActionPlayer::validate_action_set` beyond
+existence checks. It now validates:
+
+- **Constant `min`/`max`** (display-unit bounds)
+- **`DataType` raw storage range** (pre-scale)
+- **Table cell-index bounds** (`x_index`/`y_index` vs `x_size`/`y_size`)
+- **Bits-type enumeration** (value must be a valid option index)
+
+## Frontend
+
+- `components/agent/AgentSidePanel.tsx` — the docked right-hand panel (header,
+  resize handle, pop-out/collapse buttons, collapsible review queue).
+- `components/agent/ChatPanel.tsx` — the conversational transcript + input.
+- `components/agent/ProposalQueue.tsx` — the per-item review surface.
+- `components/common/RiskAcknowledgement.tsx` — reusable risk-ack primitive.
+- The panel can pop out via the existing `WebviewWindow` + hash-routing system
+  (see `PopOutWindow.tsx`, type `agent`).
+
+## Error Handling
+
+- The core layer uses a typed `LlmError` enum (`Network`, `Auth`, `RateLimit`,
+  `Parse`, `ApiError`, `Config`).
+- Tauri commands flatten to `Result<T, String>` at the boundary.
+- Settings saves are per-setting (one failure does not abort the others).

--- a/crates/libretune-app/public/manual/toc.json
+++ b/crates/libretune-app/public/manual/toc.json
@@ -1,306 +1,280 @@
 [
   {
-    "title": "Getting Started",
+    "title": "Installation",
     "path": "getting-started/installation",
-    "children": [
-      {
-        "title": "Installation",
-        "path": "getting-started/installation",
-        "children": []
-      },
-      {
-        "title": "Creating Your First Project",
-        "path": "getting-started/first-project",
-        "children": []
-      },
-      {
-        "title": "Connecting to Your ECU",
-        "path": "getting-started/connecting",
-        "children": []
-      },
-      {
-        "title": "Settings & Preferences",
-        "path": "getting-started/settings",
-        "children": []
-      }
-    ]
+    "children": []
   },
   {
-    "title": "Core Features",
+    "title": "Creating Your First Project",
+    "path": "getting-started/first-project",
+    "children": []
+  },
+  {
+    "title": "Connecting to Your ECU",
+    "path": "getting-started/connecting",
+    "children": []
+  },
+  {
+    "title": "Settings & Preferences",
+    "path": "getting-started/settings",
+    "children": []
+  },
+  {
+    "title": "Table Editing",
     "path": "features/table-editing",
     "children": [
       {
-        "title": "Table Editing",
-        "path": "features/table-editing",
-        "children": [
-          {
-            "title": "2D Tables",
-            "path": "features/table-editing/2d-tables",
-            "children": []
-          },
-          {
-            "title": "3D Visualization",
-            "path": "features/table-editing/3d-visualization",
-            "children": []
-          },
-          {
-            "title": "Keyboard Shortcuts",
-            "path": "features/table-editing/shortcuts",
-            "children": []
-          }
-        ]
-      },
-      {
-        "title": "AutoTune",
-        "path": "features/autotune",
-        "children": [
-          {
-            "title": "Usage Guide",
-            "path": "features/autotune/usage-guide",
-            "children": []
-          },
-          {
-            "title": "Setting Up AutoTune",
-            "path": "features/autotune/setup",
-            "children": []
-          },
-          {
-            "title": "Understanding Recommendations",
-            "path": "features/autotune/recommendations",
-            "children": []
-          },
-          {
-            "title": "Filters and Authority",
-            "path": "features/autotune/filters",
-            "children": []
-          }
-        ]
-      },
-      {
-        "title": "Dashboards",
-        "path": "features/dashboards",
-        "children": [
-          {
-            "title": "Using Dashboards",
-            "path": "features/dashboards/using",
-            "children": []
-          },
-          {
-            "title": "Customizing Gauges",
-            "path": "features/dashboards/customizing",
-            "children": []
-          },
-          {
-            "title": "Creating Dashboards",
-            "path": "features/dashboards/creating",
-            "children": []
-          },
-          {
-            "title": "Dashboard Validation",
-            "path": "features/dashboards/validation",
-            "children": []
-          }
-        ]
-      },
-      {
-        "title": "Math Channels",
-        "path": "features/math-channels",
+        "title": "2D Tables",
+        "path": "features/table-editing/2d-tables",
         "children": []
       },
       {
-        "title": "Data Logging",
-        "path": "features/datalog",
-        "children": []
-      },
-      {
-        "title": "Smart Recording",
-        "path": "features/smart-recording",
-        "children": []
-      },
-      {
-        "title": "Data Statistics",
-        "path": "features/data-statistics",
-        "children": []
-      },
-      {
-        "title": "Alert Rules",
-        "path": "features/alert-rules",
-        "children": []
-      },
-      {
-        "title": "Lua Scripting",
-        "path": "features/lua-scripting",
-        "children": []
-      },
-      {
-        "title": "Base Map Generator",
-        "path": "features/base-map",
-        "children": []
-      },
-      {
-        "title": "Performance Calculator",
-        "path": "features/performance-calculator",
-        "children": []
-      },
-      {
-        "title": "Diagnostic Loggers",
-        "path": "features/diagnostic-loggers",
-        "children": []
-      },
-      {
-        "title": "Tools",
-        "path": "features/tools",
-        "children": []
-      },
-      {
-        "title": "Pop-out Windows",
-        "path": "features/popout-windows",
-        "children": []
-      },
-      {
-        "title": "ECU Console",
-        "path": "features/ecu-console",
-        "children": []
-      },
-      {
-        "title": "Tune Migration",
-        "path": "features/tune-migration",
-        "children": []
-      },
-      {
-        "title": "Hardware Configuration",
-        "path": "technical/port-editor",
-        "children": []
-      },
-      {
-        "title": "Action Scripting",
-        "path": "reference/action-scripting",
-        "children": []
-      }
-    ]
-  },
-  {
-    "title": "Project Management",
-    "path": "projects/tunes",
-    "children": [
-      {
-        "title": "Managing Tunes",
-        "path": "projects/tunes",
-        "children": []
-      },
-      {
-        "title": "Version Control",
-        "path": "projects/version-control",
-        "children": []
-      },
-      {
-        "title": "Change Annotations",
-        "path": "projects/change-annotations",
-        "children": []
-      },
-      {
-        "title": "Restore Points",
-        "path": "projects/restore-points",
-        "children": []
-      },
-      {
-        "title": "Importing Projects",
-        "path": "projects/importing",
-        "children": []
-      }
-    ]
-  },
-  {
-    "title": "Reference",
-    "path": "reference/supported-ecus",
-    "children": [
-      {
-        "title": "Supported ECUs",
-        "path": "reference/supported-ecus",
-        "children": []
-      },
-      {
-        "title": "INI File Format",
-        "path": "reference/ini-format",
+        "title": "3D Visualization",
+        "path": "features/table-editing/3d-visualization",
         "children": []
       },
       {
         "title": "Keyboard Shortcuts",
-        "path": "reference/shortcuts",
-        "children": []
-      },
-      {
-        "title": "Troubleshooting",
-        "path": "reference/troubleshooting",
-        "children": []
-      },
-      {
-        "title": "Java → WASM Migration",
-        "path": "reference/java-to-wasm-migration",
+        "path": "features/table-editing/shortcuts",
         "children": []
       }
     ]
   },
   {
-    "title": "Technical Reference",
+    "title": "AutoTune",
+    "path": "features/autotune",
+    "children": [
+      {
+        "title": "Usage Guide",
+        "path": "features/autotune/usage-guide",
+        "children": []
+      },
+      {
+        "title": "Setting Up AutoTune",
+        "path": "features/autotune/setup",
+        "children": []
+      },
+      {
+        "title": "Understanding Recommendations",
+        "path": "features/autotune/recommendations",
+        "children": []
+      },
+      {
+        "title": "Filters and Authority",
+        "path": "features/autotune/filters",
+        "children": []
+      }
+    ]
+  },
+  {
+    "title": "Dashboards",
+    "path": "features/dashboards",
+    "children": [
+      {
+        "title": "Using Dashboards",
+        "path": "features/dashboards/using",
+        "children": []
+      },
+      {
+        "title": "Customizing Gauges",
+        "path": "features/dashboards/customizing",
+        "children": []
+      },
+      {
+        "title": "Creating Dashboards",
+        "path": "features/dashboards/creating",
+        "children": []
+      },
+      {
+        "title": "Dashboard Validation",
+        "path": "features/dashboards/validation",
+        "children": []
+      }
+    ]
+  },
+  {
+    "title": "Math Channels",
+    "path": "features/math-channels",
+    "children": []
+  },
+  {
+    "title": "Data Logging",
+    "path": "features/datalog",
+    "children": []
+  },
+  {
+    "title": "Smart Recording",
+    "path": "features/smart-recording",
+    "children": []
+  },
+  {
+    "title": "Data Statistics",
+    "path": "features/data-statistics",
+    "children": []
+  },
+  {
+    "title": "Alert Rules",
+    "path": "features/alert-rules",
+    "children": []
+  },
+  {
+    "title": "Lua Scripting",
+    "path": "features/lua-scripting",
+    "children": []
+  },
+  {
+    "title": "Base Map Generator",
+    "path": "features/base-map",
+    "children": []
+  },
+  {
+    "title": "Performance Calculator",
+    "path": "features/performance-calculator",
+    "children": []
+  },
+  {
+    "title": "Diagnostic Loggers",
+    "path": "features/diagnostic-loggers",
+    "children": []
+  },
+  {
+    "title": "Tools",
+    "path": "features/tools",
+    "children": []
+  },
+  {
+    "title": "Pop-out Windows",
+    "path": "features/popout-windows",
+    "children": []
+  },
+  {
+    "title": "ECU Console",
+    "path": "features/ecu-console",
+    "children": []
+  },
+  {
+    "title": "AI Assistant",
+    "path": "features/ai-assistant",
+    "children": []
+  },
+  {
+    "title": "Tune Migration",
+    "path": "features/tune-migration",
+    "children": []
+  },
+  {
+    "title": "Hardware Configuration",
+    "path": "technical/port-editor",
+    "children": []
+  },
+  {
+    "title": "Action Scripting",
+    "path": "reference/action-scripting",
+    "children": []
+  },
+  {
+    "title": "Managing Tunes",
+    "path": "projects/tunes",
+    "children": []
+  },
+  {
+    "title": "Version Control",
+    "path": "projects/version-control",
+    "children": []
+  },
+  {
+    "title": "Change Annotations",
+    "path": "projects/change-annotations",
+    "children": []
+  },
+  {
+    "title": "Restore Points",
+    "path": "projects/restore-points",
+    "children": []
+  },
+  {
+    "title": "Importing Projects",
+    "path": "projects/importing",
+    "children": []
+  },
+  {
+    "title": "Supported ECUs",
+    "path": "reference/supported-ecus",
+    "children": []
+  },
+  {
+    "title": "INI File Format",
+    "path": "reference/ini-format",
+    "children": []
+  },
+  {
+    "title": "Keyboard Shortcuts",
+    "path": "reference/shortcuts",
+    "children": []
+  },
+  {
+    "title": "Troubleshooting",
+    "path": "reference/troubleshooting",
+    "children": []
+  },
+  {
+    "title": "Java → WASM Migration",
+    "path": "reference/java-to-wasm-migration",
+    "children": []
+  },
+  {
+    "title": "Overview",
     "path": "technical/README",
-    "children": [
-      {
-        "title": "Overview",
-        "path": "technical/README",
-        "children": []
-      },
-      {
-        "title": "AutoTune Algorithm",
-        "path": "technical/autotune-algorithm",
-        "children": []
-      },
-      {
-        "title": "Table Operations",
-        "path": "technical/table-operations",
-        "children": []
-      },
-      {
-        "title": "INI Parser",
-        "path": "technical/ini-parser",
-        "children": []
-      },
-      {
-        "title": "ECU Protocol",
-        "path": "technical/ecu-protocol",
-        "children": []
-      },
-      {
-        "title": "Version Control",
-        "path": "technical/version-control",
-        "children": []
-      },
-      {
-        "title": "Lua Scripting",
-        "path": "technical/lua-scripting",
-        "children": []
-      },
-      {
-        "title": "Plugin System",
-        "path": "technical/plugin-system",
-        "children": []
-      },
-      {
-        "title": "Port Editor",
-        "path": "technical/port-editor",
-        "children": []
-      }
-    ]
+    "children": []
   },
   {
-    "title": "FAQ",
+    "title": "AutoTune Algorithm",
+    "path": "technical/autotune-algorithm",
+    "children": []
+  },
+  {
+    "title": "Table Operations",
+    "path": "technical/table-operations",
+    "children": []
+  },
+  {
+    "title": "INI Parser",
+    "path": "technical/ini-parser",
+    "children": []
+  },
+  {
+    "title": "ECU Protocol",
+    "path": "technical/ecu-protocol",
+    "children": []
+  },
+  {
+    "title": "Version Control",
+    "path": "technical/version-control",
+    "children": []
+  },
+  {
+    "title": "Lua Scripting",
+    "path": "technical/lua-scripting",
+    "children": []
+  },
+  {
+    "title": "Plugin System",
+    "path": "technical/plugin-system",
+    "children": []
+  },
+  {
+    "title": "Port Editor",
+    "path": "technical/port-editor",
+    "children": []
+  },
+  {
+    "title": "AI Assistant",
+    "path": "technical/ai-assistant",
+    "children": []
+  },
+  {
+    "title": "Frequently Asked Questions",
     "path": "faq",
-    "children": [
-      {
-        "title": "Frequently Asked Questions",
-        "path": "faq",
-        "children": []
-      }
-    ]
+    "children": []
   }
 ]

--- a/crates/libretune-app/src-tauri/Cargo.toml
+++ b/crates/libretune-app/src-tauri/Cargo.toml
@@ -25,6 +25,7 @@ tauri-plugin-window-state = "2"
 serde = { workspace = true }
 serde_json = { workspace = true }
 libretune-core = { path = "../../libretune-core" }
+async-trait = { workspace = true }
 dirs = "5"
 tokio = { workspace = true }
 tauri-plugin-dialog = "2"

--- a/crates/libretune-app/src-tauri/src/commands/agent.rs
+++ b/crates/libretune-app/src-tauri/src/commands/agent.rs
@@ -1,0 +1,222 @@
+//! Tauri commands for the AI assistant agent loop.
+//!
+//! These wrap the [`libretune_core::agent`] orchestrator and
+//! [`libretune_core::llm`] provider client. They never apply changes: a turn
+//! produces a [`Proposal`] that the frontend stages in a review queue. Only
+//! `agent_apply_proposals` mutates the working tune, and even then burning to
+//! the ECU is a separate manual user action.
+
+use crate::state::AppState;
+use libretune_core::action_scripting::Action;
+use libretune_core::agent::orchestrator::{run_turn, OrchestratorInputs, Proposal};
+use libretune_core::agent::tiers::ConstantSafetyTier;
+use libretune_core::autotune::AutoTuneAuthorityLimits;
+use libretune_core::llm::types::{LlmError, Message};
+use libretune_core::llm::{LlmClient, ProviderConfig};
+use serde::{Deserialize, Serialize};
+
+/// Construct a `ProviderConfig` from stored settings.
+fn config_from_settings(s: &crate::Settings) -> ProviderConfig {
+    ProviderConfig {
+        provider: s.ai_provider.clone(),
+        base_url: s.ai_base_url.clone(),
+        api_key: s.ai_api_key.clone(),
+        model: s.ai_model.clone(),
+    }
+}
+
+/// Build an `LlmClient` from current settings.
+/// Errors surface as `Result<T, String>` per the app's convention.
+fn build_client(s: &crate::Settings) -> Result<LlmClient, LlmError> {
+    LlmClient::new(&config_from_settings(s))
+}
+
+/// Request payload from the frontend for one assistant turn.
+#[derive(Debug, Deserialize)]
+pub struct AgentTurnRequest {
+    /// The user's message this turn.
+    pub user_message: String,
+    /// Prior conversation as the frontend has it (serialized messages).
+    pub history: Vec<SerializedMessage>,
+    /// Pre-rendered system prompt describing the ECU/tune context. The
+    /// frontend builds this from the current view (tables loaded, etc.).
+    pub system_prompt: String,
+}
+
+/// A serialized [`Message`] that round-trips through JSON.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SerializedMessage {
+    pub role: String,
+    pub content: String,
+}
+
+impl From<SerializedMessage> for Message {
+    fn from(s: SerializedMessage) -> Self {
+        match s.role.as_str() {
+            "system" => Message::system(s.content),
+            "assistant" => Message::assistant(s.content),
+            _ => Message::user(s.content),
+        }
+    }
+}
+
+/// Build a default authority-limit envelope for clamping proposals.
+fn default_authority() -> AutoTuneAuthorityLimits {
+    AutoTuneAuthorityLimits::default()
+}
+
+/// Check whether the assistant is configured and enabled. Cheap pre-flight.
+#[tauri::command]
+pub async fn agent_status(app: tauri::AppHandle) -> Result<AgentStatus, String> {
+    let s = crate::load_settings(&app);
+    Ok(AgentStatus {
+        enabled: s.ai_assistant_enabled,
+        risk_acknowledged: s.ai_risk_acknowledged,
+        provider: s.ai_provider.clone(),
+        model: s.ai_model.clone(),
+        capability_tier: s.ai_capability_tier.clone(),
+        // Configured if both provider and model are non-empty (key is optional
+        // for local providers, so we don't require it).
+        configured: !s.ai_provider.is_empty() && !s.ai_model.is_empty(),
+    })
+}
+
+#[derive(Debug, Serialize)]
+pub struct AgentStatus {
+    pub enabled: bool,
+    pub risk_acknowledged: bool,
+    pub provider: String,
+    pub model: String,
+    pub capability_tier: String,
+    pub configured: bool,
+}
+
+/// Run one assistant turn. Returns a [`Proposal`] for the review queue.
+///
+/// Does not apply anything. The frontend renders `proposal.proposed` as a
+/// reviewable list; the user explicitly approves items before
+/// `agent_apply_proposals` stages them to the working tune.
+#[tauri::command]
+pub async fn agent_send_message(
+    app: tauri::AppHandle,
+    request: AgentTurnRequest,
+) -> Result<Proposal, String> {
+    let s = crate::load_settings(&app);
+
+    // Gate: must be enabled + risk-acknowledged.
+    if !s.ai_assistant_enabled {
+        return Err("AI assistant is not enabled".to_string());
+    }
+    if !s.ai_risk_acknowledged {
+        return Err("AI assistant risk acknowledgement is missing".to_string());
+    }
+
+    let client = build_client(&s).map_err(|e| e.to_string())?;
+
+    let history: Vec<Message> = request.history.into_iter().map(Into::into).collect();
+    let inputs = OrchestratorInputs {
+        history,
+        user_message: request.user_message,
+        system_prompt: request.system_prompt,
+        current_table_values: Default::default(),
+    };
+
+    let authority = default_authority();
+    run_turn(&client, &inputs, &authority)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// Request payload for applying a subset of a proposal.
+#[derive(Debug, Deserialize)]
+pub struct ApplyProposalsRequest {
+    /// The actions to apply, exactly as the user approved them from the
+    /// proposal queue. Re-validated here before apply.
+    pub actions: Vec<Action>,
+}
+
+/// Result of applying one action.
+#[derive(Debug, Serialize)]
+pub struct ApplyResult {
+    pub applied: bool,
+    pub error: Option<String>,
+    /// Safety tier (constants only) so the UI can show what was applied.
+    pub safety_tier: Option<ConstantSafetyTier>,
+}
+
+/// Apply a list of approved actions to the working tune.
+///
+/// Each action is re-validated against the loaded definition; invalid ones are
+/// skipped with an error in the result. **Nothing is burned to the ECU** —
+/// the changes are staged in the working tune and flagged as modified, so the
+/// user must explicitly burn afterward.
+#[tauri::command]
+pub async fn agent_apply_proposals(
+    state: tauri::State<'_, AppState>,
+    request: ApplyProposalsRequest,
+) -> Result<Vec<ApplyResult>, String> {
+    use libretune_core::action_scripting::{ActionMetadata, ActionPlayer, ActionSet};
+
+    // 1. Validate every action while holding the definition lock (read-only).
+    let mut results: Vec<ApplyResult> = Vec::with_capacity(request.actions.len());
+    let mut any_applied = false;
+    {
+        let def = state.definition.lock().await;
+        let def_ref = def.as_ref();
+
+        for action in &request.actions {
+            let tier = match action {
+                Action::ConstantChange { constant_name, .. } => {
+                    Some(libretune_core::agent::constant_safety_tier(constant_name))
+                }
+                _ => None,
+            };
+
+            let set = ActionSet {
+                id: "apply".into(),
+                name: "apply".into(),
+                description: "Approved AI proposal action".into(),
+                version: "1".into(),
+                actions: vec![action.clone()],
+                metadata: ActionMetadata {
+                    created_by: "ai-assistant".into(),
+                    created_at: chrono::Utc::now().to_rfc3339(),
+                    modified_at: chrono::Utc::now().to_rfc3339(),
+                    tags: vec!["ai-applied".into()],
+                    compatible_ecus: vec![],
+                },
+            };
+
+            match ActionPlayer::validate_action_set(&set, def_ref) {
+                Ok(_warnings) => {
+                    any_applied = true;
+                    results.push(ApplyResult {
+                        applied: true,
+                        error: None,
+                        safety_tier: tier,
+                    });
+                }
+                Err(errors) => {
+                    results.push(ApplyResult {
+                        applied: false,
+                        error: Some(errors.join("; ")),
+                        safety_tier: tier,
+                    });
+                }
+            }
+        }
+    } // definition lock released here
+
+    // 2. If at least one action applied, flag the tune as modified so the
+    //    user is prompted to burn. The actual table/constant mutation is
+    //    performed by the frontend via the existing update commands (this
+    //    command validates + signals intent; it does not itself write to
+    //    tune state, to avoid duplicating the page-write path).
+    if any_applied {
+        let mut modified = state.tune_modified.lock().await;
+        *modified = true;
+    }
+
+    Ok(results)
+}
+

--- a/crates/libretune-app/src-tauri/src/commands/agent.rs
+++ b/crates/libretune-app/src-tauri/src/commands/agent.rs
@@ -8,12 +8,17 @@
 
 use crate::state::AppState;
 use libretune_core::action_scripting::Action;
-use libretune_core::agent::orchestrator::{run_turn, OrchestratorInputs, Proposal};
+use libretune_core::agent::orchestrator::{
+    run_turn, OrchestratorInputs, Proposal, ReadToolExecutor,
+};
 use libretune_core::agent::tiers::ConstantSafetyTier;
+use libretune_core::agent::tools;
 use libretune_core::autotune::AutoTuneAuthorityLimits;
 use libretune_core::llm::types::{LlmError, Message};
 use libretune_core::llm::{LlmClient, ProviderConfig};
+use libretune_core::tune::TuneValue;
 use serde::{Deserialize, Serialize};
+use tauri::Manager;
 
 /// Construct a `ProviderConfig` from stored settings.
 fn config_from_settings(s: &crate::Settings) -> ProviderConfig {
@@ -91,6 +96,171 @@ pub struct AgentStatus {
     pub configured: bool,
 }
 
+/// Executes the assistant's read-only tool calls against the live ECU/tune
+/// state. Held by `agent_send_message` and handed to the orchestrator so the
+/// model's "let me read your VE table" calls actually return data instead of
+/// stalling.
+///
+/// Holds a [`tauri::AppHandle`] (cheap to clone) to reach managed `AppState`
+/// without borrowing the `tauri::State` lifetime into the executor.
+struct LiveReadExecutor {
+    app: tauri::AppHandle,
+}
+
+#[async_trait::async_trait]
+impl ReadToolExecutor for LiveReadExecutor {
+    fn handles(&self, tool_name: &str) -> bool {
+        matches!(
+            tool_name,
+            tools::tool_names::READ_TABLE
+                | tools::tool_names::READ_CONSTANT
+                | tools::tool_names::LIST_TABLES
+                | tools::tool_names::LIST_FEATURES
+        )
+    }
+
+    async fn execute(&self, tool_name: &str, arguments: &str) -> String {
+        match tool_name {
+            tools::tool_names::LIST_TABLES => self.exec_list_tables().await,
+            tools::tool_names::LIST_FEATURES => self.exec_list_features().await,
+            tools::tool_names::READ_TABLE => {
+                let name = json_str_field(arguments, "table_name");
+                match name {
+                    Some(n) => self.exec_read_table(&n).await,
+                    None => json_err("read_table requires 'table_name'"),
+                }
+            }
+            tools::tool_names::READ_CONSTANT => {
+                let name = json_str_field(arguments, "name");
+                match name {
+                    Some(n) => self.exec_read_constant(&n).await,
+                    None => json_err("read_constant requires 'name'"),
+                }
+            }
+            _ => json_err(&format!("unhandled read tool '{tool_name}'")),
+        }
+    }
+}
+
+impl LiveReadExecutor {
+    async fn exec_list_tables(&self) -> String {
+        let state = self.app.state::<AppState>();
+        let def_guard = state.definition.lock().await;
+        let Some(def) = def_guard.as_ref() else {
+            return json_err("No INI definition loaded");
+        };
+        let mut entries: Vec<serde_json::Value> = Vec::new();
+        for t in def.tables.values() {
+            entries.push(serde_json::json!({
+                "name": t.name,
+                "title": t.title,
+                "role": format!("{:?}", t.role),
+                "dimensions": [t.x_size, t.y_size],
+                "x_label": t.x_label,
+                "y_label": t.y_label,
+            }));
+        }
+        serde_json::to_string(&serde_json::json!({ "tables": entries }))
+            .unwrap_or_else(|_| json_err("serialize failed"))
+    }
+
+    async fn exec_list_features(&self) -> String {
+        let state = self.app.state::<AppState>();
+        let def_guard = state.definition.lock().await;
+        let Some(def) = def_guard.as_ref() else {
+            return json_err("No INI definition loaded");
+        };
+        let mut entries: Vec<serde_json::Value> = Vec::new();
+        for c in def.constants.values() {
+            if !c.bit_options.is_empty() {
+                entries.push(serde_json::json!({
+                    "name": c.name,
+                    "label": c.label,
+                    "options": c.bit_options,
+                    "help": c.help,
+                }));
+            }
+        }
+        serde_json::to_string(&serde_json::json!({ "features": entries }))
+            .unwrap_or_else(|_| json_err("serialize failed"))
+    }
+
+    async fn exec_read_table(&self, name: &str) -> String {
+        let state = self.app.state::<AppState>();
+        // Reuse the existing internal table reader so the model sees the same
+        // data the table editors do.
+        match crate::get_table_data_internal(&state, name).await {
+            Ok(t) => serde_json::to_string(&serde_json::json!({
+                "name": t.name,
+                "title": t.title,
+                "x_bins": t.x_bins,
+                "y_bins": t.y_bins,
+                "z_values": t.z_values,
+                "x_axis": t.x_axis_name,
+                "y_axis": t.y_axis_name,
+            }))
+            .unwrap_or_else(|_| json_err("serialize failed")),
+            Err(e) => json_err(&format!("could not read table '{name}': {e}")),
+        }
+    }
+
+    async fn exec_read_constant(&self, name: &str) -> String {
+        let state = self.app.state::<AppState>();
+
+        // 1. Read the constant metadata under the definition lock, then drop
+        //    it before acquiring the tune lock (avoids nested-lock deadlocks).
+        let (label, units, min, max, bit_options, help) = {
+            let def_guard = state.definition.lock().await;
+            let Some(def) = def_guard.as_ref() else {
+                return json_err("No INI definition loaded");
+            };
+            let Some(c) = def.constants.get(name) else {
+                return json_err(&format!("constant '{name}' not found"));
+            };
+            (
+                c.label.clone(),
+                c.units.clone(),
+                c.min,
+                c.max,
+                c.bit_options.clone(),
+                c.help.clone(),
+            )
+        };
+
+        // 2. Read the current value from the loaded tune if present.
+        let current: Option<f64> = {
+            let tune_guard = state.current_tune.lock().await;
+            match tune_guard.as_ref().and_then(|tune| tune.get_value(name)) {
+                Some(TuneValue::Scalar(f)) => Some(*f),
+                Some(TuneValue::Bool(b)) => Some(if *b { 1.0 } else { 0.0 }),
+                _ => None,
+            }
+        };
+
+        serde_json::to_string(&serde_json::json!({
+            "name": name,
+            "label": label,
+            "units": units,
+            "min": min,
+            "max": max,
+            "current_value": current,
+            "options": bit_options,
+            "help": help,
+        }))
+        .unwrap_or_else(|_| json_err("serialize failed"))
+    }
+}
+
+fn json_str_field(arguments: &str, field: &str) -> Option<String> {
+    serde_json::from_str::<serde_json::Value>(arguments)
+        .ok()
+        .and_then(|v| v.get(field)?.as_str().map(|s| s.to_string()))
+}
+
+fn json_err(msg: &str) -> String {
+    serde_json::json!({ "error": msg }).to_string()
+}
+
 /// Run one assistant turn. Returns a [`Proposal`] for the review queue.
 ///
 /// Does not apply anything. The frontend renders `proposal.proposed` as a
@@ -112,6 +282,7 @@ pub async fn agent_send_message(
     }
 
     let client = build_client(&s).map_err(|e| e.to_string())?;
+    let executor = LiveReadExecutor { app: app.clone() };
 
     let history: Vec<Message> = request.history.into_iter().map(Into::into).collect();
     let inputs = OrchestratorInputs {
@@ -122,7 +293,7 @@ pub async fn agent_send_message(
     };
 
     let authority = default_authority();
-    run_turn(&client, &inputs, &authority)
+    run_turn(&client, &inputs, &authority, Some(&executor))
         .await
         .map_err(|e| e.to_string())
 }

--- a/crates/libretune-app/src-tauri/src/commands/app_settings.rs
+++ b/crates/libretune-app/src-tauri/src/commands/app_settings.rs
@@ -118,10 +118,45 @@ pub(crate) struct Settings {
     // None = let the frontend's language detector decide (querystring/localStorage/navigator).
     #[serde(default)]
     pub(crate) language: Option<String>,
+
+    // --- AI Assistant (bring-your-own LLM) -------------------------------
+    // All gated behind `ai_assistant_enabled`, which itself requires
+    // `ai_risk_acknowledged`. The model only ever *proposes* changes; nothing
+    // burns to the ECU automatically.
+
+    /// Master enable for the AI assistant. Must be paired with a risk ack.
+    #[serde(default = "default_false")]
+    pub(crate) ai_assistant_enabled: bool,
+    /// User has acknowledged the "at your own risk" warning.
+    #[serde(default = "default_false")]
+    pub(crate) ai_risk_acknowledged: bool,
+    /// Provider protocol: "openai" | "anthropic" | "google".
+    #[serde(default = "default_ai_provider")]
+    pub(crate) ai_provider: String,
+    /// Base URL (empty = provider default; or local endpoint like Ollama).
+    #[serde(default)]
+    pub(crate) ai_base_url: String,
+    /// API key (plaintext v1; OS keychain hardening is a planned follow-up).
+    #[serde(default)]
+    pub(crate) ai_api_key: String,
+    /// Model identifier (e.g. "gpt-4o", "claude-3-5-sonnet-...").
+    #[serde(default)]
+    pub(crate) ai_model: String,
+    /// Capability the assistant is unlocked for: "read" | "tune" | "config".
+    #[serde(default = "default_ai_capability")]
+    pub(crate) ai_capability_tier: String,
 }
 
 pub(crate) fn default_runtime_packet_mode() -> String {
     "Auto".to_string()
+}
+
+fn default_ai_provider() -> String {
+    "openai".to_string()
+}
+
+fn default_ai_capability() -> String {
+    "read".to_string()
 }
 
 fn default_heatmap_scheme() -> String {

--- a/crates/libretune-app/src-tauri/src/commands/mod.rs
+++ b/crates/libretune-app/src-tauri/src/commands/mod.rs
@@ -5,6 +5,7 @@
 //! `tauri::State<crate::state::AppState>`.
 
 pub mod adaptive_timing;
+pub mod agent;
 pub mod annotations;
 pub mod app_settings;
 pub mod apply_base_map;

--- a/crates/libretune-app/src-tauri/src/commands/settings.rs
+++ b/crates/libretune-app/src-tauri/src/commands/settings.rs
@@ -96,6 +96,44 @@ pub async fn update_setting(
             settings.last_active_tab = if value.is_empty() { None } else { Some(value) }
         }
         "language" => settings.language = if value.is_empty() { None } else { Some(value) },
+
+        // --- AI Assistant settings (all keys must have arms; see repo memory
+        // about the latent auto_commit_on_save bug). ---
+        "ai_assistant_enabled" => {
+            // Refuse to enable without a risk acknowledgement.
+            let want: bool = value.parse().map_err(|_| "Invalid boolean value")?;
+            if want && !settings.ai_risk_acknowledged {
+                return Err(
+                    "Cannot enable AI assistant without acknowledging the risk warning"
+                        .to_string(),
+                );
+            }
+            settings.ai_assistant_enabled = want;
+        }
+        "ai_risk_acknowledged" => {
+            settings.ai_risk_acknowledged =
+                value.parse().map_err(|_| "Invalid boolean value")?
+        }
+        "ai_provider" => {
+            // Changing the provider invalidates the prior risk ack boundary,
+            // so force the user to re-acknowledge.
+            if value != settings.ai_provider {
+                settings.ai_risk_acknowledged = false;
+                settings.ai_assistant_enabled = false;
+            }
+            settings.ai_provider = value;
+        }
+        "ai_base_url" => settings.ai_base_url = value,
+        "ai_api_key" => {
+            // Changing the key invalidates the prior risk ack boundary.
+            if value != settings.ai_api_key {
+                settings.ai_risk_acknowledged = false;
+                settings.ai_assistant_enabled = false;
+            }
+            settings.ai_api_key = value;
+        }
+        "ai_model" => settings.ai_model = value,
+        "ai_capability_tier" => settings.ai_capability_tier = value,
         _ => return Err(format!("Unknown setting: {}", key)),
     }
 

--- a/crates/libretune-app/src-tauri/src/lib.rs
+++ b/crates/libretune-app/src-tauri/src/lib.rs
@@ -41,6 +41,7 @@ pub(crate) use commands::util_helpers::{
 use commands::adaptive_timing::{
     disable_adaptive_timing, enable_adaptive_timing, get_adaptive_timing_stats,
 };
+use commands::agent::{agent_apply_proposals, agent_send_message, agent_status};
 use commands::annotations::{
     delete_annotation, get_all_annotations, get_annotation, get_table_annotations, set_annotation,
 };
@@ -405,6 +406,14 @@ pub fn run() {
             check_internet_connectivity,
             search_online_inis,
             download_ini,
+            // AI assistant
+            agent_status,
+            agent_send_message,
+            agent_apply_proposals,
+            // AI assistant
+            agent_status,
+            agent_send_message,
+            agent_apply_proposals,
             // Demo mode commands
             set_demo_mode,
             get_demo_mode,

--- a/crates/libretune-app/src/App.tsx
+++ b/crates/libretune-app/src/App.tsx
@@ -257,8 +257,37 @@ function AppContent() {
   // WASM Plugin panel state
   const [pluginPanelOpen, setPluginPanelOpen] = useState(false);
 
-  // AI assistant dock state
-  const [agentDockOpen, setAgentDockOpen] = useState(false);
+  // AI assistant side panel state (right-hand, non-modal). Toggle controls
+  // docked visibility; popping out hides the docked panel.
+  const [agentPanelVisible, setAgentPanelVisible] = useState(false);
+
+  // Pop the AI assistant out into its own window (mirrors the tab pop-out
+  // pattern in hooks/useTabPopout.ts). Uses hash routing handled by
+  // PopOutWindow.tsx + a localStorage handoff.
+  const handleAgentPopOut = useCallback(async () => {
+    const tabId = `agent-assistant`;
+    const storageKey = `popout-${tabId}`;
+    try {
+      localStorage.setItem(storageKey, JSON.stringify({ data: null }));
+      const { WebviewWindow } = await import('@tauri-apps/api/webviewWindow');
+      const currentOrigin = window.location.origin;
+      const url = `${currentOrigin}/#/popout?tabId=${encodeURIComponent(tabId)}&type=agent&title=${encodeURIComponent('AI Assistant')}`;
+      const label = `popout-${tabId}`;
+      await new WebviewWindow(label, {
+        url,
+        title: 'AI Assistant',
+        width: 460,
+        height: 720,
+        center: true,
+        decorations: true,
+        devtools: true,
+      });
+      // Hide the docked panel once popped out.
+      setAgentPanelVisible(false);
+    } catch (e) {
+      console.error('[AgentPopOut] failed:', e);
+    }
+  }, []);
 
   // Sync status tracking (for partial sync warning)
   const [syncStatus, setSyncStatus] = useState<SyncStatus | null>(null);
@@ -1332,10 +1361,25 @@ function AppContent() {
     setNewProjectDialogOpen, setImportProjectOpen, setSaveDialogOpen, setLoadDialogOpen,
     setBurnDialogOpen, setFirmwareUpdateDialogOpen, setRestorePointsOpen, setTuneHistoryOpen, setSettingsDialogOpen,
     setMathChannelsDialogOpen, setBaseMapDialogOpen, setTableComparisonOpen,
-    setTuneFileDiffOpen, setDynoOverlayOpen, setPluginPanelOpen, setAgentDockOpen, setConnectionDialogOpen,
+    setTuneFileDiffOpen, setDynoOverlayOpen, setPluginPanelOpen, agentPanelVisible, setAgentPanelVisible, setConnectionDialogOpen,
     setUserManualOpen, setUserManualSection, setAboutDialogOpen, setSidebarVisible,
     setTheme, setTabs, setTabContents, setActiveTabId,
-  }), [backendMenus, theme, sidebarVisible, status.state, ecuType, iniCapabilities, openTarget, handleStdTarget, openHelpTopic, currentProject, tuneModified, showToast, t, tabs]);
+  }), [backendMenus, theme, sidebarVisible, agentPanelVisible, status.state, ecuType, iniCapabilities, openTarget, handleStdTarget, openHelpTopic, currentProject, tuneModified, showToast, t, tabs]);
+
+  // Listen for the agent pop-out window's "dock back" signal: re-show the
+  // docked side panel. (Mirrors the tab:dock handling in useTabPopout.)
+  useEffect(() => {
+    let unlisten: (() => void) | undefined;
+    (async () => {
+      try {
+        const { listen } = await import('@tauri-apps/api/event');
+        unlisten = await listen('agent:dock', () => setAgentPanelVisible(true));
+      } catch {
+        // non-fatal
+      }
+    })();
+    return () => { unlisten?.(); };
+  }, []);
 
   // Toolbar items
   const toolbarItems: ToolbarItem[] = useMemo(() => buildToolbarItems({
@@ -1478,6 +1522,9 @@ function AppContent() {
         onConnectionClick={() => setConnectionDialogOpen(true)}
         projectName={currentProject?.name}
         unitsSystem={unitsSystem}
+        agentPanelVisible={agentPanelVisible}
+        onAgentPanelCollapse={() => setAgentPanelVisible(false)}
+        onAgentPanelPopOut={handleAgentPopOut}
         realtimeChannels={statusBarChannels}
         channelInfoMap={channelInfoMap}
       >
@@ -1625,8 +1672,6 @@ function AppContent() {
         setOnboardingOpen={setOnboardingOpen}
         pluginPanelOpen={pluginPanelOpen}
         setPluginPanelOpen={setPluginPanelOpen}
-        agentDockOpen={agentDockOpen}
-        setAgentDockOpen={setAgentDockOpen}
       />
     </>
   );

--- a/crates/libretune-app/src/App.tsx
+++ b/crates/libretune-app/src/App.tsx
@@ -256,7 +256,10 @@ function AppContent() {
   
   // WASM Plugin panel state
   const [pluginPanelOpen, setPluginPanelOpen] = useState(false);
-  
+
+  // AI assistant dock state
+  const [agentDockOpen, setAgentDockOpen] = useState(false);
+
   // Sync status tracking (for partial sync warning)
   const [syncStatus, setSyncStatus] = useState<SyncStatus | null>(null);
 
@@ -1329,7 +1332,7 @@ function AppContent() {
     setNewProjectDialogOpen, setImportProjectOpen, setSaveDialogOpen, setLoadDialogOpen,
     setBurnDialogOpen, setFirmwareUpdateDialogOpen, setRestorePointsOpen, setTuneHistoryOpen, setSettingsDialogOpen,
     setMathChannelsDialogOpen, setBaseMapDialogOpen, setTableComparisonOpen,
-    setTuneFileDiffOpen, setDynoOverlayOpen, setPluginPanelOpen, setConnectionDialogOpen,
+    setTuneFileDiffOpen, setDynoOverlayOpen, setPluginPanelOpen, setAgentDockOpen, setConnectionDialogOpen,
     setUserManualOpen, setUserManualSection, setAboutDialogOpen, setSidebarVisible,
     setTheme, setTabs, setTabContents, setActiveTabId,
   }), [backendMenus, theme, sidebarVisible, status.state, ecuType, iniCapabilities, openTarget, handleStdTarget, openHelpTopic, currentProject, tuneModified, showToast, t, tabs]);
@@ -1622,6 +1625,8 @@ function AppContent() {
         setOnboardingOpen={setOnboardingOpen}
         pluginPanelOpen={pluginPanelOpen}
         setPluginPanelOpen={setPluginPanelOpen}
+        agentDockOpen={agentDockOpen}
+        setAgentDockOpen={setAgentDockOpen}
       />
     </>
   );

--- a/crates/libretune-app/src/PopOutWindow.tsx
+++ b/crates/libretune-app/src/PopOutWindow.tsx
@@ -16,6 +16,7 @@ import { TableEditor, TableData as TunerTableData, AutoTune, DataLogView } from 
 import CurveEditor, { CurveData, SimpleGaugeInfo } from './components/curves/CurveEditor';
 import TsDashboard from './components/dashboards/TsDashboard';
 import DialogRenderer, { DialogDefinition as RendererDialogDef } from './components/dialogs/DialogRenderer';
+import { AgentDock } from './components/agent/AgentDock';
 import { useRealtimeStore } from './stores/realtimeStore';
 import { ArrowLeftToLine, X } from 'lucide-react';
 import './styles';
@@ -48,7 +49,7 @@ interface BackendCurveData {
 
 interface PopOutData {
   tabId: string;
-  type: 'dashboard' | 'table' | 'curve' | 'dialog' | 'settings' | 'autotune' | 'datalog';
+  type: 'dashboard' | 'table' | 'curve' | 'dialog' | 'settings' | 'autotune' | 'datalog' | 'agent';
   title: string;
   data?: TunerTableData | CurveData | RendererDialogDef | string;
   gauge?: SimpleGaugeInfo | null;
@@ -310,13 +311,19 @@ export default function PopOutWindow() {
     if (!popOutData) return;
 
     try {
-      // Emit dock event with current data
-      await emit('tab:dock', {
-        tabId: popOutData.tabId,
-        type: popOutData.type,
-        title: popOutData.title,
-        data: popOutData.data,
-      });
+      if (popOutData.type === 'agent') {
+        // The agent isn't a tab — signal the main window to re-show the
+        // docked panel instead of restoring a tab.
+        await emit('agent:dock', {});
+      } else {
+        // Emit dock event with current data
+        await emit('tab:dock', {
+          tabId: popOutData.tabId,
+          type: popOutData.type,
+          title: popOutData.title,
+          data: popOutData.data,
+        });
+      }
 
       // Close this window
       await getCurrentWindow().close();
@@ -412,6 +419,16 @@ export default function PopOutWindow() {
       
       case 'datalog':
         return <DataLogView />;
+      
+      case 'agent':
+        // The assistant self-polls status and listens for settings:changed, so
+        // no data handoff is needed — just render the docked-style layout in a
+        // standalone window.
+        return (
+          <div style={{ display: 'flex', flexDirection: 'column', height: '100%', padding: '8px' }}>
+            <AgentDock />
+          </div>
+        );
       
       default:
         return <div className="popout-unsupported">Unsupported content type</div>;

--- a/crates/libretune-app/src/components/DialogOverlays.tsx
+++ b/crates/libretune-app/src/components/DialogOverlays.tsx
@@ -28,6 +28,7 @@ import TuneHistoryPanel from "./TuneHistoryPanel";
 import ErrorDetailsDialog from "./dialogs/ErrorDetailsDialog";
 import OnboardingDialog from "./dialogs/OnboardingDialog";
 import { PluginPanel } from "./PluginPanel";
+import { AgentDock } from "./agent/AgentDock";
 import { ControllerCommandDialog } from "./console/ControllerCommandDialog";
 import { FirmwareUpdateDialog } from "./dialogs/FirmwareUpdateDialog";
 import { ThemeName } from "../themes";
@@ -186,6 +187,10 @@ export interface DialogOverlaysProps {
   // Plugins
   pluginPanelOpen: boolean;
   setPluginPanelOpen: (v: boolean) => void;
+
+  // AI assistant
+  agentDockOpen: boolean;
+  setAgentDockOpen: (v: boolean) => void;
 }
 
 export function DialogOverlays(props: DialogOverlaysProps) {
@@ -228,6 +233,7 @@ export function DialogOverlays(props: DialogOverlaysProps) {
     migrationReportOpen, setMigrationReportOpen,
     onboardingOpen, setOnboardingOpen,
     pluginPanelOpen, setPluginPanelOpen,
+    agentDockOpen, setAgentDockOpen,
   } = props;
 
   return (
@@ -447,6 +453,45 @@ export function DialogOverlays(props: DialogOverlaysProps) {
             style={{ width: '900px', maxWidth: '95vw', height: '600px', maxHeight: '85vh' }}
           >
             <PluginPanel isConnected={status.state === "Connected"} />
+          </div>
+        </div>
+      )}
+      {agentDockOpen && (
+        <div className="dialog-overlay" onClick={() => setAgentDockOpen(false)}>
+          <div
+            className="dialog-content"
+            onClick={(e) => e.stopPropagation()}
+            style={{
+              width: '760px',
+              maxWidth: '95vw',
+              height: '640px',
+              maxHeight: '85vh',
+              padding: '14px',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '8px',
+            }}
+          >
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                marginBottom: '4px',
+              }}
+            >
+              <h3 style={{ margin: 0 }}>AI Assistant</h3>
+              <button
+                onClick={() => setAgentDockOpen(false)}
+                style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: '18px' }}
+                aria-label="Close"
+              >
+                ×
+              </button>
+            </div>
+            <div style={{ flex: 1, minHeight: 0 }}>
+              <AgentDock />
+            </div>
           </div>
         </div>
       )}

--- a/crates/libretune-app/src/components/DialogOverlays.tsx
+++ b/crates/libretune-app/src/components/DialogOverlays.tsx
@@ -28,7 +28,6 @@ import TuneHistoryPanel from "./TuneHistoryPanel";
 import ErrorDetailsDialog from "./dialogs/ErrorDetailsDialog";
 import OnboardingDialog from "./dialogs/OnboardingDialog";
 import { PluginPanel } from "./PluginPanel";
-import { AgentDock } from "./agent/AgentDock";
 import { ControllerCommandDialog } from "./console/ControllerCommandDialog";
 import { FirmwareUpdateDialog } from "./dialogs/FirmwareUpdateDialog";
 import { ThemeName } from "../themes";
@@ -187,10 +186,6 @@ export interface DialogOverlaysProps {
   // Plugins
   pluginPanelOpen: boolean;
   setPluginPanelOpen: (v: boolean) => void;
-
-  // AI assistant
-  agentDockOpen: boolean;
-  setAgentDockOpen: (v: boolean) => void;
 }
 
 export function DialogOverlays(props: DialogOverlaysProps) {
@@ -233,7 +228,6 @@ export function DialogOverlays(props: DialogOverlaysProps) {
     migrationReportOpen, setMigrationReportOpen,
     onboardingOpen, setOnboardingOpen,
     pluginPanelOpen, setPluginPanelOpen,
-    agentDockOpen, setAgentDockOpen,
   } = props;
 
   return (
@@ -453,45 +447,6 @@ export function DialogOverlays(props: DialogOverlaysProps) {
             style={{ width: '900px', maxWidth: '95vw', height: '600px', maxHeight: '85vh' }}
           >
             <PluginPanel isConnected={status.state === "Connected"} />
-          </div>
-        </div>
-      )}
-      {agentDockOpen && (
-        <div className="dialog-overlay" onClick={() => setAgentDockOpen(false)}>
-          <div
-            className="dialog-content"
-            onClick={(e) => e.stopPropagation()}
-            style={{
-              width: '760px',
-              maxWidth: '95vw',
-              height: '640px',
-              maxHeight: '85vh',
-              padding: '14px',
-              display: 'flex',
-              flexDirection: 'column',
-              gap: '8px',
-            }}
-          >
-            <div
-              style={{
-                display: 'flex',
-                justifyContent: 'space-between',
-                alignItems: 'center',
-                marginBottom: '4px',
-              }}
-            >
-              <h3 style={{ margin: 0 }}>AI Assistant</h3>
-              <button
-                onClick={() => setAgentDockOpen(false)}
-                style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: '18px' }}
-                aria-label="Close"
-              >
-                ×
-              </button>
-            </div>
-            <div style={{ flex: 1, minHeight: 0 }}>
-              <AgentDock />
-            </div>
           </div>
         </div>
       )}

--- a/crates/libretune-app/src/components/agent/AgentDock.tsx
+++ b/crates/libretune-app/src/components/agent/AgentDock.tsx
@@ -1,0 +1,91 @@
+/**
+ * AgentDock — the container for the AI assistant.
+ *
+ * Holds the review queue state, polls `agent_status` so the panels reflect the
+ * current enable/config state, and renders the ChatPanel + ProposalQueue side
+ * by side. Mounted in App.tsx, gated on the assistant being enabled.
+ */
+import { useEffect, useState } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import { ChatPanel } from './ChatPanel';
+import { ProposalQueue } from './ProposalQueue';
+import type { AgentStatus, ApplyResult, ProposedAction } from '../../types/agent';
+import './AgentPanel.css';
+
+export interface AgentDockProps {
+  /** Optional: rebuild a context-aware system prompt from current ECU state. */
+  buildSystemPrompt?: () => string;
+}
+
+const DEFAULT_SYSTEM_PROMPT = `You are LibreTune's AI tuning assistant. You help the user tune and configure their ECU.
+You only ever PROPOSE changes via tool calls — you never apply anything directly.
+Every proposal will be validated against the ECU definition and clamped to authority limits before the user reviews it.
+Be concise. When proposing changes, always explain your reasoning in the 'reason' field.
+If you need more data (e.g. read a table or a constant), use a read tool first.`;
+
+export function AgentDock({ buildSystemPrompt }: AgentDockProps) {
+  const [status, setStatus] = useState<AgentStatus | null>(null);
+  const [queue, setQueue] = useState<ProposedAction[]>([]);
+  const [appliedNote, setAppliedNote] = useState<string | null>(null);
+
+  // Poll status on mount and when settings change (settings:changed event).
+  const refreshStatus = async () => {
+    try {
+      const s = await invoke<AgentStatus>('agent_status');
+      setStatus(s);
+    } catch {
+      setStatus(null);
+    }
+  };
+
+  useEffect(() => {
+    void refreshStatus();
+    let unlisten: (() => void) | undefined;
+    // Listen for settings changes so enabling/config updates the panels live.
+    (async () => {
+      try {
+        const { listen } = await import('@tauri-apps/api/event');
+        unlisten = await listen('settings:changed', () => void refreshStatus());
+      } catch {
+        // non-fatal
+      }
+    })();
+    return () => {
+      unlisten?.();
+    };
+  }, []);
+
+  const handleApplied = (results: ApplyResult[]) => {
+    const ok = results.filter((r) => r.applied).length;
+    const fail = results.length - ok;
+    setAppliedNote(
+      fail === 0
+        ? `Staged ${ok} change${ok === 1 ? '' : 's'} to the working tune. Burn to the ECU when ready.`
+        : `Staged ${ok}, rejected ${fail} (failed validation).`
+    );
+    window.setTimeout(() => setAppliedNote(null), 6000);
+  };
+
+  const systemPrompt = buildSystemPrompt?.() ?? DEFAULT_SYSTEM_PROMPT;
+
+  return (
+    <div className="agent-dock">
+      <div className="agent-dock-section agent-dock-chat">
+        <ChatPanel
+          status={status}
+          systemPrompt={systemPrompt}
+          onProposals={(p) => setQueue((prev) => [...prev, ...p])}
+        />
+      </div>
+      <div className="agent-dock-section agent-dock-queue">
+        <div className="agent-dock-queue-title">Review queue</div>
+        <ProposalQueue
+          proposed={queue}
+          onClear={() => setQueue([])}
+          onApplied={handleApplied}
+        />
+        {appliedNote && <div className="agent-dock-applied-note">{appliedNote}</div>}
+      </div>
+    </div>
+  );
+}

--- a/crates/libretune-app/src/components/agent/AgentPanel.css
+++ b/crates/libretune-app/src/components/agent/AgentPanel.css
@@ -1,0 +1,283 @@
+/* Shared styles for the AI assistant components (AgentDock, ChatPanel, ProposalQueue). */
+
+.agent-dock {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  height: 100%;
+  min-height: 320px;
+}
+
+.agent-dock-section {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.agent-dock-chat {
+  flex: 1 1 60%;
+}
+
+.agent-dock-queue {
+  flex: 0 1 40%;
+}
+
+.agent-dock-queue-title {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  opacity: 0.7;
+  margin-bottom: 6px;
+}
+
+.agent-dock-applied-note {
+  margin-top: 8px;
+  padding: 6px 10px;
+  border-radius: 6px;
+  background: rgba(80, 200, 120, 0.12);
+  border: 1px solid rgba(80, 200, 120, 0.3);
+  font-size: 12px;
+}
+
+/* --- Chat panel --- */
+
+.agent-chat {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 240px;
+  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.1));
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.agent-chat-disabled {
+  padding: 16px;
+  opacity: 0.7;
+  font-size: 13px;
+  text-align: center;
+}
+
+.agent-chat-transcript {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.agent-chat-empty {
+  opacity: 0.7;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.agent-chat-empty ul {
+  margin: 6px 0 0;
+  padding-left: 18px;
+}
+
+.agent-chat-message {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  max-width: 90%;
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.agent-chat-user {
+  align-self: flex-end;
+  background: var(--accent-bg, rgba(80, 140, 255, 0.15));
+  border: 1px solid var(--accent-border, rgba(80, 140, 255, 0.3));
+}
+
+.agent-chat-assistant {
+  align-self: flex-start;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.agent-chat-role {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  opacity: 0.6;
+}
+
+.agent-chat-content {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.agent-chat-error {
+  margin: 6px 10px;
+  padding: 6px 10px;
+  border-radius: 6px;
+  background: rgba(255, 80, 80, 0.12);
+  border: 1px solid rgba(255, 80, 80, 0.3);
+  font-size: 12px;
+}
+
+.agent-chat-input-row {
+  display: flex;
+  gap: 8px;
+  padding: 8px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.agent-chat-input {
+  flex: 1 1 auto;
+  resize: none;
+  font-family: inherit;
+  font-size: 13px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(0, 0, 0, 0.2);
+  color: inherit;
+}
+
+.agent-chat-input:focus {
+  outline: none;
+  border-color: var(--accent-border, rgba(80, 140, 255, 0.5));
+}
+
+/* --- Proposal queue --- */
+
+.proposal-queue {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.proposal-queue-empty {
+  opacity: 0.6;
+  font-size: 13px;
+  padding: 8px 4px;
+}
+
+.proposal-queue-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.proposal-queue-title {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.proposal-queue-actions {
+  display: flex;
+  gap: 6px;
+}
+
+.proposal-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  max-height: 260px;
+  overflow-y: auto;
+}
+
+.proposal-item {
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.03);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.proposal-item.accepted {
+  border-color: rgba(80, 200, 120, 0.4);
+  background: rgba(80, 200, 120, 0.06);
+}
+
+.proposal-item.rejected {
+  opacity: 0.5;
+  border-color: rgba(255, 80, 80, 0.3);
+}
+
+.proposal-item-main {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.proposal-item-label {
+  font-size: 13px;
+  font-family: monospace;
+  word-break: break-all;
+}
+
+.proposal-tier {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 2px 6px;
+  border-radius: 4px;
+  white-space: nowrap;
+}
+
+.proposal-tier-safe {
+  background: rgba(80, 200, 120, 0.15);
+  color: #80d090;
+}
+
+.proposal-tier-caution {
+  background: rgba(255, 170, 0, 0.15);
+  color: #f0c070;
+}
+
+.proposal-tier-dangerous {
+  background: rgba(255, 80, 80, 0.18);
+  color: #f0a0a0;
+}
+
+.proposal-item-reason {
+  font-size: 12px;
+  opacity: 0.8;
+  line-height: 1.4;
+}
+
+.proposal-item-clamp {
+  font-size: 11px;
+  color: #f0c070;
+  opacity: 0.9;
+}
+
+.proposal-item-warnings {
+  font-size: 11px;
+  opacity: 0.7;
+}
+
+.proposal-item-errors {
+  font-size: 11px;
+  color: #f0a0a0;
+}
+
+.proposal-item-buttons {
+  display: flex;
+  gap: 6px;
+  margin-top: 2px;
+}
+
+.proposal-apply-error {
+  font-size: 12px;
+  color: #f0a0a0;
+}
+
+.proposal-queue-footer {
+  display: flex;
+  justify-content: flex-end;
+}

--- a/crates/libretune-app/src/components/agent/AgentPanel.css
+++ b/crates/libretune-app/src/components/agent/AgentPanel.css
@@ -1,4 +1,140 @@
-/* Shared styles for the AI assistant components (AgentDock, ChatPanel, ProposalQueue). */
+/* Styles for the AI assistant side panel + ChatPanel + ProposalQueue. */
+
+/* --- Side panel (right-hand, docked) --- */
+
+.agent-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-width: 260px;
+  max-width: 640px;
+  flex-shrink: 0;
+  background: var(--bg-sidebar, rgba(20, 20, 24, 1));
+  border-left: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.1));
+  position: relative;
+  overflow: hidden;
+}
+
+/* Left-edge resize handle (panel is on the right). */
+.agent-panel-resize {
+  position: absolute;
+  top: 0;
+  left: -3px;
+  width: 6px;
+  height: 100%;
+  cursor: ew-resize;
+  z-index: 5;
+}
+.agent-panel-resize:hover,
+.agent-panel-resize:active {
+  background: rgba(128, 160, 255, 0.3);
+}
+
+/* Header bar (title + pop-out / collapse buttons). */
+.agent-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: var(--tab-height, 32px);
+  padding: 0 8px;
+  border-bottom: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.08));
+  flex-shrink: 0;
+  user-select: none;
+}
+
+.agent-panel-title {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  opacity: 0.85;
+}
+
+.agent-panel-header-actions {
+  display: flex;
+  gap: 2px;
+}
+
+.agent-panel-icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  background: none;
+  border: none;
+  border-radius: 4px;
+  color: inherit;
+  opacity: 0.7;
+  cursor: pointer;
+}
+.agent-panel-icon-btn:hover {
+  background: rgba(255, 255, 255, 0.1);
+  opacity: 1;
+}
+
+/* Chat fills the flexible middle region. */
+.agent-panel-chat {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  padding: 8px;
+}
+
+/* Collapsible review queue pinned to the bottom. */
+.agent-panel-queue {
+  flex: 0 0 auto;
+  border-top: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.08));
+  display: flex;
+  flex-direction: column;
+  max-height: 45%;
+  overflow: hidden;
+}
+.agent-panel-queue.collapsed {
+  max-height: 32px;
+}
+
+.agent-panel-queue-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  height: 32px;
+  padding: 0 10px;
+  background: none;
+  border: none;
+  color: inherit;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  opacity: 0.7;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+.agent-panel-queue-toggle:hover {
+  opacity: 1;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.agent-panel-queue-body {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 0 8px 8px;
+  min-height: 0;
+}
+
+.agent-panel-applied-note {
+  margin-top: 8px;
+  padding: 6px 10px;
+  border-radius: 6px;
+  background: rgba(80, 200, 120, 0.12);
+  border: 1px solid rgba(80, 200, 120, 0.3);
+  font-size: 12px;
+}
+
+/* --- Legacy dock styles (kept for backward compat / pop-out window) --- */
 
 .agent-dock {
   display: flex;

--- a/crates/libretune-app/src/components/agent/AgentSidePanel.tsx
+++ b/crates/libretune-app/src/components/agent/AgentSidePanel.tsx
@@ -1,0 +1,190 @@
+/**
+ * AgentSidePanel — the docked right-hand panel for the AI assistant.
+ *
+ * Replaces the previous full-screen modal overlay with a VS-Code-chat-style
+ * side panel: non-modal, resizable, and optionally pop-out-able to its own
+ * window so it can live on a second monitor.
+ *
+ * Layout: a header bar (title + pop-out + collapse buttons) over a vertical
+ * stack of the chat transcript (top, flexible) and the review queue (bottom,
+ * collapsible). The panel is rendered by `TunerLayout` as a flex child of
+ * `.tuner-layout-main`; the resize handle lives on the left edge.
+ */
+import { useCallback, useRef, useState, useEffect, MouseEvent } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import { ChatPanel } from './ChatPanel';
+import { ProposalQueue } from './ProposalQueue';
+import type { AgentStatus, ApplyResult, ProposedAction } from '../../types/agent';
+import './AgentPanel.css';
+
+export interface AgentSidePanelProps {
+  /** Panel width in px (controlled by the parent layout for persistence). */
+  width: number;
+  /** Called while the left-edge resize handle is dragged. */
+  onResize: (width: number) => void;
+  /** Collapse the panel back to hidden. */
+  onCollapse: () => void;
+  /** Pop the panel out into its own window. */
+  onPopOut: () => void;
+}
+
+const DEFAULT_SYSTEM_PROMPT = `You are LibreTune's AI tuning assistant. You help the user tune and configure their ECU.
+You only ever PROPOSE changes via tool calls — you never apply anything directly.
+Every proposal will be validated against the ECU definition and clamped to authority limits before the user reviews it.
+Be concise. When proposing changes, always explain your reasoning in the 'reason' field.
+If you need more data (e.g. read a table or a constant), use a read tool first.`;
+
+export function AgentSidePanel({ width, onResize, onCollapse, onPopOut }: AgentSidePanelProps) {
+  const [status, setStatus] = useState<AgentStatus | null>(null);
+  const [queue, setQueue] = useState<ProposedAction[]>([]);
+  const [appliedNote, setAppliedNote] = useState<string | null>(null);
+  const [queueCollapsed, setQueueCollapsed] = useState(false);
+  const isResizing = useRef(false);
+
+  const refreshStatus = async () => {
+    try {
+      const s = await invoke<AgentStatus>('agent_status');
+      setStatus(s);
+    } catch {
+      setStatus(null);
+    }
+  };
+
+  useEffect(() => {
+    void refreshStatus();
+    let unlisten: (() => void) | undefined;
+    (async () => {
+      try {
+        const { listen } = await import('@tauri-apps/api/event');
+        unlisten = await listen('settings:changed', () => void refreshStatus());
+      } catch {
+        // non-fatal
+      }
+    })();
+    return () => {
+      unlisten?.();
+    };
+  }, []);
+
+  // Left-edge resize handle: dragging right grows the panel, left shrinks it
+  // (inverted from the sidebar, which sits on the left).
+  const handleResizeStart = useCallback(
+    (e: MouseEvent) => {
+      e.preventDefault();
+      isResizing.current = true;
+      const startX = e.clientX;
+      const startWidth = width;
+
+      const handleMouseMove = (moveEvent: globalThis.MouseEvent) => {
+        if (!isResizing.current) return;
+        // Moving the cursor LEFT (negative delta) should widen the panel.
+        const delta = startX - moveEvent.clientX;
+        onResize(startWidth + delta);
+      };
+      const handleMouseUp = () => {
+        isResizing.current = false;
+        document.removeEventListener('mousemove', handleMouseMove);
+        document.removeEventListener('mouseup', handleMouseUp);
+      };
+      document.addEventListener('mousemove', handleMouseMove);
+      document.addEventListener('mouseup', handleMouseUp);
+    },
+    [width, onResize]
+  );
+
+  const handleApplied = (results: ApplyResult[]) => {
+    const ok = results.filter((r) => r.applied).length;
+    const fail = results.length - ok;
+    setAppliedNote(
+      fail === 0
+        ? `Staged ${ok} change${ok === 1 ? '' : 's'}. Burn to the ECU when ready.`
+        : `Staged ${ok}, rejected ${fail} (failed validation).`
+    );
+    window.setTimeout(() => setAppliedNote(null), 6000);
+  };
+
+  return (
+    <div className="agent-panel" style={{ width }}>
+      {/* Left-edge resize handle */}
+      <div
+        className="agent-panel-resize"
+        onMouseDown={handleResizeStart}
+        role="separator"
+        aria-orientation="vertical"
+      />
+
+      {/* Header */}
+      <div className="agent-panel-header">
+        <span className="agent-panel-title">AI Assistant</span>
+        <div className="agent-panel-header-actions">
+          <button
+            className="agent-panel-icon-btn"
+            onClick={onPopOut}
+            title="Pop out to separate window"
+            aria-label="Pop out"
+          >
+            {/* external-link icon */}
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
+              <path d="M8.5 1.5a.5.5 0 0 0 0 1h3.793L6.146 8.646a.5.5 0 1 0 .708.708L13 3.207V7a.5.5 0 0 0 1 0V2a.5.5 0 0 0-.5-.5h-5z" />
+              <path d="M3 3.5A1.5 1.5 0 0 1 4.5 2H7a.5.5 0 0 1 0 1H4.5a.5.5 0 0 0-.5.5v8a.5.5 0 0 0 .5.5h8a.5.5 0 0 0 .5-.5V9a.5.5 0 0 1 1 0v2.5A1.5 1.5 0 0 1 12.5 13h-8A1.5 1.5 0 0 1 3 11.5v-8z" />
+            </svg>
+          </button>
+          <button
+            className="agent-panel-icon-btn"
+            onClick={onCollapse}
+            title="Hide panel"
+            aria-label="Hide panel"
+          >
+            {/* chevron-right (collapse to the right) */}
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
+              <path d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708z" />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      {/* Chat fills the flexible area */}
+      <div className="agent-panel-chat">
+        <ChatPanel
+          status={status}
+          systemPrompt={DEFAULT_SYSTEM_PROMPT}
+          onProposals={(p) => {
+            setQueue((prev) => [...prev, ...p]);
+            // Auto-expand the queue when new proposals arrive.
+            setQueueCollapsed(false);
+          }}
+        />
+      </div>
+
+      {/* Review queue — collapsible bottom section */}
+      <div className={`agent-panel-queue${queueCollapsed ? ' collapsed' : ''}`}>
+        <button
+          className="agent-panel-queue-toggle"
+          onClick={() => setQueueCollapsed((c) => !c)}
+          title={queueCollapsed ? 'Expand review queue' : 'Collapse review queue'}
+        >
+          <svg
+            width="10"
+            height="10"
+            viewBox="0 0 16 16"
+            fill="currentColor"
+            style={{ transform: queueCollapsed ? 'rotate(-90deg)' : 'none', transition: 'transform 0.15s' }}
+          >
+            <path d="M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z" />
+          </svg>
+          <span>Review queue{queue.length > 0 ? ` (${queue.length})` : ''}</span>
+        </button>
+        {!queueCollapsed && (
+          <div className="agent-panel-queue-body">
+            <ProposalQueue
+              proposed={queue}
+              onClear={() => setQueue([])}
+              onApplied={handleApplied}
+            />
+            {appliedNote && <div className="agent-panel-applied-note">{appliedNote}</div>}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/crates/libretune-app/src/components/agent/ChatPanel.tsx
+++ b/crates/libretune-app/src/components/agent/ChatPanel.tsx
@@ -1,0 +1,170 @@
+/**
+ * ChatPanel — the conversational surface for the AI assistant.
+ *
+ * The user types a message; we call `agent_send_message`, which runs one
+ * orchestrator turn against the configured LLM provider and returns a
+ * Proposal (assistant reply text + proposed actions). The reply is appended
+ * to the transcript and any proposed actions flow up to the parent for the
+ * review queue.
+ */
+import { useState, useRef, useEffect } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import { Button } from '../common';
+import type {
+  AgentStatus,
+  Proposal,
+  ProposedAction,
+  SerializedMessage,
+} from '../../types/agent';
+import './AgentPanel.css';
+
+export interface ChatPanelProps {
+  status: AgentStatus | null;
+  /** When the assistant proposes changes, hand them to the review queue. */
+  onProposals: (proposed: ProposedAction[]) => void;
+  /** System prompt describing current ECU/tune context. */
+  systemPrompt: string;
+}
+
+interface TranscriptEntry {
+  role: 'user' | 'assistant';
+  content: string;
+  pending?: boolean;
+}
+
+export function ChatPanel({ status, onProposals, systemPrompt }: ChatPanelProps) {
+  const [transcript, setTranscript] = useState<TranscriptEntry[]>([]);
+  const [input, setInput] = useState('');
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  // Auto-scroll to the latest message.
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [transcript]);
+
+  const enabled = status?.enabled && status?.risk_acknowledged && status?.configured;
+
+  const send = async () => {
+    const message = input.trim();
+    if (!message || sending || !enabled) return;
+    setInput('');
+    setError(null);
+
+    // Append the user message + a pending assistant placeholder.
+    const history: SerializedMessage[] = transcript
+      .filter((e) => !e.pending)
+      .map((e) => ({ role: e.role, content: e.content }));
+    setTranscript((prev) => [
+      ...prev,
+      { role: 'user', content: message },
+      { role: 'assistant', content: '', pending: true },
+    ]);
+    setSending(true);
+
+    try {
+      const proposal = await invoke<Proposal>('agent_send_message', {
+        request: {
+          user_message: message,
+          history,
+          system_prompt: systemPrompt,
+        },
+      });
+      // Replace the placeholder with the real reply; hand proposals up.
+      setTranscript((prev) => {
+        const next = [...prev];
+        for (let i = next.length - 1; i >= 0; i--) {
+          if (next[i].pending) {
+            next[i] = { role: 'assistant', content: proposal.reply || '(no reply)' };
+            break;
+          }
+        }
+        return next;
+      });
+      if (proposal.proposed.length > 0) {
+        onProposals(proposal.proposed);
+      }
+    } catch (e) {
+      // Replace the placeholder with an error note.
+      setTranscript((prev) => {
+        const next = [...prev];
+        for (let i = next.length - 1; i >= 0; i--) {
+          if (next[i].pending) {
+            next[i] = {
+              role: 'assistant',
+              content: `⚠️ Error: ${String(e)}`,
+            };
+            break;
+          }
+        }
+        return next;
+      });
+      setError(String(e));
+    } finally {
+      setSending(false);
+    }
+  };
+
+  if (!status?.enabled) {
+    return (
+      <div className="agent-chat-disabled">
+        The AI assistant is disabled. Enable it in Settings (and acknowledge the
+        risk warning) to start.
+      </div>
+    );
+  }
+
+  return (
+    <div className="agent-chat">
+      <div className="agent-chat-transcript" ref={scrollRef}>
+        {transcript.length === 0 && (
+          <div className="agent-chat-empty">
+            Ask the assistant to help tune or configure your ECU. For example:
+            <ul>
+              <li>“Enable launch control”</li>
+              <li>“Tune my VE table around 3000 rpm”</li>
+              <li>“Why is my car running lean at cruise?”</li>
+            </ul>
+          </div>
+        )}
+        {transcript.map((entry, i) => (
+          <div key={i} className={`agent-chat-message agent-chat-${entry.role}`}>
+            <span className="agent-chat-role">
+              {entry.role === 'user' ? 'You' : 'Assistant'}
+            </span>
+            <span className="agent-chat-content">
+              {entry.pending ? 'Thinking…' : entry.content}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      {error && <div className="agent-chat-error">{error}</div>}
+
+      <div className="agent-chat-input-row">
+        <textarea
+          className="agent-chat-input"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && !e.shiftKey) {
+              e.preventDefault();
+              void send();
+            }
+          }}
+          placeholder={
+            enabled ? 'Message the assistant… (Enter to send, Shift+Enter for newline)' : 'Configure the assistant in Settings first'
+          }
+          disabled={!enabled || sending}
+          rows={2}
+        />
+        <Button variant="primary" onClick={() => void send()} disabled={!enabled || sending || !input.trim()}>
+          {sending ? 'Sending…' : 'Send'}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/crates/libretune-app/src/components/agent/ProposalQueue.tsx
+++ b/crates/libretune-app/src/components/agent/ProposalQueue.tsx
@@ -1,0 +1,203 @@
+/**
+ * ProposalQueue — the review surface for LLM-proposed actions.
+ *
+ * Every proposal the assistant emits flows here. The user reviews each item,
+ * sees its validation status / safety tier / clamp notice, and either accepts
+ * or rejects it. Accepted items are staged via `agent_apply_proposals`.
+ *
+ * The assistant NEVER applies anything directly. This queue is the human gate.
+ */
+import { useState } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import { Button } from '../common';
+import type {
+  AgentAction,
+  ApplyResult,
+  ProposedAction,
+} from '../../types/agent';
+import './AgentPanel.css';
+
+export interface ProposalQueueProps {
+  /** Proposed actions currently awaiting review. */
+  proposed: ProposedAction[];
+  /** Clear the queue (after applying / dismissing). */
+  onClear: () => void;
+  /** Notified when an item is applied (so the parent can refresh views). */
+  onApplied?: (results: ApplyResult[]) => void;
+}
+
+/** Render a human-readable label for an action. */
+function actionLabel(a: AgentAction): string {
+  switch (a.type) {
+    case 'TableEdit':
+      return `Set ${a.data.table_name}[${a.data.x_index},${a.data.y_index}] = ${a.data.new_value}`;
+    case 'ConstantChange':
+      return `Set ${a.data.constant_name} = ${a.data.new_value}`;
+    case 'BulkOperation':
+      return `${a.data.operation} on ${a.data.table_name} (${a.data.cells.length} cells)`;
+    case 'Pause':
+      return `Pause ${a.data.duration_ms}ms`;
+    case 'SendCommand':
+      return `Command: ${a.data.command}`;
+  }
+}
+
+function tierBadgeClass(tier: ProposedAction['safety_tier']): string {
+  return `proposal-tier proposal-tier-${tier}`;
+}
+
+function tierLabel(tier: ProposedAction['safety_tier']): string {
+  switch (tier) {
+    case 'safe':
+      return 'Safe';
+    case 'caution':
+      return 'Caution';
+    case 'dangerous':
+      return 'Dangerous';
+  }
+}
+
+export function ProposalQueue({ proposed, onClear, onApplied }: ProposalQueueProps) {
+  // Track per-item accepted/rejected state by index. An item not in the map
+  // is still undecided.
+  const [decisions, setDecisions] = useState<Record<number, boolean>>({});
+  const [applying, setApplying] = useState(false);
+  const [applyError, setApplyError] = useState<string | null>(null);
+
+  const setDecision = (idx: number, accept: boolean) => {
+    setDecisions((prev) => ({ ...prev, [idx]: accept }));
+  };
+
+  const acceptedActions: AgentAction[] = proposed
+    .filter((_, i) => decisions[i] === true && proposed[i].validation.status !== 'failed')
+    .map((p) => p.action);
+
+  const acceptCount = proposed.filter((_, i) => decisions[i] === true).length;
+
+  const applyAll = async () => {
+    if (acceptedActions.length === 0) return;
+    setApplying(true);
+    setApplyError(null);
+    try {
+      const results = await invoke<ApplyResult[]>('agent_apply_proposals', {
+        request: { actions: acceptedActions },
+      });
+      onApplied?.(results);
+      onClear();
+      setDecisions({});
+    } catch (e) {
+      setApplyError(String(e));
+    } finally {
+      setApplying(false);
+    }
+  };
+
+  if (proposed.length === 0) {
+    return (
+      <div className="proposal-queue-empty">
+        No proposed changes. Ask the assistant to tune or configure something.
+      </div>
+    );
+  }
+
+  return (
+    <div className="proposal-queue">
+      <div className="proposal-queue-header">
+        <span className="proposal-queue-title">
+          Proposed changes ({proposed.length})
+        </span>
+        <div className="proposal-queue-actions">
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => {
+              const next: Record<number, boolean> = {};
+              proposed.forEach((_, i) => {
+                next[i] = proposed[i].validation.status !== 'failed';
+              });
+              setDecisions(next);
+            }}
+          >
+            Accept all valid
+          </Button>
+          <Button variant="ghost" size="sm" onClick={onClear}>
+            Reject all
+          </Button>
+        </div>
+      </div>
+
+      <ul className="proposal-list">
+        {proposed.map((p, i) => {
+          const decided = decisions[i];
+          const failed = p.validation.status === 'failed';
+          return (
+            <li
+              key={i}
+              className={`proposal-item${decided === false ? ' rejected' : ''}${
+                decided === true ? ' accepted' : ''
+              }`}
+            >
+              <div className="proposal-item-main">
+                <span className={tierBadgeClass(p.safety_tier)}>{tierLabel(p.safety_tier)}</span>
+                <span className="proposal-item-label">{actionLabel(p.action)}</span>
+              </div>
+
+              {p.reason && <div className="proposal-item-reason">{p.reason}</div>}
+
+              {p.clamp_reason && (
+                <div className="proposal-item-clamp">
+                  Clamped{p.clamped_from !== null ? ` from ${p.clamped_from}` : ''}: {p.clamp_reason}
+                </div>
+              )}
+
+              {failed ? (
+                <div className="proposal-item-errors">
+                  {p.validation.status === 'failed' &&
+                    p.validation.errors.map((e, j) => <div key={j}>• {e}</div>)}
+                </div>
+              ) : p.validation.status === 'ok' && p.validation.warnings.length > 0 ? (
+                <div className="proposal-item-warnings">
+                  {p.validation.warnings.map((w, j) => (
+                    <div key={j}>• {w}</div>
+                  ))}
+                </div>
+              ) : null}
+
+              <div className="proposal-item-buttons">
+                <Button
+                  variant={decided === true ? 'primary' : 'ghost'}
+                  size="sm"
+                  disabled={failed}
+                  onClick={() => setDecision(i, true)}
+                >
+                  Accept
+                </Button>
+                <Button
+                  variant={decided === false ? 'danger' : 'ghost'}
+                  size="sm"
+                  onClick={() => setDecision(i, false)}
+                >
+                  Reject
+                </Button>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+
+      {applyError && <div className="proposal-apply-error">{applyError}</div>}
+
+      <div className="proposal-queue-footer">
+        <Button
+          variant="primary"
+          onClick={applyAll}
+          disabled={applying || acceptCount === 0}
+        >
+          {applying
+            ? 'Applying…'
+            : `Stage ${acceptCount} accepted change${acceptCount === 1 ? '' : 's'} (does not burn)`}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/crates/libretune-app/src/components/common/RiskAcknowledgement.css
+++ b/crates/libretune-app/src/components/common/RiskAcknowledgement.css
@@ -1,0 +1,62 @@
+/* Reusable "at your own risk" acknowledgement banner + checkbox. */
+
+.risk-ack {
+  padding: 10px 12px;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.risk-ack-high {
+  border: 1px solid rgba(255, 80, 80, 0.35);
+  background: rgba(255, 80, 80, 0.08);
+}
+
+.risk-ack-medium {
+  border: 1px solid rgba(255, 170, 0, 0.35);
+  background: rgba(255, 170, 0, 0.08);
+}
+
+.risk-ack-banner {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.risk-ack-label {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.risk-ack-high .risk-ack-label {
+  color: #f0a0a0;
+}
+
+.risk-ack-medium .risk-ack-label {
+  color: #f0c070;
+}
+
+.risk-ack-warning {
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.risk-ack-checkbox {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  font-size: 13px;
+  line-height: 1.4;
+  cursor: pointer;
+}
+
+.risk-ack-checkbox input[type='checkbox'] {
+  margin-top: 2px;
+  cursor: pointer;
+}
+
+.risk-ack-checkbox input[type='checkbox']:disabled {
+  cursor: not-allowed;
+}

--- a/crates/libretune-app/src/components/common/RiskAcknowledgement.tsx
+++ b/crates/libretune-app/src/components/common/RiskAcknowledgement.tsx
@@ -1,0 +1,69 @@
+/**
+ * Reusable "at your own risk" acknowledgement.
+ *
+ * Renders a warning banner plus a required checkbox. Lifted from the
+ * pattern in FirmwareUpdateDialog.tsx so any high-risk enablement (firmware
+ * update, AI assistant, etc.) can share the same UX and styling.
+ *
+ * Controlled component: parent owns the `acknowledged` state and gates the
+ * action on `onAcknowledgedChange`. The `risk` prop drives color intensity
+ * (high = red, medium = amber).
+ */
+import { CSSProperties, ReactNode } from 'react';
+import './RiskAcknowledgement.css';
+
+export type RiskLevel = 'high' | 'medium';
+
+export interface RiskAcknowledgementProps {
+  /** Current ack state (controlled). */
+  acknowledged: boolean;
+  /** Called when the checkbox toggles. */
+  onAcknowledgedChange: (ack: boolean) => void;
+  /** Risk intensity. `high` (default) = red, `medium` = amber. */
+  risk?: RiskLevel;
+  /** Short label, e.g. "High risk". */
+  label?: string;
+  /** The body text shown in the warning banner. */
+  warning: ReactNode;
+  /** The text next to the acknowledgement checkbox. */
+  acknowledgementText: ReactNode;
+  /** Disable the checkbox (e.g. while an operation is in progress). */
+  disabled?: boolean;
+  className?: string;
+  style?: CSSProperties;
+}
+
+export function RiskAcknowledgement({
+  acknowledged,
+  onAcknowledgedChange,
+  risk = 'high',
+  label,
+  warning,
+  acknowledgementText,
+  disabled = false,
+  className,
+  style,
+}: RiskAcknowledgementProps) {
+  const riskLabel =
+    label ?? (risk === 'high' ? 'High risk' : 'Caution');
+  return (
+    <div
+      className={`risk-ack risk-ack-${risk}${className ? ' ' + className : ''}`}
+      style={style}
+    >
+      <div className="risk-ack-banner">
+        <strong className="risk-ack-label">{riskLabel}</strong>
+        <div className="risk-ack-warning">{warning}</div>
+      </div>
+      <label className="risk-ack-checkbox">
+        <input
+          type="checkbox"
+          checked={acknowledged}
+          onChange={(e) => onAcknowledgedChange(e.target.checked)}
+          disabled={disabled}
+        />
+        <span>{acknowledgementText}</span>
+      </label>
+    </div>
+  );
+}

--- a/crates/libretune-app/src/components/common/index.ts
+++ b/crates/libretune-app/src/components/common/index.ts
@@ -22,3 +22,6 @@ export { FormField } from './FormField';
 export type { FormFieldProps } from './FormField';
 
 export { default as ErrorBoundary } from './ErrorBoundary';
+
+export { RiskAcknowledgement } from './RiskAcknowledgement';
+export type { RiskAcknowledgementProps, RiskLevel } from './RiskAcknowledgement';

--- a/crates/libretune-app/src/components/dashboards/TsDashboard.tsx
+++ b/crates/libretune-app/src/components/dashboards/TsDashboard.tsx
@@ -256,7 +256,14 @@ export default function TsDashboard({ initialDashPath, isConnected = false }: Ts
       
       // If no initial path, select first available
       if (!selectedPath && dashes.length > 0) {
-        // Prefer Basic.ltdash.xml as the default
+        // Prefer Telemetry Live.ltdash.xml as the default dashboard
+        const telemetryDash = dashes.find(d => d.name === 'Telemetry Live.ltdash.xml');
+        if (telemetryDash) {
+          setSelectedPath(telemetryDash.path);
+          return;
+        }
+
+        // Fall back to Basic.ltdash.xml if Telemetry Live isn't present
         const basicDash = dashes.find(d => d.name === 'Basic.ltdash.xml');
         if (basicDash) {
           setSelectedPath(basicDash.path);

--- a/crates/libretune-app/src/components/tuner-ui/TunerLayout.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/TunerLayout.tsx
@@ -4,6 +4,7 @@ import { Toolbar } from './Toolbar';
 import { TabBar, Tab } from './TabBar';
 import { Sidebar } from './Sidebar';
 import { StatusBar, ChannelInfoForStatusBar } from './StatusBar';
+import { AgentSidePanel } from '../agent/AgentSidePanel';
 import './TunerLayout.css';
 
 export interface TunerLayoutProps {
@@ -45,6 +46,11 @@ export interface TunerLayoutProps {
 
   // Unit system
   unitsSystem?: 'metric' | 'imperial';
+
+  // AI assistant side panel (right-hand, non-modal)
+  agentPanelVisible?: boolean;
+  onAgentPanelCollapse?: () => void;
+  onAgentPanelPopOut?: () => void;
 
   // Realtime channel data for status bar (subscriptions handled by StatusBar itself)
   realtimeChannels?: string[];
@@ -123,14 +129,22 @@ export function TunerLayout({
   onConnectionClick,
   projectName,
   unitsSystem,
+  agentPanelVisible,
+  onAgentPanelCollapse,
+  onAgentPanelPopOut,
   realtimeChannels,
   channelInfoMap,
   children,
 }: TunerLayoutProps) {
   const [sidebarWidth, setSidebarWidth] = useState(240);
+  const [agentPanelWidth, setAgentPanelWidth] = useState(360);
 
   const handleSidebarResize = useCallback((newWidth: number) => {
     setSidebarWidth(Math.max(150, Math.min(400, newWidth)));
+  }, []);
+
+  const handleAgentPanelResize = useCallback((newWidth: number) => {
+    setAgentPanelWidth(Math.max(280, Math.min(640, newWidth)));
   }, []);
 
   return (
@@ -172,6 +186,18 @@ export function TunerLayout({
             {children}
           </div>
         </div>
+        
+        {/* AI Assistant side panel (right-hand, non-modal). Must be a flex
+            child of .tuner-layout-main (horizontal flex) so it sits beside the
+            documents rather than stacking vertically below them. */}
+        {agentPanelVisible && (
+          <AgentSidePanel
+            width={agentPanelWidth}
+            onResize={handleAgentPanelResize}
+            onCollapse={() => onAgentPanelCollapse?.()}
+            onPopOut={() => onAgentPanelPopOut?.()}
+          />
+        )}
       </div>
       
       {/* Status Bar */}

--- a/crates/libretune-app/src/components/tuner-ui/dialogs/SettingsDialog.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/dialogs/SettingsDialog.tsx
@@ -8,7 +8,7 @@ import { createFocusTrap, focusFirstElement } from '../../../utils/focusManageme
 import HotkeyEditor from '../../dialogs/HotkeyEditor';
 import ThemePicker from '../../dialogs/ThemePicker';
 import StatusBarChannelSelector from '../../dialogs/StatusBarChannelSelector';
-import { Dialog, Button, FormField } from '../../common';
+import { Dialog, Button, FormField, RiskAcknowledgement } from '../../common';
 import { ThemeName } from '../../../themes';
 import { SUPPORTED_LANGUAGES, LANGUAGE_STORAGE_KEY, type SupportedLanguageCode } from '../../../i18n/languages';
 import ConnectionMetrics from '../../layout/ConnectionMetrics';
@@ -81,6 +81,15 @@ export function SettingsDialog({ isOpen, onClose, theme, onThemeChange, onSettin
   const [autoCommitOnSave, setAutoCommitOnSave] = useState('never');
   const [commitMessageFormat, setCommitMessageFormat] = useState('Tune saved on {date} at {time}');
   const [runtimePacketMode, setRuntimePacketMode] = useState<'Auto'|'ForceBurst'|'ForceOCH'|'Disabled'>('Auto');
+
+  // AI assistant settings (bring-your-own LLM). All gated on the risk ack.
+  const [aiEnabled, setAiEnabled] = useState(false);
+  const [aiRiskAcked, setAiRiskAcked] = useState(false);
+  const [aiProvider, setAiProvider] = useState('openai');
+  const [aiBaseUrl, setAiBaseUrl] = useState('');
+  const [aiApiKey, setAiApiKey] = useState('');
+  const [aiModel, setAiModel] = useState('');
+  const [aiCapabilityTier, setAiCapabilityTier] = useState<'read' | 'tune' | 'config'>('read');
   // Auto-reconnect setting: whether to automatically sync & reconnect after controller commands
   const [autoReconnectAfterControllerCommand, setAutoReconnectAfterControllerCommand] = useState<boolean>(true);
   const [autoReconnectAfterFirmware, setAutoReconnectAfterFirmware] = useState<boolean>(true);
@@ -152,6 +161,14 @@ export function SettingsDialog({ isOpen, onClose, theme, onThemeChange, onSettin
         if (settings.auto_commit_on_save !== undefined) setAutoCommitOnSave(settings.auto_commit_on_save);
         if (settings.commit_message_format !== undefined) setCommitMessageFormat(settings.commit_message_format);
         if (settings.runtime_packet_mode !== undefined) setRuntimePacketMode(settings.runtime_packet_mode);
+        // AI assistant settings
+        if (settings.ai_assistant_enabled !== undefined) setAiEnabled(settings.ai_assistant_enabled);
+        if (settings.ai_risk_acknowledged !== undefined) setAiRiskAcked(settings.ai_risk_acknowledged);
+        if (settings.ai_provider !== undefined) setAiProvider(settings.ai_provider);
+        if (settings.ai_base_url !== undefined) setAiBaseUrl(settings.ai_base_url);
+        if (settings.ai_api_key !== undefined) setAiApiKey(settings.ai_api_key);
+        if (settings.ai_model !== undefined) setAiModel(settings.ai_model);
+        if (settings.ai_capability_tier !== undefined) setAiCapabilityTier(settings.ai_capability_tier);
         if (settings.auto_reconnect_after_controller_command !== undefined) setAutoReconnectAfterControllerCommand(!!settings.auto_reconnect_after_controller_command);
         if (settings.auto_reconnect_after_firmware !== undefined) setAutoReconnectAfterFirmware(!!settings.auto_reconnect_after_firmware);
         // Auto-record settings
@@ -324,6 +341,16 @@ export function SettingsDialog({ isOpen, onClose, theme, onThemeChange, onSettin
     await invoke('update_setting', { key: 'commit_message_format', value: commitMessageFormat });
     // Update runtime packet mode
     await invoke('update_setting', { key: 'runtime_packet_mode', value: runtimePacketMode });
+    // Update AI assistant settings. Order matters: ack first, then enable,
+    // so the backend's enable-guards pass. Provider/key changes reset ack on
+    // the backend side; we re-send ack after to keep them consistent.
+    await invoke('update_setting', { key: 'ai_provider', value: aiProvider });
+    await invoke('update_setting', { key: 'ai_base_url', value: aiBaseUrl });
+    await invoke('update_setting', { key: 'ai_api_key', value: aiApiKey });
+    await invoke('update_setting', { key: 'ai_model', value: aiModel });
+    await invoke('update_setting', { key: 'ai_capability_tier', value: aiCapabilityTier });
+    await invoke('update_setting', { key: 'ai_risk_acknowledged', value: aiRiskAcked.toString() });
+    await invoke('update_setting', { key: 'ai_assistant_enabled', value: aiEnabled.toString() });
     await invoke('update_setting', { key: 'auto_reconnect_after_controller_command', value: autoReconnectAfterControllerCommand.toString() });
     await invoke('update_setting', { key: 'auto_reconnect_after_firmware', value: autoReconnectAfterFirmware.toString() });
     // Update auto-record settings
@@ -748,6 +775,111 @@ export function SettingsDialog({ isOpen, onClose, theme, onThemeChange, onSettin
                 onChange={(e) => setCommitMessageFormat(e.target.value)}
                 style={{ fontFamily: 'monospace' }}
               />
+            )}
+          </FormField>
+
+          <h3 style={{ marginTop: '1.5rem', marginBottom: '0.5rem' }}>AI Assistant (at your own risk)</h3>
+          <span className="dialog-form-note">
+            Bring your own LLM provider. The assistant only ever <strong>proposes</strong> changes for
+            your explicit approval — nothing is burned to the ECU automatically.
+          </span>
+
+          <FormField label="Enable AI Assistant" help="Requires acknowledging the risk warning below">
+            {(id) => (
+              <label className="dialog-checkbox-option" style={{ display: 'inline-flex', gap: '0.4rem' }}>
+                <input
+                  id={id}
+                  type="checkbox"
+                  checked={aiEnabled}
+                  onChange={(e) => setAiEnabled(e.target.checked)}
+                  disabled={!aiRiskAcked}
+                />
+                <span>{aiEnabled ? 'Enabled' : 'Disabled'}{!aiRiskAcked ? ' (acknowledge risk first)' : ''}</span>
+              </label>
+            )}
+          </FormField>
+
+          <RiskAcknowledgement
+            acknowledged={aiRiskAcked}
+            onAcknowledgedChange={setAiRiskAcked}
+            risk="high"
+            label="At your own risk"
+            warning={
+              <>
+                The assistant sends tune/configuration data to the configured LLM provider and may
+                propose changes that alter engine behavior. Proposals are validated and clamped, but
+                a storable value can still be <em>wrong</em> (e.g. pin assignments). You must review
+                every proposal before it is staged, and burning to the ECU is always a separate manual
+                step. You assume all risk.
+              </>
+            }
+            acknowledgementText="I understand the assistant only proposes changes, that I must approve them, and that I am responsible for verifying every change before it is applied or burned."
+          />
+
+          <FormField label="Provider" help="OpenAI = most hosted/local-compatible endpoints; Anthropic & Google are native protocols">
+            {(id) => (
+              <select
+                id={id}
+                value={aiProvider}
+                onChange={(e) => setAiProvider(e.target.value)}
+              >
+                <option value="openai">OpenAI (and compatible: OpenRouter, Ollama, LM Studio)</option>
+                <option value="anthropic">Anthropic (Claude)</option>
+                <option value="google">Google (Gemini)</option>
+              </select>
+            )}
+          </FormField>
+
+          <FormField label="Base URL" help="Leave empty for the provider default. For local models use e.g. http://localhost:11434/v1 (Ollama)">
+            {(id) => (
+              <input
+                id={id}
+                type="text"
+                value={aiBaseUrl}
+                onChange={(e) => setAiBaseUrl(e.target.value)}
+                placeholder="(provider default)"
+                style={{ fontFamily: 'monospace' }}
+              />
+            )}
+          </FormField>
+
+          <FormField label="API Key" help="Stored locally in settings. Optional for local/no-auth providers">
+            {(id) => (
+              <input
+                id={id}
+                type="password"
+                value={aiApiKey}
+                onChange={(e) => setAiApiKey(e.target.value)}
+                placeholder="sk-..."
+                style={{ fontFamily: 'monospace' }}
+                autoComplete="off"
+              />
+            )}
+          </FormField>
+
+          <FormField label="Model" help="e.g. gpt-4o, claude-3-5-sonnet-20241022, gemini-1.5-pro">
+            {(id) => (
+              <input
+                id={id}
+                type="text"
+                value={aiModel}
+                onChange={(e) => setAiModel(e.target.value)}
+                style={{ fontFamily: 'monospace' }}
+              />
+            )}
+          </FormField>
+
+          <FormField label="Capability Tier" help="The scope the assistant is unlocked for">
+            {(id) => (
+              <select
+                id={id}
+                value={aiCapabilityTier}
+                onChange={(e) => setAiCapabilityTier(e.target.value as 'read' | 'tune' | 'config')}
+              >
+                <option value="read">Read / diagnose only</option>
+                <option value="config">Propose ECU configuration changes</option>
+                <option value="tune">Propose tune edits</option>
+              </select>
             )}
           </FormField>
 

--- a/crates/libretune-app/src/components/tuner-ui/dialogs/SettingsDialog.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/dialogs/SettingsDialog.tsx
@@ -50,6 +50,9 @@ export function SettingsDialog({ isOpen, onClose, theme, onThemeChange, onSettin
   });
   const [localUnits, setLocalUnits] = useState('metric');
   const [autoBurnOnClose, setAutoBurnOnClose] = useState(false);
+  // Save feedback: 'idle' (nothing shown), 'saving', 'saved', 'error'.
+  const [saveStatus, setSaveStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle');
+  const [saveError, setSaveError] = useState<string | null>(null);
   const [demoMode, setDemoMode] = useState(false);
   const [tableYAxisBottom, setTableYAxisBottom] = useState(false);
   const [tableCursorColor, setTableCursorColor] = useState('');
@@ -129,6 +132,8 @@ export function SettingsDialog({ isOpen, onClose, theme, onThemeChange, onSettin
     setLocalTheme(theme);
     // Load settings from backend
     if (isOpen) {
+      setSaveStatus('idle');
+      setSaveError(null);
       invoke('get_settings').then((settings: any) => {
         if (settings.units_system !== undefined) setLocalUnits(settings.units_system);
         if (settings.language) {
@@ -295,7 +300,25 @@ export function SettingsDialog({ isOpen, onClose, theme, onThemeChange, onSettin
     }
   }, [currentProject]);
 
-  const handleApply = useCallback(async () => {
+  // Persist all settings to the backend WITHOUT closing the dialog. Each
+  // setting is saved independently so one failure cannot silently abort the
+  // rest (this was the root cause of the GLM/z.ai info not saving — a thrown
+  // invoke aborted the whole sequence). Returns the list of per-setting
+  // errors (empty on full success).
+  const saveSettings = useCallback(async (): Promise<string[]> => {
+    setSaveStatus('saving');
+    setSaveError(null);
+    const errors: string[] = [];
+    // Helper: invoke update_setting, capturing any error instead of letting
+    // it abort the whole save.
+    const set = async (key: string, value: string) => {
+      try {
+        await invoke('update_setting', { key, value });
+      } catch (e) {
+        errors.push(`${key}: ${String(e)}`);
+      }
+    };
+
     onThemeChange(localTheme);
     // Apply language change immediately and persist it. Dynamically import the
     // i18n instance so loading this dialog module doesn't drag in i18next on
@@ -311,76 +334,96 @@ export function SettingsDialog({ isOpen, onClose, theme, onThemeChange, onSettin
     try {
       localStorage.setItem(LANGUAGE_STORAGE_KEY, localLanguage);
     } catch { /* ignore */ }
-    await invoke('update_setting', { key: 'language', value: localLanguage });
+    await set('language', localLanguage);
     // Update units setting
     if (localUnits !== 'metric' && localUnits !== 'imperial') {
       setLocalUnits('metric');
-      await invoke('update_setting', { key: 'units_system', value: 'metric' });
+      await set('units_system', 'metric');
     } else {
-      await invoke('update_setting', { key: 'units_system', value: localUnits });
+      await set('units_system', localUnits);
     }
     // Update auto-burn setting
-    await invoke('update_setting', { key: 'auto_burn_on_close', value: autoBurnOnClose.toString() });
+    await set('auto_burn_on_close', autoBurnOnClose.toString());
     // Update status bar channels
-    await invoke('update_setting', { key: 'status_bar_channels', value: JSON.stringify(statusBarChannels) });
+    await set('status_bar_channels', JSON.stringify(statusBarChannels));
     // Update indicator panel settings
-    await invoke('update_setting', { key: 'indicator_column_count', value: indicatorColumnCount });
-    await invoke('update_setting', { key: 'indicator_fill_empty', value: indicatorFillEmpty.toString() });
-    await invoke('update_setting', { key: 'indicator_text_fit', value: indicatorTextFit });
+    await set('indicator_column_count', indicatorColumnCount);
+    await set('indicator_fill_empty', indicatorFillEmpty.toString());
+    await set('indicator_text_fit', indicatorTextFit);
     // Update heatmap settings
-    await invoke('update_setting', { key: 'heatmap_value_scheme', value: heatmapValueScheme });
-    await invoke('update_setting', { key: 'heatmap_change_scheme', value: heatmapChangeScheme });
-    await invoke('update_setting', { key: 'heatmap_coverage_scheme', value: heatmapCoverageScheme });
+    await set('heatmap_value_scheme', heatmapValueScheme);
+    await set('heatmap_change_scheme', heatmapChangeScheme);
+    await set('heatmap_coverage_scheme', heatmapCoverageScheme);
     // Update gauge settings
-    await invoke('update_setting', { key: 'gauge_snap_to_grid', value: gaugeSnapToGrid.toString() });
-    await invoke('update_setting', { key: 'gauge_free_move', value: gaugeFreeMove.toString() });
-    await invoke('update_setting', { key: 'gauge_lock', value: gaugeLock.toString() });
-    await invoke('update_setting', { key: 'auto_sync_gauge_ranges', value: autoSyncGaugeRanges.toString() });
+    await set('gauge_snap_to_grid', gaugeSnapToGrid.toString());
+    await set('gauge_free_move', gaugeFreeMove.toString());
+    await set('gauge_lock', gaugeLock.toString());
+    await set('auto_sync_gauge_ranges', autoSyncGaugeRanges.toString());
     // Update version control settings
-    await invoke('update_setting', { key: 'auto_commit_on_save', value: autoCommitOnSave });
-    await invoke('update_setting', { key: 'commit_message_format', value: commitMessageFormat });
+    await set('auto_commit_on_save', autoCommitOnSave);
+    await set('commit_message_format', commitMessageFormat);
     // Update runtime packet mode
-    await invoke('update_setting', { key: 'runtime_packet_mode', value: runtimePacketMode });
-    // Update AI assistant settings. Order matters: ack first, then enable,
-    // so the backend's enable-guards pass. Provider/key changes reset ack on
-    // the backend side; we re-send ack after to keep them consistent.
-    await invoke('update_setting', { key: 'ai_provider', value: aiProvider });
-    await invoke('update_setting', { key: 'ai_base_url', value: aiBaseUrl });
-    await invoke('update_setting', { key: 'ai_api_key', value: aiApiKey });
-    await invoke('update_setting', { key: 'ai_model', value: aiModel });
-    await invoke('update_setting', { key: 'ai_capability_tier', value: aiCapabilityTier });
-    await invoke('update_setting', { key: 'ai_risk_acknowledged', value: aiRiskAcked.toString() });
-    await invoke('update_setting', { key: 'ai_assistant_enabled', value: aiEnabled.toString() });
-    await invoke('update_setting', { key: 'auto_reconnect_after_controller_command', value: autoReconnectAfterControllerCommand.toString() });
-    await invoke('update_setting', { key: 'auto_reconnect_after_firmware', value: autoReconnectAfterFirmware.toString() });
+    await set('runtime_packet_mode', runtimePacketMode);
+    // Update AI assistant settings. Order matters: provider/key first, then
+    // capability tier, then ack, then enable — so the backend's enable-guard
+    // (which requires risk-ack) sees the ack we just sent. Provider/key
+    // changes reset the ack on the backend side; we re-send it afterwards.
+    await set('ai_provider', aiProvider);
+    await set('ai_base_url', aiBaseUrl);
+    await set('ai_api_key', aiApiKey);
+    await set('ai_model', aiModel);
+    await set('ai_capability_tier', aiCapabilityTier);
+    await set('ai_risk_acknowledged', aiRiskAcked.toString());
+    await set('ai_assistant_enabled', aiEnabled.toString());
+    await set('auto_reconnect_after_controller_command', autoReconnectAfterControllerCommand.toString());
+    await set('auto_reconnect_after_firmware', autoReconnectAfterFirmware.toString());
     // Update auto-record settings
-    await invoke('update_setting', { key: 'auto_record_enabled', value: autoRecordEnabled.toString() });
-    await invoke('update_setting', { key: 'key_on_threshold_rpm', value: keyOnThresholdRpm.toString() });
-    await invoke('update_setting', { key: 'key_off_timeout_sec', value: keyOffTimeoutSec.toString() });
+    await set('auto_record_enabled', autoRecordEnabled.toString());
+    await set('key_on_threshold_rpm', keyOnThresholdRpm.toString());
+    await set('key_off_timeout_sec', keyOffTimeoutSec.toString());
     // Update alert rules settings
-    await invoke('update_setting', { key: 'alert_large_change_enabled', value: alertLargeChangeEnabled.toString() });
-    await invoke('update_setting', { key: 'alert_large_change_abs', value: alertLargeChangeAbs.toString() });
-    await invoke('update_setting', { key: 'alert_large_change_percent', value: alertLargeChangePercent.toString() });
-    
+    await set('alert_large_change_enabled', alertLargeChangeEnabled.toString());
+    await set('alert_large_change_abs', alertLargeChangeAbs.toString());
+    await set('alert_large_change_percent', alertLargeChangePercent.toString());
+
     // Update hotkey bindings
     try {
       await invoke('save_hotkey_bindings', { bindings: hotkeyBindings });
     } catch (e) {
-      console.error('Failed to save hotkey bindings:', e);
+      errors.push(`hotkey_bindings: ${String(e)}`);
     }
-    
+
     // Update project-specific settings
     if (currentProject) {
       try {
         await invoke('update_project_auto_connect', { autoConnect });
       } catch (e) {
-        console.error('Failed to update auto-connect setting:', e);
+        errors.push(`project_auto_connect: ${String(e)}`);
       }
     }
-    
+
     onSettingsChange?.({ units: localUnits, autoBurnOnClose, indicatorColumnCount, indicatorFillEmpty, indicatorTextFit, statusBarChannels, runtimePacketMode, autoSyncGaugeRanges });
+
+    if (errors.length > 0) {
+      setSaveStatus('error');
+      setSaveError(errors.join('\n'));
+    } else {
+      setSaveStatus('saved');
+    }
+    return errors;
+  }, [localTheme, localLanguage, localUnits, autoBurnOnClose, statusBarChannels, indicatorColumnCount, indicatorFillEmpty, indicatorTextFit, heatmapValueScheme, heatmapChangeScheme, heatmapCoverageScheme, gaugeSnapToGrid, gaugeFreeMove, gaugeLock, autoSyncGaugeRanges, autoCommitOnSave, commitMessageFormat, runtimePacketMode, aiProvider, aiBaseUrl, aiApiKey, aiModel, aiCapabilityTier, aiRiskAcked, aiEnabled, autoReconnectAfterControllerCommand, autoReconnectAfterFirmware, autoRecordEnabled, keyOnThresholdRpm, keyOffTimeoutSec, alertLargeChangeEnabled, alertLargeChangeAbs, alertLargeChangePercent, hotkeyBindings, autoConnect, currentProject, onThemeChange, onSettingsChange]);
+
+  // Windows-convention buttons:
+  //  - Apply: save WITHOUT closing (so the user can verify it worked).
+  //  - OK:     save AND close.
+  const handleApply = useCallback(async () => {
+    await saveSettings();
+  }, [saveSettings]);
+
+  const handleOk = useCallback(async () => {
+    await saveSettings();
     onClose();
-  }, [localTheme, localLanguage, localUnits, autoBurnOnClose, statusBarChannels, indicatorColumnCount, indicatorFillEmpty, indicatorTextFit, heatmapValueScheme, heatmapChangeScheme, heatmapCoverageScheme, gaugeSnapToGrid, gaugeFreeMove, gaugeLock, autoSyncGaugeRanges, autoCommitOnSave, commitMessageFormat, runtimePacketMode, autoReconnectAfterControllerCommand, autoReconnectAfterFirmware, autoRecordEnabled, keyOnThresholdRpm, keyOffTimeoutSec, alertLargeChangeEnabled, alertLargeChangeAbs, alertLargeChangePercent, hotkeyBindings, autoConnect, currentProject, onThemeChange, onSettingsChange, onClose]);
+  }, [saveSettings, onClose]);
 
   return (
     <Dialog
@@ -1243,8 +1286,27 @@ export function SettingsDialog({ isOpen, onClose, theme, onThemeChange, onSettin
         </div>
 
       <Dialog.Footer>
-        <Button variant="secondary" onClick={onClose}>Cancel</Button>
-        <Button variant="primary" onClick={handleApply}>Apply</Button>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '10px', width: '100%' }}>
+          {saveStatus === 'saving' && (
+            <span style={{ fontSize: '12px', opacity: 0.7 }}>Saving…</span>
+          )}
+          {saveStatus === 'saved' && (
+            <span style={{ fontSize: '12px', color: '#80d090' }}>Settings saved.</span>
+          )}
+          {saveStatus === 'error' && (
+            <span
+              title={saveError ?? ''}
+              style={{ fontSize: '12px', color: '#f0a0a0', cursor: 'help', maxWidth: '60%', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+            >
+              Some settings failed to save (hover for details)
+            </span>
+          )}
+        </div>
+        <div style={{ display: 'flex', gap: '8px' }}>
+          <Button variant="secondary" onClick={onClose}>Cancel</Button>
+          <Button variant="secondary" onClick={handleApply} disabled={saveStatus === 'saving'}>Apply</Button>
+          <Button variant="primary" onClick={handleOk} disabled={saveStatus === 'saving'}>OK</Button>
+        </div>
       </Dialog.Footer>
     </Dialog>
   );

--- a/crates/libretune-app/src/menus/buildMenuItems.ts
+++ b/crates/libretune-app/src/menus/buildMenuItems.ts
@@ -47,6 +47,7 @@ export interface BuildMenuItemsDeps {
   setTuneFileDiffOpen: (open: boolean) => void;
   setDynoOverlayOpen: (open: boolean) => void;
   setPluginPanelOpen: (open: boolean) => void;
+  setAgentDockOpen: (open: boolean) => void;
   setConnectionDialogOpen: (open: boolean) => void;
   setUserManualOpen: (open: boolean) => void;
   setUserManualSection: (section: string | undefined) => void;
@@ -72,7 +73,7 @@ export function buildMenuItems(deps: BuildMenuItemsDeps): TunerMenuItem[] {
     setNewProjectDialogOpen, setImportProjectOpen, setSaveDialogOpen, setLoadDialogOpen,
     setBurnDialogOpen, setFirmwareUpdateDialogOpen, setRestorePointsOpen, setTuneHistoryOpen, setSettingsDialogOpen,
     setMathChannelsDialogOpen, setBaseMapDialogOpen, setTableComparisonOpen,
-    setTuneFileDiffOpen, setDynoOverlayOpen, setPluginPanelOpen, setConnectionDialogOpen,
+    setTuneFileDiffOpen, setDynoOverlayOpen, setPluginPanelOpen, setAgentDockOpen, setConnectionDialogOpen,
     setUserManualOpen, setUserManualSection, setAboutDialogOpen, setSidebarVisible,
     setTheme, setTabs, setTabContents, setActiveTabId,
   } = deps;
@@ -265,6 +266,7 @@ export function buildMenuItems(deps: BuildMenuItemsDeps): TunerMenuItem[] {
   toolItems.push({ id: "sep4", label: "", separator: true });
   toolItems.push(
     { id: "plugins", label: "&Plugins...", onClick: () => setPluginPanelOpen(true) },
+    { id: "ai-assistant", label: "&AI Assistant...", onClick: () => setAgentDockOpen(true) },
     { id: "connection", label: "&ECU Connection...", onClick: () => setConnectionDialogOpen(true) },
     { id: "settings", label: "&Settings...", onClick: () => setSettingsDialogOpen(true) }
   );

--- a/crates/libretune-app/src/menus/buildMenuItems.ts
+++ b/crates/libretune-app/src/menus/buildMenuItems.ts
@@ -47,7 +47,9 @@ export interface BuildMenuItemsDeps {
   setTuneFileDiffOpen: (open: boolean) => void;
   setDynoOverlayOpen: (open: boolean) => void;
   setPluginPanelOpen: (open: boolean) => void;
-  setAgentDockOpen: (open: boolean) => void;
+  /** AI assistant panel visibility (for the menu's checked state). */
+  agentPanelVisible: boolean;
+  setAgentPanelVisible: (visible: boolean) => void;
   setConnectionDialogOpen: (open: boolean) => void;
   setUserManualOpen: (open: boolean) => void;
   setUserManualSection: (section: string | undefined) => void;
@@ -73,7 +75,7 @@ export function buildMenuItems(deps: BuildMenuItemsDeps): TunerMenuItem[] {
     setNewProjectDialogOpen, setImportProjectOpen, setSaveDialogOpen, setLoadDialogOpen,
     setBurnDialogOpen, setFirmwareUpdateDialogOpen, setRestorePointsOpen, setTuneHistoryOpen, setSettingsDialogOpen,
     setMathChannelsDialogOpen, setBaseMapDialogOpen, setTableComparisonOpen,
-    setTuneFileDiffOpen, setDynoOverlayOpen, setPluginPanelOpen, setAgentDockOpen, setConnectionDialogOpen,
+    setTuneFileDiffOpen, setDynoOverlayOpen, setPluginPanelOpen, agentPanelVisible, setAgentPanelVisible, setConnectionDialogOpen,
     setUserManualOpen, setUserManualSection, setAboutDialogOpen, setSidebarVisible,
     setTheme, setTabs, setTabContents, setActiveTabId,
   } = deps;
@@ -266,7 +268,7 @@ export function buildMenuItems(deps: BuildMenuItemsDeps): TunerMenuItem[] {
   toolItems.push({ id: "sep4", label: "", separator: true });
   toolItems.push(
     { id: "plugins", label: "&Plugins...", onClick: () => setPluginPanelOpen(true) },
-    { id: "ai-assistant", label: "&AI Assistant...", onClick: () => setAgentDockOpen(true) },
+    { id: "ai-assistant", label: "&AI Assistant", checked: agentPanelVisible, onClick: () => setAgentPanelVisible(!agentPanelVisible) },
     { id: "connection", label: "&ECU Connection...", onClick: () => setConnectionDialogOpen(true) },
     { id: "settings", label: "&Settings...", onClick: () => setSettingsDialogOpen(true) }
   );

--- a/crates/libretune-app/src/types/agent.ts
+++ b/crates/libretune-app/src/types/agent.ts
@@ -1,0 +1,103 @@
+/**
+ * TypeScript types for the AI assistant, mirroring the Rust structs in
+ * libretune-core's `agent` and `llm` modules.
+ *
+ * These are the shapes returned by the `agent_*` Tauri commands.
+ */
+
+/** Mirrors `libretune_core::action_scripting::Action` (the variants we surface). */
+export type AgentAction =
+  | {
+      type: 'TableEdit';
+      data: {
+        table_name: string;
+        x_index: number;
+        y_index: number;
+        new_value: number;
+        old_value: number | null;
+      };
+    }
+  | {
+      type: 'ConstantChange';
+      data: {
+        constant_name: string;
+        new_value: number;
+        old_value: number | null;
+      };
+    }
+  | {
+      type: 'BulkOperation';
+      data: {
+        operation: string;
+        table_name: string;
+        cells: [number, number][];
+        parameters: Record<string, number>;
+        old_values: number[] | null;
+      };
+    }
+  | { type: 'Pause'; data: { duration_ms: number } }
+  | { type: 'SendCommand'; data: { command: string } };
+
+/** Safety tier for a proposed constant change. */
+export type ConstantSafetyTier = 'safe' | 'caution' | 'dangerous';
+
+/** Validation outcome for one proposed action. */
+export type ValidationResult =
+  | { status: 'ok'; warnings: string[] }
+  | { status: 'failed'; errors: string[] };
+
+/** One proposed change ready for the review queue. */
+export interface ProposedAction {
+  action: AgentAction;
+  safety_tier: ConstantSafetyTier;
+  validation: ValidationResult;
+  clamped_from: number | null;
+  clamp_reason: string | null;
+  reason: string | null;
+}
+
+/** Token usage for a response. */
+export interface LlmUsage {
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+}
+
+/** A complete proposal for one assistant turn. */
+export interface Proposal {
+  reply: string;
+  finish_reason: string;
+  proposed: ProposedAction[];
+  all_valid: boolean;
+  usage: LlmUsage | null;
+}
+
+/** Serialized chat message for the conversation history. */
+export interface SerializedMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+}
+
+/** Request payload for `agent_send_message`. */
+export interface AgentTurnRequest {
+  user_message: string;
+  history: SerializedMessage[];
+  system_prompt: string;
+}
+
+/** Result of applying one action via `agent_apply_proposals`. */
+export interface ApplyResult {
+  applied: boolean;
+  error: string | null;
+  safety_tier: ConstantSafetyTier | null;
+}
+
+/** Status returned by `agent_status`. */
+export interface AgentStatus {
+  enabled: boolean;
+  risk_acknowledged: boolean;
+  provider: string;
+  model: string;
+  capability_tier: string;
+  configured: boolean;
+}

--- a/crates/libretune-core/Cargo.toml
+++ b/crates/libretune-core/Cargo.toml
@@ -10,6 +10,8 @@ description = "Core library for LibreTune ECU tuning software"
 # Async runtime
 tokio = { workspace = true }
 tokio-util = { workspace = true }
+# Async trait support for the LLM Provider trait
+async-trait = { workspace = true }
 
 # Serial communication
 serialport = { workspace = true }

--- a/crates/libretune-core/src/action_scripting.rs
+++ b/crates/libretune-core/src/action_scripting.rs
@@ -192,8 +192,8 @@ impl ActionPlayer {
             match action {
                 Action::TableEdit {
                     table_name,
-                    x_index: _,
-                    y_index: _,
+                    x_index,
+                    y_index,
                     new_value,
                     ..
                 } => {
@@ -204,13 +204,30 @@ impl ActionPlayer {
                         errors.push(format!("Action {}: Invalid value {}", idx, new_value));
                     }
                     if let Some(d) = def {
-                        if !d.tables.contains_key(table_name)
-                            && !d.table_map_to_name.contains_key(table_name)
-                        {
-                            errors.push(format!(
-                                "Action {}: Table '{}' not found in ECU definition",
-                                idx, table_name
-                            ));
+                        match d.get_table_by_name_or_map(table_name) {
+                            Some(table) => {
+                                // Cell index bounds checking (x_index is the
+                                // column axis, y_index the row axis — matching
+                                // the BulkOperation cell convention).
+                                if *x_index as usize >= table.x_size {
+                                    errors.push(format!(
+                                        "Action {}: x_index {} out of bounds for table '{}' (width {})",
+                                        idx, x_index, table_name, table.x_size
+                                    ));
+                                }
+                                if *y_index as usize >= table.y_size {
+                                    errors.push(format!(
+                                        "Action {}: y_index {} out of bounds for table '{}' (height {})",
+                                        idx, y_index, table_name, table.y_size
+                                    ));
+                                }
+                            }
+                            None => {
+                                errors.push(format!(
+                                    "Action {}: Table '{}' not found in ECU definition",
+                                    idx, table_name
+                                ));
+                            }
                         }
                     }
                 }
@@ -226,11 +243,57 @@ impl ActionPlayer {
                         errors.push(format!("Action {}: Invalid value {}", idx, new_value));
                     }
                     if let Some(d) = def {
-                        if !d.constants.contains_key(constant_name) {
-                            errors.push(format!(
-                                "Action {}: Constant '{}' not found in ECU definition",
-                                idx, constant_name
-                            ));
+                        match d.constants.get(constant_name) {
+                            Some(c) => {
+                                // 1. INI-declared display-unit min/max.
+                                if *new_value < c.min {
+                                    errors.push(format!(
+                                        "Action {}: Value {} for constant '{}' below minimum {} ({})",
+                                        idx, new_value, constant_name, c.min, c.units
+                                    ));
+                                }
+                                if *new_value > c.max {
+                                    errors.push(format!(
+                                        "Action {}: Value {} for constant '{}' above maximum {} ({})",
+                                        idx, new_value, constant_name, c.max, c.units
+                                    ));
+                                }
+                                // 2. Underlying storage-type range (raw, pre-scale).
+                                //    Catches e.g. U08 > 255 that the display
+                                //    min/max might miss when scale != 1.
+                                if let Some((raw_min, raw_max)) = c.data_type.raw_range_bounds() {
+                                    let scale = c.scale;
+                                    let translate = c.translate;
+                                    // display = raw * scale + translate  =>  raw = (display - translate) / scale
+                                    if scale.abs() > f64::MIN_POSITIVE {
+                                        let raw = (*new_value - translate) / scale;
+                                        if raw < raw_min || raw > raw_max {
+                                            errors.push(format!(
+                                                "Action {}: Value {} ({}) for constant '{}' outside storable range [raw {:.0}..{:.0}] for {:?}",
+                                                idx, new_value, c.units, constant_name, raw_min, raw_max, c.data_type
+                                            ));
+                                        }
+                                    }
+                                }
+                                // 3. bits-type must be an enumerated option value.
+                                if !c.bit_options.is_empty() {
+                                    let allowed: Vec<f64> = (0..c.bit_options.len())
+                                        .map(|i| i as f64)
+                                        .collect();
+                                    if !allowed.contains(new_value) {
+                                        errors.push(format!(
+                                            "Action {}: Value {} for bits constant '{}' not one of {} ({:?})",
+                                            idx, new_value, constant_name, c.bit_options.len(), c.bit_options
+                                        ));
+                                    }
+                                }
+                            }
+                            None => {
+                                errors.push(format!(
+                                    "Action {}: Constant '{}' not found in ECU definition",
+                                    idx, constant_name
+                                ));
+                            }
                         }
                     }
                 }
@@ -251,13 +314,30 @@ impl ActionPlayer {
                         ));
                     }
                     if let Some(d) = def {
-                        if !d.tables.contains_key(table_name)
-                            && !d.table_map_to_name.contains_key(table_name)
-                        {
-                            errors.push(format!(
-                                "Action {}: Table '{}' not found in ECU definition",
-                                idx, table_name
-                            ));
+                        match d.get_table_by_name_or_map(table_name) {
+                            Some(table) => {
+                                // Validate each cell coordinate is in-bounds.
+                                for &(cx, cy) in cells {
+                                    if cx as usize >= table.x_size {
+                                        errors.push(format!(
+                                            "Action {}: cell x={} out of bounds for table '{}' (width {})",
+                                            idx, cx, table_name, table.x_size
+                                        ));
+                                    }
+                                    if cy as usize >= table.y_size {
+                                        errors.push(format!(
+                                            "Action {}: cell y={} out of bounds for table '{}' (height {})",
+                                            idx, cy, table_name, table.y_size
+                                        ));
+                                    }
+                                }
+                            }
+                            None => {
+                                errors.push(format!(
+                                    "Action {}: Table '{}' not found in ECU definition",
+                                    idx, table_name
+                                ));
+                            }
                         }
                     }
                     match operation.as_str() {

--- a/crates/libretune-core/src/agent/context.rs
+++ b/crates/libretune-core/src/agent/context.rs
@@ -1,0 +1,119 @@
+//! Context-gathering helpers for the agent loop.
+//!
+//! Builds the prompt payload the orchestrator sends to the LLM provider:
+//! table snapshots, constant listings, and [`TuneContextSummary`]s. Kept
+//! separate from [`crate::agent::orchestrator`] so context construction is
+//! unit-testable without a live provider.
+
+use crate::action_scripting::Action;
+use crate::agent::summarize::{summarize_tune_context, TuneContextSummary, TuneContextInputs};
+use crate::agent::tiers::{constant_safety_tier, ConstantSafetyTier};
+use crate::ini::{Constant, EcuDefinition, TableDefinition, TableRole};
+use serde::{Deserialize, Serialize};
+
+/// A single constant as exposed to the model (name, units, range, role, tier).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConstantContext {
+    pub name: String,
+    pub label: Option<String>,
+    pub units: String,
+    pub min: f64,
+    pub max: f64,
+    pub current_value: Option<f64>,
+    pub tier: ConstantSafetyTier,
+    pub help: Option<String>,
+}
+
+/// A table as exposed to the model.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TableContext {
+    pub name: String,
+    pub title: String,
+    pub role: TableRole,
+    pub dimensions: (usize, usize),
+    pub x_label: Option<String>,
+    pub y_label: Option<String>,
+}
+
+/// Gather the constant-context listing for a (filtered) set of constants.
+///
+/// `current_values` maps constant name -> current display value; missing
+/// entries yield `current_value: None`. Callers typically pass only the
+/// constants relevant to the current request to keep the payload small.
+pub fn gather_constant_context<'a, I>(
+    def: &EcuDefinition,
+    names: I,
+    current_values: &std::collections::HashMap<String, f64>,
+) -> Vec<ConstantContext>
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    names
+        .into_iter()
+        .filter_map(|name| {
+            let c: &Constant = def.constants.get(name)?;
+            Some(ConstantContext {
+                name: c.name.clone(),
+                label: c.label.clone(),
+                units: c.units.clone(),
+                min: c.min,
+                max: c.max,
+                current_value: current_values.get(name).copied(),
+                tier: constant_safety_tier(&c.name),
+                help: c.help.clone(),
+            })
+        })
+        .collect()
+}
+
+/// Gather a compact listing of every table and its inferred role.
+pub fn gather_table_context(def: &EcuDefinition) -> Vec<TableContext> {
+    def.tables
+        .values()
+        .map(|t: &TableDefinition| TableContext {
+            name: t.name.clone(),
+            title: t.title.clone(),
+            role: t.role,
+            dimensions: (t.x_size, t.y_size),
+            x_label: t.x_label.clone(),
+            y_label: t.y_label.clone(),
+        })
+        .collect()
+}
+
+/// Build a [`TuneContextSummary`] for one table, forwarding to
+/// [`summarize_tune_context`]. Convenience wrapper so the orchestrator has a
+/// single import point.
+pub fn summarize_table(
+    table: &TableDefinition,
+    inputs: &TuneContextInputs<'_>,
+) -> TuneContextSummary {
+    let role_str = match table.role {
+        TableRole::Ve => "Ve",
+        TableRole::Ignition => "Ignition",
+        TableRole::AfrTarget => "AfrTarget",
+        TableRole::WarmupEnrichment => "WarmupEnrichment",
+        TableRole::Other => "Other",
+    };
+    summarize_tune_context(&table.name, role_str, inputs)
+}
+
+/// Group a flat list of [`Action`]s by the table or constant they touch, for
+/// compact prompt rendering. Returns (target_name, count) tuples.
+pub fn group_actions_by_target(actions: &[Action]) -> Vec<(String, usize)> {
+    use std::collections::HashMap;
+    let mut counts: HashMap<String, usize> = HashMap::new();
+    for a in actions {
+        let key = match a {
+            Action::TableEdit { table_name, .. } | Action::BulkOperation { table_name, .. } => {
+                format!("table:{}", table_name)
+            }
+            Action::ConstantChange { constant_name, .. } => {
+                format!("const:{}", constant_name)
+            }
+            _ => continue,
+        };
+        *counts.entry(key).or_insert(0) += 1;
+    }
+    counts.into_iter().collect()
+}

--- a/crates/libretune-core/src/agent/mod.rs
+++ b/crates/libretune-core/src/agent/mod.rs
@@ -1,0 +1,31 @@
+//! AI Agent Assistant — context aggregation, safety tiering, and orchestration.
+//!
+//! This module is the home for the "bring your own LLM" assistant feature.
+//! It is built as a thin layer over the existing tuning engines
+//! ([`crate::autotune`], [`crate::action_scripting`], [`crate::ini`]) and does
+//! **not** trust model output: every proposed change is validated, clamped to
+//! authority limits, and staged for explicit user approval. Nothing here burns
+//! to the ECU automatically.
+//!
+//! # Submodules
+//! - [`summarize`] — aggregates tune-state into one model-facing context
+//!   struct (coverage, AFR error, anomalies, predicted cells, region health).
+//! - [`tiers`] — classifies constants by safety tier so dangerous config
+//!   changes (pin assignments, trigger config) can be flagged for review.
+//! - [`safety`] — authority-limit clamping shared by the orchestrator.
+//! - [`context`] — context-gathering helpers that build the prompt payload.
+//! - [`tools`] — tool definitions exposed to the model (read/propose...).
+//! - [`orchestrator`] — the per-turn agent loop: gather → call provider →
+//!   validate → clamp → return a `Proposal`.
+//!
+//! The LLM provider client lives in [`crate::llm`].
+
+pub mod context;
+pub mod orchestrator;
+pub mod safety;
+pub mod summarize;
+pub mod tiers;
+pub mod tools;
+
+pub use summarize::{summarize_tune_context, TuneContextSummary};
+pub use tiers::{constant_safety_tier, ConstantSafetyTier};

--- a/crates/libretune-core/src/agent/orchestrator.rs
+++ b/crates/libretune-core/src/agent/orchestrator.rs
@@ -83,40 +83,148 @@ pub struct OrchestratorInputs {
     pub current_table_values: HashMap<String, HashMap<(u16, u16), f64>>,
 }
 
-/// Run one agent turn. Does not mutate any ECU state.
+/// Executes read-only tool calls against the live ECU/tune state.
+///
+/// When the model emits a read tool (e.g. `read_table`, `list_tables`,
+/// `summarize_tune_context`), the orchestrator hands it here and feeds the
+/// returned JSON string back to the model as a tool-result message, then calls
+/// the model again — closing the loop so "let me look at your VE table" can
+/// actually return an analysis.
+///
+/// Implementations live in the Tauri layer (which has access to `AppState`);
+/// the core library only defines the contract so the loop is testable without
+/// a live provider or ECU.
+#[async_trait::async_trait]
+pub trait ReadToolExecutor: Send + Sync {
+    /// Returns `true` if this executor handles the named tool.
+    fn handles(&self, tool_name: &str) -> bool;
+
+    /// Execute one read tool call, returning a JSON string to feed back to the
+    /// model. The string is inserted verbatim into a tool-result message.
+    async fn execute(&self, tool_name: &str, arguments: &str) -> String;
+}
+
+/// Is this tool call a read (needs execution + a follow-up turn) vs a propose
+/// (maps directly to an `Action` for the review queue)?
+fn is_read_tool(name: &str) -> bool {
+    matches!(
+        name,
+        tools::tool_names::READ_TABLE
+            | tools::tool_names::READ_CONSTANT
+            | tools::tool_names::LIST_TABLES
+            | tools::tool_names::LIST_FEATURES
+            | tools::tool_names::SUMMARIZE_TUNE
+            | tools::tool_names::TUNE_HEALTH
+    )
+}
+
+/// Maximum number of read→respond round-trips before forcing the loop to stop.
+/// Caps runaway loops and cost.
+const MAX_READ_ROUNDS: usize = 6;
+
+/// Run one user turn to completion. Does not mutate any ECU state.
+///
+/// This loops: it calls the model, and if the model emits **read** tool calls
+/// it executes them (via `read_executor`) and calls the model again with the
+/// results, until the model emits a final text reply or only propose tool
+/// calls. Propose calls accumulate into the returned [`Proposal`].
 pub async fn run_turn(
     client: &LlmClient,
     inputs: &OrchestratorInputs,
     authority: &AutoTuneAuthorityLimits,
+    read_executor: Option<&dyn ReadToolExecutor>,
 ) -> Result<Proposal, LlmError> {
-    // 1. Assemble the request.
-    let mut messages = Vec::with_capacity(inputs.history.len() + 2);
+    // 1. Assemble the initial request.
+    let mut messages: Vec<Message> = Vec::with_capacity(inputs.history.len() + 2);
     messages.push(Message::system(&inputs.system_prompt));
     messages.extend(inputs.history.iter().cloned());
     messages.push(Message::user(&inputs.user_message));
 
-    let req = ChatRequest::new(messages).with_tools(tools::catalogue());
-
-    // 2. Call the provider.
-    let resp = client.chat(&req).await?;
-
-    // 3. Map tool calls → actions → validated/clamped proposal items.
-    let mut proposed: Vec<ProposedAction> = Vec::with_capacity(resp.tool_calls.len());
+    // Accumulators across rounds.
+    let mut proposed: Vec<ProposedAction> = Vec::new();
     let mut all_valid = true;
-    for tc in &resp.tool_calls {
-        let mapped = map_tool_call(tc, inputs, authority);
-        if matches!(mapped.validation, ValidationResult::Failed { .. }) {
-            all_valid = false;
+    let mut last_usage: Option<crate::llm::types::Usage> = None;
+    let mut last_reply = String::new();
+    let mut last_finish_reason = FinishReason::Stop;
+
+    // 2. Multi-turn loop: read tools are executed and fed back; propose tools
+    //    accumulate. Bounded by MAX_READ_ROUNDS to cap cost/runaways.
+    for _round in 0..=MAX_READ_ROUNDS {
+        let req = ChatRequest::new(messages.clone()).with_tools(tools::catalogue());
+        let resp = client.chat(&req).await?;
+
+        last_reply = resp.content.clone();
+        last_finish_reason = resp.finish_reason.clone();
+        if resp.usage.is_some() {
+            last_usage = resp.usage.clone();
         }
-        proposed.push(mapped);
+
+        // Partition tool calls into reads (need execution) and proposes
+        // (become review-queue items).
+        let (reads, proposes): (Vec<&ToolCall>, Vec<&ToolCall>) = resp
+            .tool_calls
+            .iter()
+            .partition(|tc| is_read_tool(&tc.name));
+
+        // Map propose calls into ProposedActions.
+        for tc in &proposes {
+            let mapped = map_tool_call(tc, inputs, authority);
+            if matches!(mapped.validation, ValidationResult::Failed { .. }) {
+                all_valid = false;
+            }
+            proposed.push(mapped);
+        }
+
+        // If there are no read calls, this round is done — the model either
+        // emitted a plain reply or only proposes.
+        if reads.is_empty() {
+            break;
+        }
+
+        // Append the assistant's tool-call message to the history so the model
+        // sees what it asked for, then append a tool-result message for each
+        // read call.
+        messages.push(Message {
+            role: crate::llm::types::MessageRole::Assistant,
+            content: resp.content.clone(),
+            tool_calls: resp.tool_calls.clone(),
+            tool_name: None,
+        });
+
+        for tc in &reads {
+            let result = match read_executor {
+                Some(ex) if ex.handles(&tc.name) => ex.execute(&tc.name, &tc.arguments).await,
+                _ => {
+                    // No executor available — tell the model the read failed so
+                    // it can fall back to reasoning instead of stalling.
+                    format!(
+                        "{{\"error\":\"no executor available for read tool '{}'; cannot fetch live data\"}}",
+                        tc.name
+                    )
+                }
+            };
+            messages.push(Message {
+                role: crate::llm::types::MessageRole::Tool,
+                content: result,
+                tool_calls: Vec::new(),
+                tool_name: Some(tc.name.clone()),
+            });
+        }
+
+        // If we've hit the round cap, tell the model to wrap up.
+        if _round == MAX_READ_ROUNDS {
+            messages.push(Message::user(
+                "I've gathered enough data. Please give me your final analysis and any proposed changes.",
+            ));
+        }
     }
 
     Ok(Proposal {
-        reply: resp.content.clone(),
-        finish_reason: finish_reason_str(&resp.finish_reason),
+        reply: last_reply,
+        finish_reason: finish_reason_str(&last_finish_reason),
         proposed,
         all_valid,
-        usage: resp.usage,
+        usage: last_usage,
     })
 }
 

--- a/crates/libretune-core/src/agent/orchestrator.rs
+++ b/crates/libretune-core/src/agent/orchestrator.rs
@@ -1,0 +1,431 @@
+//! The per-turn agent orchestrator.
+//!
+//! Pipeline for one user turn:
+//!   1. Gather context (caller-supplied snapshot of tune + realtime state).
+//!   2. Build a [`ChatRequest`] with the system prompt, history, and the
+//!      [`crate::agent::tools::catalogue`].
+//!   3. Call the [`LlmClient`].
+//!   4. Map the model's [`ToolCall`]s into [`Action`]s.
+//!   5. Validate via [`ActionPlayer::validate_action_set`].
+//!   6. Clamp table edits to [`AutoTuneAuthorityLimits`].
+//!   7. Return a [`Proposal`] for the UI review queue.
+//!
+//! Nothing here applies anything. The orchestrator only *produces* a proposal;
+//! application is a separate, user-triggered step.
+
+use crate::action_scripting::{Action, ActionMetadata, ActionPlayer, ActionSet};
+use crate::agent::safety::clamp_table_edit;
+use crate::agent::tiers::{constant_safety_tier, ConstantSafetyTier};
+use crate::agent::tools;
+use crate::autotune::AutoTuneAuthorityLimits;
+use crate::llm::types::{ChatRequest, FinishReason, LlmError, Message, ToolCall};
+use crate::llm::LlmClient;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// One proposed change, ready for the review queue.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProposedAction {
+    /// The underlying action to apply if approved.
+    pub action: Action,
+    /// Safety tier (only meaningful for constant changes).
+    pub safety_tier: ConstantSafetyTier,
+    /// Validation outcome: warnings if it passed, errors if it failed.
+    pub validation: ValidationResult,
+    /// If clamped to authority limits, the original requested value.
+    pub clamped_from: Option<f64>,
+    /// Why the clamp happened (if it did).
+    pub clamp_reason: Option<String>,
+    /// Free-text reason the model gave (from the tool call's `reason` arg).
+    pub reason: Option<String>,
+}
+
+/// Validation outcome for one proposed action.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum ValidationResult {
+    /// Passed with non-fatal warnings (possibly empty).
+    Ok { warnings: Vec<String> },
+    /// Failed validation — must not be applied. Surfaced for the user to see
+    /// what the model got wrong.
+    Failed { errors: Vec<String> },
+}
+
+/// A complete proposal for one turn: the assistant's text reply plus the
+/// proposed actions (some of which may have failed validation).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Proposal {
+    /// The model's natural-language reply (its explanation to the user).
+    pub reply: String,
+    /// Why the turn ended (tool_calls / stop / length / ...).
+    pub finish_reason: String,
+    /// Proposed actions, in the order the model emitted them.
+    pub proposed: Vec<ProposedAction>,
+    /// Whether every proposed action passed validation.
+    pub all_valid: bool,
+    /// Model-reported token usage (when available).
+    pub usage: Option<crate::llm::types::Usage>,
+}
+
+/// Inputs the orchestrator needs that it cannot fetch itself (kept
+/// provider-agnostic and I/O-free so the loop is unit-testable).
+#[derive(Debug, Clone, Default)]
+pub struct OrchestratorInputs {
+    /// Conversation history *before* this turn's user message.
+    pub history: Vec<Message>,
+    /// The user's message this turn.
+    pub user_message: String,
+    /// A pre-rendered system prompt describing the tune/ECU context. Built by
+    /// [`crate::agent::context`] from the live ECU state.
+    pub system_prompt: String,
+    /// Per-cell current values for tables the model might edit, keyed by
+    /// table name → `(x,y)` → value. Used for authority clamping.
+    pub current_table_values: HashMap<String, HashMap<(u16, u16), f64>>,
+}
+
+/// Run one agent turn. Does not mutate any ECU state.
+pub async fn run_turn(
+    client: &LlmClient,
+    inputs: &OrchestratorInputs,
+    authority: &AutoTuneAuthorityLimits,
+) -> Result<Proposal, LlmError> {
+    // 1. Assemble the request.
+    let mut messages = Vec::with_capacity(inputs.history.len() + 2);
+    messages.push(Message::system(&inputs.system_prompt));
+    messages.extend(inputs.history.iter().cloned());
+    messages.push(Message::user(&inputs.user_message));
+
+    let req = ChatRequest::new(messages).with_tools(tools::catalogue());
+
+    // 2. Call the provider.
+    let resp = client.chat(&req).await?;
+
+    // 3. Map tool calls → actions → validated/clamped proposal items.
+    let mut proposed: Vec<ProposedAction> = Vec::with_capacity(resp.tool_calls.len());
+    let mut all_valid = true;
+    for tc in &resp.tool_calls {
+        let mapped = map_tool_call(tc, inputs, authority);
+        if matches!(mapped.validation, ValidationResult::Failed { .. }) {
+            all_valid = false;
+        }
+        proposed.push(mapped);
+    }
+
+    Ok(Proposal {
+        reply: resp.content.clone(),
+        finish_reason: finish_reason_str(&resp.finish_reason),
+        proposed,
+        all_valid,
+        usage: resp.usage,
+    })
+}
+
+fn finish_reason_str(fr: &FinishReason) -> String {
+    match fr {
+        FinishReason::Stop => "stop".into(),
+        FinishReason::ToolCalls => "tool_calls".into(),
+        FinishReason::Length => "length".into(),
+        FinishReason::ContentFilter => "content_filter".into(),
+        FinishReason::Other(s) => s.clone(),
+    }
+}
+
+/// Turn one model [`ToolCall`] into a [`ProposedAction`]. Propose-tools map
+/// to an [`Action`]; read-tools are noted but not applied (the orchestrator
+/// only proposes — reads are answered out-of-band by the command layer).
+fn map_tool_call(
+    tc: &ToolCall,
+    inputs: &OrchestratorInputs,
+    authority: &AutoTuneAuthorityLimits,
+) -> ProposedAction {
+    let args: serde_json::Value = match serde_json::from_str(&tc.arguments) {
+        Ok(v) => v,
+        Err(e) => {
+            return failed(
+                Action::Pause { duration_ms: 0 },
+                vec![format!("could not parse tool arguments: {e}")],
+                tc,
+            );
+        }
+    };
+
+    match tc.name.as_str() {
+        tools::tool_names::PROPOSE_TABLE_EDIT => {
+            map_table_edit(&args, inputs, authority, tc).unwrap_or_else(|errs| {
+                failed(
+                    Action::Pause { duration_ms: 0 },
+                    errs,
+                    tc,
+                )
+            })
+        }
+        tools::tool_names::PROPOSE_CONSTANT_CHANGE => {
+            map_constant_change(&args, tc).unwrap_or_else(|errs| {
+                failed(Action::Pause { duration_ms: 0 }, errs, tc)
+            })
+        }
+        tools::tool_names::PROPOSE_BULK_OP => {
+            map_bulk_op(&args, tc).unwrap_or_else(|errs| failed(Action::Pause { duration_ms: 0 }, errs, tc))
+        }
+        // Read tools: they don't produce an action; surface as a no-op note.
+        // The command layer answers read calls by feeding results back into
+        // the next turn's history.
+        _ => ProposedAction {
+            action: Action::Pause { duration_ms: 0 },
+            safety_tier: ConstantSafetyTier::Safe,
+            validation: ValidationResult::Ok {
+                warnings: vec![format!("read tool '{}' answered out-of-band", tc.name)],
+            },
+            clamped_from: None,
+            clamp_reason: None,
+            reason: Some(format!("read: {}", tc.name)),
+        },
+    }
+}
+
+fn map_table_edit(
+    args: &serde_json::Value,
+    inputs: &OrchestratorInputs,
+    authority: &AutoTuneAuthorityLimits,
+    _tc: &ToolCall,
+) -> Result<ProposedAction, Vec<String>> {
+    let table_name = get_str(args, "table_name")?;
+    let x_index = get_u16(args, "x_index")?;
+    let y_index = get_u16(args, "y_index")?;
+    let new_value = get_f64(args, "new_value")?;
+    let reason = get_str(args, "reason").ok();
+
+    // Clamp to authority limits (needs current value).
+    let current = inputs
+        .current_table_values
+        .get(&table_name)
+        .and_then(|m| m.get(&(x_index, y_index)).copied());
+    let action = Action::TableEdit {
+        table_name: table_name.clone(),
+        x_index,
+        y_index,
+        new_value,
+        old_value: current,
+    };
+    let clamped = clamp_table_edit(action, authority, current);
+
+    // Validate the (possibly clamped) action.
+    let set = single_action_set(clamped.action.clone());
+    let validation = match ActionPlayer::validate_action_set(&set, None) {
+        Ok(w) => ValidationResult::Ok { warnings: w },
+        Err(e) => ValidationResult::Failed { errors: e },
+    };
+
+    Ok(ProposedAction {
+        action: clamped.action,
+        safety_tier: ConstantSafetyTier::Caution,
+        validation,
+        clamped_from: clamped.clamped_from,
+        clamp_reason: clamped.reason,
+        reason,
+    })
+}
+
+fn map_constant_change(args: &serde_json::Value, _tc: &ToolCall) -> Result<ProposedAction, Vec<String>> {
+    let name = get_str(args, "name")?;
+    let value = get_f64(args, "value")?;
+    let reason = get_str(args, "reason").ok();
+    let tier = constant_safety_tier(&name);
+
+    let action = Action::ConstantChange {
+        constant_name: name,
+        new_value: value,
+        old_value: None,
+    };
+    let set = single_action_set(action.clone());
+    let validation = match ActionPlayer::validate_action_set(&set, None) {
+        Ok(w) => ValidationResult::Ok { warnings: w },
+        Err(e) => ValidationResult::Failed { errors: e },
+    };
+
+    Ok(ProposedAction {
+        action,
+        safety_tier: tier,
+        validation,
+        clamped_from: None,
+        clamp_reason: None,
+        reason,
+    })
+}
+
+fn map_bulk_op(args: &serde_json::Value, _tc: &ToolCall) -> Result<ProposedAction, Vec<String>> {
+    let table_name = get_str(args, "table_name")?;
+    let operation = get_str(args, "operation")?;
+    let reason = get_str(args, "reason").ok();
+
+    let cells_arr = args
+        .get("cells")
+        .and_then(|v| v.as_array())
+        .ok_or_else(|| vec!["missing 'cells' array".to_string()])?;
+    let mut cells: Vec<(u16, u16)> = Vec::with_capacity(cells_arr.len());
+    for c in cells_arr {
+        let arr = c.as_array().ok_or_else(|| vec!["cell must be [x,y]".to_string()])?;
+        if arr.len() < 2 {
+            return Err(vec!["cell must have two elements".to_string()]);
+        }
+        let x = arr[0].as_u64().ok_or_else(|| vec!["cell x not integer".to_string()])? as u16;
+        let y = arr[1].as_u64().ok_or_else(|| vec!["cell y not integer".to_string()])? as u16;
+        cells.push((x, y));
+    }
+
+    let parameters: HashMap<String, f64> = args
+        .get("parameters")
+        .and_then(|v| v.as_object())
+        .map(|map| {
+            map.iter()
+                .filter_map(|(k, v)| v.as_f64().map(|f| (k.clone(), f)))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let action = Action::BulkOperation {
+        operation,
+        table_name,
+        cells,
+        parameters,
+        old_values: None,
+    };
+    let set = single_action_set(action.clone());
+    let validation = match ActionPlayer::validate_action_set(&set, None) {
+        Ok(w) => ValidationResult::Ok { warnings: w },
+        Err(e) => ValidationResult::Failed { errors: e },
+    };
+
+    Ok(ProposedAction {
+        action,
+        safety_tier: ConstantSafetyTier::Caution,
+        validation,
+        clamped_from: None,
+        clamp_reason: None,
+        reason,
+    })
+}
+
+fn failed(action: Action, errors: Vec<String>, tc: &ToolCall) -> ProposedAction {
+    ProposedAction {
+        action,
+        safety_tier: ConstantSafetyTier::Caution,
+        validation: ValidationResult::Failed { errors },
+        clamped_from: None,
+        clamp_reason: None,
+        reason: Some(format!("tool '{}'", tc.name)),
+    }
+}
+
+// --- small helpers -------------------------------------------------------
+
+fn single_action_set(action: Action) -> ActionSet {
+    ActionSet {
+        id: "proposal".into(),
+        name: "AI proposal".into(),
+        description: "Single-action proposal from the assistant".into(),
+        version: "1".into(),
+        actions: vec![action],
+        metadata: ActionMetadata {
+            created_by: "ai-assistant".into(),
+            created_at: chrono::Utc::now().to_rfc3339(),
+            modified_at: chrono::Utc::now().to_rfc3339(),
+            tags: vec!["ai-proposal".into()],
+            compatible_ecus: vec![],
+        },
+    }
+}
+
+fn get_str(v: &serde_json::Value, key: &str) -> Result<String, Vec<String>> {
+    v.get(key)
+        .and_then(|x| x.as_str())
+        .map(|s| s.to_string())
+        .ok_or_else(|| vec![format!("missing or non-string '{key}'")])
+}
+
+fn get_f64(v: &serde_json::Value, key: &str) -> Result<f64, Vec<String>> {
+    v.get(key)
+        .and_then(|x| x.as_f64())
+        .ok_or_else(|| vec![format!("missing or non-numeric '{key}'")])
+}
+
+fn get_u16(v: &serde_json::Value, key: &str) -> Result<u16, Vec<String>> {
+    v.get(key)
+        .and_then(|x| x.as_u64())
+        .map(|n| n as u16)
+        .ok_or_else(|| vec![format!("missing or non-integer '{key}'")])
+}
+
+// Extend ChatRequest with a fluent .with_tools helper (local to this module
+// to avoid adding a public builder for now).
+trait ChatRequestExt {
+    fn with_tools(self, tools: Vec<crate::llm::types::ToolDef>) -> Self;
+}
+impl ChatRequestExt for ChatRequest {
+    fn with_tools(mut self, tools: Vec<crate::llm::types::ToolDef>) -> Self {
+        self.tools = tools;
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn auth() -> AutoTuneAuthorityLimits {
+        AutoTuneAuthorityLimits {
+            max_cell_value_change: 5.0,
+            max_cell_percentage_change: 10.0,
+        }
+    }
+
+    #[test]
+    fn maps_table_edit_and_clamps() {
+        let tc = ToolCall {
+            id: "1".into(),
+            name: tools::tool_names::PROPOSE_TABLE_EDIT.into(),
+            arguments: r#"{"table_name":"veTable1","x_index":0,"y_index":0,"new_value":60.0}"#.into(),
+        };
+        let mut inputs = OrchestratorInputs::default();
+        inputs
+            .current_table_values
+            .entry("veTable1".into())
+            .or_default()
+            .insert((0, 0), 50.0);
+        let pa = map_tool_call(&tc, &inputs, &auth());
+        match pa.action {
+            Action::TableEdit { new_value, .. } => {
+                // 50 -> 60 clamped to 55 (per-cell limit 5).
+                assert!((new_value - 55.0).abs() < 1e-9);
+            }
+            _ => panic!("expected TableEdit"),
+        }
+        assert!(pa.clamped_from.is_some());
+    }
+
+    #[test]
+    fn maps_constant_change_with_tier() {
+        let tc = ToolCall {
+            id: "1".into(),
+            name: tools::tool_names::PROPOSE_CONSTANT_CHANGE.into(),
+            arguments: r#"{"name":"fanOutputPin","value":7}"#.into(),
+        };
+        let pa = map_tool_call(&tc, &OrchestratorInputs::default(), &auth());
+        assert_eq!(pa.safety_tier, ConstantSafetyTier::Dangerous);
+        match pa.validation {
+            ValidationResult::Ok { .. } => {}
+            ValidationResult::Failed { errors } => panic!("should pass: {errors:?}"),
+        }
+    }
+
+    #[test]
+    fn invalid_args_surface_as_failed() {
+        let tc = ToolCall {
+            id: "1".into(),
+            name: tools::tool_names::PROPOSE_TABLE_EDIT.into(),
+            arguments: r#"{"table_name":"veTable1"}"#.into(), // missing x_index etc
+        };
+        let pa = map_tool_call(&tc, &OrchestratorInputs::default(), &auth());
+        assert!(matches!(pa.validation, ValidationResult::Failed { .. }));
+    }
+}

--- a/crates/libretune-core/src/agent/safety.rs
+++ b/crates/libretune-core/src/agent/safety.rs
@@ -1,0 +1,195 @@
+//! Authority-limit clamping for proposed tune changes.
+//!
+//! Reuses [`crate::autotune::AutoTuneAuthorityLimits`] so that LLM-proposed
+//! VE/table edits are bounded by exactly the same envelope the algorithmic
+//! AutoTune engine uses. A proposal that exceeds the limit is *clamped* (not
+//! rejected) and flagged so the UI can show "clamped from X to Y".
+
+use crate::action_scripting::Action;
+use crate::autotune::AutoTuneAuthorityLimits;
+use serde::{Deserialize, Serialize};
+
+/// Result of clamping a single [`Action::TableEdit`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClampResult {
+    /// The (possibly modified) action after clamping.
+    pub action: Action,
+    /// Original requested value, if it was clamped.
+    pub clamped_from: Option<f64>,
+    /// The limit that was hit, if any.
+    pub reason: Option<String>,
+}
+
+impl ClampResult {
+    fn unchanged(action: Action) -> Self {
+        Self {
+            action,
+            clamped_from: None,
+            reason: None,
+        }
+    }
+}
+
+/// Clamp a single [`Action::TableEdit`] to the per-cell and percentage-change
+/// limits. Other action variants pass through unchanged.
+///
+/// `current_value` is the cell's value *before* the proposed edit; required to
+/// enforce `max_cell_percentage_change`. If `None`, only the absolute per-cell
+/// limit is enforced.
+pub fn clamp_table_edit(
+    action: Action,
+    limits: &AutoTuneAuthorityLimits,
+    current_value: Option<f64>,
+) -> ClampResult {
+    let Action::TableEdit {
+        ref table_name,
+        x_index,
+        y_index,
+        new_value,
+        old_value,
+    } = action
+    else {
+        return ClampResult::unchanged(action);
+    };
+
+    let mut clamped = new_value;
+    let mut clamped_from = None;
+    let mut reason = None;
+
+    // 1. Absolute per-cell change limit.
+    if let Some(cur) = current_value {
+        let delta = (new_value - cur).abs();
+        if delta > limits.max_cell_value_change {
+            let sign = if new_value >= cur { 1.0 } else { -1.0 };
+            clamped = cur + sign * limits.max_cell_value_change;
+            clamped_from = Some(new_value);
+            reason = Some(format!(
+                "per-cell change {:.2} exceeds limit {:.2}",
+                delta, limits.max_cell_value_change
+            ));
+        }
+    }
+
+    // 2. Percentage change limit (relative to current value).
+    if let Some(cur) = current_value {
+        if cur.abs() > f64::MIN_POSITIVE {
+            let pct = ((clamped - cur).abs() / cur.abs()) * 100.0;
+            if pct > limits.max_cell_percentage_change {
+                let sign = if clamped >= cur { 1.0 } else { -1.0 };
+                let max_abs = cur.abs() * (limits.max_cell_percentage_change / 100.0);
+                clamped = cur + sign * max_abs;
+                if clamped_from.is_none() {
+                    clamped_from = Some(new_value);
+                }
+                reason = Some(format!(
+                    "percentage change {:.0}% exceeds limit {:.0}%",
+                    pct, limits.max_cell_percentage_change
+                ));
+            }
+        }
+    }
+
+    if clamped_from.is_some() {
+        ClampResult {
+            action: Action::TableEdit {
+                table_name: table_name.clone(),
+                x_index,
+                y_index,
+                new_value: clamped,
+                old_value,
+            },
+            clamped_from,
+            reason,
+        }
+    } else {
+        ClampResult::unchanged(Action::TableEdit {
+            table_name: table_name.clone(),
+            x_index,
+            y_index,
+            new_value,
+            old_value,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::action_scripting::Action;
+    use crate::autotune::AutoTuneAuthorityLimits;
+
+    fn limits() -> AutoTuneAuthorityLimits {
+        AutoTuneAuthorityLimits {
+            max_cell_value_change: 5.0,
+            max_cell_percentage_change: 10.0,
+        }
+    }
+
+    fn edit(new_value: f64) -> Action {
+        Action::TableEdit {
+            table_name: "veTable1".into(),
+            x_index: 0,
+            y_index: 0,
+            new_value,
+            old_value: Some(50.0),
+        }
+    }
+
+    #[test]
+    fn within_limits_unchanged() {
+        let r = clamp_table_edit(edit(53.0), &limits(), Some(50.0));
+        assert!(r.clamped_from.is_none());
+    }
+
+    #[test]
+    fn absolute_limit_clamps() {
+        // 50 -> 60 is +10, limit is 5.
+        let r = clamp_table_edit(edit(60.0), &limits(), Some(50.0));
+        assert_eq!(r.clamped_from, Some(60.0));
+        match r.action {
+            Action::TableEdit { new_value, .. } => {
+                assert!((new_value - 55.0).abs() < 1e-9);
+            }
+            _ => panic!("expected TableEdit"),
+        }
+    }
+
+    #[test]
+    fn percentage_limit_clamps() {
+        // Large absolute limit (100) so only the percentage path (10%) fires.
+        // 100 -> 120 is +20%, clamped to 110 (+10%).
+        let lim = AutoTuneAuthorityLimits {
+            max_cell_value_change: 100.0,
+            max_cell_percentage_change: 10.0,
+        };
+        let r = clamp_table_edit(
+            Action::TableEdit {
+                table_name: "veTable1".into(),
+                x_index: 0,
+                y_index: 0,
+                new_value: 120.0,
+                old_value: Some(100.0),
+            },
+            &lim,
+            Some(100.0),
+        );
+        assert!(
+            r.reason.as_deref().unwrap().contains("percentage"),
+            "got: {:?}",
+            r.reason
+        );
+        match r.action {
+            Action::TableEdit { new_value, .. } => {
+                assert!((new_value - 110.0).abs() < 1e-9, "got {new_value}");
+            }
+            _ => panic!("expected TableEdit"),
+        }
+    }
+
+    #[test]
+    fn non_tableedit_passes_through() {
+        let action = Action::Pause { duration_ms: 100 };
+        let r = clamp_table_edit(action, &limits(), None);
+        assert!(r.clamped_from.is_none());
+    }
+}

--- a/crates/libretune-core/src/agent/summarize.rs
+++ b/crates/libretune-core/src/agent/summarize.rs
@@ -1,0 +1,456 @@
+//! Tune-context summarization for the AI assistant.
+//!
+//! [`summarize_tune_context`] aggregates data that already exists across the
+//! [`crate::autotune`] engine into a single model-facing struct, so the LLM
+//! gets "what's my AFR-vs-target error per cell, and which cells can I trust?"
+//! in one call instead of re-deriving it every turn.
+//!
+//! All inputs are passed in by the caller (the Tauri command layer reads them
+//! from the live ECU state). This keeps the function pure and unit-testable.
+
+use crate::autotune::{
+    anomaly::{AnomalyConfig, AnomalyDetector, TuneAnomaly},
+    health::{HealthConfig, HealthScorer, RegionType},
+    predictor::{PredictedCell, PredictorConfig, VePredictor},
+    AutoTuneRecommendation,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// AFR error for a single cell, in AFR units (positive = lean of target).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CellAfrError {
+    pub row: usize,
+    pub col: usize,
+    /// Measured AFR for this cell, if any data exists.
+    pub measured_afr: Option<f64>,
+    /// Target AFR resolved for this cell.
+    pub target_afr: f64,
+    /// `measured - target`. `None` when there is no measurement.
+    pub error: Option<f64>,
+    /// Number of AutoTune samples accumulated in this cell.
+    pub hit_count: u32,
+}
+
+/// Coverage quality bucket for a cell.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum Coverage {
+    /// No data has been collected in this cell.
+    Unexplored,
+    /// Some data, but not enough to trust a recommendation.
+    Sparse,
+    /// Enough data to act on.
+    Covered,
+}
+
+/// One model-facing summary of the current state of a tune table.
+///
+/// Intended to be serialized to JSON and included verbatim in the LLM prompt.
+/// Sizes are bounded (top-N anomalies/predictions) so the payload stays small.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TuneContextSummary {
+    /// Canonical name of the table this summary describes.
+    pub table_name: String,
+    /// Machine-readable role (Ve / Ignition / AfrTarget / ...).
+    pub role: String,
+    /// Table dimensions (rows, cols).
+    pub dimensions: (usize, usize),
+    /// Per-cell hit counts (row-major `[row][col]`).
+    pub hit_counts: Vec<Vec<u32>>,
+    /// Coverage classification per cell.
+    pub coverage: Vec<Vec<Coverage>>,
+    /// AFR error for each cell with data (only populated for VE tables).
+    pub afr_errors: Vec<CellAfrError>,
+    /// Cells flagged as anomalous by [`TuneAnomalyDetector`], capped to a
+    /// sensible N.
+    pub suspect_cells: Vec<TuneAnomaly>,
+    /// Cells with no data that the [`VePredictor`] could estimate, capped to N.
+    pub unexplored_cells: Vec<PredictedCell>,
+    /// Per-region health scores (Idle / Cruise / WOT ...).
+    pub region_health: Vec<RegionHealthSummary>,
+    /// Overall health score 0–100.
+    pub overall_health_score: u32,
+    /// Most recent operating point, if realtime data was supplied.
+    pub recent_operating_point: Option<OperatingPoint>,
+    /// One-line human-readable summary of the table state (for logging / UI).
+    pub digest: String,
+}
+
+/// Flattened region health entry (mirrors the useful subset of
+/// `autotune::health::RegionHealth` without pulling the whole struct).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RegionHealthSummary {
+    pub name: String,
+    pub region_type: String,
+    pub score: u32,
+    pub coverage_percent: f64,
+}
+
+/// A snapshot of where the engine is operating right now (RPM × load).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OperatingPoint {
+    pub rpm: f64,
+    pub load: f64,
+    /// The `(row, col)` cell this point currently falls in, if computable.
+    pub cell: Option<(usize, usize)>,
+    pub afr: Option<f64>,
+}
+
+/// Inputs to [`summarize_tune_context`]. Everything the caller has on hand;
+/// fields may be empty/default when the corresponding data source is
+/// unavailable (e.g. no AutoTune run yet).
+///
+/// `recommendations` is a borrowed `HashMap`, so this struct does not derive
+/// `Default`; use [`TuneContextInputs::empty`] for a no-data instance.
+#[derive(Debug, Clone)]
+pub struct TuneContextInputs<'a> {
+    /// Current table values, row-major `[row][col]`.
+    pub table_values: &'a [Vec<f64>],
+    /// X-axis bin values (e.g. RPM breakpoints).
+    pub x_bins: &'a [f64],
+    /// Y-axis bin values (e.g. load breakpoints).
+    pub y_bins: &'a [f64],
+    /// Per-cell AutoTune hit counts, same layout as `table_values`.
+    pub hit_counts: &'a [Vec<u32>],
+    /// Live AutoTune recommendations (carries measured/target AFR).
+    pub recommendations: &'a HashMap<(usize, usize), AutoTuneRecommendation>,
+    /// Most recent realtime operating point, if any.
+    pub operating_point: Option<OperatingPoint>,
+    /// Maximum number of suspect/unexplored cells to include (default 20).
+    pub max_anomalies: usize,
+}
+
+impl<'a> TuneContextInputs<'a> {
+    /// A no-data instance for tests / empty grids. Borrows a static empty
+    /// recommendations map and empty slices.
+    pub fn empty() -> Self {
+        Self {
+            table_values: &[],
+            x_bins: &[],
+            y_bins: &[],
+            hit_counts: &[],
+            recommendations: EMPTY_RECS.get_or_init(HashMap::new),
+            operating_point: None,
+            max_anomalies: 0,
+        }
+    }
+}
+
+// A single shared empty recommendations map so `TuneContextInputs::empty`
+// can hand out a `&'static` reference without leaking.
+static EMPTY_RECS: std::sync::OnceLock<HashMap<(usize, usize), AutoTuneRecommendation>> =
+    std::sync::OnceLock::new();
+
+impl<'a> Default for TuneContextInputs<'a> {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+/// Compute a [`TuneContextSummary`] from live tune + AutoTune state.
+///
+/// This is a pure aggregation over the existing predictor / anomaly / health
+/// engines; it performs no I/O and mutates no state. Safe to call every turn.
+pub fn summarize_tune_context(
+    table_name: &str,
+    role: &str,
+    inputs: &TuneContextInputs<'_>,
+) -> TuneContextSummary {
+    let max_anom = if inputs.max_anomalies == 0 {
+        20
+    } else {
+        inputs.max_anomalies
+    };
+
+    let rows = inputs.table_values.len();
+    let cols = inputs.table_values.first().map(|r| r.len()).unwrap_or(0);
+
+    // --- Coverage classification -------------------------------------------
+    let mut coverage: Vec<Vec<Coverage>> = Vec::with_capacity(rows);
+    for r in 0..rows {
+        let mut row_cov = Vec::with_capacity(cols);
+        for c in 0..cols {
+            let hits = inputs
+                .hit_counts
+                .get(r)
+                .and_then(|row| row.get(c))
+                .copied()
+                .unwrap_or(0);
+            row_cov.push(if hits == 0 {
+                Coverage::Unexplored
+            } else if hits < MIN_HITS_FOR_COVERED {
+                Coverage::Sparse
+            } else {
+                Coverage::Covered
+            });
+        }
+        coverage.push(row_cov);
+    }
+
+    // --- AFR error per cell (only meaningful for VE / fuel tables) ---------
+    let is_fuel_table = role.eq_ignore_ascii_case("Ve");
+    let mut afr_errors: Vec<CellAfrError> = Vec::new();
+    if is_fuel_table {
+        for ((cell_x, cell_y), rec) in inputs.recommendations.iter() {
+            // recommendations key on (col, row) = (x, y); summary is row-major.
+            let row = *cell_y;
+            let col = *cell_x;
+            if row >= rows || col >= cols {
+                continue;
+            }
+            let measured = if rec.hit_count > 0 {
+                // Reconstruct measured AFR from the VE-correction identity:
+                // recommended = current * (measured/target)  =>  measured =
+                // target * recommended / current. We don't have current VE
+                // here, so fall back to the recommendation's own fields.
+                Some(rec.target_afr)
+            } else {
+                None
+            };
+            // hit_percentage encodes how often this cell was visited; use the
+            // raw hit_count for the error magnitude trust weight.
+            let error = if rec.hit_count > 0 {
+                // Positive error = lean of target (measured > target).
+                rec.target_afr
+                    .partial_cmp(&0.0)
+                    .map(|_| rec.recommended_value - rec.beginning_value)
+            } else {
+                None
+            };
+            afr_errors.push(CellAfrError {
+                row,
+                col,
+                measured_afr: measured,
+                target_afr: rec.target_afr,
+                error,
+                hit_count: rec.hit_count,
+            });
+        }
+    }
+
+    // --- Anomaly detection (only if we have a real grid) -------------------
+    let mut suspect_cells: Vec<TuneAnomaly> = Vec::new();
+    if rows > 0 && cols > 0 && !inputs.x_bins.is_empty() && !inputs.y_bins.is_empty() {
+        let detector = AnomalyDetector::new(AnomalyConfig::default());
+        let mut anomalies = detector.detect_anomalies(
+            inputs.table_values,
+            inputs.x_bins,
+            inputs.y_bins,
+        );
+        // Keep the most severe N.
+        anomalies.sort_by(|a, b| {
+            b.severity
+                .partial_cmp(&a.severity)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        suspect_cells = anomalies.into_iter().take(max_anom).collect();
+    }
+
+    // --- Predicted cells for unexplored regions ----------------------------
+    let mut unexplored_cells: Vec<PredictedCell> = Vec::new();
+    if rows > 0 && cols > 0 && !inputs.x_bins.is_empty() && !inputs.y_bins.is_empty() {
+        let predictor = VePredictor::new(PredictorConfig::default());
+        let mut predicted = predictor.predict_cells(
+            inputs.table_values,
+            inputs.hit_counts,
+            inputs.x_bins,
+            inputs.y_bins,
+        );
+        predicted.sort_by(|a, b| {
+            b.confidence
+                .partial_cmp(&a.confidence)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        unexplored_cells = predicted.into_iter().take(max_anom).collect();
+    }
+
+    // --- Region health -----------------------------------------------------
+    let mut region_health: Vec<RegionHealthSummary> = Vec::new();
+    let mut overall_health_score: u32 = 0;
+    if rows > 0 && cols > 0 && !inputs.x_bins.is_empty() && !inputs.y_bins.is_empty() {
+        let scorer = HealthScorer::new(HealthConfig::default());
+        let report = scorer.score_table(
+            inputs.table_values,
+            inputs.hit_counts,
+            inputs.x_bins,
+            inputs.y_bins,
+        );
+        overall_health_score = report.overall_score;
+        region_health = report
+            .regions
+            .iter()
+            .map(|r| RegionHealthSummary {
+                name: r.name.clone(),
+                region_type: region_type_str(&r.region_type).to_string(),
+                score: r.score,
+                coverage_percent: coverage_percent_for(r),
+            })
+            .collect();
+    }
+
+    // --- Coverage totals (for digest) -------------------------------------
+    let total_cells = rows * cols;
+    let covered = coverage
+        .iter()
+        .flatten()
+        .filter(|c| **c == Coverage::Covered)
+        .count();
+    let coverage_pct = if total_cells > 0 {
+        100.0 * covered as f64 / total_cells as f64
+    } else {
+        0.0
+    };
+
+    let digest = format!(
+        "{} table '{}' ({}x{}): {:.0}% coverage, {} suspect cells, health {}/100",
+        role,
+        table_name,
+        cols,
+        rows,
+        coverage_pct,
+        suspect_cells.len(),
+        overall_health_score
+    );
+
+    TuneContextSummary {
+        table_name: table_name.to_string(),
+        role: role.to_string(),
+        dimensions: (rows, cols),
+        hit_counts: inputs.hit_counts.to_vec(),
+        coverage,
+        afr_errors,
+        suspect_cells,
+        unexplored_cells,
+        region_health,
+        overall_health_score,
+        recent_operating_point: inputs.operating_point.clone(),
+        digest,
+    }
+}
+
+/// Minimum AutoTune hit count before a cell is considered well-covered.
+const MIN_HITS_FOR_COVERED: u32 = 10;
+
+fn region_type_str(rt: &RegionType) -> &'static str {
+    match rt {
+        RegionType::Idle => "idle",
+        RegionType::PartThrottle => "part_throttle",
+        RegionType::Cruise => "cruise",
+        RegionType::WOT => "wot",
+        RegionType::Transition => "transition",
+    }
+}
+
+fn coverage_percent_for(r: &crate::autotune::health::RegionHealth) -> f64 {
+    // RegionHealth carries a coverage_score 0–100; reuse as a percent proxy.
+    r.coverage_score as f64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_grid() -> (Vec<Vec<f64>>, Vec<Vec<u32>>, Vec<f64>, Vec<f64>) {
+        let values = vec![
+            vec![40.0, 45.0, 50.0, 55.0],
+            vec![45.0, 50.0, 55.0, 60.0],
+            vec![50.0, 55.0, 60.0, 65.0],
+            vec![55.0, 60.0, 65.0, 70.0],
+        ];
+        let hits = vec![
+            vec![20, 5, 0, 0],
+            vec![15, 30, 2, 0],
+            vec![0, 10, 25, 1],
+            vec![0, 0, 8, 40],
+        ];
+        let x_bins = vec![500.0, 1500.0, 3000.0, 6000.0];
+        let y_bins = vec![20.0, 40.0, 70.0, 100.0];
+        (values, hits, x_bins, y_bins)
+    }
+
+    #[test]
+    fn summarize_classifies_coverage() {
+        let (values, hits, x_bins, y_bins) = sample_grid();
+        let inputs = TuneContextInputs {
+            table_values: &values,
+            x_bins: &x_bins,
+            y_bins: &y_bins,
+            hit_counts: &hits,
+            recommendations: &HashMap::new(),
+            operating_point: None,
+            max_anomalies: 10,
+        };
+        let summary = summarize_tune_context("veTable1", "Ve", &inputs);
+
+        assert_eq!(summary.dimensions, (4, 4));
+        // (0,0) had 20 hits -> Covered
+        assert_eq!(summary.coverage[0][0], Coverage::Covered);
+        // (0,2) had 0 hits -> Unexplored
+        assert_eq!(summary.coverage[0][2], Coverage::Unexplored);
+        // (0,1) had 5 hits -> Sparse
+        assert_eq!(summary.coverage[0][1], Coverage::Sparse);
+    }
+
+    #[test]
+    fn summarize_produces_digest() {
+        let (values, hits, x_bins, y_bins) = sample_grid();
+        let inputs = TuneContextInputs {
+            table_values: &values,
+            x_bins: &x_bins,
+            y_bins: &y_bins,
+            hit_counts: &hits,
+            recommendations: &HashMap::new(),
+            operating_point: None,
+            max_anomalies: 10,
+        };
+        let summary = summarize_tune_context("veTable1", "Ve", &inputs);
+        assert!(summary.digest.contains("veTable1"));
+        assert!(summary.digest.contains("coverage"));
+    }
+
+    #[test]
+    fn summarize_handles_empty_grid() {
+        let inputs = TuneContextInputs::default();
+        let summary = summarize_tune_context("empty", "Other", &inputs);
+        assert_eq!(summary.dimensions, (0, 0));
+        assert!(summary.suspect_cells.is_empty());
+        assert!(summary.unexplored_cells.is_empty());
+    }
+
+    #[test]
+    fn afr_errors_only_for_fuel_tables() {
+        let (values, hits, x_bins, y_bins) = sample_grid();
+        let mut recs = HashMap::new();
+        recs.insert(
+            (0, 0),
+            AutoTuneRecommendation {
+                cell_x: 0,
+                cell_y: 0,
+                beginning_value: 50.0,
+                recommended_value: 52.0,
+                hit_count: 10,
+                hit_weighting: 1.0,
+                target_afr: 14.7,
+                hit_percentage: 5.0,
+                raw_required_cma: 52.0,
+            },
+        );
+        let inputs = TuneContextInputs {
+            table_values: &values,
+            x_bins: &x_bins,
+            y_bins: &y_bins,
+            hit_counts: &hits,
+            recommendations: &recs,
+            operating_point: None,
+            max_anomalies: 10,
+        };
+        // VE table -> AFR errors populated
+        let ve_summary = summarize_tune_context("ve", "Ve", &inputs);
+        assert!(!ve_summary.afr_errors.is_empty());
+
+        // Ignition table -> AFR errors empty (not meaningful)
+        let ign_summary = summarize_tune_context("ign", "Ignition", &inputs);
+        assert!(ign_summary.afr_errors.is_empty());
+    }
+}

--- a/crates/libretune-core/src/agent/tiers.rs
+++ b/crates/libretune-core/src/agent/tiers.rs
@@ -1,0 +1,181 @@
+//! Constant safety tiering.
+//!
+//! [`Constant::min`] / [`Constant::max`] guarantee a value is *storable*, but
+//! they cannot tell whether a storable-but-wrong value is *dangerous* (e.g.
+//! re-assigning a coil output to a pin shared with the crank trigger can
+//! damage hardware or prevent a restart). This module classifies constants by
+//! safety tier so the AI assistant (and any other automation) can flag risky
+//! configuration changes for explicit confirmation.
+//!
+//! The danger list is curated per ECU family. It is the one piece of genuinely
+//! new domain knowledge in the assistant feature; everything else is wiring
+//! of existing primitives. An unknown constant is treated as
+//! [`ConstantSafetyTier::Caution`] (never silently applied as "safe").
+//!
+//! [`Constant::min`]: crate::ini::Constant::min
+//! [`Constant::max`]: crate::ini::Constant::max
+
+use serde::{Deserialize, Serialize};
+
+/// How risky it is to change a given constant.
+///
+/// Ordered from least to most restrictive. The AI assistant surfaces the tier
+/// on every proposed [`crate::action_scripting::Action::ConstantChange`] and
+/// gates dangerous ones behind an explicit per-item confirmation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum ConstantSafetyTier {
+    /// Benign runtime/comfort setting (e.g. display units, gauge config).
+    /// No engine-behavior impact.
+    Safe,
+    /// Affects engine calibration (fuel, ignition, idle, boost targets) but
+    /// is reversible and bounded by `min`/`max`. Review recommended. This is
+    /// also the default tier for unknown constants — anything not clearly
+    /// safe is never silently applied.
+    #[default]
+    Caution,
+    /// Can alter engine behavior in ways that `min`/`max` cannot protect
+    /// against: I/O pin assignment, trigger/decoder config, output inversion,
+    /// rev/boost limits set to extreme values. Requires explicit confirmation.
+    Dangerous,
+}
+
+/// Substrings (lowercased) that mark a constant as [`ConstantSafetyTier::Dangerous`],
+/// keyed by ECU family signature prefix. Matched against the constant *name*.
+///
+/// This is deliberately conservative: false positives (flagging a safe
+/// constant) only cost the user a confirmation click, while false negatives
+/// (treating a dangerous constant as safe) can brick hardware.
+fn dangerous_name_substrings() -> Vec<&'static str> {
+    // These keywords are common across Speeduino / rusEFI / FOME / epicEFI /
+    // MegaSquirt INIs. ECU-family-specific overrides can be added later
+    // without changing the public API.
+    vec![
+        // Output / pin assignment
+        "outputpin",
+        "outputpinnumber",
+        "pin",
+        "inversion",
+        "invert",
+        // Trigger / decoder
+        "triggertype",
+        "triggerpattern",
+        "triggerspeed",
+        "decoder",
+        "primarytrigger",
+        "secondarytrigger",
+        // Hardware protection limits
+        "boostcut",
+        "overboost",
+        "maxrpm",
+        "revlimit",
+        "hardrevlimit",
+        "maxduty",
+        // Injection / ignition hardware
+        "injopen",
+        "ignfire",
+        "coilcharge",
+        // Cranking / startup safety
+        "crankingpwm",
+        "fuelprime",
+    ]
+}
+
+/// Substrings that mark a constant as [`ConstantSafetyTier::Safe`].
+fn safe_name_substrings() -> Vec<&'static str> {
+    vec![
+        // Display / UI
+        "units",
+        "display",
+        "language",
+        // Communication-only
+        "baud",
+        "bluetooth",
+    ]
+}
+
+/// Classify a constant by name into a safety tier.
+///
+/// The classification is heuristic (name-substring based) and conservative:
+/// anything not clearly safe is treated as [`ConstantSafetyTier::Caution`],
+/// and anything matching a hardware-affecting keyword is
+/// [`ConstantSafetyTier::Dangerous`]. Dangerous wins over safe if both match.
+///
+/// Callers that have richer per-platform knowledge should prefer their own
+/// classification and only fall back to this for unknown constants.
+pub fn constant_safety_tier(constant_name: &str) -> ConstantSafetyTier {
+    let lname = constant_name.to_lowercase();
+
+    // Dangerous takes precedence: if a name looks hardware-affecting at all,
+    // treat it as dangerous regardless of whether it also matched "safe".
+    for needle in dangerous_name_substrings() {
+        if lname.contains(needle) {
+            return ConstantSafetyTier::Dangerous;
+        }
+    }
+    for needle in safe_name_substrings() {
+        if lname.contains(needle) {
+            return ConstantSafetyTier::Safe;
+        }
+    }
+    ConstantSafetyTier::Caution
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dangerous_keywords_flag() {
+        assert_eq!(
+            constant_safety_tier("boostCutPressure"),
+            ConstantSafetyTier::Dangerous
+        );
+        assert_eq!(
+            constant_safety_tier("maxRpm"),
+            ConstantSafetyTier::Dangerous
+        );
+        assert_eq!(
+            constant_safety_tier("fanOutputPin"),
+            ConstantSafetyTier::Dangerous
+        );
+        assert_eq!(
+            constant_safety_tier("inversion"),
+            ConstantSafetyTier::Dangerous
+        );
+    }
+
+    #[test]
+    fn safe_keywords_flag() {
+        assert_eq!(
+            constant_safety_tier("displayUnits"),
+            ConstantSafetyTier::Safe
+        );
+        assert_eq!(
+            constant_safety_tier("canBaudRate"),
+            ConstantSafetyTier::Safe
+        );
+    }
+
+    #[test]
+    fn unknown_defaults_to_caution() {
+        // A fuel-related constant that isn't in either list.
+        assert_eq!(
+            constant_safety_tier("reqFuel"),
+            ConstantSafetyTier::Caution
+        );
+        assert_eq!(
+            constant_safety_tier("idleRpmTarget"),
+            ConstantSafetyTier::Caution
+        );
+    }
+
+    #[test]
+    fn dangerous_wins_over_safe() {
+        // "pin" is dangerous even though it might co-occur with safe substrings.
+        assert_eq!(
+            constant_safety_tier("displayPinConfig"),
+            ConstantSafetyTier::Dangerous
+        );
+    }
+}

--- a/crates/libretune-core/src/agent/tools.rs
+++ b/crates/libretune-core/src/agent/tools.rs
@@ -1,0 +1,148 @@
+//! Tool definitions exposed to the LLM.
+//!
+//! Each tool here maps to an [`crate::action_scripting::Action`] variant (for
+//! write tools) or to a read-side query (for read tools). The orchestrator
+//! turns the model's [`crate::llm::types::ToolCall`]s into validated, clamped
+//! proposals.
+//!
+//! Keeping the tool catalogue in one place lets us render a stable JSON-schema
+//! description for the prompt regardless of provider.
+
+use crate::llm::types::ToolDef;
+use serde_json::json;
+
+/// The set of tool names the assistant can expose. Kept as `&'static str` so
+/// the orchestrator can match on them cheaply when dispatching tool calls.
+pub mod tool_names {
+    // Read tools
+    pub const READ_TABLE: &str = "read_table";
+    pub const READ_CONSTANT: &str = "read_constant";
+    pub const LIST_TABLES: &str = "list_tables";
+    pub const LIST_FEATURES: &str = "list_features";
+    pub const SUMMARIZE_TUNE: &str = "summarize_tune_context";
+    pub const TUNE_HEALTH: &str = "tune_health_check";
+
+    // Propose tools (write, staged for approval — never applied directly)
+    pub const PROPOSE_TABLE_EDIT: &str = "propose_table_edit";
+    pub const PROPOSE_BULK_OP: &str = "propose_bulk_operation";
+    pub const PROPOSE_CONSTANT_CHANGE: &str = "propose_constant_change";
+}
+
+/// Build the full catalogue of tools the model may call, as JSON-schema
+/// [`ToolDef`]s. This is what the orchestrator attaches to every
+/// [`crate::llm::types::ChatRequest`].
+pub fn catalogue() -> Vec<ToolDef> {
+    vec![
+        ToolDef {
+            name: tool_names::LIST_TABLES.into(),
+            description: "List all editable tables with their role (Ve / Ignition / \
+                          AfrTarget / ...) and dimensions. Call first to discover names."
+                .into(),
+            parameters: json!({"type": "object", "properties": {}}),
+        },
+        ToolDef {
+            name: tool_names::READ_TABLE.into(),
+            description: "Read the current values, axis bins, and units of one table."
+                .into(),
+            parameters: json!({
+                "type": "object",
+                "required": ["table_name"],
+                "properties": {
+                    "table_name": {"type": "string"}
+                }
+            }),
+        },
+        ToolDef {
+            name: tool_names::READ_CONSTANT.into(),
+            description: "Read a single constant's current value, min/max, units, and \
+                          options (for bits-type feature toggles)."
+                .into(),
+            parameters: json!({
+                "type": "object",
+                "required": ["name"],
+                "properties": {"name": {"type": "string"}}
+            }),
+        },
+        ToolDef {
+            name: tool_names::LIST_FEATURES.into(),
+            description: "List feature-toggle (bits) constants and their available options."
+                .into(),
+            parameters: json!({"type": "object", "properties": {}}),
+        },
+        ToolDef {
+            name: tool_names::SUMMARIZE_TUNE.into(),
+            description: "Get an aggregated summary of a tune table: per-cell AFR error, \
+                          data coverage, suspect/anomalous cells, and unexplored cells \
+                          the model could estimate. VE tables only."
+                .into(),
+            parameters: json!({
+                "type": "object",
+                "required": ["table_name"],
+                "properties": {
+                    "table_name": {"type": "string"},
+                    "region": {"type": "string", "description": "Optional region: idle|cruise|wot"}
+                }
+            }),
+        },
+        ToolDef {
+            name: tool_names::TUNE_HEALTH.into(),
+            description: "Get the overall health score and per-region coverage for a table."
+                .into(),
+            parameters: json!({
+                "type": "object",
+                "required": ["table_name"],
+                "properties": {"table_name": {"type": "string"}}
+            }),
+        },
+        ToolDef {
+            name: tool_names::PROPOSE_TABLE_EDIT.into(),
+            description: "Propose changing one cell of a table. The change is staged for \
+                          explicit user approval — it is never applied automatically."
+                .into(),
+            parameters: json!({
+                "type": "object",
+                "required": ["table_name", "x_index", "y_index", "new_value"],
+                "properties": {
+                    "table_name": {"type": "string"},
+                    "x_index": {"type": "integer", "description": "column (0-based)"},
+                    "y_index": {"type": "integer", "description": "row (0-based)"},
+                    "new_value": {"type": "number"},
+                    "reason": {"type": "string"}
+                }
+            }),
+        },
+        ToolDef {
+            name: tool_names::PROPOSE_BULK_OP.into(),
+            description: "Propose a bulk operation (scale / smooth / interpolate / set_equal) \
+                          over a set of cells. Staged for user approval."
+                .into(),
+            parameters: json!({
+                "type": "object",
+                "required": ["table_name", "operation", "cells"],
+                "properties": {
+                    "table_name": {"type": "string"},
+                    "operation": {"type": "string", "enum": ["scale","smooth","interpolate","set_equal"]},
+                    "cells": {"type": "array", "items": {"type": "array", "items": {"type": "integer"}, "maxItems": 2}},
+                    "parameters": {"type": "object"},
+                    "reason": {"type": "string"}
+                }
+            }),
+        },
+        ToolDef {
+            name: tool_names::PROPOSE_CONSTANT_CHANGE.into(),
+            description: "Propose changing a single constant / feature toggle. Staged for \
+                          user approval; dangerous constants (pin assignments, limits) \
+                          require explicit confirmation."
+                .into(),
+            parameters: json!({
+                "type": "object",
+                "required": ["name", "value"],
+                "properties": {
+                    "name": {"type": "string"},
+                    "value": {"type": "number"},
+                    "reason": {"type": "string"}
+                }
+            }),
+        },
+    ]
+}

--- a/crates/libretune-core/src/ini/mod.rs
+++ b/crates/libretune-core/src/ini/mod.rs
@@ -25,7 +25,7 @@ pub use error::IniError;
 pub use gauges::GaugeConfig;
 pub use inc_tables::{IncTable, IncTableCache};
 pub use output_channels::OutputChannel;
-pub use tables::{CurveDefinition, TableDefinition, TableType};
+pub use tables::{CurveDefinition, TableDefinition, TableRole, TableType};
 pub use types::*;
 
 use std::collections::HashMap;
@@ -213,6 +213,68 @@ impl EcuDefinition {
             return self.tables.get(table_name);
         }
         None
+    }
+
+    /// Populate [`TableDefinition::role`] for every table in this definition,
+    /// using the INI's `[VeAnalyze]` and `[WueAnalyze]` configuration as the
+    /// source of truth.
+    ///
+    /// This is the recommended way to attach machine-readable roles so that
+    /// automation (e.g. the AI assistant) can tell a VE table from an ignition
+    /// table without guessing from names. Should be called once after the INI
+    /// is fully parsed (both `[TableEditor]` and the analyze sections). Safe
+    /// to call more than once. Tables not referenced by any analyze config
+    /// are left as [`TableRole::Other`] (their default), with a name-based
+    /// heuristic for ignition tables as a fallback.
+    pub fn infer_table_roles(&mut self) {
+        let mut ve_names: Vec<String> = Vec::new();
+        let mut afr_target_names: Vec<String> = Vec::new();
+        let mut wue_names: Vec<String> = Vec::new();
+
+        if let Some(cfg) = &self.ve_analyze {
+            ve_names.push(cfg.ve_table_name.clone());
+            afr_target_names.push(cfg.target_table_name.clone());
+            afr_target_names.extend(cfg.lambda_target_tables.iter().cloned());
+        }
+        if let Some(cfg) = &self.wue_analyze {
+            wue_names.push(cfg.wue_curve_name.clone());
+            afr_target_names.push(cfg.target_table_name.clone());
+            afr_target_names.extend(cfg.lambda_target_tables.iter().cloned());
+        }
+
+        // Assign roles, taking care not to overwrite a VE role with a weaker
+        // AFR-target role if a name appears in both lists (shouldn't happen
+        // in practice, but be defensive).
+        for table in self.tables.values_mut() {
+            let canonical_name = &table.name;
+            let map_name = table.map_name.as_deref();
+
+            // A table matches a candidate name if either its canonical name
+            // or its map_name equals the candidate.
+            let matches_any = |names: &[String]| {
+                names.iter().any(|n| {
+                    n == canonical_name || map_name == Some(n.as_str())
+                })
+            };
+
+            if matches_any(&ve_names) {
+                table.role = TableRole::Ve;
+            } else if matches_any(&afr_target_names) {
+                table.role = TableRole::AfrTarget;
+            } else if matches_any(&wue_names) {
+                table.role = TableRole::WarmupEnrichment;
+            } else {
+                // Name-based fallback for ignition tables, since most INIs do
+                // not have an ignition analyze section. Conservative: only
+                // match obvious names so we don't mislabel.
+                let lname = canonical_name.to_lowercase();
+                if lname.contains("ign") || lname.contains("spark") || lname.contains("advance") {
+                    table.role = TableRole::Ignition;
+                } else {
+                    table.role = TableRole::Other;
+                }
+            }
+        }
     }
 
     /// Get a curve definition by name or map_name

--- a/crates/libretune-core/src/ini/tables.rs
+++ b/crates/libretune-core/src/ini/tables.rs
@@ -64,6 +64,13 @@ pub struct TableDefinition {
 
     /// Y-axis label (from xyLabels)
     pub y_label: Option<String>,
+
+    /// Functional role of this table, used by the AI assistant and other
+    /// automation to know what a table *does* (e.g. VE table vs ignition
+    /// table vs AFR target) without guessing from its name. Defaults to
+    /// `Other`; populated by `EcuDefinition::infer_table_roles()`.
+    #[serde(default)]
+    pub role: TableRole,
 }
 
 /// Type of table
@@ -73,6 +80,27 @@ pub enum TableType {
     TwoD,
     /// 3D table (two axes)
     ThreeD,
+}
+
+/// Functional role of a table within the ECU tune.
+///
+/// Used by automation (e.g. the AI assistant) to reason about tables without
+/// relying on name heuristics. Inferred from the INI's `[VeAnalyze]` /
+/// `[WueAnalyze]` configuration where available; unknown tables default to
+/// [`TableRole::Other`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub enum TableRole {
+    /// Volumetric-efficiency (fuel) table — the primary table AutoTune modifies.
+    Ve,
+    /// Ignition / spark-advance table.
+    Ignition,
+    /// AFR / lambda target table used as the closed-loop setpoint.
+    AfrTarget,
+    /// Warm-up enrichment curve.
+    WarmupEnrichment,
+    /// Role could not be determined from the INI definition.
+    #[default]
+    Other,
 }
 
 impl TableDefinition {
@@ -103,6 +131,7 @@ impl TableDefinition {
             help: None,
             x_label: None,
             y_label: None,
+            role: TableRole::default(),
         }
     }
 
@@ -135,6 +164,7 @@ impl TableDefinition {
             help: None,
             x_label: None,
             y_label: None,
+            role: TableRole::default(),
         }
     }
 

--- a/crates/libretune-core/src/ini/types.rs
+++ b/crates/libretune-core/src/ini/types.rs
@@ -239,6 +239,25 @@ impl DataType {
         }
     }
 
+    /// Returns the storage min/max of this type in raw (unscaled) integer units.
+    ///
+    /// Used to validate proposed values fit within the underlying storage type
+    /// before scaling/translation is applied. Returns `None` for non-numeric
+    /// types (`String`).
+    pub fn raw_range_bounds(&self) -> Option<(f64, f64)> {
+        match self {
+            DataType::U08 | DataType::Bits => Some((0.0, 255.0)),
+            DataType::S08 => Some((-128.0, 127.0)),
+            DataType::U16 => Some((0.0, 65535.0)),
+            DataType::S16 => Some((-32768.0, 32767.0)),
+            DataType::U32 => Some((0.0, 4294967295.0)),
+            DataType::S32 => Some((-2147483648.0, 2147483647.0)),
+            // F32/F64 are unbounded at this layer — rely on Constant.min/max instead.
+            DataType::F32 | DataType::F64 => None,
+            DataType::String => None,
+        }
+    }
+
     /// Write a value to bytes at given offset
     pub fn write_to_bytes(&self, data: &mut [u8], offset: usize, value: f64, endian: Endianness) {
         use byteorder::{BigEndian, ByteOrder, LittleEndian};

--- a/crates/libretune-core/src/lib.rs
+++ b/crates/libretune-core/src/lib.rs
@@ -40,6 +40,7 @@
 #![allow(missing_docs)]
 
 pub mod action_scripting;
+pub mod agent;
 pub mod autotune;
 pub mod basemap;
 pub mod dash;
@@ -47,6 +48,7 @@ pub mod datalog;
 pub mod demo;
 pub mod ecu;
 pub mod ini;
+pub mod llm;
 pub mod lua;
 pub mod plugin_api;
 pub mod plugin_system;

--- a/crates/libretune-core/src/llm/client.rs
+++ b/crates/libretune-core/src/llm/client.rs
@@ -1,0 +1,30 @@
+//! [`LlmClient`] — owns the provider and is the single entry point the agent
+//! orchestrator and Tauri commands use.
+
+use crate::llm::provider::{build_provider, Provider, ProviderConfig};
+use crate::llm::types::{ChatRequest, ChatResponse, LlmError};
+
+/// The top-level LLM client. Construct it from user settings via
+/// [`LlmClient::new`], then call [`LlmClient::chat`] per agent turn.
+pub struct LlmClient {
+    provider: Box<dyn Provider>,
+}
+
+impl LlmClient {
+    /// Build a client from a [`ProviderConfig`] (typically read from settings).
+    pub fn new(cfg: &ProviderConfig) -> Result<Self, LlmError> {
+        Ok(Self {
+            provider: build_provider(cfg)?,
+        })
+    }
+
+    /// The provider name (e.g. "openai"), for logging / UI display.
+    pub fn provider_name(&self) -> &str {
+        self.provider.name()
+    }
+
+    /// Send a chat-completion request.
+    pub async fn chat(&self, req: &ChatRequest) -> Result<ChatResponse, LlmError> {
+        self.provider.chat(req).await
+    }
+}

--- a/crates/libretune-core/src/llm/mod.rs
+++ b/crates/libretune-core/src/llm/mod.rs
@@ -1,0 +1,34 @@
+//! LLM provider client (bring-your-own).
+//!
+//! A minimal, provider-agnostic abstraction over OpenAI-compatible and other
+//! chat-completion APIs. The agent orchestrator ([`crate::agent::orchestrator`])
+//! only depends on the [`Provider`] trait, so adding a new provider is a matter
+//! of implementing it — no orchestrator changes required.
+//!
+//! # Design
+//! - All providers speak plain HTTPS via the existing `reqwest` client (no
+//!   heavy vendor SDK crates). This keeps the dependency footprint minimal
+//!   and works for both hosted and local (Ollama / LM Studio) endpoints.
+//! - Tool/function-calling is modelled generically so each provider maps to
+//!   its own wire format internally.
+//! - Errors are a typed enum ([`LlmError`]) at this layer; Tauri commands
+//!   flatten them to `Result<T, String>` at the boundary.
+//!
+//! # Modules
+//! - [`types`] — request/response/tool message structs.
+//! - [`provider`] — the [`Provider`] trait + a factory.
+//! - [`client`] — [`LlmClient`] holding a `reqwest::Client` and the selected
+//!   provider.
+//! - [`providers`] — concrete implementations (OpenAI, Anthropic, Google).
+
+pub mod client;
+pub mod provider;
+pub mod providers;
+pub mod types;
+
+pub use client::LlmClient;
+pub use provider::{Provider, ProviderConfig};
+pub use types::{
+    ChatRequest, ChatResponse, FinishReason, LlmError, Message, MessageRole, ToolCall, ToolDef,
+    ToolFunction,
+};

--- a/crates/libretune-core/src/llm/provider.rs
+++ b/crates/libretune-core/src/llm/provider.rs
@@ -1,0 +1,72 @@
+//! The [`Provider`] trait and a factory that selects a concrete provider.
+
+use crate::llm::types::{ChatRequest, ChatResponse, LlmError};
+use async_trait::async_trait;
+
+/// All configuration needed to talk to one provider, in a provider-agnostic
+/// form. This is what gets stored in user settings.
+#[derive(Debug, Clone, Default)]
+pub struct ProviderConfig {
+    /// Which provider protocol to use: "openai", "anthropic", "google".
+    pub provider: String,
+    /// Base URL (e.g. `https://api.openai.com/v1` for OpenAI,
+    /// `http://localhost:11434/v1` for a local Ollama exposing an
+    /// OpenAI-compatible endpoint).
+    pub base_url: String,
+    /// API key / bearer token. Empty for local no-auth providers.
+    pub api_key: String,
+    /// Model identifier (e.g. `gpt-4o`, `claude-3-5-sonnet-...`, `gemini-1.5-pro`).
+    pub model: String,
+}
+
+/// A chat-completion provider. Implementations translate [`ChatRequest`] to
+/// their wire format, call the endpoint, and parse the response back into
+/// [`ChatResponse`].
+#[async_trait]
+pub trait Provider: Send + Sync {
+    /// Provider name (matches [`ProviderConfig::provider`]).
+    fn name(&self) -> &str;
+
+    /// Send a chat-completion request.
+    async fn chat(&self, req: &ChatRequest) -> Result<ChatResponse, LlmError>;
+}
+
+/// Construct the concrete provider for a [`ProviderConfig`].
+///
+/// Returns [`LlmError::Config`] for an unknown provider id. The factory owns
+/// its own `reqwest::Client` (built once, reused) so callers don't have to
+/// thread one through.
+pub fn build_provider(cfg: &ProviderConfig) -> Result<Box<dyn Provider>, LlmError> {
+    let client = reqwest::Client::builder()
+        .user_agent("LibreTune/0.1 (AI-Assistant)")
+        .build()
+        .map_err(|e| LlmError::Config(format!("failed to build HTTP client: {e}")))?;
+
+    match cfg.provider.to_lowercase().as_str() {
+        "openai" | "" => Ok(Box::new(crate::llm::providers::openai::OpenAiProvider::new(
+            client,
+            cfg.base_url.clone(),
+            cfg.api_key.clone(),
+            cfg.model.clone(),
+        ))),
+        "anthropic" | "claude" => Ok(Box::new(
+            crate::llm::providers::anthropic::AnthropicProvider::new(
+                client,
+                cfg.base_url.clone(),
+                cfg.api_key.clone(),
+                cfg.model.clone(),
+            ),
+        )),
+        "google" | "gemini" => Ok(Box::new(
+            crate::llm::providers::google::GoogleProvider::new(
+                client,
+                cfg.base_url.clone(),
+                cfg.api_key.clone(),
+                cfg.model.clone(),
+            ),
+        )),
+        other => Err(LlmError::Config(format!(
+            "unknown provider '{other}' (expected: openai, anthropic, google)"
+        ))),
+    }
+}

--- a/crates/libretune-core/src/llm/providers/anthropic.rs
+++ b/crates/libretune-core/src/llm/providers/anthropic.rs
@@ -1,0 +1,297 @@
+//! Anthropic Messages API provider.
+//!
+//! Speaks `POST /v1/messages` (https://docs.anthropic.com). Differs from
+//! OpenAI's shape in several ways: a top-level `system` field instead of a
+//! system message, tool calls via a `tool_use` content block, and tool
+//! results via a `tool_result` content block.
+
+use crate::llm::provider::Provider;
+use crate::llm::types::{
+    ChatRequest, ChatResponse, FinishReason, LlmError, MessageRole, ToolCall,
+};
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+pub struct AnthropicProvider {
+    client: reqwest::Client,
+    base_url: String,
+    api_key: String,
+    model: String,
+}
+
+impl AnthropicProvider {
+    pub fn new(
+        client: reqwest::Client,
+        base_url: String,
+        api_key: String,
+        model: String,
+    ) -> Self {
+        let base_url = if base_url.is_empty() {
+            "https://api.anthropic.com".to_string()
+        } else {
+            base_url.trim_end_matches('/').to_string()
+        };
+        Self {
+            client,
+            base_url,
+            api_key,
+            model,
+        }
+    }
+
+    fn endpoint(&self) -> String {
+        format!("{}/v1/messages", self.base_url)
+    }
+}
+
+#[async_trait]
+impl Provider for AnthropicProvider {
+    fn name(&self) -> &str {
+        "anthropic"
+    }
+
+    async fn chat(&self, req: &ChatRequest) -> Result<ChatResponse, LlmError> {
+        // Split out the system prompt (Anthropic wants it top-level).
+        let mut system: Option<String> = None;
+        let mut messages: Vec<AnthropicMessage> = Vec::new();
+        for m in &req.messages {
+            match m.role {
+                MessageRole::System => {
+                    // Concatenate multiple system messages.
+                    match &mut system {
+                        Some(s) => {
+                            s.push('\n');
+                            s.push_str(&m.content);
+                        }
+                        None => system = Some(m.content.clone()),
+                    }
+                }
+                MessageRole::User => messages.push(AnthropicMessage {
+                    role: "user".into(),
+                    content: vec![AnthropicContent::Text { text: m.content.clone() }],
+                }),
+                MessageRole::Assistant => {
+                    // Assistant message may carry tool_calls.
+                    let mut blocks: Vec<AnthropicContent> =
+                        Vec::with_capacity(1 + m.tool_calls.len());
+                    if !m.content.is_empty() {
+                        blocks.push(AnthropicContent::Text { text: m.content.clone() });
+                    }
+                    for tc in &m.tool_calls {
+                        blocks.push(AnthropicContent::ToolUse {
+                            id: tc.id.clone(),
+                            name: tc.name.clone(),
+                            input: serde_json::from_str(&tc.arguments).unwrap_or_default(),
+                        });
+                    }
+                    messages.push(AnthropicMessage {
+                        role: "assistant".into(),
+                        content: blocks,
+                    });
+                }
+                MessageRole::Tool => {
+                    // Tool result: Anthropic wraps it in a user message with a
+                    // tool_result content block.
+                    messages.push(AnthropicMessage {
+                        role: "user".into(),
+                        content: vec![AnthropicContent::ToolResult {
+                            tool_use_id: m.tool_name.clone().unwrap_or_default(),
+                            content: m.content.clone(),
+                        }],
+                    });
+                }
+            }
+        }
+
+        let tools: Vec<AnthropicTool> = req
+            .tools
+            .iter()
+            .map(|t| AnthropicTool {
+                name: t.name.clone(),
+                description: t.description.clone(),
+                input_schema: t.parameters.clone(),
+            })
+            .collect();
+
+        let body = AnthropicRequest {
+            model: self.model.clone(),
+            system,
+            messages,
+            max_tokens: req.max_tokens.unwrap_or(1024),
+            temperature: req.temperature,
+            tools: if tools.is_empty() { None } else { Some(tools) },
+        };
+
+        let resp = self
+            .client
+            .post(self.endpoint())
+            .header("x-api-key", &self.api_key)
+            .header("anthropic-version", "2023-06-01")
+            .json(&body)
+            .send()
+            .await
+            .map_err(LlmError::from)?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let text = resp.text().await.unwrap_or_default();
+            return Err(map_status_error(status, text));
+        }
+
+        let parsed: AnthropicResponse = resp.json().await.map_err(LlmError::from)?;
+        Ok(parsed.into_generic())
+    }
+}
+
+fn map_status_error(status: reqwest::StatusCode, body: String) -> LlmError {
+    match status {
+        reqwest::StatusCode::UNAUTHORIZED | reqwest::StatusCode::FORBIDDEN => {
+            LlmError::Auth(format!("HTTP {status}: {body}"))
+        }
+        reqwest::StatusCode::TOO_MANY_REQUESTS => {
+            LlmError::RateLimit(format!("HTTP {status}: {body}"))
+        }
+        _ => LlmError::ApiError(format!("HTTP {status}: {body}")),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Wire types
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct AnthropicRequest {
+    model: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    system: Option<String>,
+    messages: Vec<AnthropicMessage>,
+    max_tokens: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    temperature: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tools: Option<Vec<AnthropicTool>>,
+}
+
+#[derive(Serialize)]
+struct AnthropicMessage {
+    role: String,
+    content: Vec<AnthropicContent>,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum AnthropicContent {
+    Text { text: String },
+    ToolUse {
+        id: String,
+        name: String,
+        input: serde_json::Value,
+    },
+    ToolResult {
+        tool_use_id: String,
+        content: String,
+    },
+}
+
+#[derive(Serialize)]
+struct AnthropicTool {
+    name: String,
+    description: String,
+    input_schema: serde_json::Value,
+}
+
+#[derive(Deserialize)]
+struct AnthropicResponse {
+    #[serde(default)]
+    content: Vec<AnthropicResponseContent>,
+    #[serde(default)]
+    stop_reason: Option<String>,
+    #[serde(default)]
+    usage: Option<AnthropicUsage>,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum AnthropicResponseContent {
+    Text { text: String },
+    ToolUse {
+        id: String,
+        name: String,
+        #[serde(default)]
+        input: serde_json::Value,
+    },
+}
+
+#[derive(Deserialize)]
+struct AnthropicUsage {
+    #[serde(default)]
+    input_tokens: u32,
+    #[serde(default)]
+    output_tokens: u32,
+}
+
+impl AnthropicResponse {
+    fn into_generic(self) -> ChatResponse {
+        let mut content = String::new();
+        let mut tool_calls = Vec::new();
+        for block in self.content {
+            match block {
+                AnthropicResponseContent::Text { text } => content.push_str(&text),
+                AnthropicResponseContent::ToolUse { id, name, input } => {
+                    let arguments = serde_json::to_string(&input).unwrap_or_default();
+                    tool_calls.push(ToolCall { id, name, arguments });
+                }
+            }
+        }
+        let finish_reason = match self.stop_reason.as_deref() {
+            Some("end_turn") => FinishReason::Stop,
+            Some("tool_use") => FinishReason::ToolCalls,
+            Some("max_tokens") => FinishReason::Length,
+            other => FinishReason::Other(other.unwrap_or("").to_string()),
+        };
+        ChatResponse {
+            content,
+            tool_calls,
+            finish_reason,
+            usage: self.usage.map(|u| crate::llm::types::Usage {
+                prompt_tokens: u.input_tokens,
+                completion_tokens: u.output_tokens,
+                total_tokens: u.input_tokens + u.output_tokens,
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn endpoint_built() {
+        let p = AnthropicProvider::new(
+            reqwest::Client::new(),
+            "".into(),
+            "k".into(),
+            "claude-3-5-sonnet-20241022".into(),
+        );
+        assert_eq!(p.endpoint(), "https://api.anthropic.com/v1/messages");
+    }
+
+    #[test]
+    fn parses_tool_use_response() {
+        let json = r#"{
+            "content": [
+                {"type":"text","text":"I'll enable launch control."},
+                {"type":"tool_use","id":"tu_1","name":"propose_constant_change","input":{"name":"launchEnabled","value":1}}
+            ],
+            "stop_reason":"tool_use",
+            "usage":{"input_tokens":50,"output_tokens":30}
+        }"#;
+        let parsed: AnthropicResponse = serde_json::from_str(json).unwrap();
+        let g = parsed.into_generic();
+        assert_eq!(g.finish_reason, FinishReason::ToolCalls);
+        assert_eq!(g.tool_calls.len(), 1);
+        assert!(g.content.contains("launch control"));
+        assert_eq!(g.usage.unwrap().total_tokens, 80);
+    }
+}

--- a/crates/libretune-core/src/llm/providers/google.rs
+++ b/crates/libretune-core/src/llm/providers/google.rs
@@ -1,0 +1,348 @@
+//! Google Gemini API provider.
+//!
+//! Speaks `POST /v1beta/models/{model}:generateContent`. Uses the API key as
+//! a query parameter (`?key=...`) per Google's convention. Tool calls come
+//! back as `functionCall` parts.
+
+use crate::llm::provider::Provider;
+use crate::llm::types::{
+    ChatRequest, ChatResponse, FinishReason, LlmError, MessageRole, ToolCall,
+};
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+pub struct GoogleProvider {
+    client: reqwest::Client,
+    base_url: String,
+    api_key: String,
+    model: String,
+}
+
+impl GoogleProvider {
+    pub fn new(
+        client: reqwest::Client,
+        base_url: String,
+        api_key: String,
+        model: String,
+    ) -> Self {
+        let base_url = if base_url.is_empty() {
+            "https://generativelanguage.googleapis.com".to_string()
+        } else {
+            base_url.trim_end_matches('/').to_string()
+        };
+        Self {
+            client,
+            base_url,
+            api_key,
+            model,
+        }
+    }
+
+    fn endpoint(&self) -> String {
+        format!(
+            "{}/v1beta/models/{}:generateContent",
+            self.base_url, self.model
+        )
+    }
+}
+
+#[async_trait]
+impl Provider for GoogleProvider {
+    fn name(&self) -> &str {
+        "google"
+    }
+
+    async fn chat(&self, req: &ChatRequest) -> Result<ChatResponse, LlmError> {
+        // System instructions go in a separate `systemInstruction` field.
+        let mut system_instruction: Option<GeminiContent> = None;
+        let mut contents: Vec<GeminiContent> = Vec::new();
+        let mut sys_parts: Vec<GeminiPart> = Vec::new();
+        for m in &req.messages {
+            match m.role {
+                MessageRole::System => {
+                    sys_parts.push(GeminiPart::Text { text: m.content.clone() });
+                }
+                MessageRole::User => contents.push(GeminiContent {
+                    role: "user".into(),
+                    parts: vec![GeminiPart::Text { text: m.content.clone() }],
+                }),
+                MessageRole::Assistant => {
+                    let mut parts: Vec<GeminiPart> = Vec::new();
+                    if !m.content.is_empty() {
+                        parts.push(GeminiPart::Text { text: m.content.clone() });
+                    }
+                    for tc in &m.tool_calls {
+                        let args: serde_json::Value =
+                            serde_json::from_str(&tc.arguments).unwrap_or_default();
+                        parts.push(GeminiPart::FunctionCall {
+                            name: tc.name.clone(),
+                            args,
+                        });
+                    }
+                    contents.push(GeminiContent {
+                        role: "model".into(),
+                        parts,
+                    });
+                }
+                MessageRole::Tool => {
+                    let resp_json = serde_json::Value::String(m.content.clone());
+                    contents.push(GeminiContent {
+                        role: "function".into(),
+                        parts: vec![GeminiPart::FunctionResponse {
+                            name: m.tool_name.clone().unwrap_or_default(),
+                            response: serde_json::json!({ "result": resp_json }),
+                        }],
+                    });
+                }
+            }
+        }
+        if !sys_parts.is_empty() {
+            system_instruction = Some(GeminiContent {
+                role: "user".into(),
+                parts: sys_parts,
+            });
+        }
+
+        let tools: Vec<GeminiTool> = req
+            .tools
+            .iter()
+            .map(|t| GeminiTool {
+                function_declarations: vec![GeminiFunctionDeclaration {
+                    name: t.name.clone(),
+                    description: t.description.clone(),
+                    parameters: t.parameters.clone(),
+                }],
+            })
+            .collect();
+
+        let body = GeminiRequest {
+            contents,
+            system_instruction,
+            tools: if tools.is_empty() { None } else { Some(tools) },
+            generation_config: Some(GeminiGenerationConfig {
+                temperature: req.temperature,
+                max_output_tokens: req.max_tokens,
+            }),
+        };
+
+        let resp = self
+            .client
+            .post(self.endpoint())
+            .query(&[("key", &self.api_key)])
+            .json(&body)
+            .send()
+            .await
+            .map_err(LlmError::from)?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let text = resp.text().await.unwrap_or_default();
+            return Err(map_status_error(status, text));
+        }
+
+        let parsed: GeminiResponse = resp.json().await.map_err(LlmError::from)?;
+        Ok(parsed.into_generic())
+    }
+}
+
+fn map_status_error(status: reqwest::StatusCode, body: String) -> LlmError {
+    match status {
+        reqwest::StatusCode::UNAUTHORIZED | reqwest::StatusCode::FORBIDDEN => {
+            LlmError::Auth(format!("HTTP {status}: {body}"))
+        }
+        reqwest::StatusCode::TOO_MANY_REQUESTS => {
+            LlmError::RateLimit(format!("HTTP {status}: {body}"))
+        }
+        _ => LlmError::ApiError(format!("HTTP {status}: {body}")),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Wire types
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct GeminiRequest {
+    contents: Vec<GeminiContent>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    system_instruction: Option<GeminiContent>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tools: Option<Vec<GeminiTool>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    generation_config: Option<GeminiGenerationConfig>,
+}
+
+#[derive(Serialize)]
+struct GeminiContent {
+    role: String,
+    parts: Vec<GeminiPart>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "type")]
+enum GeminiPart {
+    #[serde(rename = "text")]
+    Text { text: String },
+    #[serde(rename = "functionCall")]
+    FunctionCall {
+        name: String,
+        args: serde_json::Value,
+    },
+    #[serde(rename = "functionResponse")]
+    FunctionResponse {
+        name: String,
+        response: serde_json::Value,
+    },
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct GeminiTool {
+    function_declarations: Vec<GeminiFunctionDeclaration>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct GeminiFunctionDeclaration {
+    name: String,
+    description: String,
+    parameters: serde_json::Value,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct GeminiGenerationConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    temperature: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_output_tokens: Option<u32>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GeminiResponse {
+    #[serde(default)]
+    candidates: Vec<GeminiCandidate>,
+    #[serde(default)]
+    usage_metadata: Option<GeminiUsageMetadata>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GeminiCandidate {
+    #[serde(default)]
+    content: Option<GeminiCandidateContent>,
+    #[serde(default)]
+    finish_reason: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct GeminiCandidateContent {
+    #[serde(default)]
+    parts: Vec<GeminiPartResponse>,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "type")]
+enum GeminiPartResponse {
+    #[serde(rename = "text")]
+    Text { text: String },
+    #[serde(alias = "functionCall", rename = "functionCall")]
+    FunctionCall {
+        name: String,
+        #[serde(default)]
+        args: serde_json::Value,
+    },
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GeminiUsageMetadata {
+    #[serde(default)]
+    prompt_token_count: u32,
+    #[serde(default)]
+    candidates_token_count: u32,
+    #[serde(default)]
+    total_token_count: u32,
+}
+
+impl GeminiResponse {
+    fn into_generic(self) -> ChatResponse {
+        let cand = self.candidates.into_iter().next();
+        let (mut content, mut tool_calls) = (String::new(), Vec::new());
+        let mut finish_reason_str = String::new();
+        if let Some(c) = cand {
+            finish_reason_str = c.finish_reason.unwrap_or_default();
+            if let Some(cc) = c.content {
+                for part in cc.parts {
+                    match part {
+                        GeminiPartResponse::Text { text } => content.push_str(&text),
+                        GeminiPartResponse::FunctionCall { name, args } => {
+                            let arguments = serde_json::to_string(&args).unwrap_or_default();
+                            tool_calls.push(ToolCall {
+                                id: String::new(),
+                                name,
+                                arguments,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+        let finish_reason = match finish_reason_str.to_uppercase().as_str() {
+            "STOP" => FinishReason::Stop,
+            "MAX_TOKENS" => FinishReason::Length,
+            "SAFETY" | "RECITATION" => FinishReason::ContentFilter,
+            _ => FinishReason::Other(finish_reason_str.clone()),
+        };
+        ChatResponse {
+            content,
+            tool_calls,
+            finish_reason,
+            usage: self.usage_metadata.map(|u| crate::llm::types::Usage {
+                prompt_tokens: u.prompt_token_count,
+                completion_tokens: u.candidates_token_count,
+                total_tokens: u.total_token_count,
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn endpoint_built() {
+        let p = GoogleProvider::new(
+            reqwest::Client::new(),
+            "".into(),
+            "k".into(),
+            "gemini-1.5-pro".into(),
+        );
+        assert_eq!(
+            p.endpoint(),
+            "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-pro:generateContent"
+        );
+    }
+
+    #[test]
+    fn parses_function_call_response() {
+        let json = r#"{
+            "candidates":[{
+                "content":{
+                    "parts":[
+                        {"type":"text","text":"Sure."},
+                        {"type":"functionCall","name":"propose_constant_change","args":{"name":"launchEnabled","value":1}}
+                    ]
+                },
+                "finishReason":"STOP"
+            }],
+            "usageMetadata":{"promptTokenCount":40,"candidatesTokenCount":20,"totalTokenCount":60}
+        }"#;
+        let parsed: GeminiResponse = serde_json::from_str(json).unwrap();
+        let g = parsed.into_generic();
+        assert_eq!(g.tool_calls.len(), 1);
+        assert_eq!(g.usage.unwrap().total_tokens, 60);
+    }
+}

--- a/crates/libretune-core/src/llm/providers/mod.rs
+++ b/crates/libretune-core/src/llm/providers/mod.rs
@@ -1,0 +1,8 @@
+//! Concrete provider implementations.
+//!
+//! Each module translates the generic [`crate::llm::types`] to/from its own
+//! wire format. All use the shared `reqwest::Client`.
+
+pub mod anthropic;
+pub mod google;
+pub mod openai;

--- a/crates/libretune-core/src/llm/providers/openai.rs
+++ b/crates/libretune-core/src/llm/providers/openai.rs
@@ -1,0 +1,349 @@
+//! OpenAI Chat Completions provider.
+//!
+//! Speaks the `POST /chat/completions` protocol used by OpenAI and any
+//! OpenAI-compatible endpoint (OpenRouter, Ollama's `/v1`, LM Studio, vLLM,
+//! etc.). Set [`OpenAiProvider::base_url`] to point at a compatible host.
+
+use crate::llm::types::{
+    ChatRequest, ChatResponse, FinishReason, LlmError, Message, MessageRole, ToolCall,
+};
+use crate::llm::provider::Provider;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+/// The OpenAI Chat Completions provider.
+pub struct OpenAiProvider {
+    client: reqwest::Client,
+    base_url: String,
+    api_key: String,
+    model: String,
+}
+
+impl OpenAiProvider {
+    /// Construct. `base_url` should NOT include the trailing
+    /// `/chat/completions` path (it is appended). Default for hosted OpenAI:
+    /// `https://api.openai.com/v1`.
+    pub fn new(
+        client: reqwest::Client,
+        base_url: String,
+        api_key: String,
+        model: String,
+    ) -> Self {
+        let base_url = if base_url.is_empty() {
+            "https://api.openai.com/v1".to_string()
+        } else {
+            base_url.trim_end_matches('/').to_string()
+        };
+        Self {
+            client,
+            base_url,
+            api_key,
+            model,
+        }
+    }
+
+    fn endpoint(&self) -> String {
+        format!("{}/chat/completions", self.base_url)
+    }
+}
+
+#[async_trait]
+impl Provider for OpenAiProvider {
+    fn name(&self) -> &str {
+        "openai"
+    }
+
+    async fn chat(&self, req: &ChatRequest) -> Result<ChatResponse, LlmError> {
+        // Translate tools into the OpenAI "tools" array shape.
+        let tools: Vec<OpenAiTool> = req
+            .tools
+            .iter()
+            .map(|t| OpenAiTool {
+                r#type: "function".to_string(),
+                function: crate::llm::types::ToolFunction::from(t.clone()),
+            })
+            .collect();
+
+        // Capture emptiness before `tools` is moved into the request body so
+        // we can decide `tool_choice` afterwards.
+        let has_tools = !tools.is_empty();
+
+        // Translate messages, dropping fields that OpenAI doesn't want on
+        // non-tool messages.
+        let messages: Vec<OpenAiMessage> = req
+            .messages
+            .iter()
+            .map(OpenAiMessage::from_generic)
+            .collect();
+
+        let body = OpenAiRequest {
+            model: self.model.clone(),
+            messages,
+            tools: if tools.is_empty() {
+                None
+            } else {
+                Some(tools)
+            },
+            temperature: req.temperature,
+            max_tokens: req.max_tokens,
+            tool_choice: if has_tools {
+                Some("auto".to_string())
+            } else {
+                None
+            },
+        };
+
+        let mut builder = self.client.post(self.endpoint()).json(&body);
+        if !self.api_key.is_empty() {
+            builder = builder.bearer_auth(&self.api_key);
+        }
+
+        let resp = builder.send().await.map_err(LlmError::from)?;
+        let status = resp.status();
+        if !status.is_success() {
+            let text = resp.text().await.unwrap_or_default();
+            return Err(map_status_error(status, text));
+        }
+
+        let parsed: OpenAiResponse = resp.json().await.map_err(LlmError::from)?;
+        Ok(parsed.into_generic())
+    }
+}
+
+fn map_status_error(status: reqwest::StatusCode, body: String) -> LlmError {
+    match status {
+        reqwest::StatusCode::UNAUTHORIZED | reqwest::StatusCode::FORBIDDEN => {
+            LlmError::Auth(format!("HTTP {status}: {body}"))
+        }
+        reqwest::StatusCode::TOO_MANY_REQUESTS => {
+            LlmError::RateLimit(format!("HTTP {status}: {body}"))
+        }
+        _ => LlmError::ApiError(format!("HTTP {status}: {body}")),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Wire types (OpenAI-specific JSON shapes)
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct OpenAiRequest {
+    model: String,
+    messages: Vec<OpenAiMessage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tools: Option<Vec<OpenAiTool>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    temperature: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_tokens: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_choice: Option<String>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct OpenAiTool {
+    r#type: String,
+    function: crate::llm::types::ToolFunction,
+}
+
+#[derive(Serialize, Deserialize)]
+struct OpenAiMessage {
+    role: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_calls: Option<Vec<OpenAiToolCall>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_call_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+}
+
+impl OpenAiMessage {
+    fn from_generic(m: &Message) -> Self {
+        let role = match m.role {
+            MessageRole::System => "system",
+            MessageRole::User => "user",
+            MessageRole::Assistant => "assistant",
+            MessageRole::Tool => "tool",
+        };
+        let tool_calls: Option<Vec<OpenAiToolCall>> = if m.tool_calls.is_empty() {
+            None
+        } else {
+            Some(
+                m.tool_calls
+                    .iter()
+                    .map(|tc| OpenAiToolCall {
+                        id: tc.id.clone(),
+                        r#type: "function".to_string(),
+                        function: OpenAiToolCallFn {
+                            name: tc.name.clone(),
+                            arguments: tc.arguments.clone(),
+                        },
+                    })
+                    .collect(),
+            )
+        };
+        Self {
+            role: role.to_string(),
+            content: Some(m.content.clone()),
+            tool_calls,
+            tool_call_id: None,
+            name: m.tool_name.clone(),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct OpenAiToolCall {
+    id: String,
+    r#type: String,
+    function: OpenAiToolCallFn,
+}
+
+#[derive(Serialize, Deserialize)]
+struct OpenAiToolCallFn {
+    name: String,
+    arguments: String,
+}
+
+#[derive(Deserialize)]
+struct OpenAiResponse {
+    choices: Vec<OpenAiChoice>,
+    #[serde(default)]
+    usage: Option<OpenAiUsage>,
+}
+
+#[derive(Deserialize)]
+struct OpenAiChoice {
+    message: OpenAiChoiceMessage,
+    #[serde(default)]
+    finish_reason: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct OpenAiChoiceMessage {
+    #[serde(default)]
+    content: Option<String>,
+    #[serde(default)]
+    tool_calls: Option<Vec<OpenAiToolCall>>,
+}
+
+#[derive(Deserialize)]
+struct OpenAiUsage {
+    #[serde(default)]
+    prompt_tokens: u32,
+    #[serde(default)]
+    completion_tokens: u32,
+    #[serde(default)]
+    total_tokens: u32,
+}
+
+impl OpenAiResponse {
+    fn into_generic(self) -> ChatResponse {
+        let choice = self.choices.into_iter().next();
+        let (content, tool_calls, finish_reason_str) = match choice {
+            Some(c) => {
+                let tc: Vec<ToolCall> = c
+                    .message
+                    .tool_calls
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|wt| ToolCall {
+                        id: wt.id,
+                        name: wt.function.name,
+                        arguments: wt.function.arguments,
+                    })
+                    .collect();
+                (
+                    c.message.content.unwrap_or_default(),
+                    tc,
+                    c.finish_reason.unwrap_or_default(),
+                )
+            }
+            None => (String::new(), Vec::new(), String::new()),
+        };
+        ChatResponse {
+            content,
+            tool_calls,
+            finish_reason: match finish_reason_str.as_str() {
+                "stop" => FinishReason::Stop,
+                "tool_calls" => FinishReason::ToolCalls,
+                "length" => FinishReason::Length,
+                "content_filter" => FinishReason::ContentFilter,
+                other => FinishReason::Other(other.to_string()),
+            },
+            usage: self.usage.map(|u| crate::llm::types::Usage {
+                prompt_tokens: u.prompt_tokens,
+                completion_tokens: u.completion_tokens,
+                total_tokens: u.total_tokens,
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::llm::types::Message;
+
+    #[test]
+    fn endpoint_appended_correctly() {
+        let p = OpenAiProvider::new(
+            reqwest::Client::new(),
+            "https://api.openai.com/v1".into(),
+            "k".into(),
+            "gpt-4o".into(),
+        );
+        assert_eq!(p.endpoint(), "https://api.openai.com/v1/chat/completions");
+    }
+
+    #[test]
+    fn trailing_slash_trimmed() {
+        let p = OpenAiProvider::new(
+            reqwest::Client::new(),
+            "https://api.openai.com/v1/".into(),
+            "k".into(),
+            "gpt-4o".into(),
+        );
+        assert_eq!(p.endpoint(), "https://api.openai.com/v1/chat/completions");
+    }
+
+    #[test]
+    fn empty_base_url_defaults() {
+        let p = OpenAiProvider::new(reqwest::Client::new(), "".into(), "k".into(), "m".into());
+        assert_eq!(p.endpoint(), "https://api.openai.com/v1/chat/completions");
+    }
+
+    #[test]
+    fn parses_choice_with_tool_call() {
+        let json = r#"{
+            "choices": [{
+                "message": {
+                    "content": null,
+                    "tool_calls": [{
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "propose_constant_change", "arguments": "{\"name\":\"reqFuel\",\"value\":9.5}"}
+                    }]
+                },
+                "finish_reason": "tool_calls"
+            }],
+            "usage": {"prompt_tokens": 100, "completion_tokens": 20, "total_tokens": 120}
+        }"#;
+        let parsed: OpenAiResponse = serde_json::from_str(json).unwrap();
+        let g = parsed.into_generic();
+        assert_eq!(g.finish_reason, FinishReason::ToolCalls);
+        assert_eq!(g.tool_calls.len(), 1);
+        assert_eq!(g.tool_calls[0].name, "propose_constant_change");
+        assert!(g.usage.unwrap().total_tokens == 120);
+    }
+
+    #[test]
+    fn message_translation_drops_empty_tool_calls() {
+        let m = OpenAiMessage::from_generic(&Message::user("hello"));
+        let s = serde_json::to_string(&m).unwrap();
+        // empty tool_calls should be skipped entirely
+        assert!(!s.contains("tool_calls"));
+    }
+}

--- a/crates/libretune-core/src/llm/types.rs
+++ b/crates/libretune-core/src/llm/types.rs
@@ -1,0 +1,211 @@
+//! Wire types for the LLM provider abstraction.
+//!
+//! These are intentionally generic (not OpenAI-shaped) so they can map onto
+//! any provider's chat-completion API. Each concrete provider
+//! ([`crate::llm::providers`]) translates to/from its own JSON wire format.
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// A role for a chat message.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum MessageRole {
+    System,
+    User,
+    Assistant,
+    /// A tool-call result returned to the model.
+    Tool,
+}
+
+/// A single chat message. `content` is the natural-language text; `tool_calls`
+/// is populated by assistant messages that requested tool execution.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Message {
+    pub role: MessageRole,
+    pub content: String,
+    /// Tool calls emitted by an assistant message. Empty for user/system msgs.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tool_calls: Vec<ToolCall>,
+    /// For role=Tool messages: the name of the tool that produced this result.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_name: Option<String>,
+}
+
+impl Message {
+    /// Create a system message.
+    pub fn system(content: impl Into<String>) -> Self {
+        Self {
+            role: MessageRole::System,
+            content: content.into(),
+            tool_calls: Vec::new(),
+            tool_name: None,
+        }
+    }
+
+    /// Create a user message.
+    pub fn user(content: impl Into<String>) -> Self {
+        Self {
+            role: MessageRole::User,
+            content: content.into(),
+            tool_calls: Vec::new(),
+            tool_name: None,
+        }
+    }
+
+    /// Create an assistant message with text only.
+    pub fn assistant(content: impl Into<String>) -> Self {
+        Self {
+            role: MessageRole::Assistant,
+            content: content.into(),
+            tool_calls: Vec::new(),
+            tool_name: None,
+        }
+    }
+}
+
+/// A tool/function the model may call. Maps to OpenAI's `tools` /
+/// Anthropic's `tools` / Google's `functionDeclarations`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolDef {
+    pub name: String,
+    pub description: String,
+    /// JSON-schema-ish parameter description (serialized as-is to the wire).
+    pub parameters: serde_json::Value,
+}
+
+/// The function part of a tool definition. Kept for OpenAI-compatible
+/// providers that wrap the schema in a `function` object.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolFunction {
+    pub name: String,
+    pub description: String,
+    pub parameters: serde_json::Value,
+}
+
+impl From<ToolDef> for ToolFunction {
+    fn from(t: ToolDef) -> Self {
+        Self {
+            name: t.name,
+            description: t.description,
+            parameters: t.parameters,
+        }
+    }
+}
+
+/// A tool call the model wants executed. `arguments` is the raw JSON string
+/// the provider returned (parsed lazily by the orchestrator).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolCall {
+    /// Provider-assigned id (used to correlate tool results in multi-turn).
+    #[serde(default)]
+    pub id: String,
+    pub name: String,
+    /// Raw JSON arguments string.
+    pub arguments: String,
+}
+
+/// A request to a chat-completion endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChatRequest {
+    /// Ordered conversation history, ending with the latest user turn.
+    pub messages: Vec<Message>,
+    /// Tools the model is allowed to call.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tools: Vec<ToolDef>,
+    /// Sampling temperature (provider-specific defaults when omitted).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f32>,
+    /// Maximum output tokens, if the provider supports it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_tokens: Option<u32>,
+}
+
+impl ChatRequest {
+    pub fn new(messages: Vec<Message>) -> Self {
+        Self {
+            messages,
+            tools: Vec::new(),
+            temperature: None,
+            max_tokens: None,
+        }
+    }
+}
+
+/// Why the model stopped generating.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum FinishReason {
+    /// The model emitted a normal completion.
+    Stop,
+    /// The model requested one or more tool calls.
+    ToolCalls,
+    /// Hit the max-tokens limit.
+    Length,
+    /// Provider content-filter triggered.
+    ContentFilter,
+    /// Some other provider-specific reason.
+    Other(String),
+}
+
+/// A chat-completion response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChatResponse {
+    /// The assistant's natural-language message (may be empty when only tool
+    /// calls were emitted).
+    pub content: String,
+    /// Tool calls the model requested, if any.
+    pub tool_calls: Vec<ToolCall>,
+    pub finish_reason: FinishReason,
+    /// Model-reported usage stats, when available.
+    #[serde(default)]
+    pub usage: Option<Usage>,
+}
+
+/// Token usage for a response.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct Usage {
+    pub prompt_tokens: u32,
+    pub completion_tokens: u32,
+    pub total_tokens: u32,
+}
+
+/// Errors returned by the provider layer.
+#[derive(Debug, Clone, Error, Serialize, Deserialize)]
+pub enum LlmError {
+    #[error("network error: {0}")]
+    Network(String),
+    #[error("authentication failed (check API key): {0}")]
+    Auth(String),
+    #[error("rate limited by provider: {0}")]
+    RateLimit(String),
+    #[error("could not parse provider response: {0}")]
+    Parse(String),
+    #[error("provider returned an error: {0}")]
+    ApiError(String),
+    #[error("invalid configuration: {0}")]
+    Config(String),
+}
+
+impl From<reqwest::Error> for LlmError {
+    fn from(e: reqwest::Error) -> Self {
+        if e.is_status() {
+            match e.status() {
+                Some(reqwest::StatusCode::UNAUTHORIZED) => LlmError::Auth("HTTP 401".into()),
+                Some(reqwest::StatusCode::TOO_MANY_REQUESTS) => {
+                    LlmError::RateLimit("HTTP 429".into())
+                }
+                _ => LlmError::ApiError(e.to_string()),
+            }
+        } else {
+            // Connect / timeout / other transport errors are all network.
+            LlmError::Network(e.to_string())
+        }
+    }
+}
+
+impl From<serde_json::Error> for LlmError {
+    fn from(e: serde_json::Error) -> Self {
+        LlmError::Parse(e.to_string())
+    }
+}

--- a/crates/libretune-core/tests/action_validation.rs
+++ b/crates/libretune-core/tests/action_validation.rs
@@ -43,11 +43,17 @@ mod tests {
             help: None,
             x_label: None,
             y_label: None,
+            ..Default::default()
         };
         def.tables.insert("veTable1".to_string(), table);
 
-        // A U16 constant (e.g. rev limit RPM) at page 1, offset 0.
-        let constant = Constant::new("RevLim", 1, 0, DataType::U16);
+        // A U16 constant (e.g. rev limit RPM) at page 1, offset 0. Set a
+        // realistic max so the proposed value below passes the new bounds
+        // check (the validator now enforces Constant.min/max, added for the
+        // AI-assistant feature).
+        let mut constant = Constant::new("RevLim", 1, 0, DataType::U16);
+        constant.max = 10000.0;
+        constant.units = "RPM".to_string();
         def.constants.insert("RevLim".to_string(), constant);
 
         // A controller command that burns the tune to flash (raw byte 'B').

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -37,6 +37,7 @@
 - [Tools](./features/tools.md)
 - [Pop-out Windows](./features/popout-windows.md)
 - [ECU Console](./features/ecu-console.md)
+- [AI Assistant](./features/ai-assistant.md)
 - [Tune Migration](./features/tune-migration.md)
 - [Hardware Configuration](./technical/port-editor.md)
 - [Action Scripting](./reference/action-scripting.md)
@@ -68,6 +69,7 @@
 - [Lua Scripting](./technical/lua-scripting.md)
 - [Plugin System](./technical/plugin-system.md)
 - [Port Editor](./technical/port-editor.md)
+- [AI Assistant](./technical/ai-assistant.md)
 
 # FAQ
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -32,6 +32,7 @@ All notable changes to LibreTune will be documented in this file.
 - **Change Annotations** — Annotate individual tune changes with notes explaining the purpose of each modification.
 - **WASM Plugin System** — Secure, sandboxed plugin architecture using WebAssembly. Plugins declare permissions and run without external dependencies.
 - **Dashboard Validation** — Automated validation of dashboard configurations against INI channel definitions.
+- **AI Assistant** — Bring-your-own-LLM co-pilot that helps tune and configure your ECU. Supports OpenAI, Anthropic, and Google providers (plus any OpenAI-compatible local endpoint like Ollama). The assistant only ever *proposes* changes — every proposal is validated against the INI, clamped to authority limits, and staged in a review queue for explicit user approval. Nothing burns automatically. Lives in a docked side panel (resizable, pop-out-able). Gated behind an "at your own risk" enablement.
 - Git-based tune versioning with commit history, branches, and auto-commit settings
 - Comprehensive documentation system (API docs + user manual)
 - TuneHistoryPanel for viewing and managing tune history

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -22,6 +22,21 @@ Yes. Use **File → Import TS Project** to import your TunerStudio project folde
 
 Yes. LibreTune uses the same INI format as TunerStudio. Your existing INI files should work without modification.
 
+### Can the AI Assistant tune my car for me?
+
+No — and that's deliberate. The AI Assistant is a **co-pilot**: it can read your
+tables, diagnose problems, and *propose* changes, but it never applies or burns
+anything automatically. Every proposal flows to a review queue where you accept
+or reject each change before it's staged to the working tune. Burning to the ECU
+is always a separate manual step. See [AI Assistant](./features/ai-assistant.md)
+for the full safety model.
+
+### Do I need an OpenAI account to use the AI Assistant?
+
+No. The assistant is **bring-your-own-LLM**. You can use OpenAI, Anthropic,
+Google, or run a local model (e.g. via Ollama) so your data never leaves your
+machine. See [Providers](./features/ai-assistant.md#providers).
+
 ## Connection Issues
 
 ### My ECU doesn't appear in the port list

--- a/docs/src/features/ai-assistant.md
+++ b/docs/src/features/ai-assistant.md
@@ -1,0 +1,180 @@
+# AI Assistant
+
+LibreTune includes an optional **AI Assistant** that can help you tune and
+configure your ECU. It is a **bring-your-own-LLM** feature: you supply the
+provider, API key, and model (OpenAI, Anthropic, Google, or any
+OpenAI-compatible local endpoint such as Ollama), and the assistant acts as a
+co-pilot.
+
+> ⚠️ **At your own risk.** The assistant can propose changes that affect
+> engine behavior. It only ever *proposes*; nothing is applied or burned
+> automatically. See [Safety Model](#safety-model) below.
+
+## Overview
+
+The assistant lives in a **docked side panel** on the right side of the window
+(similar to VS Code's chat), so you can chat with it while still viewing and
+editing tables and dashboards. It can also be **popped out** into its own
+window for multi-monitor setups.
+
+What the assistant can do:
+
+- **Explain** tables, constants, and gauges in plain English.
+- **Diagnose** problems from tune data and table health.
+- **Propose ECU configuration changes** (feature enablement, scalar constants).
+- **Propose tune edits** to individual cells or bulk regions.
+- **Read tables live** and analyze them in the same conversation — when it says
+  "let me look at your VE table," it actually reads the data and comes back with
+  an analysis.
+
+The assistant is **not** a closed-loop controller. It does not run every
+realtime tick — that remains the job of the algorithmic [AutoTune](./autotune.md)
+engine. Think of it as a smart strategy and explanation layer on top of the
+existing tools.
+
+## Enabling the Assistant
+
+1. Open **Tools → Settings**.
+2. Scroll to the **AI Assistant (at your own risk)** section.
+3. Read the risk warning and check the acknowledgement box.
+4. Fill in the provider details (see [Providers](#providers)).
+5. Choose a **Capability Tier** (see below).
+6. Check **Enable AI Assistant**.
+7. Click **Apply** (saves without closing) or **OK** (saves and closes).
+
+> **Note:** Each setting saves independently. If one setting fails to save
+> (for example, enabling without a risk acknowledgement), the others still save
+> and the failure is shown in the dialog footer.
+
+### Capability Tiers
+
+| Tier | What it allows |
+|------|----------------|
+| **Read / diagnose only** | Explain and analyze. Cannot propose changes. Start here until you trust the assistant. |
+| **Propose ECU configuration changes** | Propose constant changes (feature toggles, scalars). |
+| **Propose tune edits** | Propose table-cell edits and bulk operations. |
+
+## Using the Assistant
+
+1. Open **Tools → AI Assistant** (a toggle — click again to hide the panel).
+2. Type a message in the chat input. Examples:
+   - "Can you review my ignition table?"
+   - "How does my VE table look? Any glaring issues?"
+   - "Enable launch control."
+   - "Explain the fuelAlgorithm setting."
+3. The assistant may **read data first** (it will say "Let me pull up…"), then
+   reply with an analysis. This is normal — it's gathering context.
+4. If the assistant wants to make changes, it emits a **proposal** that appears
+   in the **Review queue** at the bottom of the panel.
+5. Each proposed item shows:
+   - **What** it wants to change (table cell, constant, bulk operation).
+   - **Why** it wants to change it (the assistant's reasoning).
+   - **Safety tier** (Safe / Caution / Dangerous) for configuration changes.
+   - **Validation status** — whether the proposal is within the INI's declared bounds.
+   - **Clamp notice** — if a tuning proposal exceeded the authority limit.
+6. Accept or reject each item, or click **Accept all valid**.
+7. Click **Stage accepted changes** to apply them to the working tune.
+8. **Burn** the tune to the ECU separately, only when you are satisfied.
+
+### The Side Panel
+
+- **Resizable** — drag the left edge to resize (280–640px).
+- **Collapsible review queue** — click the queue header to collapse/expand it.
+  It auto-expands when new proposals arrive.
+- **Pop-out** — click the external-link icon in the panel header to open the
+  assistant in its own window. Use that window's **Dock** button to bring it
+  back to the docked panel.
+
+## Providers
+
+LibreTune speaks each provider's **native protocol** (not just an
+OpenAI-compatible shim):
+
+| Provider | Setting value | Notes |
+|----------|---------------|-------|
+| **OpenAI** | `openai` | Also works with any OpenAI-compatible endpoint: OpenRouter, Ollama (`/v1`), LM Studio, vLLM. |
+| **Anthropic** | `anthropic` | Claude models (`claude-3-5-sonnet-…`, etc.). |
+| **Google** | `google` | Gemini models (`gemini-1.5-pro`, etc.). |
+
+### Provider Settings
+
+- **Base URL** — leave empty for the provider default. For a local model, point
+  at its endpoint, e.g. `http://localhost:11434/v1` for Ollama.
+- **API key** — your provider key. Optional for local/no-auth endpoints.
+- **Model** — e.g. `gpt-4o`, `claude-3-5-sonnet-20241022`, `gemini-1.5-pro`.
+  The model **must support tool/function calling** for the assistant to work.
+
+### Local Models (Recommended for Privacy)
+
+Because you bring your own model, you control where your data goes. For maximum
+privacy, run a local model with [Ollama](https://ollama.com):
+
+1. Install Ollama and pull a tool-capable model (e.g. `ollama pull llama3.1`).
+2. In settings, set **Provider** = OpenAI, **Base URL** = `http://localhost:11434/v1`.
+3. Leave the API key empty.
+4. Set **Model** to the model name you pulled.
+
+Tune data never leaves your machine.
+
+## Safety Model
+
+The assistant is deliberately constrained at multiple layers:
+
+| Layer | What it does |
+|-------|--------------|
+| **Propose only** | The model emits tool calls that become a proposal list. It has no apply/burn command. |
+| **INI validation** | Every proposal is checked against the loaded INI: table/constant existence, cell-index bounds, `min`/`max`, `DataType` storage range, and bits-type enum values. |
+| **Authority clamping** | Tune edits are clamped to the same per-cell and percentage limits used by AutoTune (`AutoTuneAuthorityLimits`). |
+| **Human approval** | Accepted proposals are staged; they do not burn automatically. |
+| **Dangerous-constant flagging** | Constants that affect pins, triggers, output inversion, or hard limits are marked **Dangerous** and require explicit per-item confirmation. |
+| **No ECU burn** | The assistant has no burn command. You must click Burn yourself. |
+| **Read-loop bounded** | Multi-turn read interactions are capped (6 rounds) to prevent runaway cost. |
+
+### How proposals are validated
+
+When the assistant proposes a value, the validator checks three things:
+
+1. **Display-unit bounds** — the INI declares `min` and `max` for every
+   constant. A proposed value outside that range is rejected with an error.
+2. **Storage-type range** — even before scaling, the raw value must fit the
+   underlying type (e.g. a `U16` must be 0–65535). This catches values the
+   display bounds might miss when `scale ≠ 1`.
+3. **Bits-type enumeration** — for feature toggles, the value must be a valid
+   index into the constant's declared options.
+
+## Tips for Good Results
+
+- **Start with the Read tier** until you understand how the assistant reasons.
+- **Ask it to read first**: "Read my VE table and tell me which cells have good
+  data coverage" gives it context before it proposes edits.
+- **Be specific**: "Lean out the 3000 RPM / 80 kPa cell by 2%" is safer than
+  "fix my tune."
+- **Review every clamp**: if a value was authority-clamped, the original
+  requested value and reason are shown in the review queue.
+- **Compare with AutoTune**: for VE tables, the algorithmic AutoTune engine
+  remains the ground truth. Use the assistant for strategy, then cross-check
+  its proposals.
+
+## Troubleshooting
+
+| Problem | Likely cause / fix |
+|---------|-------------------|
+| "AI assistant is not enabled" | Enable it in Settings and acknowledge the risk warning. |
+| "AI assistant risk acknowledgement is missing" | Check the acknowledgement box in the AI Assistant settings section. |
+| "Authentication failed" | Check your API key. |
+| "Could not parse provider response" | The model may not support tool/function calling. Use a model that does (e.g. `gpt-4o`, `claude-3-5-sonnet`). |
+| Proposals fail validation | The model asked for an out-of-bounds value or a non-existent table/constant. Reject it and rephrase your request. |
+| Assistant does not propose changes | You may be in Read tier, or the model chose not to call a tool. Ask more specifically, or raise the capability tier. |
+| Assistant stalls after "let me look at…" | This should not happen — the read loop executes reads and feeds results back. If it does, the model may be returning no tool calls; check the provider/model supports tool calling. |
+| Settings don't save when I hit Apply | Look at the footer of the settings dialog — it shows which setting failed (hover for details). |
+
+## Privacy & Data Handling
+
+- **Hosted providers** (OpenAI, Anthropic, Google): tune data and ECU context
+  are sent over HTTPS to that provider. Do not use them with sensitive data
+  unless you trust their policies.
+- **Local providers** (Ollama, LM Studio, vLLM): data stays on your machine.
+- **API key storage**: the key is stored locally in LibreTune's settings file
+  (plaintext in v1). OS-keychain storage is planned as a follow-up.
+- Changing the provider or API key resets the risk acknowledgement, so you
+  re-confirm before the assistant is re-enabled.

--- a/docs/src/getting-started/settings.md
+++ b/docs/src/getting-started/settings.md
@@ -225,6 +225,53 @@ Available placeholders:
 
 ---
 
+## AI Assistant
+
+The **AI Assistant** is a bring-your-own-LLM co-pilot that can help you tune and
+configure your ECU. See [AI Assistant](../features/ai-assistant.md) for full
+usage details.
+
+> ⚠️ **At your own risk.** The assistant only ever *proposes* changes; nothing
+> is applied or burned automatically.
+
+### Enabling
+
+1. Scroll to the **AI Assistant (at your own risk)** section.
+2. Read the risk warning and check the acknowledgement box.
+3. Configure the provider (see below).
+4. Check **Enable AI Assistant**.
+5. Click **Apply** (save without closing) or **OK** (save and close).
+
+### Provider
+
+- **OpenAI** — hosted OpenAI, or any OpenAI-compatible endpoint (OpenRouter,
+  Ollama, LM Studio, vLLM).
+- **Anthropic** — Claude models.
+- **Google** — Gemini models.
+
+### Base URL
+
+Leave empty for the provider default. For a local model, set this to the local
+endpoint, e.g. `http://localhost:11434/v1` for Ollama.
+
+### API Key
+
+Your provider key. Optional for local/no-auth endpoints. Stored locally in the
+settings file.
+
+### Model
+
+A tool/function-calling-capable model (e.g. `gpt-4o`,
+`claude-3-5-sonnet-20241022`, `gemini-1.5-pro`).
+
+### Capability Tier
+
+- **Read / diagnose only** — explain and analyze; cannot propose changes.
+- **Propose ECU configuration changes** — propose constant changes.
+- **Propose tune edits** — propose table-cell and bulk edits.
+
+---
+
 ## AutoTune Settings
 
 Default values for AutoTune parameters.

--- a/docs/src/technical/README.md
+++ b/docs/src/technical/README.md
@@ -21,6 +21,7 @@ This section provides in-depth technical documentation for LibreTune's core algo
 ### Core Systems
 - **[Version Control](./version-control.md)** - Git integration, tune fingerprinting, and migration detection
 - **[Lua Scripting](./lua-scripting.md)** - Sandboxed runtime, API reference, and security model
+- **[AI Assistant](./ai-assistant.md)** - Bring-your-own-LLM agent loop, provider trait, validation extensions
 
 ## Philosophy
 

--- a/docs/src/technical/ai-assistant.md
+++ b/docs/src/technical/ai-assistant.md
@@ -1,0 +1,162 @@
+# AI Assistant Architecture
+
+This document describes the technical architecture of LibreTune's bring-your-own-LLM
+AI Assistant. It is intended for developers contributing to or extending the feature.
+
+## Design Principles
+
+1. **Bring your own model** — LibreTune never hosts a model. The user supplies the
+   provider, key, and model. This keeps the feature dependency-free and private.
+2. **Propose, never apply** — the assistant's only output is a validated, clamped
+   *proposal*. Application and burn are always separate, user-triggered steps.
+3. **Reuse existing primitives** — the assistant is a thin layer over the existing
+   `Action` enum, `validate_action_set`, AutoTune engines, and INI metadata. It does
+   not duplicate safety logic.
+4. **Provider-agnostic** — a single `Provider` trait abstracts all LLM backends. The
+   orchestrator never sees provider-specific JSON.
+
+## Module Layout
+
+```
+crates/libretune-core/src/
+├── agent/
+│   ├── mod.rs           # module root + re-exports
+│   ├── orchestrator.rs  # multi-turn agent loop + ReadToolExecutor trait
+│   ├── tools.rs         # tool catalogue (JSON-schema tool definitions)
+│   ├── context.rs       # context-gathering helpers (constants, tables)
+│   ├── summarize.rs     # summarize_tune_context() aggregation
+│   ├── safety.rs        # authority-limit clamping
+│   └── tiers.rs         # constant safety tiering (Safe/Caution/Dangerous)
+└── llm/
+    ├── mod.rs           # module root
+    ├── types.rs         # ChatRequest/ChatResponse/Message/ToolCall/LlmError
+    ├── provider.rs      # Provider trait + factory
+    ├── client.rs        # LlmClient (top-level entry point)
+    └── providers/
+        ├── openai.rs    # OpenAI Chat Completions (native protocol)
+        ├── anthropic.rs # Anthropic Messages API (native protocol)
+        └── google.rs    # Google Gemini generateContent (native protocol)
+```
+
+The Tauri layer wraps these in `crates/libretune-app/src-tauri/src/commands/agent.rs`
+(commands: `agent_status`, `agent_send_message`, `agent_apply_proposals`).
+
+## The Agent Loop
+
+One user turn runs a **multi-turn loop** inside `orchestrator::run_turn`:
+
+```
+user message
+     │
+     ▼
+┌─────────────────────────────────────────────┐
+│  build ChatRequest (system + history + msg) │
+│  + tool catalogue                            │
+└──────────────────────┬──────────────────────┘
+                       ▼
+              call Provider::chat
+                       │
+        ┌──────────────┴───────────────┐
+        ▼                              ▼
+  read tool calls?              propose tool calls?
+        │                              │
+        ▼                              ▼
+  execute via                 map → Action[]
+  ReadToolExecutor            validate_action_set
+        │                     clamp to authority
+        ▼                     accumulate into Proposal
+  append tool-result                   │
+  messages to history                  │
+        │                              │
+        ▼                              ▼
+  loop back ─────────────►  (no reads left? → done)
+                                   │
+                                   ▼
+                            return Proposal
+```
+
+The loop is bounded by `MAX_READ_ROUNDS` (6) to cap cost and prevent runaway
+conversations. Read results are fed back as tool-result messages so the model can
+reason over actual table/constant data before emitting its final reply.
+
+## The Provider Trait
+
+```rust
+#[async_trait]
+pub trait Provider: Send + Sync {
+    fn name(&self) -> &str;
+    async fn chat(&self, req: &ChatRequest) -> Result<ChatResponse, LlmError>;
+}
+```
+
+Each concrete provider translates the generic `ChatRequest` to its wire format
+(OpenAI `tools[]`, Anthropic `tool_use` blocks, Gemini `functionDeclarations`),
+calls its endpoint via the shared `reqwest` client, and parses the response back
+into a generic `ChatResponse`. Adding a new provider requires only implementing
+this trait — no orchestrator changes.
+
+## The ReadToolExecutor Trait
+
+```rust
+#[async_trait]
+pub trait ReadToolExecutor: Send + Sync {
+    fn handles(&self, tool_name: &str) -> bool;
+    async fn execute(&self, tool_name: &str, arguments: &str) -> String;
+}
+```
+
+The core library defines this contract; the Tauri layer implements it as
+`LiveReadExecutor`, which reaches `AppState` via `tauri::Manager::state()` and
+reads tables/constants against the loaded definition and tune. This split keeps
+the loop unit-testable without a live provider or ECU.
+
+## Tool Catalogue
+
+Defined in `agent/tools.rs`. The model may call:
+
+| Tool | Type | Purpose |
+|------|------|---------|
+| `list_tables` | read | Discover table names + roles + dimensions |
+| `read_table` | read | Get a table's values, axis bins, units |
+| `read_constant` | read | Get a constant's value, min/max, options |
+| `list_features` | read | List feature-toggle (bits) constants |
+| `summarize_tune_context` | read | Aggregated coverage + AFR error + anomalies |
+| `tune_health_check` | read | Per-region health scores |
+| `propose_table_edit` | propose | Stage a single-cell edit (reviewed + clamped) |
+| `propose_bulk_operation` | propose | Stage scale/smooth/interpolate (reviewed) |
+| `propose_constant_change` | propose | Stage a constant change (tier-flagged) |
+
+## TableRole Inference
+
+`EcuDefinition::infer_table_roles()` attaches a machine-readable `TableRole`
+enum (`Ve`, `Ignition`, `AfrTarget`, `WarmupEnrichment`, `Other`) to every
+`TableDefinition`, derived from the INI's `[VeAnalyze]` and `[WueAnalyze]`
+sections. This lets the assistant know what a table *does* without guessing from
+its name.
+
+## Validation Extensions
+
+The assistant motivated extending `ActionPlayer::validate_action_set` beyond
+existence checks. It now validates:
+
+- **Constant `min`/`max`** (display-unit bounds)
+- **`DataType` raw storage range** (pre-scale)
+- **Table cell-index bounds** (`x_index`/`y_index` vs `x_size`/`y_size`)
+- **Bits-type enumeration** (value must be a valid option index)
+
+## Frontend
+
+- `components/agent/AgentSidePanel.tsx` — the docked right-hand panel (header,
+  resize handle, pop-out/collapse buttons, collapsible review queue).
+- `components/agent/ChatPanel.tsx` — the conversational transcript + input.
+- `components/agent/ProposalQueue.tsx` — the per-item review surface.
+- `components/common/RiskAcknowledgement.tsx` — reusable risk-ack primitive.
+- The panel can pop out via the existing `WebviewWindow` + hash-routing system
+  (see `PopOutWindow.tsx`, type `agent`).
+
+## Error Handling
+
+- The core layer uses a typed `LlmError` enum (`Network`, `Auth`, `RateLimit`,
+  `Parse`, `ApiError`, `Config`).
+- Tauri commands flatten to `Result<T, String>` at the boundary.
+- Settings saves are per-setting (one failure does not abort the others).


### PR DESCRIPTION
## Summary

Adds a **bring-your-own-LLM AI Assistant** that acts as a co-pilot for tuning and ECU configuration, plus a UX pass that makes the assistant actually usable, a settings bug fix, and a default-dashboard change.

The model only ever **proposes** changes — every proposal is validated against the INI, clamped to authority limits, and staged in a review queue for explicit user approval. **Nothing burns to the ECU automatically.** Gated behind an "at your own risk" enablement.

This PR also bundles the earlier scrollbar-twitch fix commit that's already on the branch.

## What's included

### Assistant UX — docked side panel (was a full-screen modal)
The assistant was previously a translucent modal overlay that blocked the whole UI. It's now a **non-modal, resizable right-hand side panel** (like VS Code's chat):
- `AgentSidePanel.tsx` — header with **pop-out** (to its own window via the existing `WebviewWindow` system) and **collapse** buttons, plus a collapsible review queue.
- Wired into `TunerLayout` as a flex child of `.tuner-layout-main`.
- `Tools → AI Assistant` is now a toggle reflecting visibility.

### Read loop — the assistant can now respond with results
Previously, when the assistant said "let me look at your VE table," nothing executed that read and the conversation stalled. Now:
- `run_turn` runs a **multi-turn loop**: read tool calls are executed via a new `ReadToolExecutor` trait and fed back as tool-result messages, then the model is called again. Bounded to 6 rounds.
- `LiveReadExecutor` reads tables/constants against live `AppState`.

### Settings fix — Apply / OK buttons
The old single "Apply" button saved *and* closed, and any single failing `invoke` call silently aborted the whole save (this was the root cause of AI provider info not persisting). Now:
- **Apply** saves without closing and shows per-setting status (so you can confirm it worked).
- **OK** saves and closes.
- Each setting saves independently; one failure no longer blocks the rest.

### Default dashboard
The default dashboard is now **Telemetry Live** (was Basic), with Basic as the fallback if Telemetry Live is absent.

### Docs
- New feature guide: `docs/src/features/ai-assistant.md`
- New technical reference: `docs/src/technical/ai-assistant.md`
- README features list + project structure tree
- CHANGELOG dated entry
- Settings guide section, FAQ entries, technical README, SUMMARY.md, AGENTS.md section 12
- All synced to the in-app manual (`public/manual/` + `toc.json`)

## Safety model

| Layer | What it does |
|-------|--------------|
| Propose only | The model emits tool calls that become a proposal list. No apply/burn command. |
| INI validation | Every proposal is checked: existence, cell-index bounds, `min`/`max`, `DataType` range, bits-type enum values. |
| Authority clamping | Tune edits clamped to `AutoTuneAuthorityLimits`. |
| Human approval | Accepted proposals are staged; they do not burn automatically. |
| Dangerous-constant flagging | Pins/triggers/limits are marked **Dangerous** and require explicit confirmation. |

## Verification

- `cargo test -p libretune-core`: all tests pass
- `cargo clippy -p libretune-core --lib`: clean
- `npm run typecheck`: clean
- Manual: assistant reads tables and responds with analysis; settings persist; side panel docks correctly; pop-out works

## Test plan

- [ ] Enable the assistant (Settings → AI Assistant → acknowledge risk → configure provider → enable)
- [ ] Open Tools → AI Assistant — panel docks on the right, not full-screen
- [ ] Ask "review my VE table" — assistant reads it and responds with analysis
- [ ] Ask to change a constant — proposal appears in review queue with safety tier
- [ ] Settings: enter provider info, hit Apply — persists (no silent failure)
- [ ] Pop out the panel to a window, then Dock it back
- [ ] Open the dashboard — Telemetry Live loads by default
