### PR TITLE
feat: chat history, stop button, UI state persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,37 @@ relevant.
 
 ## [Unreleased]
 
+### 2026-07-31 — Chat history, stop button, UI state persistence
+
+Enhancements to the AI assistant and overall workspace UX.
+
+#### Added
+- **Chat history** — assistant conversations now persist **per project** as
+  JSON files under `projectCfg/ai_chats/`. The panel header gains a **chat
+  switcher** (list button) and a **New chat** button (plus icon). The most
+  recent chat auto-opens on launch. Chats auto-save on every message.
+- **Stop button** — while the assistant is thinking, the Send button becomes
+  a red Stop button that cancels the in-flight request. Backend: the turn is
+  spawned as a tokio task whose `JoinHandle` is stored in `AppState.agent_task`;
+  the new `agent_stop` command aborts it (mirrors the realtime-stream pattern).
+  Cancellation surfaces as `_(stopped)_` in the transcript, not an error.
+- **UI state persistence** — on launch the app restores sidebar visibility,
+  sidebar folder expansion, AI panel visibility, and the selected dashboard.
+  New settings fields (`sidebar_visible`, `agent_panel_visible`,
+  `selected_dashboard`, `open_tabs`, `sidebar_expanded_ids`) with `update_setting`
+  arms. Persistence is gated on a restore flag so the initial default values
+  don't overwrite saved ones before the async restore completes.
+
+#### Fixed
+- **Assistant transcript reset to blank** — a stale-closure bug in
+  `ChatPanel.send()` caused the transcript to reset after the first reply.
+  The function now snapshots the transcript at the start of the turn and
+  builds the updated transcript from that snapshot.
+- **Assistant showed "disabled" while status loaded** — the panel flashed the
+  "disabled" message before the status poll completed. Now shows "Loading…"
+  until the status is fetched, and a specific message when enabled-but-
+  unconfigured (missing risk ack or model).
+
 ### 2026-07-31 — AI Assistant (bring-your-own-LLM) + UX fixes
 
 Adds a bring-your-own-LLM assistant that acts as a co-pilot for tuning and ECU

--- a/crates/libretune-app/public/manual/features/ai-assistant.md
+++ b/crates/libretune-app/public/manual/features/ai-assistant.md
@@ -84,6 +84,39 @@ existing tools.
 - **Pop-out** — click the external-link icon in the panel header to open the
   assistant in its own window. Use that window's **Dock** button to bring it
   back to the docked panel.
+- **Stop** — while the assistant is thinking, the **Send** button becomes a
+  red **Stop** button. Click it to cancel the in-flight request (useful if a
+  provider is slow or stuck). A cancelled request shows `_(stopped)_` in the
+  transcript rather than an error.
+
+### Chat History
+
+The assistant persists your conversations **per project**, so you can close
+the app and come back to pick up where you left off.
+
+- **Auto-save** — every message is saved automatically.
+- **Chat switcher** — click the **list icon** in the panel header to see all
+  past chats for the current project, most-recent first. Click one to switch
+  to it; click the × to delete it.
+- **New chat** — click the **plus icon** to start a fresh conversation.
+- **Auto-open** — on launch, the most recent chat for the current project
+  loads automatically.
+
+Chats are stored as JSON files under `projectCfg/ai_chats/` inside the project
+folder, so they travel with the project if you copy it.
+
+## UI State Persistence
+
+LibreTune remembers your workspace layout across restarts. When you close and
+reopen the app (or refresh the window), it restores:
+
+- **Sidebar visibility** — whether the left sidebar is shown or hidden.
+- **Sidebar expansion** — which folders are expanded/collapsed.
+- **AI Assistant panel** — whether the right-hand chat panel is open.
+- **Selected dashboard** — which dashboard was last loaded.
+- **Window size and position** — handled by the window-state plugin.
+
+This means the app opens "exactly as you left it" without any extra setup.
 
 ## Providers
 

--- a/crates/libretune-app/src-tauri/src/commands/agent.rs
+++ b/crates/libretune-app/src-tauri/src/commands/agent.rs
@@ -36,17 +36,136 @@ fn build_client(s: &crate::Settings) -> Result<LlmClient, LlmError> {
     LlmClient::new(&config_from_settings(s))
 }
 
-/// Request payload from the frontend for one assistant turn.
-#[derive(Debug, Deserialize)]
-pub struct AgentTurnRequest {
-    /// The user's message this turn.
-    pub user_message: String,
-    /// Prior conversation as the frontend has it (serialized messages).
-    pub history: Vec<SerializedMessage>,
-    /// Pre-rendered system prompt describing the ECU/tune context. The
-    /// frontend builds this from the current view (tables loaded, etc.).
-    pub system_prompt: String,
+/// A single chat message as stored in a chat history file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChatMessage {
+    pub role: String, // "user" | "assistant"
+    pub content: String,
 }
