### PR TITLE
fix: unbreak CI after the AI assistant merge (fmt, test compile, act(…

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/agent.rs
+++ b/crates/libretune-app/src-tauri/src/commands/agent.rs
@@ -166,7 +166,6 @@ pub async fn agent_delete_chat(
     Ok(())
 }
 
-
 /// A serialized [`Message`] that round-trips through JSON.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SerializedMessage {
@@ -566,4 +565,3 @@ pub async fn agent_apply_proposals(
 
     Ok(results)
 }
-

--- a/crates/libretune-app/src-tauri/src/commands/app_settings.rs
+++ b/crates/libretune-app/src-tauri/src/commands/app_settings.rs
@@ -140,7 +140,6 @@ pub(crate) struct Settings {
     // All gated behind `ai_assistant_enabled`, which itself requires
     // `ai_risk_acknowledged`. The model only ever *proposes* changes; nothing
     // burns to the ECU automatically.
-
     /// Master enable for the AI assistant. Must be paired with a risk ack.
     #[serde(default = "default_false")]
     pub(crate) ai_assistant_enabled: bool,

--- a/crates/libretune-app/src-tauri/src/commands/demo.rs
+++ b/crates/libretune-app/src-tauri/src/commands/demo.rs
@@ -222,6 +222,7 @@ mod demo_mode_tests {
             connection_factory: Mutex::new(None),
             math_channels: Mutex::new(Vec::new()),
             stream_stats: Mutex::new(StreamStats::default()),
+            agent_task: Mutex::new(None),
         };
 
         let dev_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))

--- a/crates/libretune-app/src-tauri/src/commands/settings.rs
+++ b/crates/libretune-app/src-tauri/src/commands/settings.rs
@@ -121,15 +121,13 @@ pub async fn update_setting(
             let want: bool = value.parse().map_err(|_| "Invalid boolean value")?;
             if want && !settings.ai_risk_acknowledged {
                 return Err(
-                    "Cannot enable AI assistant without acknowledging the risk warning"
-                        .to_string(),
+                    "Cannot enable AI assistant without acknowledging the risk warning".to_string(),
                 );
             }
             settings.ai_assistant_enabled = want;
         }
         "ai_risk_acknowledged" => {
-            settings.ai_risk_acknowledged =
-                value.parse().map_err(|_| "Invalid boolean value")?
+            settings.ai_risk_acknowledged = value.parse().map_err(|_| "Invalid boolean value")?
         }
         "ai_provider" => {
             // Changing the provider invalidates the prior risk ack boundary,

--- a/crates/libretune-app/src-tauri/src/lib.rs
+++ b/crates/libretune-app/src-tauri/src/lib.rs
@@ -42,8 +42,8 @@ use commands::adaptive_timing::{
     disable_adaptive_timing, enable_adaptive_timing, get_adaptive_timing_stats,
 };
 use commands::agent::{
-    agent_apply_proposals, agent_delete_chat, agent_list_chats, agent_load_chat,
-    agent_save_chat, agent_send_message, agent_status, agent_stop,
+    agent_apply_proposals, agent_delete_chat, agent_list_chats, agent_load_chat, agent_save_chat,
+    agent_send_message, agent_status, agent_stop,
 };
 use commands::annotations::{
     delete_annotation, get_all_annotations, get_annotation, get_table_annotations, set_annotation,

--- a/crates/libretune-app/src-tauri/src/tests.rs
+++ b/crates/libretune-app/src-tauri/src/tests.rs
@@ -134,6 +134,7 @@ mod concurrency_tests {
             connection_factory: Mutex::new(None),
             math_channels: Mutex::new(Vec::new()),
             stream_stats: Mutex::new(StreamStats::default()),
+            agent_task: Mutex::new(None),
         });
 
         // Simulate execute_controller_command pattern: lock def -> sleep -> lock conn
@@ -282,6 +283,7 @@ signature = "Speeduino 2023-04"
             connection_factory: Mutex::new(None),
             math_channels: Mutex::new(Vec::new()),
             stream_stats: Mutex::new(StreamStats::default()),
+            agent_task: Mutex::new(None),
         };
 
         let matches = find_matching_inis_from_state(&state, "Speeduino 2023-05").await;
@@ -350,6 +352,7 @@ signature = "Speeduino 2023-04"
             connection_factory: Mutex::new(None),
             math_channels: Mutex::new(Vec::new()),
             stream_stats: Mutex::new(StreamStats::default()),
+            agent_task: Mutex::new(None),
         };
 
         let matches = find_matching_inis_from_state(&state, "Speeduino 2023-05").await;
