### PR TITLE
fix(datalogging): stop recording on definition change, drop lock befo…

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/data_logging.rs
+++ b/crates/libretune-app/src-tauri/src/commands/data_logging.rs
@@ -6,6 +6,73 @@ use std::collections::HashMap;
 
 use crate::state::AppState;
 
+/// If `logger` is actively recording, stops it and returns `true`. Pulled
+/// out of `stop_recording_on_definition_change` so the actual stop/preserve
+/// behavior is unit-testable without constructing a full `AppState`.
+fn stop_if_recording(logger: &mut DataLogger) -> bool {
+    if logger.is_recording() {
+        logger.stop();
+        true
+    } else {
+        false
+    }
+}
+
+/// Stops any in-progress recording. Call this from every place that
+/// overwrites `state.definition` (reconnect to a different ECU, load a
+/// different INI, toggle demo mode, open a different project). A running
+/// recording's channel list was resolved against the OLD definition;
+/// continuing to record against a new one can silently record all-zero
+/// columns for channels that no longer exist, or worse, real values from a
+/// same-named channel with different units/scale into the same CSV column
+/// with no indication anything changed. Fail closed instead: stop the
+/// recording (preserving what was already collected) rather than let it
+/// silently keep going against data it was never validated against.
+pub(crate) async fn stop_recording_on_definition_change(state: &AppState) {
+    let mut logger = state.data_logger.lock().await;
+    if stop_if_recording(&mut logger) {
+        eprintln!(
+            "[WARN] Data logging stopped: ECU definition changed mid-recording. \
+             Existing entries are preserved; start a new recording to continue."
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stops_an_active_recording() {
+        let mut logger = DataLogger::new(vec!["rpm".to_string()]);
+        logger.start();
+        assert!(logger.is_recording());
+
+        assert!(stop_if_recording(&mut logger));
+        assert!(!logger.is_recording());
+    }
+
+    #[test]
+    fn no_op_when_not_recording() {
+        let mut logger = DataLogger::new(vec!["rpm".to_string()]);
+        assert!(!logger.is_recording());
+
+        assert!(!stop_if_recording(&mut logger));
+        assert!(!logger.is_recording());
+    }
+
+    #[test]
+    fn preserves_already_recorded_entries() {
+        let mut logger = DataLogger::new(vec!["rpm".to_string()]);
+        logger.start();
+        logger.record(vec![1234.0]);
+        assert_eq!(logger.entry_count(), 1);
+
+        stop_if_recording(&mut logger);
+        assert_eq!(logger.entry_count(), 1);
+    }
+}
+
 #[derive(Serialize)]
 pub struct LoggingStatus {
     is_recording: bool,
@@ -141,42 +208,51 @@ pub async fn clear_log(state: tauri::State<'_, AppState>) -> Result<(), String> 
 
 #[tauri::command]
 pub async fn save_log(state: tauri::State<'_, AppState>, path: String) -> Result<(), String> {
-    let logger = state.data_logger.lock().await;
-    let channels = logger.channels();
+    // Build the CSV string while holding the lock (needed to read the
+    // logger), then drop it before the blocking disk write below — holding
+    // it across std::fs::write stalls every other data-logging command
+    // (stop/status/clear, or a UI status poll) for however long the write
+    // takes.
+    let csv = {
+        let logger = state.data_logger.lock().await;
+        let channels = logger.channels();
 
-    // Skip columns that are zero for the entire log: an INI defines far more
-    // output channels than the ECU (or demo simulator) actually streams, and
-    // those never-seen channels are logged as 0.0. Writing them out buries
-    // the real data in hundreds of dead columns.
-    let mut has_data = vec![false; channels.len()];
-    for entry in logger.entries() {
-        for (i, &val) in entry.values.iter().enumerate() {
-            if val != 0.0 {
-                has_data[i] = true;
+        // Skip columns that are zero for the entire log: an INI defines far
+        // more output channels than the ECU (or demo simulator) actually
+        // streams, and those never-seen channels are logged as 0.0. Writing
+        // them out buries the real data in hundreds of dead columns.
+        let mut has_data = vec![false; channels.len()];
+        for entry in logger.entries() {
+            for (i, &val) in entry.values.iter().enumerate() {
+                if val != 0.0 {
+                    has_data[i] = true;
+                }
             }
         }
-    }
 
-    let mut csv = String::new();
-    csv.push_str("Time (ms)");
-    for (i, channel) in channels.iter().enumerate() {
-        if has_data[i] {
-            csv.push(',');
-            csv.push_str(channel);
-        }
-    }
-    csv.push('\n');
-
-    for entry in logger.entries() {
-        csv.push_str(&format!("{}", entry.timestamp.as_millis()));
-        for (i, val) in entry.values.iter().enumerate() {
+        let mut csv = String::new();
+        csv.push_str("Time (ms)");
+        for (i, channel) in channels.iter().enumerate() {
             if has_data[i] {
                 csv.push(',');
-                csv.push_str(&format!("{:.4}", val));
+                csv.push_str(channel);
             }
         }
         csv.push('\n');
-    }
+
+        for entry in logger.entries() {
+            csv.push_str(&format!("{}", entry.timestamp.as_millis()));
+            for (i, val) in entry.values.iter().enumerate() {
+                if has_data[i] {
+                    csv.push(',');
+                    csv.push_str(&format!("{:.4}", val));
+                }
+            }
+            csv.push('\n');
+        }
+
+        csv
+    };
 
     std::fs::write(&path, csv).map_err(|e| format!("Failed to save log: {}", e))?;
 

--- a/crates/libretune-app/src-tauri/src/commands/demo.rs
+++ b/crates/libretune-app/src-tauri/src/commands/demo.rs
@@ -150,6 +150,7 @@ pub(crate) async fn apply_demo_enable(
         let mut def_guard = state.definition.lock().await;
         *def_guard = Some(def);
     }
+    crate::commands::data_logging::stop_recording_on_definition_change(state).await;
 
     // Set demo mode flag
     {

--- a/crates/libretune-app/src-tauri/src/commands/load_ini.rs
+++ b/crates/libretune-app/src-tauri/src/commands/load_ini.rs
@@ -45,6 +45,12 @@ pub async fn load_ini(
             *guard = Some(def);
             drop(guard);
 
+            // An in-progress recording's channels were resolved against the
+            // OLD definition — stop it rather than silently mixing
+            // incompatible data into the same log. See
+            // stop_recording_on_definition_change for details.
+            crate::commands::data_logging::stop_recording_on_definition_change(&state).await;
+
             // Cache output channels to avoid repeated cloning in realtime streaming loop
             let mut channels_cache_guard = state.cached_output_channels.lock().await;
             *channels_cache_guard = Some(Arc::new(def_clone.output_channels.clone()));

--- a/crates/libretune-app/src-tauri/src/commands/project_lifecycle.rs
+++ b/crates/libretune-app/src-tauri/src/commands/project_lifecycle.rs
@@ -38,6 +38,7 @@ pub async fn create_project(
     let mut def_guard = state.definition.lock().await;
     *def_guard = Some(def.clone());
     drop(def_guard);
+    crate::commands::data_logging::stop_recording_on_definition_change(&state).await;
 
     // Initialize TuneCache from definition
     let cache = TuneCache::from_definition(&def);
@@ -252,6 +253,7 @@ pub async fn open_project(
     let def_clone = def.clone();
     *def_guard = Some(def);
     drop(def_guard);
+    crate::commands::data_logging::stop_recording_on_definition_change(&state).await;
 
     // Save project path before moving project into mutex
     let project_path = project.path.clone();

--- a/crates/libretune-app/src-tauri/src/commands/update_project_ini.rs
+++ b/crates/libretune-app/src-tauri/src/commands/update_project_ini.rs
@@ -38,6 +38,7 @@ pub async fn update_project_ini(
     let def_clone = new_def.clone();
     *def_guard = Some(new_def);
     drop(def_guard);
+    crate::commands::data_logging::stop_recording_on_definition_change(&state).await;
 
     // Update settings with new INI path
     let mut settings = load_settings(&app);


### PR DESCRIPTION
## Description
Two independent issues found while auditing the datalogging subsystem
(same audit approach that found #97's AutoTune bug):

1. **Correctness — silent data corruption, no prior guard at all**: a
   recording's channel list is resolved once, at `start_logging` time,
   from whatever ECU definition is loaded then. Nothing that changes
   `state.definition` afterward — reconnecting to a different ECU, loading
   a different INI, opening a different project, toggling demo mode —
   ever stopped or invalidated an active recording. `feed_data_logger`
   keeps matching the old channel names against the new definition's data
   every tick: channels missing from the new definition silently record
   as `0.0`, and same-named channels with different units/scale (e.g. MAP
   in kPa vs. PSI) get real but semantically incompatible values appended
   into the same CSV column with the same header and no discontinuity
   marker. Same failure shape as the AutoTune stale-session bug fixed in
   #97, just with no partial guard at all beforehand.
2. **Responsiveness**: `save_log` performed a synchronous `std::fs::write`
   while still holding the `data_logger` lock, stalling any other
   data-logging command (stop/status/clear, or a UI status poll) for
   however long the write takes.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues
N/A — found during a follow-up concurrency/correctness audit of the
datalogging subsystem, not tied to a filed issue.

## Changes Made
- Added `stop_recording_on_definition_change()`, called from every site
  that overwrites `state.definition` (`load_ini`, `create_project`,
  `open_project`, `update_project_ini`, demo mode enable). Fails closed:
  stops the recording (preserving everything already collected) rather
  than let it silently keep going against data it was never validated
  against.
- `save_log` now builds the CSV string inside a scoped block, drops the
  `data_logger` lock, then writes to disk.

## Testing
- [x] I have tested these changes locally
- [x] New and existing tests pass (`cargo test` — 24/24, including 3 new
      unit tests covering `stop_if_recording`'s core behavior directly)
- [ ] The UI works correctly with these changes — not manually verified
      against a live recording session; covered by unit tests instead

## Checklist
- [x] Code compiles without errors
- [x] No new clippy warnings (`cargo clippy`)
- [x] Code is formatted (`cargo fmt`)
- [x] TypeScript compiles without errors (`npx tsc --noEmit`) — no
      frontend changes
- [ ] Documentation updated if needed
- [x] Commit messages follow conventional format

## Screenshots (if applicable)
N/A — internal correctness/concurrency fix, no visual/UI change.