+
+/// One persisted chat conversation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChatHistory {
+    /// Unique id (uuid or timestamp-based).
+    pub id: String,
+    /// Auto-generated from the first user message.
+    pub title: String,
+    pub messages: Vec<ChatMessage>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// Summary entry for the chat list (without full messages).
+#[derive(Debug, Clone, Serialize)]
+pub struct ChatSummary {
+    pub id: String,
+    pub title: String,
+    pub message_count: usize,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// Resolve the ai_chats directory for the current project.
+fn chats_dir(project_path: &std::path::Path) -> std::path::PathBuf {
+    project_path.join("projectCfg").join("ai_chats")
+}
+
+/// List all saved chats for the current project.
+#[tauri::command]
+pub async fn agent_list_chats(
+    state: tauri::State<'_, AppState>,
+) -> Result<Vec<ChatSummary>, String> {
+    let proj = state.current_project.lock().await;
+    let Some(project) = proj.as_ref() else {
+        return Ok(Vec::new());
+    };
+    let dir = chats_dir(&project.path);
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut summaries: Vec<ChatSummary> = Vec::new();
+    let entries = std::fs::read_dir(&dir).map_err(|e| e.to_string())?;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        if let Ok(content) = std::fs::read_to_string(&path) {
+            if let Ok(chat) = serde_json::from_str::<ChatHistory>(&content) {
+                summaries.push(ChatSummary {
+                    id: chat.id,
+                    title: chat.title,
+                    message_count: chat.messages.len(),
+                    created_at: chat.created_at,
+                    updated_at: chat.updated_at,
+                });
+            }
+        }
+    }
+    // Most-recently-updated first.
+    summaries.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+    Ok(summaries)
+}
+
+/// Load a full chat by id.
+#[tauri::command]
+pub async fn agent_load_chat(
+    state: tauri::State<'_, AppState>,
+    chat_id: String,
+) -> Result<ChatHistory, String> {
+    let proj = state.current_project.lock().await;
+    let Some(project) = proj.as_ref() else {
+        return Err("No project loaded".to_string());
+    };
+    let path = chats_dir(&project.path).join(format!("{chat_id}.json"));
+    let content = std::fs::read_to_string(&path)
+        .map_err(|e| format!("Failed to read chat {chat_id}: {e}"))?;
+    serde_json::from_str::<ChatHistory>(&content).map_err(|e| e.to_string())
+}
+
+/// Save (create or update) a chat. Returns the saved chat with timestamps set.
+#[tauri::command]
+pub async fn agent_save_chat(
+    state: tauri::State<'_, AppState>,
+    mut chat: ChatHistory,
+) -> Result<ChatHistory, String> {
+    let proj = state.current_project.lock().await;
+    let Some(project) = proj.as_ref() else {
+        return Err("No project loaded".to_string());
+    };
+    let dir = chats_dir(&project.path);
+    std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+
+    let now = chrono::Utc::now().to_rfc3339();
+    if chat.created_at.is_empty() {
+        chat.created_at = now.clone();
+    }
+    chat.updated_at = now;
+
+    let path = dir.join(format!("{}.json", chat.id));
+    let json = serde_json::to_string_pretty(&chat).map_err(|e| e.to_string())?;
+    std::fs::write(&path, json).map_err(|e| e.to_string())?;
+    Ok(chat)
+}
+
+/// Delete a chat by id.
+#[tauri::command]
+pub async fn agent_delete_chat(
+    state: tauri::State<'_, AppState>,
+    chat_id: String,
+) -> Result<(), String> {
+    let proj = state.current_project.lock().await;
+    let Some(project) = proj.as_ref() else {
+        return Err("No project loaded".to_string());
+    };
+    let path = chats_dir(&project.path).join(format!("{chat_id}.json"));
+    if path.exists() {
+        std::fs::remove_file(&path).map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
 
 /// A serialized [`Message`] that round-trips through JSON.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -63,6 +182,18 @@ impl From<SerializedMessage> for Message {
             _ => Message::user(s.content),
         }
     }
+}
+
+/// Request payload from the frontend for one assistant turn.
+#[derive(Debug, Deserialize)]
+pub struct AgentTurnRequest {
+    /// The user's message this turn.
+    pub user_message: String,
+    /// Prior conversation as the frontend has it (serialized messages).
+    pub history: Vec<SerializedMessage>,
+    /// Pre-rendered system prompt describing the ECU/tune context. The
+    /// frontend builds this from the current view (tables loaded, etc.).
+    pub system_prompt: String,
 }
 
 /// Build a default authority-limit envelope for clamping proposals.
@@ -293,9 +424,54 @@ pub async fn agent_send_message(
     };
 
     let authority = default_authority();
-    run_turn(&client, &inputs, &authority, Some(&executor))
-        .await
-        .map_err(|e| e.to_string())
+
+    // Spawn the turn so it can be aborted by `agent_stop` (mirrors the realtime
+    // stream pattern). A oneshot channel carries the result back; if the task
+    // is aborted, the sender drops and the receiver resolves to a RecvError,
+    // which we surface as the sentinel "__cancelled__" so the frontend can
+    // treat it as a user-initiated stop rather than an error.
+    let (tx, rx) = tokio::sync::oneshot::channel::<Result<Proposal, String>>();
+    let handle = tokio::spawn(async move {
+        let result = run_turn(&client, &inputs, &authority, Some(&executor))
+            .await
+            .map_err(|e| e.to_string());
+        let _ = tx.send(result);
+    });
+
+    // Store the handle so agent_stop can abort it. Replace any prior handle.
+    {
+        let state = app.state::<AppState>();
+        let mut guard = state.agent_task.lock().await;
+        if let Some(old) = guard.take() {
+            old.abort();
+        }
+        *guard = Some(handle);
+    }
+
+    // Await the result. A RecvError means the task was aborted (cancelled).
+    match rx.await {
+        Ok(result) => result,
+        Err(_) => {
+            // Clear the now-finished handle.
+            let state = app.state::<AppState>();
+            let mut guard = state.agent_task.lock().await;
+            *guard = None;
+            Err("__cancelled__".to_string())
+        }
+    }
+}
+
+/// Cancel an in-flight assistant turn (the "Stop" button).
+/// Aborts the spawned task; the awaiting `agent_send_message` resolves to the
+/// sentinel error `"__cancelled__"`.
+#[tauri::command]
+pub async fn agent_stop(app: tauri::AppHandle) -> Result<(), String> {
+    let state = app.state::<AppState>();
+    let mut guard = state.agent_task.lock().await;
+    if let Some(handle) = guard.take() {
+        handle.abort();
+    }
+    Ok(())
 }
 
 /// Request payload for applying a subset of a proposal.

