### PR TITLE
fix(dashboard): infinite validate_dashboard loop starved Settings Apply/OK

### DIFF
--- a/crates/libretune-app/src/components/dashboards/hooks/useGaugeRangeSync.ts
+++ b/crates/libretune-app/src/components/dashboards/hooks/useGaugeRangeSync.ts
@@ -75,6 +75,16 @@ export function useGaugeRangeSync(
     }
   }, [dashFile, setDashFile]);
 
+  // Keep a ref to the latest sync fn / flags so the INI-change effect below can
+  // call them WITHOUT listing them as deps. Listing `dashFile`/`syncGaugeRanges`
+  // as deps there creates an infinite loop: syncing creates a new `dashFile`
+  // object → recreates `syncGaugeRanges` → retriggers the effect → re-sync...
+  // (the trigger should be `syncToken` ONLY).
+  const syncStateRef = useRef({ syncGaugeRanges, autoSyncEnabled, dashFile });
+  useEffect(() => {
+    syncStateRef.current = { syncGaugeRanges, autoSyncEnabled, dashFile };
+  });
+
   // Auto-sync once on initial dashboard load
   useEffect(() => {
     if (!dashFile) return;
@@ -84,13 +94,16 @@ export function useGaugeRangeSync(
     syncGaugeRanges();
   }, [dashFile, syncGaugeRanges, autoSyncEnabled]);
 
-  // Auto-sync on INI/definition changes
+  // Auto-sync on INI/definition changes. Depends on `syncToken` ONLY (the event
+  // counter); reads the latest sync fn/flags/dashFile from the ref so it doesn't
+  // re-run every time syncing mutates `dashFile`.
   useEffect(() => {
-    if (!dashFile) return;
-    if (!autoSyncEnabled) return;
     if (syncToken === 0) return;
-    syncGaugeRanges();
-  }, [syncToken, dashFile, syncGaugeRanges, autoSyncEnabled]);
+    const { syncGaugeRanges: doSync, autoSyncEnabled: enabled, dashFile: file } = syncStateRef.current;
+    if (!file) return;
+    if (!enabled) return;
+    doSync();
+  }, [syncToken]);
 
   // Load auto-sync preference once
   useEffect(() => {


### PR DESCRIPTION
## Problem

Clicking **Apply** (or **OK**) in the Settings dialog greys out both buttons permanently, and the only way to exit the dialog is the window's **X** button.

## Root cause

`useDashboardValidation` was firing `validate_dashboard` in an **infinite loop** whenever a dashboard was loaded with gauge-range auto-sync enabled. This saturated the Tauri IPC channel, so the ~30 `await invoke('update_setting')` calls in `SettingsDialog.saveSettings()` never resolved — leaving `saveStatus` stuck at `'saving'` (which disables both buttons) forever.

The loop was in `useGaugeRangeSync` (`hooks/useGaugeRangeSync.ts`). Its INI/definition-change effect listed:

```ts
}, [syncToken, dashFile, syncGaugeRanges, autoSyncEnabled]);
```

`syncGaugeRanges` is a `useCallback` whose dependency is `dashFile`. Syncing creates a **new** `dashFile` object (`setDashFile({...dashFile, ...})`), which recreates `syncGaugeRanges`, which re-triggers the effect — and since `syncToken` stays `> 0` after a `definition:loaded`/`ini:changed` event, the effect re-syncs every time → infinite loop:

```
event → syncToken=1 → sync → new dashFile → new syncGaugeRanges
       → effect re-runs (syncToken still 1) → sync → new dashFile → ...
```

This was a **pre-existing** bug (not introduced by #101), but it's what made Apply unusable.

## Fix

Decouple the INI-change effect's trigger from its payload. The effect should re-run only when `syncToken` changes (the actual event signal); the latest `syncGaugeRanges`/`autoSyncEnabled`/`dashFile` are read from a ref instead of being deps:

```ts
const syncStateRef = useRef({ syncGaugeRanges, autoSyncEnabled, dashFile });
useEffect(() => { syncStateRef.current = { syncGaugeRanges, autoSyncEnabled, dashFile }; });

useEffect(() => {
  if (syncToken === 0) return;
  const { syncGaugeRanges: doSync, autoSyncEnabled: enabled, dashFile: file } = syncStateRef.current;
  if (!file || !enabled) return;
  doSync();
}, [syncToken]); // ← syncToken ONLY
```

Now syncing mutates state without re-triggering itself.

## Verification

- Confirmed at runtime: the `validate_dashboard` spam that previously ran continuously **stops** after the fix (only the expected 2–3 initial calls remain).
- `npm run typecheck` — passes
- `npx vitest run` — 17 files / 106 tests pass

## Note

This is the actual fix for the Apply/OK hang reported against #101. (The earlier `try/finally` guard in `saveSettings` protected against thrown errors but could not help here because the `await`s were genuinely not resolving due to the backend starvation.)
