### PR TITLE
feat(ui): Redesign loading overlay with smooth gradient-arc spinner

### DIFF
--- a/crates/libretune-app/src/contexts/LoadingContext.css
+++ b/crates/libretune-app/src/contexts/LoadingContext.css
@@ -4,16 +4,16 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.6);
-  backdrop-filter: blur(4px);
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(6px);
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 10000;
-  animation: fadeIn 0.15s ease-out;
+  animation: lt-loader-fade 0.18s ease-out;
 }
 
-@keyframes fadeIn {
+@keyframes lt-loader-fade {
   from {
     opacity: 0;
   }
@@ -26,30 +26,39 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 16px;
-  padding: 32px 48px;
+  gap: 18px;
+  padding: 28px 44px;
   background: var(--card-bg);
   border: 1px solid var(--border-color);
-  border-radius: 12px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+  border-radius: 16px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.45);
+  animation: lt-loader-pop 0.22s cubic-bezier(0.2, 0.8, 0.2, 1);
 }
 
+@keyframes lt-loader-pop {
+  from {
+    opacity: 0;
+    transform: scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+/* Smooth gradient-arc spinner: a ring with a soft fading tail.
+   No hard asymmetric edge, so it reads as clean and professional. */
 .loading-spinner {
-  width: 48px;
-  height: 48px;
-  position: relative;
-}
-
-.spinner-ring {
-  width: 100%;
-  height: 100%;
-  border: 3px solid var(--border-color);
-  border-top-color: var(--accent-color);
+  width: 36px;
+  height: 36px;
   border-radius: 50%;
-  animation: spin 0.8s linear infinite;
+  background: conic-gradient(transparent 0%, var(--accent-color) 100%);
+  -webkit-mask: radial-gradient(farthest-side, transparent calc(100% - 3px), #000 calc(100% - 3px));
+          mask: radial-gradient(farthest-side, transparent calc(100% - 3px), #000 calc(100% - 3px));
+  animation: lt-loader-spin 0.9s linear infinite;
 }
 
-@keyframes spin {
+@keyframes lt-loader-spin {
   from {
     transform: rotate(0deg);
   }
@@ -59,8 +68,9 @@
 }
 
 .loading-message {
-  font-size: 14px;
-  color: var(--text-primary);
+  font-size: 13px;
+  letter-spacing: 0.01em;
+  color: var(--text-secondary);
   font-weight: 500;
   text-align: center;
   max-width: 250px;

--- a/crates/libretune-app/src/contexts/LoadingContext.tsx
+++ b/crates/libretune-app/src/contexts/LoadingContext.tsx
@@ -58,11 +58,9 @@ interface LoadingOverlayProps {
 
 function LoadingOverlay({ message }: LoadingOverlayProps) {
   return (
-    <div className="loading-overlay">
+    <div className="loading-overlay" role="status" aria-live="polite">
       <div className="loading-content">
-        <div className="loading-spinner">
-          <div className="spinner-ring"></div>
-        </div>
+        <div className="loading-spinner" aria-hidden="true" />
         <div className="loading-message">{message}</div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Replaces the loading overlay's spinner with a cleaner, more professional animation, and refines the surrounding card. The previous spinner read as "janky" — this makes it calm and modern.

## Before / After

| Aspect | Before | After |
|---|---|---|
| Spinner | Hard asymmetric `border-top-color` ring (one bright quarter), 48px, 0.8s | Smooth conic-gradient arc that fades accent→transparent (comet-tail), 36px, 0.9s |
| Card radius | 12px | 16px (softer) |
| Entrance | Fade only | Fade + subtle scale-in (`cubic-bezier` ease) |
| Backdrop | blur 4px @ 60% black | blur 6px @ 55% black |
| Message | Primary color, 14px | Secondary color, 13px, slight letter-spacing |

## Why

The old spinner colored only **one quarter** of a border ring and rotated it. That single hard, bright arc catching the eye on each rotation is exactly what reads as cheap/janky. The new spinner uses a `conic-gradient` with a soft fading tail (the style used by modern Material Design / iOS loaders), so there's no hard edge catching the eye as it rotates.

The change is kept **simple** over complex — just a smoother version of the same idea.

## Scope

This one overlay powers **every** loading state in the app, so all call sites get the upgrade at once:
- `App.tsx` → "Initializing LibreTune…", "Loading project…", "Loading tune file…"
- `useEcuEventListeners.ts` → "Syncing with ECU…"

## Technical notes

- **Theme-aware**: uses `--accent-color` / `--card-bg` / `--text-secondary`, so it recolors correctly across every theme.
- **Collision-proof keyframes**: renamed `@keyframes spin` / `fadeIn` → `lt-loader-*`. The old names are redefined in 5 other CSS files (`TsDashboard.css`, `ImportProjectWizard.css`, `SignatureMismatchDialog.css`, `TuneComparisonDialog.css`, `TableEditor2D.css`), and since CSS keyframes are global, the old names were silently fighting each other.
- **Accessibility**: added `role="status"` + `aria-live="polite"` on the overlay, `aria-hidden` on the decorative spinner.

## Verification

- `npm run typecheck` passes clean
- Manually verified in the running app — loading overlay renders correctly on project/tune load

## Files changed

- `crates/libretune-app/src/contexts/LoadingContext.tsx` — simplified markup, a11y attributes
- `crates/libretune-app/src/contexts/LoadingContext.css` — new spinner, refined overlay card, prefixed keyframes