@@ -421,6 +424,7 @@ signature = "Speeduino 2023-04"
             connection_factory: Mutex::new(None),
             math_channels: Mutex::new(Vec::new()),
             stream_stats: Mutex::new(StreamStats::default()),
+            agent_task: Mutex::new(None),
         };
 
         // Partial match case
@@ -504,6 +508,7 @@ signature = "Speeduino 2023-04"
             connection_factory: Mutex::new(None),
             math_channels: Mutex::new(Vec::new()),
             stream_stats: Mutex::new(StreamStats::default()),
+            agent_task: Mutex::new(None),
         };
 
         // Install factory returning a partial matching signature

--- a/crates/libretune-app/src/components/tuner-ui/__tests__/SettingsDialog.test.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/__tests__/SettingsDialog.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 
@@ -31,6 +31,16 @@ describe('SettingsDialog', () => {
       </UnitPreferencesProvider>
     );
 
+    // The dialog also fires get_hotkey_bindings/get_available_channels/
+    // get_demo_mode on mount (unmocked here, so they resolve via the
+    // catch-all Promise.resolve() branch above). Flush a macrotask tick
+    // inside act() so their .then() chains fully settle now — otherwise
+    // one can resolve in the gap between two later awaits and log a real
+    // (if harmless) "not wrapped in act(...)" warning.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
     // Find the runtime select and ensure value is loaded
     // Locate the runtime select specifically by its label
     const label = screen.getByText('Default Runtime Packet Mode');
@@ -45,7 +55,7 @@ describe('SettingsDialog', () => {
 
     // Click Apply
     const applyBtn = screen.getByText('Apply');
-    userEvent.click(applyBtn);
+    await userEvent.click(applyBtn);
 
     // Ensure update_setting called with runtime_packet_mode and that it matches the select's value
     const expectedMode = runtimeSelect.value;
@@ -56,6 +66,13 @@ describe('SettingsDialog', () => {
     // Also ensure auto_reconnect setting is saved
     await waitFor(() => {
       expect(invoke).toHaveBeenCalledWith('update_setting', { key: 'auto_reconnect_after_controller_command', value: 'false' });
+    });
+
+    // Flush once more so any state update Apply triggers after its last
+    // update_setting call (e.g. a save-status flag) settles inside act()
+    // before we assert on console.error below.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
     });
 
     // No unexpected console errors (React warnings)

--- a/crates/libretune-core/src/action_scripting.rs
+++ b/crates/libretune-core/src/action_scripting.rs
@@ -277,9 +277,8 @@ impl ActionPlayer {
                                 }
                                 // 3. bits-type must be an enumerated option value.
                                 if !c.bit_options.is_empty() {
-                                    let allowed: Vec<f64> = (0..c.bit_options.len())
-                                        .map(|i| i as f64)
-                                        .collect();
+                                    let allowed: Vec<f64> =
+                                        (0..c.bit_options.len()).map(|i| i as f64).collect();
                                     if !allowed.contains(new_value) {
                                         errors.push(format!(
                                             "Action {}: Value {} for bits constant '{}' not one of {} ({:?})",

--- a/crates/libretune-core/src/agent/context.rs
+++ b/crates/libretune-core/src/agent/context.rs
@@ -6,7 +6,7 @@
 //! unit-testable without a live provider.
 
 use crate::action_scripting::Action;
-use crate::agent::summarize::{summarize_tune_context, TuneContextSummary, TuneContextInputs};
+use crate::agent::summarize::{summarize_tune_context, TuneContextInputs, TuneContextSummary};
 use crate::agent::tiers::{constant_safety_tier, ConstantSafetyTier};
 use crate::ini::{Constant, EcuDefinition, TableDefinition, TableRole};
 use serde::{Deserialize, Serialize};

--- a/crates/libretune-core/src/agent/orchestrator.rs
+++ b/crates/libretune-core/src/agent/orchestrator.rs
@@ -258,23 +258,12 @@ fn map_tool_call(
     };
 
     match tc.name.as_str() {
-        tools::tool_names::PROPOSE_TABLE_EDIT => {
-            map_table_edit(&args, inputs, authority, tc).unwrap_or_else(|errs| {
-                failed(
-                    Action::Pause { duration_ms: 0 },
-                    errs,
-                    tc,
-                )
-            })
-        }
-        tools::tool_names::PROPOSE_CONSTANT_CHANGE => {
-            map_constant_change(&args, tc).unwrap_or_else(|errs| {
-                failed(Action::Pause { duration_ms: 0 }, errs, tc)
-            })
-        }
-        tools::tool_names::PROPOSE_BULK_OP => {
-            map_bulk_op(&args, tc).unwrap_or_else(|errs| failed(Action::Pause { duration_ms: 0 }, errs, tc))
-        }
+        tools::tool_names::PROPOSE_TABLE_EDIT => map_table_edit(&args, inputs, authority, tc)
+            .unwrap_or_else(|errs| failed(Action::Pause { duration_ms: 0 }, errs, tc)),
+        tools::tool_names::PROPOSE_CONSTANT_CHANGE => map_constant_change(&args, tc)
+            .unwrap_or_else(|errs| failed(Action::Pause { duration_ms: 0 }, errs, tc)),
+        tools::tool_names::PROPOSE_BULK_OP => map_bulk_op(&args, tc)
+            .unwrap_or_else(|errs| failed(Action::Pause { duration_ms: 0 }, errs, tc)),
         // Read tools: they don't produce an action; surface as a no-op note.
         // The command layer answers read calls by feeding results back into
         // the next turn's history.
@@ -334,7 +323,10 @@ fn map_table_edit(
     })
 }
 
-fn map_constant_change(args: &serde_json::Value, _tc: &ToolCall) -> Result<ProposedAction, Vec<String>> {
+fn map_constant_change(
+    args: &serde_json::Value,
+    _tc: &ToolCall,
+) -> Result<ProposedAction, Vec<String>> {
     let name = get_str(args, "name")?;
     let value = get_f64(args, "value")?;
     let reason = get_str(args, "reason").ok();
@@ -372,12 +364,18 @@ fn map_bulk_op(args: &serde_json::Value, _tc: &ToolCall) -> Result<ProposedActio
         .ok_or_else(|| vec!["missing 'cells' array".to_string()])?;
     let mut cells: Vec<(u16, u16)> = Vec::with_capacity(cells_arr.len());
     for c in cells_arr {
-        let arr = c.as_array().ok_or_else(|| vec!["cell must be [x,y]".to_string()])?;
+        let arr = c
+            .as_array()
+            .ok_or_else(|| vec!["cell must be [x,y]".to_string()])?;
         if arr.len() < 2 {
             return Err(vec!["cell must have two elements".to_string()]);
         }
-        let x = arr[0].as_u64().ok_or_else(|| vec!["cell x not integer".to_string()])? as u16;
-        let y = arr[1].as_u64().ok_or_else(|| vec!["cell y not integer".to_string()])? as u16;
+        let x = arr[0]
+            .as_u64()
+            .ok_or_else(|| vec!["cell x not integer".to_string()])? as u16;
+        let y = arr[1]
+            .as_u64()
+            .ok_or_else(|| vec!["cell y not integer".to_string()])? as u16;
         cells.push((x, y));
     }
 
@@ -492,7 +490,8 @@ mod tests {
         let tc = ToolCall {
             id: "1".into(),
             name: tools::tool_names::PROPOSE_TABLE_EDIT.into(),
-            arguments: r#"{"table_name":"veTable1","x_index":0,"y_index":0,"new_value":60.0}"#.into(),
+            arguments: r#"{"table_name":"veTable1","x_index":0,"y_index":0,"new_value":60.0}"#
+                .into(),
         };
         let mut inputs = OrchestratorInputs::default();
         inputs

--- a/crates/libretune-core/src/agent/summarize.rs
+++ b/crates/libretune-core/src/agent/summarize.rs
@@ -233,11 +233,8 @@ pub fn summarize_tune_context(
     let mut suspect_cells: Vec<TuneAnomaly> = Vec::new();
     if rows > 0 && cols > 0 && !inputs.x_bins.is_empty() && !inputs.y_bins.is_empty() {
         let detector = AnomalyDetector::new(AnomalyConfig::default());
-        let mut anomalies = detector.detect_anomalies(
-            inputs.table_values,
-            inputs.x_bins,
-            inputs.y_bins,
-        );
+        let mut anomalies =
+            detector.detect_anomalies(inputs.table_values, inputs.x_bins, inputs.y_bins);
         // Keep the most severe N.
         anomalies.sort_by(|a, b| {
             b.severity

--- a/crates/libretune-core/src/agent/tiers.rs
+++ b/crates/libretune-core/src/agent/tiers.rs
@@ -160,10 +160,7 @@ mod tests {
     #[test]
     fn unknown_defaults_to_caution() {
         // A fuel-related constant that isn't in either list.
-        assert_eq!(
-            constant_safety_tier("reqFuel"),
-            ConstantSafetyTier::Caution
-        );
+        assert_eq!(constant_safety_tier("reqFuel"), ConstantSafetyTier::Caution);
         assert_eq!(
             constant_safety_tier("idleRpmTarget"),
             ConstantSafetyTier::Caution

--- a/crates/libretune-core/src/agent/tools.rs
+++ b/crates/libretune-core/src/agent/tools.rs
@@ -42,8 +42,7 @@ pub fn catalogue() -> Vec<ToolDef> {
         },
         ToolDef {
             name: tool_names::READ_TABLE.into(),
-            description: "Read the current values, axis bins, and units of one table."
-                .into(),
+            description: "Read the current values, axis bins, and units of one table.".into(),
             parameters: json!({
                 "type": "object",
                 "required": ["table_name"],
@@ -65,8 +64,7 @@ pub fn catalogue() -> Vec<ToolDef> {
         },
         ToolDef {
             name: tool_names::LIST_FEATURES.into(),
-            description: "List feature-toggle (bits) constants and their available options."
-                .into(),
+            description: "List feature-toggle (bits) constants and their available options.".into(),
             parameters: json!({"type": "object", "properties": {}}),
         },
         ToolDef {
@@ -86,8 +84,7 @@ pub fn catalogue() -> Vec<ToolDef> {
         },
         ToolDef {
             name: tool_names::TUNE_HEALTH.into(),
-            description: "Get the overall health score and per-region coverage for a table."
-                .into(),
+            description: "Get the overall health score and per-region coverage for a table.".into(),
             parameters: json!({
                 "type": "object",
                 "required": ["table_name"],

--- a/crates/libretune-core/src/ini/mod.rs
+++ b/crates/libretune-core/src/ini/mod.rs
@@ -252,9 +252,9 @@ impl EcuDefinition {
             // A table matches a candidate name if either its canonical name
             // or its map_name equals the candidate.
             let matches_any = |names: &[String]| {
-                names.iter().any(|n| {
-                    n == canonical_name || map_name == Some(n.as_str())
-                })
+                names
+                    .iter()
+                    .any(|n| n == canonical_name || map_name == Some(n.as_str()))
             };
 
             if matches_any(&ve_names) {

--- a/crates/libretune-core/src/llm/provider.rs
+++ b/crates/libretune-core/src/llm/provider.rs
@@ -43,12 +43,14 @@ pub fn build_provider(cfg: &ProviderConfig) -> Result<Box<dyn Provider>, LlmErro
         .map_err(|e| LlmError::Config(format!("failed to build HTTP client: {e}")))?;
 
     match cfg.provider.to_lowercase().as_str() {
-        "openai" | "" => Ok(Box::new(crate::llm::providers::openai::OpenAiProvider::new(
-            client,
-            cfg.base_url.clone(),
-            cfg.api_key.clone(),
-            cfg.model.clone(),
-        ))),
+        "openai" | "" => Ok(Box::new(
+            crate::llm::providers::openai::OpenAiProvider::new(
+                client,
+                cfg.base_url.clone(),
+                cfg.api_key.clone(),
+                cfg.model.clone(),
+            ),
+        )),
         "anthropic" | "claude" => Ok(Box::new(
             crate::llm::providers::anthropic::AnthropicProvider::new(
                 client,

--- a/crates/libretune-core/src/llm/providers/anthropic.rs
+++ b/crates/libretune-core/src/llm/providers/anthropic.rs
@@ -6,9 +6,7 @@
 //! results via a `tool_result` content block.
 
 use crate::llm::provider::Provider;
-use crate::llm::types::{
-    ChatRequest, ChatResponse, FinishReason, LlmError, MessageRole, ToolCall,
-};
+use crate::llm::types::{ChatRequest, ChatResponse, FinishReason, LlmError, MessageRole, ToolCall};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
@@ -20,12 +18,7 @@ pub struct AnthropicProvider {
 }
 
 impl AnthropicProvider {
-    pub fn new(
-        client: reqwest::Client,
-        base_url: String,
-        api_key: String,
-        model: String,
-    ) -> Self {
+    pub fn new(client: reqwest::Client, base_url: String, api_key: String, model: String) -> Self {
         let base_url = if base_url.is_empty() {
             "https://api.anthropic.com".to_string()
         } else {
@@ -68,14 +61,18 @@ impl Provider for AnthropicProvider {
                 }
                 MessageRole::User => messages.push(AnthropicMessage {
                     role: "user".into(),
-                    content: vec![AnthropicContent::Text { text: m.content.clone() }],
+                    content: vec![AnthropicContent::Text {
+                        text: m.content.clone(),
+                    }],
                 }),
                 MessageRole::Assistant => {
                     // Assistant message may carry tool_calls.
                     let mut blocks: Vec<AnthropicContent> =
                         Vec::with_capacity(1 + m.tool_calls.len());
                     if !m.content.is_empty() {
-                        blocks.push(AnthropicContent::Text { text: m.content.clone() });
+                        blocks.push(AnthropicContent::Text {
+                            text: m.content.clone(),
+                        });
                     }
                     for tc in &m.tool_calls {
                         blocks.push(AnthropicContent::ToolUse {
@@ -181,7 +178,9 @@ struct AnthropicMessage {
 #[derive(Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 enum AnthropicContent {
-    Text { text: String },
+    Text {
+        text: String,
+    },
     ToolUse {
         id: String,
         name: String,
@@ -213,7 +212,9 @@ struct AnthropicResponse {
 #[derive(Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 enum AnthropicResponseContent {
-    Text { text: String },
+    Text {
+        text: String,
+    },
     ToolUse {
         id: String,
         name: String,
@@ -239,7 +240,11 @@ impl AnthropicResponse {
                 AnthropicResponseContent::Text { text } => content.push_str(&text),
                 AnthropicResponseContent::ToolUse { id, name, input } => {
                     let arguments = serde_json::to_string(&input).unwrap_or_default();
-                    tool_calls.push(ToolCall { id, name, arguments });
+                    tool_calls.push(ToolCall {
+                        id,
+                        name,
+                        arguments,
+                    });
                 }
             }
         }

--- a/crates/libretune-core/src/llm/providers/google.rs
+++ b/crates/libretune-core/src/llm/providers/google.rs
@@ -5,9 +5,7 @@
 //! back as `functionCall` parts.
 
 use crate::llm::provider::Provider;
-use crate::llm::types::{
-    ChatRequest, ChatResponse, FinishReason, LlmError, MessageRole, ToolCall,
-};
+use crate::llm::types::{ChatRequest, ChatResponse, FinishReason, LlmError, MessageRole, ToolCall};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
@@ -19,12 +17,7 @@ pub struct GoogleProvider {
 }
 
 impl GoogleProvider {
-    pub fn new(
-        client: reqwest::Client,
-        base_url: String,
-        api_key: String,
-        model: String,
-    ) -> Self {
+    pub fn new(client: reqwest::Client, base_url: String, api_key: String, model: String) -> Self {
         let base_url = if base_url.is_empty() {
             "https://generativelanguage.googleapis.com".to_string()
         } else {
@@ -60,16 +53,22 @@ impl Provider for GoogleProvider {
         for m in &req.messages {
             match m.role {
                 MessageRole::System => {
-                    sys_parts.push(GeminiPart::Text { text: m.content.clone() });
+                    sys_parts.push(GeminiPart::Text {
+                        text: m.content.clone(),
+                    });
                 }
                 MessageRole::User => contents.push(GeminiContent {
                     role: "user".into(),
-                    parts: vec![GeminiPart::Text { text: m.content.clone() }],
+                    parts: vec![GeminiPart::Text {
+                        text: m.content.clone(),
+                    }],
                 }),
                 MessageRole::Assistant => {
                     let mut parts: Vec<GeminiPart> = Vec::new();
                     if !m.content.is_empty() {
-                        parts.push(GeminiPart::Text { text: m.content.clone() });
+                        parts.push(GeminiPart::Text {
+                            text: m.content.clone(),
+                        });
                     }
                     for tc in &m.tool_calls {
                         let args: serde_json::Value =

--- a/crates/libretune-core/src/llm/providers/openai.rs
+++ b/crates/libretune-core/src/llm/providers/openai.rs
@@ -4,10 +4,10 @@
 //! OpenAI-compatible endpoint (OpenRouter, Ollama's `/v1`, LM Studio, vLLM,
 //! etc.). Set [`OpenAiProvider::base_url`] to point at a compatible host.
 
+use crate::llm::provider::Provider;
 use crate::llm::types::{
     ChatRequest, ChatResponse, FinishReason, LlmError, Message, MessageRole, ToolCall,
 };
-use crate::llm::provider::Provider;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
@@ -23,12 +23,7 @@ impl OpenAiProvider {
     /// Construct. `base_url` should NOT include the trailing
     /// `/chat/completions` path (it is appended). Default for hosted OpenAI:
     /// `https://api.openai.com/v1`.
-    pub fn new(
-        client: reqwest::Client,
-        base_url: String,
-        api_key: String,
-        model: String,
-    ) -> Self {
+    pub fn new(client: reqwest::Client, base_url: String, api_key: String, model: String) -> Self {
         let base_url = if base_url.is_empty() {
             "https://api.openai.com/v1".to_string()
         } else {
@@ -79,11 +74,7 @@ impl Provider for OpenAiProvider {
         let body = OpenAiRequest {
             model: self.model.clone(),
             messages,
-            tools: if tools.is_empty() {
-                None
-            } else {
-                Some(tools)
-            },
+            tools: if tools.is_empty() { None } else { Some(tools) },
             temperature: req.temperature,
             max_tokens: req.max_tokens,
             tool_choice: if has_tools {


### PR DESCRIPTION
## Description
Three independent, previously-undiagnosed problems introduced by the AI
assistant merge (`de3e073`/`4b325b6`) that broke CI for every subsequent
PR — all confirmed live on `main` before this fix:

1. **`cargo fmt --all -- --check` failed** on ~15 files under
   `crates/libretune-core/src/{agent,llm}/*` and a few `commands/*.rs`
   files — never run through `cargo fmt` before merging.
2. **`cargo test` didn't even compile**: `demo.rs` and `tests.rs`
   construct `AppState` directly and were missing the new `agent_task`
   field, so the whole Rust test binary failed with 6x "missing field"
   errors.
3. **`SettingsDialog.test.tsx`'s "loads runtime_packet_mode..." test
   genuinely failed** (reproduced in isolation, not flaky): the dialog's
   mount effect fires several unmocked `invoke()` calls whose resolution
   could land outside any `act()` boundary, and `userEvent.click()`
   wasn't awaited.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues
N/A — found while investigating why CI kept failing on unrelated PRs
after the AI assistant merge.

## Changes Made
- Ran `cargo fmt --all` (whitespace only — diff matches fmt's own
  reported line counts, no logic changes).
- Added `agent_task: Mutex::new(None),` at all 6 `AppState` construction
  sites in `demo.rs`/`tests.rs`.
- `SettingsDialog.test.tsx`: awaited `userEvent.click(applyBtn)` and
  added two `act()`-wrapped macrotask flushes so pending state updates
  from the dialog's mount-time and Apply-time async calls settle before
  the `console.error` assertion.

## Testing
- [x] I have tested these changes locally
- [x] New and existing tests pass (`cargo test` — 21/21; `npm test` —
      full suite green; `SettingsDialog.test.tsx` specifically rerun 5x
      to confirm the fix isn't just lucky timing)
- [x] The UI works correctly with these changes — no behavior change,
      pure fix/format

## Checklist
- [x] Code compiles without errors
- [x] No new clippy warnings (`cargo clippy`)
- [x] Code is formatted (`cargo fmt`)
- [x] TypeScript compiles without errors (`npx tsc --noEmit`)
- [ ] Documentation updated if needed
- [x] Commit messages follow conventional format

## Screenshots (if applicable)
N/A — CI/test infrastructure fix, no visual/UI change.