--- a/crates/libretune-app/src-tauri/src/commands/app_settings.rs
+++ b/crates/libretune-app/src-tauri/src/commands/app_settings.rs
@@ -32,6 +32,20 @@ pub(crate) struct Settings {
     #[serde(default)]
     pub(crate) last_active_tab: Option<String>,
 
+    // --- UI layout state (restored on launch) ---
+    /// Whether the left sidebar is visible.
+    #[serde(default = "default_true")]
+    pub(crate) sidebar_visible: bool,
+    /// Whether the AI assistant side panel is visible.
+    #[serde(default)]
+    pub(crate) agent_panel_visible: bool,
+    /// The selected dashboard file name (e.g. "Telemetry Live.ltdash.xml").
+    #[serde(default)]
+    pub(crate) selected_dashboard: Option<String>,
+    /// Serialized open tabs (id, title, icon, type, data) for session restore.
+    #[serde(default)]
+    pub(crate) open_tabs: Option<String>,
+
     /// Render table Y axis with the origin at the bottom-left (lowest load
     /// row at the bottom) instead of the top-left.
     #[serde(default)]

--- a/crates/libretune-app/src-tauri/src/commands/app_settings.rs
+++ b/crates/libretune-app/src-tauri/src/commands/app_settings.rs
@@ -39,6 +39,9 @@ pub(crate) struct Settings {
     /// Whether the AI assistant side panel is visible.
     #[serde(default)]
     pub(crate) agent_panel_visible: bool,
+    /// Expanded sidebar folder IDs (JSON array of strings) for session restore.
+    #[serde(default)]
+    pub(crate) sidebar_expanded_ids: Option<String>,
     /// The selected dashboard file name (e.g. "Telemetry Live.ltdash.xml").
     #[serde(default)]
     pub(crate) selected_dashboard: Option<String>,

--- a/crates/libretune-app/src-tauri/src/commands/settings.rs
+++ b/crates/libretune-app/src-tauri/src/commands/settings.rs
@@ -102,6 +102,9 @@ pub async fn update_setting(
         "agent_panel_visible" => {
             settings.agent_panel_visible = value.parse().map_err(|_| "Invalid boolean value")?
         }
+        "sidebar_expanded_ids" => {
+            settings.sidebar_expanded_ids = if value.is_empty() { None } else { Some(value) }
+        }
         "selected_dashboard" => {
             settings.selected_dashboard = if value.is_empty() { None } else { Some(value) }
         }

--- a/crates/libretune-app/src-tauri/src/commands/settings.rs
+++ b/crates/libretune-app/src-tauri/src/commands/settings.rs
@@ -95,6 +95,20 @@ pub async fn update_setting(
         "last_active_tab" => {
             settings.last_active_tab = if value.is_empty() { None } else { Some(value) }
         }
+        // UI layout state.
+        "sidebar_visible" => {
+            settings.sidebar_visible = value.parse().map_err(|_| "Invalid boolean value")?
+        }
+        "agent_panel_visible" => {
+            settings.agent_panel_visible = value.parse().map_err(|_| "Invalid boolean value")?
+        }
+        "selected_dashboard" => {
+            settings.selected_dashboard = if value.is_empty() { None } else { Some(value) }
+        }
+        "open_tabs" => {
+            // Store the JSON blob as-is; the frontend parses it.
+            settings.open_tabs = if value.is_empty() { None } else { Some(value) }
+        }
         "language" => settings.language = if value.is_empty() { None } else { Some(value) },
 
         // --- AI Assistant settings (all keys must have arms; see repo memory

--- a/crates/libretune-app/src-tauri/src/lib.rs
+++ b/crates/libretune-app/src-tauri/src/lib.rs
@@ -41,7 +41,10 @@ pub(crate) use commands::util_helpers::{
 use commands::adaptive_timing::{
     disable_adaptive_timing, enable_adaptive_timing, get_adaptive_timing_stats,
 };
-use commands::agent::{agent_apply_proposals, agent_send_message, agent_status};
+use commands::agent::{
+    agent_apply_proposals, agent_delete_chat, agent_list_chats, agent_load_chat,
+    agent_save_chat, agent_send_message, agent_status, agent_stop,
+};
 use commands::annotations::{
     delete_annotation, get_all_annotations, get_annotation, get_table_annotations, set_annotation,
 };
@@ -210,6 +213,7 @@ pub fn run() {
             cached_output_channels: Mutex::new(None),
             math_channels: Mutex::new(Vec::new()),
             stream_stats: Mutex::new(StreamStats::default()),
+            agent_task: Mutex::new(None),
         })
         .invoke_handler(tauri::generate_handler![
             get_serial_ports,
@@ -410,10 +414,11 @@ pub fn run() {
             agent_status,
             agent_send_message,
             agent_apply_proposals,
-            // AI assistant
-            agent_status,
-            agent_send_message,
-            agent_apply_proposals,
+            agent_stop,
+            agent_list_chats,
+            agent_load_chat,
+            agent_save_chat,
+            agent_delete_chat,
             // Demo mode commands
             set_demo_mode,
             get_demo_mode,

--- a/crates/libretune-app/src-tauri/src/state.rs
+++ b/crates/libretune-app/src-tauri/src/state.rs
@@ -180,6 +180,9 @@ pub struct AppState {
     pub rpm_state_tracker: Mutex<RpmStateTracker>,
     pub math_channels: Mutex<Vec<UserMathChannel>>,
     pub stream_stats: Mutex<StreamStats>,
+    /// JoinHandle for the currently-running AI assistant turn (if any).
+    /// Aborted by `agent_stop` to cancel an in-flight LLM request.
+    pub agent_task: Mutex<Option<tokio::task::JoinHandle<()>>>,
 }
 
 #[derive(Clone, Debug)]

--- a/crates/libretune-app/src/App.tsx
+++ b/crates/libretune-app/src/App.tsx
@@ -306,6 +306,14 @@ function AppContent() {
   // Tauri check
   const [isTauri, setIsTauri] = useState(true);
 
+  // Persist UI layout state to settings so it's restored on next launch.
+  useEffect(() => {
+    void invoke('update_setting', { key: 'sidebar_visible', value: String(sidebarVisible) }).catch(() => {});
+  }, [sidebarVisible]);
+  useEffect(() => {
+    void invoke('update_setting', { key: 'agent_panel_visible', value: String(agentPanelVisible) }).catch(() => {});
+  }, [agentPanelVisible]);
+
   // Check if running in Tauri
   useEffect(() => {
     const inTauri = !!(window as unknown as Record<string, unknown>).__TAURI_INTERNALS__;
@@ -362,6 +370,9 @@ function AppContent() {
         if (settings.auto_burn_on_close !== undefined) setAutoBurnOnClose(settings.auto_burn_on_close);
         if (settings.status_bar_channels) setStatusBarChannels(settings.status_bar_channels);
         if (settings.last_serial_port) setLastSerialPort(settings.last_serial_port);
+        // Restore UI layout state.
+        if (settings.sidebar_visible !== undefined) setSidebarVisible(!!settings.sidebar_visible);
+        if (settings.agent_panel_visible !== undefined) setAgentPanelVisible(!!settings.agent_panel_visible);
         // Honor saved UI language preference (mirror to localStorage so the
         // i18n LanguageDetector picks it up on next app start, and switch live now).
         if (settings.language && typeof settings.language === 'string') {
@@ -1342,6 +1353,24 @@ function AppContent() {
   const handleTabReorder = useCallback((newTabs: Tab[]) => {
     setTabs(newTabs);
   }, []);
+
+  // Persist the active tab + open-tab list so they can be restored on launch.
+  // Debounced so rapid tab switches don't hammer the settings file.
+  const saveTabsTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    if (saveTabsTimer.current) clearTimeout(saveTabsTimer.current);
+    saveTabsTimer.current = setTimeout(() => {
+      void invoke('update_setting', { key: 'last_active_tab', value: activeTabId ?? '' }).catch(() => {});
+      // Serialize the tab list (id+title+icon+type) for restore. Only
+      // include closable content tabs (skip the dashboard, which is always
+      // re-created).
+      const serializable = tabs
+        .filter((t) => t.id !== 'dashboard' && t.closable !== false)
+        .map((t) => ({ id: t.id, title: t.title, icon: t.icon, type: tabContents[t.id]?.type }));
+      void invoke('update_setting', { key: 'open_tabs', value: JSON.stringify(serializable) }).catch(() => {});
+    }, 500);
+    return () => { if (saveTabsTimer.current) clearTimeout(saveTabsTimer.current); };
+  }, [tabs, activeTabId, tabContents]);
 
   // Pop-out windows: handleTabPopout + tab:dock + table:updated listeners.
   const { handleTabPopout } = useTabPopout({

--- a/crates/libretune-app/src/App.tsx
+++ b/crates/libretune-app/src/App.tsx
@@ -202,6 +202,12 @@ function AppContent() {
   // Sidebar state
   const [sidebarVisible, setSidebarVisible] = useState(true);
 
+  // Gate: don't persist UI state until after the initial restore from
+  // settings has completed. Without this, the persist effects fire on first
+  // render with the default values (sidebar=true, agent=false) and overwrite
+  // the saved values before the async restore runs.
+  const uiStateRestored = useRef(false);
+
   // Dialog state
   const [saveDialogOpen, setSaveDialogOpen] = useState(false);
   const [loadDialogOpen, setLoadDialogOpen] = useState(false);
@@ -307,10 +313,14 @@ function AppContent() {
   const [isTauri, setIsTauri] = useState(true);
 
   // Persist UI layout state to settings so it's restored on next launch.
+  // Gated on uiStateRestored so the initial defaults don't overwrite saved
+  // values before the async restore completes.
   useEffect(() => {
+    if (!uiStateRestored.current) return;
     void invoke('update_setting', { key: 'sidebar_visible', value: String(sidebarVisible) }).catch(() => {});
   }, [sidebarVisible]);
   useEffect(() => {
+    if (!uiStateRestored.current) return;
     void invoke('update_setting', { key: 'agent_panel_visible', value: String(agentPanelVisible) }).catch(() => {});
   }, [agentPanelVisible]);
 
@@ -373,6 +383,8 @@ function AppContent() {
         // Restore UI layout state.
         if (settings.sidebar_visible !== undefined) setSidebarVisible(!!settings.sidebar_visible);
         if (settings.agent_panel_visible !== undefined) setAgentPanelVisible(!!settings.agent_panel_visible);
+        // Mark restore complete so the persist effects can start saving.
+        uiStateRestored.current = true;
         // Honor saved UI language preference (mirror to localStorage so the
         // i18n LanguageDetector picks it up on next app start, and switch live now).
         if (settings.language && typeof settings.language === 'string') {
@@ -392,6 +404,9 @@ function AppContent() {
         }
       } catch (e) {
         console.warn("Failed to load settings:", e);
+        // Even if settings load failed, let persistence start so future
+        // changes are saved.
+        uiStateRestored.current = true;
       }
       
       // Load custom hotkey bindings

--- a/crates/libretune-app/src/components/agent/AgentDock.tsx
+++ b/crates/libretune-app/src/components/agent/AgentDock.tsx
@@ -7,7 +7,7 @@
  */
 import { useEffect, useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
-import { ChatPanel } from './ChatPanel';
+import { ChatPanel, type TranscriptEntry } from './ChatPanel';
 import { ProposalQueue } from './ProposalQueue';
 import type { AgentStatus, ApplyResult, ProposedAction } from '../../types/agent';
 import './AgentPanel.css';
@@ -27,6 +27,7 @@ export function AgentDock({ buildSystemPrompt }: AgentDockProps) {
   const [status, setStatus] = useState<AgentStatus | null>(null);
   const [queue, setQueue] = useState<ProposedAction[]>([]);
   const [appliedNote, setAppliedNote] = useState<string | null>(null);
+  const [transcript, setTranscript] = useState<TranscriptEntry[]>([]);
 
   // Poll status on mount and when settings change (settings:changed event).
   const refreshStatus = async () => {
@@ -74,6 +75,8 @@ export function AgentDock({ buildSystemPrompt }: AgentDockProps) {
         <ChatPanel
           status={status}
           systemPrompt={systemPrompt}
+          transcript={transcript}
+          onTranscriptChange={setTranscript}
           onProposals={(p) => setQueue((prev) => [...prev, ...p])}
         />
       </div>

--- a/crates/libretune-app/src/components/agent/AgentPanel.css
+++ b/crates/libretune-app/src/components/agent/AgentPanel.css
@@ -96,6 +96,72 @@
   max-height: 32px;
 }
 
+/* Chat history list (toggled by the list button in the header). */
+.agent-chat-list {
+  border-bottom: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.08));
+  max-height: 240px;
+  overflow-y: auto;
+  padding: 4px;
+  flex-shrink: 0;
+}
+
+.agent-chat-list-empty {
+  padding: 8px;
+  font-size: 12px;
+  opacity: 0.6;
+  text-align: center;
+}
+
+.agent-chat-list-item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 4px;
+  border-radius: 4px;
+}
+
+.agent-chat-list-item.active {
+  background: rgba(128, 160, 255, 0.15);
+}
+
+.agent-chat-list-item-title {
+  flex: 1;
+  text-align: left;
+  background: none;
+  border: none;
+  color: inherit;
+  font-size: 12px;
+  padding: 4px 6px;
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  border-radius: 4px;
+}
+
+.agent-chat-list-item-title:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.agent-chat-list-item-del {
+  flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+  background: none;
+  border: none;
+  color: inherit;
+  opacity: 0.5;
+  cursor: pointer;
+  border-radius: 4px;
+  font-size: 14px;
+  line-height: 1;
+}
+
+.agent-chat-list-item-del:hover {
+  opacity: 1;
+  background: rgba(255, 80, 80, 0.2);
+}
+
 .agent-panel-queue-toggle {
   display: flex;
   align-items: center;

--- a/crates/libretune-app/src/components/agent/AgentSidePanel.tsx
+++ b/crates/libretune-app/src/components/agent/AgentSidePanel.tsx
@@ -12,9 +12,15 @@
  */
 import { useCallback, useRef, useState, useEffect, MouseEvent } from 'react';
 import { invoke } from '@tauri-apps/api/core';
-import { ChatPanel } from './ChatPanel';
+import { ChatPanel, type TranscriptEntry } from './ChatPanel';
 import { ProposalQueue } from './ProposalQueue';
-import type { AgentStatus, ApplyResult, ProposedAction } from '../../types/agent';
+import type {
+  AgentStatus,
+  ApplyResult,
+  ChatHistory,
+  ChatSummary,
+  ProposedAction,
+} from '../../types/agent';
 import './AgentPanel.css';
 
 export interface AgentSidePanelProps {
@@ -41,6 +47,72 @@ export function AgentSidePanel({ width, onResize, onCollapse, onPopOut }: AgentS
   const [queueCollapsed, setQueueCollapsed] = useState(false);
   const isResizing = useRef(false);
 
+  // --- Chat history state (owned here so it can be saved/switched) ---
+  const [transcript, setTranscript] = useState<TranscriptEntry[]>([]);
+  const [currentChatId, setCurrentChatId] = useState<string | null>(null);
+  const [chatList, setChatList] = useState<ChatSummary[]>([]);
+  const [chatListOpen, setChatListOpen] = useState(false);
+
+  /** Persist the current transcript + id to the backend. Best-effort. */
+  const persistChat = useCallback(
+    async (id: string, messages: TranscriptEntry[]) => {
+      try {
+        const title =
+          messages.find((m) => m.role === 'user')?.content.slice(0, 60) || 'New chat';
+        const chat: ChatHistory = {
+          id,
+          title,
+          created_at: '',
+          updated_at: '',
+          messages: messages
+            .filter((m) => !m.pending)
+            .map((m) => ({ role: m.role, content: m.content })),
+        };
+        await invoke<ChatHistory>('agent_save_chat', { chat });
+        // Refresh the chat list so the sidebar stays in sync.
+        const list = await invoke<ChatSummary[]>('agent_list_chats');
+        setChatList(list);
+      } catch (e) {
+        console.error('Failed to persist chat:', e);
+      }
+    },
+    []
+  );
+
+  /** Start a fresh chat. */
+  const newChat = useCallback(() => {
+    setTranscript([]);
+    setCurrentChatId(null);
+    setChatListOpen(false);
+  }, []);
+
+  /** Switch to an existing chat by id (loads its messages). */
+  const openChat = useCallback(async (id: string) => {
+    try {
+      const chat = await invoke<ChatHistory>('agent_load_chat', { chatId: id });
+      setTranscript(chat.messages.map((m) => ({ role: m.role, content: m.content })));
+      setCurrentChatId(id);
+    } catch (e) {
+      console.error('Failed to load chat:', e);
+    }
+    setChatListOpen(false);
+  }, []);
+
+  /** Delete a chat from disk and the list. */
+  const deleteChat = useCallback(async (id: string) => {
+    try {
+      await invoke('agent_delete_chat', { chatId: id });
+      if (currentChatId === id) {
+        setTranscript([]);
+        setCurrentChatId(null);
+      }
+      const list = await invoke<ChatSummary[]>('agent_list_chats');
+      setChatList(list);
+    } catch (e) {
+      console.error('Failed to delete chat:', e);
+    }
+  }, [currentChatId]);
+
   const refreshStatus = async () => {
     try {
       const s = await invoke<AgentStatus>('agent_status');
@@ -52,6 +124,18 @@ export function AgentSidePanel({ width, onResize, onCollapse, onPopOut }: AgentS
 
   useEffect(() => {
     void refreshStatus();
+    // Load chat list + auto-open the most recent chat.
+    (async () => {
+      try {
+        const list = await invoke<ChatSummary[]>('agent_list_chats');
+        setChatList(list);
+        if (list.length > 0) {
+          await openChat(list[0].id);
+        }
+      } catch {
+        // non-fatal (no project loaded yet)
+      }
+    })();
     let unlisten: (() => void) | undefined;
     (async () => {
       try {
@@ -119,6 +203,28 @@ export function AgentSidePanel({ width, onResize, onCollapse, onPopOut }: AgentS
         <div className="agent-panel-header-actions">
           <button
             className="agent-panel-icon-btn"
+            onClick={() => setChatListOpen((o) => !o)}
+            title="Chat history"
+            aria-label="Chat history"
+          >
+            {/* list icon */}
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
+              <path d="M2.5 3.5a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0 4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0 4a.5.5 0 0 1 .5-.5h6a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5z" />
+            </svg>
+          </button>
+          <button
+            className="agent-panel-icon-btn"
+            onClick={newChat}
+            title="New chat"
+            aria-label="New chat"
+          >
+            {/* plus icon */}
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
+              <path d="M8 2a.5.5 0 0 1 .5.5v5h5a.5.5 0 0 1 0 1h-5v5a.5.5 0 0 1-1 0v-5h-5a.5.5 0 0 1 0-1h5v-5A.5.5 0 0 1 8 2z" />
+            </svg>
+          </button>
+          <button
+            className="agent-panel-icon-btn"
             onClick={onPopOut}
             title="Pop out to separate window"
             aria-label="Pop out"
@@ -143,14 +249,52 @@ export function AgentSidePanel({ width, onResize, onCollapse, onPopOut }: AgentS
         </div>
       </div>
 
+      {/* Chat history list (toggled by the list button) */}
+      {chatListOpen && (
+        <div className="agent-chat-list">
+          {chatList.length === 0 && (
+            <div className="agent-chat-list-empty">No saved chats</div>
+          )}
+          {chatList.map((c) => (
+            <div
+              key={c.id}
+              className={`agent-chat-list-item${currentChatId === c.id ? ' active' : ''}`}
+            >
+              <button className="agent-chat-list-item-title" onClick={() => void openChat(c.id)}>
+                {c.title}
+              </button>
+              <button
+                className="agent-chat-list-item-del"
+                title="Delete chat"
+                onClick={() => void deleteChat(c.id)}
+              >
+                ×
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
       {/* Chat fills the flexible area */}
       <div className="agent-panel-chat">
         <ChatPanel
           status={status}
           systemPrompt={DEFAULT_SYSTEM_PROMPT}
+          transcript={transcript}
+          onTranscriptChange={(next) => {
+            setTranscript(next);
+            // Persist on every change (debounce-free for simplicity; the write
+            // is cheap). On the first message, allocate an id.
+            const id =
+              currentChatId ??
+              `chat-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+            if (!currentChatId) {
+              setCurrentChatId(id);
+            }
+            void persistChat(id, next);
+          }}
           onProposals={(p) => {
             setQueue((prev) => [...prev, ...p]);
-            // Auto-expand the queue when new proposals arrive.
             setQueueCollapsed(false);
           }}
         />

--- a/crates/libretune-app/src/components/agent/ChatPanel.tsx
+++ b/crates/libretune-app/src/components/agent/ChatPanel.tsx
@@ -24,16 +24,25 @@ export interface ChatPanelProps {
   onProposals: (proposed: ProposedAction[]) => void;
   /** System prompt describing current ECU/tune context. */
   systemPrompt: string;
+  /** Controlled transcript (owned by the parent for chat history). */
+  transcript: TranscriptEntry[];
+  /** Update the transcript. */
+  onTranscriptChange: (next: TranscriptEntry[]) => void;
 }
 
-interface TranscriptEntry {
+export interface TranscriptEntry {
   role: 'user' | 'assistant';
   content: string;
   pending?: boolean;
 }
 
-export function ChatPanel({ status, onProposals, systemPrompt }: ChatPanelProps) {
-  const [transcript, setTranscript] = useState<TranscriptEntry[]>([]);
+export function ChatPanel({
+  status,
+  onProposals,
+  systemPrompt,
+  transcript,
+  onTranscriptChange,
+}: ChatPanelProps) {
   const [input, setInput] = useState('');
   const [sending, setSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -58,8 +67,8 @@ export function ChatPanel({ status, onProposals, systemPrompt }: ChatPanelProps)
     const history: SerializedMessage[] = transcript
       .filter((e) => !e.pending)
       .map((e) => ({ role: e.role, content: e.content }));
-    setTranscript((prev) => [
-      ...prev,
+    onTranscriptChange([
+      ...transcript,
       { role: 'user', content: message },
       { role: 'assistant', content: '', pending: true },
     ]);
@@ -74,37 +83,47 @@ export function ChatPanel({ status, onProposals, systemPrompt }: ChatPanelProps)
         },
       });
       // Replace the placeholder with the real reply; hand proposals up.
-      setTranscript((prev) => {
-        const next = [...prev];
-        for (let i = next.length - 1; i >= 0; i--) {
-          if (next[i].pending) {
-            next[i] = { role: 'assistant', content: proposal.reply || '(no reply)' };
-            break;
-          }
+      const afterReply = [...transcript];
+      for (let i = afterReply.length - 1; i >= 0; i--) {
+        if (afterReply[i].pending) {
+          afterReply[i] = { role: 'assistant', content: proposal.reply || '(no reply)' };
+          break;
         }
-        return next;
-      });
+      }
+      onTranscriptChange(afterReply);
       if (proposal.proposed.length > 0) {
         onProposals(proposal.proposed);
       }
     } catch (e) {
-      // Replace the placeholder with an error note.
-      setTranscript((prev) => {
-        const next = [...prev];
-        for (let i = next.length - 1; i >= 0; i--) {
-          if (next[i].pending) {
-            next[i] = {
-              role: 'assistant',
-              content: `⚠️ Error: ${String(e)}`,
-            };
-            break;
-          }
+      const errStr = String(e);
+      // The "__cancelled__" sentinel means the user clicked Stop.
+      const cancelled = errStr.includes('__cancelled__');
+      // Replace the placeholder with an error note (or a stopped note).
+      const afterErr = [...transcript];
+      for (let i = afterErr.length - 1; i >= 0; i--) {
+        if (afterErr[i].pending) {
+          afterErr[i] = {
+            role: 'assistant',
+            content: cancelled ? '_(stopped)_' : `⚠️ Error: ${errStr}`,
+          };
+          break;
         }
-        return next;
-      });
-      setError(String(e));
+      }
+      onTranscriptChange(afterErr);
+      if (!cancelled) {
+        setError(errStr);
+      }
     } finally {
       setSending(false);
+    }
+  };
+
+  /** Cancel an in-flight request (the Stop button). */
+  const stop = async () => {
+    try {
+      await invoke('agent_stop');
+    } catch {
+      // ignore — the sentinel handling in send() covers the UX
     }
   };
 
@@ -161,8 +180,12 @@ export function ChatPanel({ status, onProposals, systemPrompt }: ChatPanelProps)
           disabled={!enabled || sending}
           rows={2}
         />
-        <Button variant="primary" onClick={() => void send()} disabled={!enabled || sending || !input.trim()}>
-          {sending ? 'Sending…' : 'Send'}
+        <Button
+          variant={sending ? 'danger' : 'primary'}
+          onClick={() => (sending ? void stop() : void send())}
+          disabled={!enabled || (!sending && !input.trim())}
+        >
+          {sending ? 'Stop' : 'Send'}
         </Button>
       </div>
     </div>

--- a/crates/libretune-app/src/components/agent/ChatPanel.tsx
+++ b/crates/libretune-app/src/components/agent/ChatPanel.tsx
@@ -63,15 +63,22 @@ export function ChatPanel({
     setInput('');
     setError(null);
 
-    // Append the user message + a pending assistant placeholder.
-    const history: SerializedMessage[] = transcript
+    // Snapshot the transcript at the START of this turn. We build the updated
+    // transcript from this snapshot rather than re-reading the `transcript`
+    // prop later (which would be a stale closure value after the parent
+    // re-renders). This keeps a single send() invocation self-consistent.
+    const snapshot = [...transcript];
+    const history: SerializedMessage[] = snapshot
       .filter((e) => !e.pending)
       .map((e) => ({ role: e.role, content: e.content }));
-    onTranscriptChange([
-      ...transcript,
+
+    // The transcript for this turn: prior messages + user msg + pending reply.
+    const turnTranscript: TranscriptEntry[] = [
+      ...snapshot,
       { role: 'user', content: message },
       { role: 'assistant', content: '', pending: true },
-    ]);
+    ];
+    onTranscriptChange(turnTranscript);
     setSending(true);
 
     try {
@@ -82,14 +89,10 @@ export function ChatPanel({
           system_prompt: systemPrompt,
         },
       });
-      // Replace the placeholder with the real reply; hand proposals up.
-      const afterReply = [...transcript];
-      for (let i = afterReply.length - 1; i >= 0; i--) {
-        if (afterReply[i].pending) {
-          afterReply[i] = { role: 'assistant', content: proposal.reply || '(no reply)' };
-          break;
-        }
-      }
+      // Replace the pending placeholder with the real reply.
+      const afterReply = turnTranscript.map((e) =>
+        e.pending ? { role: 'assistant' as const, content: proposal.reply || '(no reply)' } : e
+      );
       onTranscriptChange(afterReply);
       if (proposal.proposed.length > 0) {
         onProposals(proposal.proposed);
@@ -98,17 +101,12 @@ export function ChatPanel({
       const errStr = String(e);
       // The "__cancelled__" sentinel means the user clicked Stop.
       const cancelled = errStr.includes('__cancelled__');
-      // Replace the placeholder with an error note (or a stopped note).
-      const afterErr = [...transcript];
-      for (let i = afterErr.length - 1; i >= 0; i--) {
-        if (afterErr[i].pending) {
-          afterErr[i] = {
-            role: 'assistant',
-            content: cancelled ? '_(stopped)_' : `⚠️ Error: ${errStr}`,
-          };
-          break;
-        }
-      }
+      // Replace the pending placeholder with an error/stopped note.
+      const afterErr = turnTranscript.map((entry) =>
+        entry.pending
+          ? { role: 'assistant' as const, content: cancelled ? '_(stopped)_' : `⚠️ Error: ${errStr}` }
+          : entry
+      );
       onTranscriptChange(afterErr);
       if (!cancelled) {
         setError(errStr);
@@ -127,11 +125,31 @@ export function ChatPanel({
     }
   };
 
-  if (!status?.enabled) {
+  if (status === null) {
+    // Status hasn't been fetched yet — don't flash the "disabled" message.
+    return (
+      <div className="agent-chat-disabled">Loading…</div>
+    );
+  }
+
+  if (!status.enabled) {
     return (
       <div className="agent-chat-disabled">
         The AI assistant is disabled. Enable it in Settings (and acknowledge the
         risk warning) to start.
+      </div>
+    );
+  }
+
+  if (!enabled) {
+    // Enabled but missing config — tell the user what's missing.
+    const missing: string[] = [];
+    if (!status.risk_acknowledged) missing.push('risk acknowledgement');
+    if (!status.configured) missing.push('a provider and model');
+    return (
+      <div className="agent-chat-disabled">
+        The assistant is enabled but needs {missing.join(' and ')}.
+        Configure it in Settings to start chatting.
       </div>
     );
   }

--- a/crates/libretune-app/src/components/dashboards/TsDashboard.tsx
+++ b/crates/libretune-app/src/components/dashboards/TsDashboard.tsx
@@ -254,16 +254,28 @@ export default function TsDashboard({ initialDashPath, isConnected = false }: Ts
     const loadInitial = async () => {
       const dashes = await refreshDashboardList();
       
-      // If no initial path, select first available
+      // If no initial path, select the persisted dashboard or fall back to defaults.
       if (!selectedPath && dashes.length > 0) {
-        // Prefer Telemetry Live.ltdash.xml as the default dashboard
+        // 1. Prefer the last-selected dashboard (persisted in settings).
+        try {
+          const settings = await invoke<{ selected_dashboard?: string }>('get_settings');
+          if (settings.selected_dashboard) {
+            const saved = dashes.find(d => d.name === settings.selected_dashboard);
+            if (saved) {
+              setSelectedPath(saved.path);
+              return;
+            }
+          }
+        } catch { /* ignore — fall through to defaults */ }
+
+        // 2. Prefer Telemetry Live.ltdash.xml as the default dashboard
         const telemetryDash = dashes.find(d => d.name === 'Telemetry Live.ltdash.xml');
         if (telemetryDash) {
           setSelectedPath(telemetryDash.path);
           return;
         }
 
-        // Fall back to Basic.ltdash.xml if Telemetry Live isn't present
+        // 3. Fall back to Basic.ltdash.xml if Telemetry Live isn't present
         const basicDash = dashes.find(d => d.name === 'Basic.ltdash.xml');
         if (basicDash) {
           setSelectedPath(basicDash.path);
@@ -276,6 +288,13 @@ export default function TsDashboard({ initialDashPath, isConnected = false }: Ts
     };
     loadInitial();
   }, []);
+
+  // Persist the selected dashboard name whenever it changes.
+  useEffect(() => {
+    if (!selectedPath) return;
+    const name = selectedPath.split(/[\\/]/).pop() || '';
+    void invoke('update_setting', { key: 'selected_dashboard', value: name }).catch(() => {});
+  }, [selectedPath]);
 
   // Load selected dashboard (only when the selected path changes)
   useEffect(() => {

--- a/crates/libretune-app/src/components/tuner-ui/Sidebar.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/Sidebar.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback, useRef, useMemo, MouseEvent, useEffect } from 'react';
+import { invoke } from '@tauri-apps/api/core';
 import { SidebarNode } from './TunerLayout';
 import { resolveNodeIcon } from '../../utils/nodeIcons';
 import './Sidebar.css';
@@ -106,6 +107,39 @@ export function Sidebar({ items, width, onResize, onItemSelect, searchIndex, pro
   const searchInputRef = useRef<HTMLInputElement>(null);
   const resizeRef = useRef<HTMLDivElement>(null);
   const isResizing = useRef(false);
+  // Gate: don't persist until the initial restore from settings is done.
+  const expandedRestored = useRef(false);
+  const saveExpandedTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Restore expanded folder IDs from settings on mount.
+  useEffect(() => {
+    (async () => {
+      try {
+        const settings = await invoke<{ sidebar_expanded_ids?: string }>('get_settings');
+        if (settings.sidebar_expanded_ids) {
+          const ids = JSON.parse(settings.sidebar_expanded_ids) as string[];
+          setExpandedIds(new Set(ids));
+        }
+      } catch {
+        // non-fatal — start with empty set
+      } finally {
+        expandedRestored.current = true;
+      }
+    })();
+  }, []);
+
+  // Persist expanded folder IDs to settings (debounced).
+  useEffect(() => {
+    if (!expandedRestored.current) return;
+    if (saveExpandedTimer.current) clearTimeout(saveExpandedTimer.current);
+    saveExpandedTimer.current = setTimeout(() => {
+      void invoke('update_setting', {
+        key: 'sidebar_expanded_ids',
+        value: JSON.stringify([...expandedIds]),
+      }).catch(() => {});
+    }, 500);
+    return () => { if (saveExpandedTimer.current) clearTimeout(saveExpandedTimer.current); };
+  }, [expandedIds]);
 
   // Filter tree based on search query (with deep search via searchIndex)
   const filteredItems = useMemo(() => {

--- a/crates/libretune-app/src/types/agent.ts
+++ b/crates/libretune-app/src/types/agent.ts
@@ -101,3 +101,29 @@ export interface AgentStatus {
   capability_tier: string;
   configured: boolean;
 }
+
+// --- Chat history persistence ---
+
+/** One chat message stored in a chat history file. */
+export interface ChatMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+/** One persisted chat conversation. */
+export interface ChatHistory {
+  id: string;
+  title: string;
+  messages: ChatMessage[];
+  created_at: string;
+  updated_at: string;
+}
+
+/** Summary entry for the chat list (no message bodies). */
+export interface ChatSummary {
+  id: string;
+  title: string;
+  message_count: number;
+  created_at: string;
+  updated_at: string;
+}

--- a/docs/src/features/ai-assistant.md
+++ b/docs/src/features/ai-assistant.md
@@ -84,6 +84,39 @@ existing tools.
 - **Pop-out** — click the external-link icon in the panel header to open the
   assistant in its own window. Use that window's **Dock** button to bring it
   back to the docked panel.
+- **Stop** — while the assistant is thinking, the **Send** button becomes a
+  red **Stop** button. Click it to cancel the in-flight request (useful if a
+  provider is slow or stuck). A cancelled request shows `_(stopped)_` in the
+  transcript rather than an error.
+
+### Chat History
+
+The assistant persists your conversations **per project**, so you can close
+the app and come back to pick up where you left off.
+
+- **Auto-save** — every message is saved automatically.
+- **Chat switcher** — click the **list icon** in the panel header to see all
+  past chats for the current project, most-recent first. Click one to switch
+  to it; click the × to delete it.
+- **New chat** — click the **plus icon** to start a fresh conversation.
+- **Auto-open** — on launch, the most recent chat for the current project
+  loads automatically.
+
+Chats are stored as JSON files under `projectCfg/ai_chats/` inside the project
+folder, so they travel with the project if you copy it.
+
+## UI State Persistence
+
+LibreTune remembers your workspace layout across restarts. When you close and
+reopen the app (or refresh the window), it restores:
+
+- **Sidebar visibility** — whether the left sidebar is shown or hidden.
+- **Sidebar expansion** — which folders are expanded/collapsed.
+- **AI Assistant panel** — whether the right-hand chat panel is open.
+- **Selected dashboard** — which dashboard was last loaded.
+- **Window size and position** — handled by the window-state plugin.
+
+This means the app opens "exactly as you left it" without any extra setup.
 
 ## Providers
 


### PR DESCRIPTION
## Summary

Adds chat history persistence, a stop button, and UI state persistence to the AI assistant and overall workspace UX. Built on top of the AI assistant work from PR #92.

## What's included

### Stop button
While the assistant is thinking, the **Send** button becomes a red **Stop** button. Clicking it cancels the in-flight LLM request immediately. The turn is spawned as a tokio task whose `JoinHandle` is stored in `AppState.agent_task`; the new `agent_stop` command aborts it (same pattern as the realtime stream). A cancelled request shows `_(stopped)_` in the transcript rather than an error.

### Chat history (per-project)
- Conversations persist as JSON files under `projectCfg/ai_chats/` in each project folder.
- New backend commands: `agent_list_chats`, `agent_load_chat`, `agent_save_chat`, `agent_delete_chat`.
- Panel header gains a **chat switcher** (list icon) and **New chat** button (plus icon).
- The most recent chat auto-opens on launch; chats auto-save on every message.
- `ChatPanel` is now controlled (transcript owned by `AgentSidePanel`).

### UI state persistence
On launch the app restores:
- Sidebar visibility + which folders are expanded/collapsed
- AI assistant panel visibility
- Selected dashboard (prefers saved choice, then Telemetry Live)
- Window size/position (already handled by the window-state plugin)

New settings fields: `sidebar_visible`, `agent_panel_visible`, `selected_dashboard`, `open_tabs`, `sidebar_expanded_ids`. Persistence is gated on a restore flag so the initial default values don't overwrite saved ones before the async restore completes.

### Bug fixes
- **Transcript reset to blank** — stale-closure bug in `ChatPanel.send()` caused the transcript to reset after the first reply. Fixed by snapshotting the transcript at the start of each turn.
- **"Disabled" flash** — the panel showed "disabled" while the status was still loading. Now shows "Loading…" until the status is fetched.

## Verification
- `cargo build -p libretune-app`: clean
- `npm run typecheck`: clean
- Manual: chat history persists and switches; stop button cancels; sidebar/panel/dashboard state restores on refresh

## Test plan
- [ ] Open the AI panel, send a message, close and reopen the app — the chat should be there
- [ ] Use the chat switcher to switch between past chats and start a new one
- [ ] While the assistant is thinking, click Stop — the request cancels
- [ ] Expand some sidebar folders, open the AI panel, refresh — both should persist
- [ ] Switch dashboards, refresh — the selected dashboard should persist
