### PR TITLE
fix(plugin_system): wire WASM host-function API and add permission co…

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/wasm_plugin.rs
+++ b/crates/libretune-app/src-tauri/src/commands/wasm_plugin.rs
@@ -5,10 +5,27 @@
 
 use crate::state::AppState;
 use libretune_core::plugin_system::{
-    PluginConfig as WasmPluginConfig, PluginManager as WasmPluginManager,
-    PluginManifest as WasmPluginManifest,
+    Permission as WasmPermission, PluginConfig as WasmPluginConfig,
+    PluginManager as WasmPluginManager, PluginManifest as WasmPluginManifest,
 };
 use serde::{Deserialize, Serialize};
+
+/// Parse the frontend's string permission names (e.g. from consent-dialog
+/// checkboxes) into typed [`WasmPermission`]s, ignoring anything unrecognized
+/// rather than failing the whole load — an unrecognized name just can't be
+/// granted, which is the safe default.
+fn parse_permissions(names: &[String]) -> Vec<WasmPermission> {
+    names
+        .iter()
+        .filter_map(|n| match n.as_str() {
+            "ReadTables" => Some(WasmPermission::ReadTables),
+            "WriteConstants" => Some(WasmPermission::WriteConstants),
+            "SubscribeChannels" => Some(WasmPermission::SubscribeChannels),
+            "ExecuteActions" => Some(WasmPermission::ExecuteActions),
+            _ => None,
+        })
+        .collect()
+}
 
 /// Serializable plugin info returned to the frontend.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -35,13 +52,20 @@ fn new_plugin_manager() -> WasmPluginManager {
 ///
 /// # Arguments
 /// * `path` - Path to the .wasm plugin file
-/// * `manifest_json` - JSON string with plugin manifest
+/// * `manifest_json` - JSON string with plugin manifest (the permissions the
+///   plugin is *requesting*)
+/// * `approved_permissions` - The permission names the user actually
+///   approved (e.g. via a consent dialog listing the manifest's request).
+///   Only permissions present in both this list and the manifest are
+///   granted — a manifest can never self-grant a permission the user didn't
+///   check.
 ///
 /// Returns: Plugin name on success
 #[tauri::command]
 pub async fn load_wasm_plugin(
     path: String,
     manifest_json: String,
+    approved_permissions: Vec<String>,
     state: tauri::State<'_, AppState>,
 ) -> Result<String, String> {
     let manifest: WasmPluginManifest = serde_json::from_str(&manifest_json)
@@ -52,10 +76,12 @@ pub async fn load_wasm_plugin(
         return Err(format!("WASM file not found: {}", path));
     }
 
+    let approved = parse_permissions(&approved_permissions);
+
     let mut pm_guard = state.wasm_plugin_manager.lock().await;
     let pm = pm_guard.get_or_insert_with(new_plugin_manager);
 
-    let name = pm.load_plugin(manifest, wasm_path)?;
+    let name = pm.load_plugin(manifest, wasm_path, &approved)?;
     Ok(name)
 }
 
@@ -90,7 +116,11 @@ pub async fn list_wasm_plugins(
                                 m.version.clone(),
                                 m.description.clone(),
                                 m.author.clone(),
-                                m.permissions.iter().map(|p| format!("{:?}", p)).collect(),
+                                plugin
+                                    .granted_permissions()
+                                    .iter()
+                                    .map(|p| format!("{:?}", p))
+                                    .collect(),
                             )
                         } else {
                             (String::new(), String::new(), String::new(), vec![])
@@ -145,8 +175,8 @@ pub async fn get_wasm_plugin_info(
         description: manifest.description.clone(),
         author: manifest.author.clone(),
         state: format!("{:?}", stats.state),
-        permissions: manifest
-            .permissions
+        permissions: plugin
+            .granted_permissions()
             .iter()
             .map(|p| format!("{:?}", p))
             .collect(),

--- a/crates/libretune-app/src/components/PluginPanel.css
+++ b/crates/libretune-app/src/components/PluginPanel.css
@@ -377,6 +377,62 @@
   flex: 1;
 }
 
+.plugin-consent-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(15, 23, 42, 0.75);
+  backdrop-filter: blur(4px);
+}
+
+.plugin-consent-dialog {
+  width: min(420px, 90vw);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.5rem;
+  background: rgb(15, 23, 42);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 12px;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
+}
+
+.plugin-consent-dialog h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  color: var(--text-primary);
+  word-break: break-word;
+}
+
+.plugin-consent-warning {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  line-height: 1.4;
+}
+
+.plugin-consent-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.75rem;
+  background: rgba(30, 41, 59, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.1);
+  border-radius: 6px;
+}
+
+.plugin-consent-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
 /* Responsive */
 @media (max-width: 768px) {
   .plugin-panel {

--- a/crates/libretune-app/src/components/PluginPanel.tsx
+++ b/crates/libretune-app/src/components/PluginPanel.tsx
@@ -18,11 +18,15 @@ interface PluginPanelProps {
   isConnected: boolean;
 }
 
+const ALL_PERMISSIONS = ["ReadTables", "WriteConstants", "SubscribeChannels", "ExecuteActions"];
+
 export const PluginPanel: React.FC<PluginPanelProps> = ({ isConnected }) => {
   const [plugins, setPlugins] = useState<Plugin[]>([]);
   const [loading, setLoading] = useState(false);
   const [selectedPlugin, setSelectedPlugin] = useState<string | null>(null);
   const [showPermissions, setShowPermissions] = useState(false);
+  const [pendingPlugin, setPendingPlugin] = useState<{ path: string; name: string } | null>(null);
+  const [consentedPermissions, setConsentedPermissions] = useState<Set<string>>(new Set());
 
   // Load list of plugins
   const loadPlugins = useCallback(async () => {
@@ -42,7 +46,9 @@ export const PluginPanel: React.FC<PluginPanelProps> = ({ isConnected }) => {
     loadPlugins();
   }, [loadPlugins]);
 
-  // Load plugin from file
+  // Pick a plugin file, then open the permission-consent dialog instead of
+  // loading immediately — permissions must be explicitly approved here, not
+  // auto-granted from a self-declared manifest.
   const handleLoadPlugin = useCallback(async () => {
     try {
       const files = await open({
@@ -53,22 +59,59 @@ export const PluginPanel: React.FC<PluginPanelProps> = ({ isConnected }) => {
       });
 
       if (files && !Array.isArray(files)) {
-        // Create a default manifest for the plugin based on filename
         const filename = (files as string).split("/").pop()?.split("\\").pop()?.replace(".wasm", "") || "unknown";
-        const manifest = JSON.stringify({
-          name: filename,
-          version: "1.0.0",
-          description: `Plugin loaded from ${filename}.wasm`,
-          author: "Unknown",
-          permissions: ["ReadTables"],
-        });
-        await invoke("load_wasm_plugin", { path: files, manifestJson: manifest });
-        await loadPlugins();
+        setConsentedPermissions(new Set());
+        setPendingPlugin({ path: files as string, name: filename });
       }
     } catch (error) {
       console.error("Failed to load plugin:", error);
     }
-  }, [loadPlugins]);
+  }, []);
+
+  const togglePendingPermission = useCallback((perm: string) => {
+    setConsentedPermissions((prev) => {
+      const next = new Set(prev);
+      if (next.has(perm)) {
+        next.delete(perm);
+      } else {
+        next.add(perm);
+      }
+      return next;
+    });
+  }, []);
+
+  const cancelPendingPlugin = useCallback(() => {
+    setPendingPlugin(null);
+    setConsentedPermissions(new Set());
+  }, []);
+
+  // User has reviewed the requested permissions and approved a subset (or
+  // all, or none) of them — only the checked ones are ever granted, on the
+  // Rust side, regardless of what the manifest claims to want.
+  const confirmPendingPlugin = useCallback(async () => {
+    if (!pendingPlugin) return;
+    try {
+      const approved = Array.from(consentedPermissions);
+      const manifest = JSON.stringify({
+        name: pendingPlugin.name,
+        version: "1.0.0",
+        description: `Plugin loaded from ${pendingPlugin.name}.wasm`,
+        author: "Unknown",
+        permissions: approved,
+      });
+      await invoke("load_wasm_plugin", {
+        path: pendingPlugin.path,
+        manifestJson: manifest,
+        approvedPermissions: approved,
+      });
+      await loadPlugins();
+    } catch (error) {
+      console.error("Failed to load plugin:", error);
+    } finally {
+      setPendingPlugin(null);
+      setConsentedPermissions(new Set());
+    }
+  }, [pendingPlugin, consentedPermissions, loadPlugins]);
 
   // Unload plugin
   const handleUnloadPlugin = useCallback(
@@ -272,6 +315,43 @@ export const PluginPanel: React.FC<PluginPanelProps> = ({ isConnected }) => {
           </div>
         )}
       </div>
+
+      {pendingPlugin && (
+        <div className="plugin-consent-overlay" role="dialog" aria-modal="true">
+          <div className="plugin-consent-dialog">
+            <h3>Grant permissions to "{pendingPlugin.name}"?</h3>
+            <p className="plugin-consent-warning">
+              This plugin runs sandboxed WebAssembly code. Check only the capabilities you want
+              to allow — anything left unchecked will be denied, regardless of what the plugin
+              requests.
+            </p>
+            <div className="plugin-consent-list">
+              {ALL_PERMISSIONS.map((perm) => {
+                const { label, Icon } = getPermissionDisplay(perm);
+                return (
+                  <label key={perm} className="plugin-consent-item">
+                    <input
+                      type="checkbox"
+                      checked={consentedPermissions.has(perm)}
+                      onChange={() => togglePendingPermission(perm)}
+                    />
+                    {Icon && <Icon size={14} aria-hidden />}
+                    <span>{label}</span>
+                  </label>
+                );
+              })}
+            </div>
+            <div className="plugin-actions">
+              <button className="plugin-button plugin-button-secondary" onClick={cancelPendingPlugin}>
+                Cancel
+              </button>
+              <button className="plugin-button plugin-button-primary" onClick={confirmPendingPlugin}>
+                Load Plugin
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/crates/libretune-core/src/plugin_api.rs
+++ b/crates/libretune-core/src/plugin_api.rs
@@ -24,15 +24,6 @@ impl PluginApiContext {
             plugin_manager: Mutex::new(plugin_manager),
         }
     }
-
-    /// Check if plugin has permission (non-panicking).
-    fn check_permission(&self, plugin_name: &str, perm: Permission) -> bool {
-        if let Ok(manager) = self.plugin_manager.lock() {
-            manager.check_permission(plugin_name, perm)
-        } else {
-            false
-        }
-    }
 }
 
 /// Plugin API response for any function call.
@@ -164,21 +155,19 @@ impl PluginLogMessage {
 /// Requires `ReadTables` permission.
 ///
 /// # Arguments
-/// * `plugin_name` - Name of calling plugin
+/// * `granted` - Permissions granted to the calling plugin instance
 /// * `table_name` - Name of table to read
 /// * `row`, `col` - Cell coordinates (-1 for header)
 ///
 /// # Returns
 /// ApiResponse with value as bytes or error
 pub fn api_get_table_data(
-    _ctx: &PluginApiContext,
-    plugin_name: &str,
+    granted: &[Permission],
     _table_name: &str,
     _row: i32,
     _col: i32,
 ) -> ApiResponse {
-    // Permission check
-    if !_ctx.check_permission(plugin_name, Permission::ReadTables) {
+    if !granted.contains(&Permission::ReadTables) {
         return ApiResponse::permission_denied("ReadTables");
     }
 
@@ -193,18 +182,13 @@ pub fn api_get_table_data(
 /// Requires `ReadTables` permission (constants are table-like data).
 ///
 /// # Arguments
-/// * `plugin_name` - Name of calling plugin
+/// * `granted` - Permissions granted to the calling plugin instance
 /// * `constant_name` - Name of constant
 ///
 /// # Returns
 /// ApiResponse with value as bytes or error
-pub fn api_get_constant(
-    _ctx: &PluginApiContext,
-    plugin_name: &str,
-    _constant_name: &str,
-) -> ApiResponse {
-    // Permission check
-    if !_ctx.check_permission(plugin_name, Permission::ReadTables) {
+pub fn api_get_constant(granted: &[Permission], _constant_name: &str) -> ApiResponse {
+    if !granted.contains(&Permission::ReadTables) {
         return ApiResponse::permission_denied("ReadTables");
     }
 
@@ -218,20 +202,18 @@ pub fn api_get_constant(
 /// Requires `WriteConstants` permission.
 ///
 /// # Arguments
-/// * `plugin_name` - Name of calling plugin
+/// * `granted` - Permissions granted to the calling plugin instance
 /// * `constant_name` - Name of constant
 /// * `value_bytes` - Raw bytes to write
 ///
 /// # Returns
 /// ApiResponse with success or error
 pub fn api_set_constant(
-    _ctx: &PluginApiContext,
-    plugin_name: &str,
+    granted: &[Permission],
     _constant_name: &str,
     _value_bytes: &[u8],
 ) -> ApiResponse {
-    // Permission check
-    if !_ctx.check_permission(plugin_name, Permission::WriteConstants) {
+    if !granted.contains(&Permission::WriteConstants) {
         return ApiResponse::permission_denied("WriteConstants");
     }
 
@@ -245,18 +227,13 @@ pub fn api_set_constant(
 /// Requires `SubscribeChannels` permission.
 ///
 /// # Arguments
-/// * `plugin_name` - Name of calling plugin
+/// * `granted` - Permissions granted to the calling plugin instance
 /// * `channel_name` - Name of channel (e.g., "RPM", "AFR")
 ///
 /// # Returns
 /// ApiResponse with channel ID or error
-pub fn api_subscribe_channel(
-    _ctx: &PluginApiContext,
-    plugin_name: &str,
-    _channel_name: &str,
-) -> ApiResponse {
-    // Permission check
-    if !_ctx.check_permission(plugin_name, Permission::SubscribeChannels) {
+pub fn api_subscribe_channel(granted: &[Permission], _channel_name: &str) -> ApiResponse {
+    if !granted.contains(&Permission::SubscribeChannels) {
         return ApiResponse::permission_denied("SubscribeChannels");
     }
 
@@ -271,23 +248,38 @@ pub fn api_subscribe_channel(
 /// Requires `SubscribeChannels` permission.
 ///
 /// # Arguments
-/// * `plugin_name` - Name of calling plugin
+/// * `granted` - Permissions granted to the calling plugin instance
 /// * `channel_id` - ID from subscribe call
 ///
 /// # Returns
 /// ApiResponse with current value or error
-pub fn api_get_channel_value(
-    _ctx: &PluginApiContext,
-    plugin_name: &str,
-    _channel_id: u32,
-) -> ApiResponse {
-    // Permission check
-    if !_ctx.check_permission(plugin_name, Permission::SubscribeChannels) {
+pub fn api_get_channel_value(granted: &[Permission], _channel_id: u32) -> ApiResponse {
+    if !granted.contains(&Permission::SubscribeChannels) {
         return ApiResponse::permission_denied("SubscribeChannels");
     }
 
     // Implementation would fetch current value
     ApiResponse::ok(vec![0u8; 4]) // f32 value as bytes
+}
+
+/// Host function: Execute action sequence.
+///
+/// # Permissions
+/// Requires `ExecuteActions` permission.
+///
+/// # Arguments
+/// * `granted` - Permissions granted to the calling plugin instance
+/// * `action_json` - JSON-encoded action data
+///
+/// # Returns
+/// ApiResponse with execution result or error
+pub fn api_execute_action(granted: &[Permission], _action_json: &str) -> ApiResponse {
+    if !granted.contains(&Permission::ExecuteActions) {
+        return ApiResponse::permission_denied("ExecuteActions");
+    }
+
+    // Implementation would parse JSON and execute action
+    ApiResponse::ok_empty()
 }
 
 /// Host function: Log a message from plugin.
@@ -299,7 +291,6 @@ pub fn api_get_channel_value(
 /// * `level` - Log level (0=Debug, 1=Info, 2=Warn, 3=Error)
 /// * `message` - Message text
 pub fn api_log_message(
-    _ctx: &PluginApiContext,
     plugin_name: impl Into<String>,
     level: i32,
     message: impl Into<String>,
@@ -310,31 +301,6 @@ pub fn api_log_message(
     // In real implementation, would write to log file or channel
     eprintln!("{}", log_msg.format_display());
 
-    ApiResponse::ok_empty()
-}
-
-/// Host function: Execute action sequence.
-///
-/// # Permissions
-/// Requires `ExecuteActions` permission.
-///
-/// # Arguments
-/// * `plugin_name` - Name of calling plugin
-/// * `action_json` - JSON-encoded action data
-///
-/// # Returns
-/// ApiResponse with execution result or error
-pub fn api_execute_action(
-    _ctx: &PluginApiContext,
-    plugin_name: &str,
-    _action_json: &str,
-) -> ApiResponse {
-    // Permission check
-    if !_ctx.check_permission(plugin_name, Permission::ExecuteActions) {
-        return ApiResponse::permission_denied("ExecuteActions");
-    }
-
-    // Implementation would parse JSON and execute action
     ApiResponse::ok_empty()
 }
 
@@ -461,51 +427,88 @@ mod tests {
 
     #[test]
     fn test_api_get_table_data_no_permission() {
-        let ctx = create_test_context();
-        let resp = api_get_table_data(&ctx, "unknown_plugin", "veTable1", 0, 0);
+        let resp = api_get_table_data(&[], "veTable1", 0, 0);
         assert!(!resp.success);
         assert!(resp.error.contains("Permission denied"));
     }
 
     #[test]
+    fn test_api_get_table_data_with_permission() {
+        let resp = api_get_table_data(&[Permission::ReadTables], "veTable1", 0, 0);
+        assert!(resp.success);
+        assert_eq!(resp.data.len(), 4);
+    }
+
+    #[test]
     fn test_api_get_constant_no_permission() {
-        let ctx = create_test_context();
-        let resp = api_get_constant(&ctx, "unknown_plugin", "rpm");
+        let resp = api_get_constant(&[], "rpm");
         assert!(!resp.success);
     }
 
     #[test]
+    fn test_api_get_constant_with_permission() {
+        let resp = api_get_constant(&[Permission::ReadTables], "rpm");
+        assert!(resp.success);
+    }
+
+    #[test]
     fn test_api_set_constant_no_permission() {
-        let ctx = create_test_context();
-        let resp = api_set_constant(&ctx, "unknown_plugin", "rpm", &[0, 0, 0, 0]);
+        let resp = api_set_constant(&[], "rpm", &[0, 0, 0, 0]);
+        assert!(!resp.success);
+    }
+
+    #[test]
+    fn test_api_set_constant_with_permission() {
+        let resp = api_set_constant(&[Permission::WriteConstants], "rpm", &[0, 0, 0, 0]);
+        assert!(resp.success);
+    }
+
+    #[test]
+    fn test_api_set_constant_read_permission_insufficient() {
+        // ReadTables alone must not satisfy a WriteConstants check.
+        let resp = api_set_constant(&[Permission::ReadTables], "rpm", &[0, 0, 0, 0]);
         assert!(!resp.success);
     }
 
     #[test]
     fn test_api_subscribe_channel_no_permission() {
-        let ctx = create_test_context();
-        let resp = api_subscribe_channel(&ctx, "unknown_plugin", "RPM");
+        let resp = api_subscribe_channel(&[], "RPM");
         assert!(!resp.success);
+    }
+
+    #[test]
+    fn test_api_subscribe_channel_with_permission() {
+        let resp = api_subscribe_channel(&[Permission::SubscribeChannels], "RPM");
+        assert!(resp.success);
     }
 
     #[test]
     fn test_api_get_channel_value_no_permission() {
-        let ctx = create_test_context();
-        let resp = api_get_channel_value(&ctx, "unknown_plugin", 0);
+        let resp = api_get_channel_value(&[], 0);
         assert!(!resp.success);
+    }
+
+    #[test]
+    fn test_api_get_channel_value_with_permission() {
+        let resp = api_get_channel_value(&[Permission::SubscribeChannels], 0);
+        assert!(resp.success);
     }
 
     #[test]
     fn test_api_execute_action_no_permission() {
-        let ctx = create_test_context();
-        let resp = api_execute_action(&ctx, "unknown_plugin", "{}");
+        let resp = api_execute_action(&[], "{}");
         assert!(!resp.success);
     }
 
     #[test]
+    fn test_api_execute_action_with_permission() {
+        let resp = api_execute_action(&[Permission::ExecuteActions], "{}");
+        assert!(resp.success);
+    }
+
+    #[test]
     fn test_api_log_message_always_allowed() {
-        let ctx = create_test_context();
-        let resp = api_log_message(&ctx, "test_plugin", 1, "test log");
+        let resp = api_log_message("test_plugin", 1, "test log");
         assert!(resp.success);
     }
 

--- a/crates/libretune-core/src/plugin_system.rs
+++ b/crates/libretune-core/src/plugin_system.rs
@@ -21,10 +21,257 @@
 //!
 //! All API calls check permissions before executing.
 
+use crate::plugin_api;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::Path;
-use wasmtime::{Engine, Instance, Linker, Module, Store};
+use wasmtime::{Caller, Engine, Extern, Instance, Linker, Memory, Module, Store};
+
+/// Maximum length (bytes) accepted for a guest-supplied string argument
+/// (table/constant/channel name, action JSON). Guards against a malicious or
+/// buggy plugin claiming an absurd `len` and forcing a huge host allocation.
+const MAX_GUEST_STRING_LEN: usize = 64 * 1024;
+
+/// Sentinel return codes shared by every host function. Plugin-side glue code
+/// (bindgen or hand-written) should treat any negative value as failure.
+mod host_result {
+    /// Call succeeded.
+    pub const OK: i32 = 0;
+    /// Calling plugin lacks the permission this call requires.
+    pub const PERMISSION_DENIED: i32 = -1;
+    /// Guest pointer/length was invalid (OOB, bad UTF-8, no memory export).
+    pub const INVALID_ARGS: i32 = -2;
+}
+
+/// Per-instance state attached to the plugin's [`wasmtime::Store`]. This is
+/// what host functions consult to know which plugin is calling and what it
+/// was actually granted — never the shared [`PluginManager`], so a host
+/// function invoked from inside a WASM call can never re-enter a lock held by
+/// whatever is currently driving that plugin's execution.
+struct PluginHostState {
+    plugin_name: String,
+    permissions: Vec<Permission>,
+}
+
+/// Fetch the guest's exported linear memory, or an [`host_result::INVALID_ARGS`] error.
+fn get_memory(caller: &mut Caller<'_, PluginHostState>) -> Result<Memory, i32> {
+    match caller.get_export("memory") {
+        Some(Extern::Memory(mem)) => Ok(mem),
+        _ => Err(host_result::INVALID_ARGS),
+    }
+}
+
+/// Read a UTF-8 string out of the guest's linear memory at `ptr`/`len`,
+/// bounds- and size-checked so a hostile plugin can't force an OOB read or an
+/// unbounded host allocation.
+fn read_guest_string(
+    caller: &mut Caller<'_, PluginHostState>,
+    ptr: i32,
+    len: i32,
+) -> Result<String, i32> {
+    if ptr < 0 || len < 0 || len as usize > MAX_GUEST_STRING_LEN {
+        return Err(host_result::INVALID_ARGS);
+    }
+    let memory = get_memory(caller)?;
+    let mut buf = vec![0u8; len as usize];
+    memory
+        .read(&caller, ptr as usize, &mut buf)
+        .map_err(|_| host_result::INVALID_ARGS)?;
+    String::from_utf8(buf).map_err(|_| host_result::INVALID_ARGS)
+}
+
+/// Write raw bytes into the guest's linear memory at `ptr`.
+fn write_guest_bytes(
+    caller: &mut Caller<'_, PluginHostState>,
+    ptr: i32,
+    data: &[u8],
+) -> Result<(), i32> {
+    if ptr < 0 {
+        return Err(host_result::INVALID_ARGS);
+    }
+    let memory = get_memory(caller)?;
+    memory
+        .write(&mut *caller, ptr as usize, data)
+        .map_err(|_| host_result::INVALID_ARGS)
+}
+
+/// Register every host function a plugin may import under the `"env"`
+/// module. Each one checks the calling plugin's *own* granted permissions
+/// (from [`PluginHostState`], fixed at load time) before doing anything —
+/// this is the boundary [`crate::plugin_api`]'s permission checks actually
+/// protect once a plugin can call back into the host at all.
+fn register_host_functions(linker: &mut Linker<PluginHostState>) -> Result<(), String> {
+    linker
+        .func_wrap(
+            "env",
+            "log_message",
+            |mut caller: Caller<'_, PluginHostState>,
+             level: i32,
+             msg_ptr: i32,
+             msg_len: i32|
+             -> i32 {
+                let message = match read_guest_string(&mut caller, msg_ptr, msg_len) {
+                    Ok(s) => s,
+                    Err(code) => return code,
+                };
+                let plugin_name = caller.data().plugin_name.clone();
+                let resp = plugin_api::api_log_message(plugin_name, level, message);
+                if resp.success {
+                    host_result::OK
+                } else {
+                    host_result::INVALID_ARGS
+                }
+            },
+        )
+        .map_err(|e| format!("Failed to register log_message: {}", e))?;
+
+    linker
+        .func_wrap(
+            "env",
+            "get_table_data",
+            |mut caller: Caller<'_, PluginHostState>,
+             name_ptr: i32,
+             name_len: i32,
+             row: i32,
+             col: i32,
+             out_ptr: i32|
+             -> i32 {
+                let table_name = match read_guest_string(&mut caller, name_ptr, name_len) {
+                    Ok(s) => s,
+                    Err(code) => return code,
+                };
+                let permissions = caller.data().permissions.clone();
+                let resp = plugin_api::api_get_table_data(&permissions, &table_name, row, col);
+                if !resp.success {
+                    return host_result::PERMISSION_DENIED;
+                }
+                match write_guest_bytes(&mut caller, out_ptr, &resp.data) {
+                    Ok(()) => host_result::OK,
+                    Err(code) => code,
+                }
+            },
+        )
+        .map_err(|e| format!("Failed to register get_table_data: {}", e))?;
+
+    linker
+        .func_wrap(
+            "env",
+            "get_constant",
+            |mut caller: Caller<'_, PluginHostState>,
+             name_ptr: i32,
+             name_len: i32,
+             out_ptr: i32|
+             -> i32 {
+                let name = match read_guest_string(&mut caller, name_ptr, name_len) {
+                    Ok(s) => s,
+                    Err(code) => return code,
+                };
+                let permissions = caller.data().permissions.clone();
+                let resp = plugin_api::api_get_constant(&permissions, &name);
+                if !resp.success {
+                    return host_result::PERMISSION_DENIED;
+                }
+                match write_guest_bytes(&mut caller, out_ptr, &resp.data) {
+                    Ok(()) => host_result::OK,
+                    Err(code) => code,
+                }
+            },
+        )
+        .map_err(|e| format!("Failed to register get_constant: {}", e))?;
+
+    linker
+        .func_wrap(
+            "env",
+            "set_constant",
+            |mut caller: Caller<'_, PluginHostState>,
+             name_ptr: i32,
+             name_len: i32,
+             value: f32|
+             -> i32 {
+                let name = match read_guest_string(&mut caller, name_ptr, name_len) {
+                    Ok(s) => s,
+                    Err(code) => return code,
+                };
+                let permissions = caller.data().permissions.clone();
+                let resp = plugin_api::api_set_constant(&permissions, &name, &value.to_le_bytes());
+                if resp.success {
+                    host_result::OK
+                } else {
+                    host_result::PERMISSION_DENIED
+                }
+            },
+        )
+        .map_err(|e| format!("Failed to register set_constant: {}", e))?;
+
+    linker
+        .func_wrap(
+            "env",
+            "subscribe_channel",
+            |mut caller: Caller<'_, PluginHostState>,
+             name_ptr: i32,
+             name_len: i32,
+             out_ptr: i32|
+             -> i32 {
+                let name = match read_guest_string(&mut caller, name_ptr, name_len) {
+                    Ok(s) => s,
+                    Err(code) => return code,
+                };
+                let permissions = caller.data().permissions.clone();
+                let resp = plugin_api::api_subscribe_channel(&permissions, &name);
+                if !resp.success {
+                    return host_result::PERMISSION_DENIED;
+                }
+                match write_guest_bytes(&mut caller, out_ptr, &resp.data) {
+                    Ok(()) => host_result::OK,
+                    Err(code) => code,
+                }
+            },
+        )
+        .map_err(|e| format!("Failed to register subscribe_channel: {}", e))?;
+
+    linker
+        .func_wrap(
+            "env",
+            "get_channel_value",
+            |mut caller: Caller<'_, PluginHostState>, channel_id: i32, out_ptr: i32| -> i32 {
+                if channel_id < 0 {
+                    return host_result::INVALID_ARGS;
+                }
+                let permissions = caller.data().permissions.clone();
+                let resp = plugin_api::api_get_channel_value(&permissions, channel_id as u32);
+                if !resp.success {
+                    return host_result::PERMISSION_DENIED;
+                }
+                match write_guest_bytes(&mut caller, out_ptr, &resp.data) {
+                    Ok(()) => host_result::OK,
+                    Err(code) => code,
+                }
+            },
+        )
+        .map_err(|e| format!("Failed to register get_channel_value: {}", e))?;
+
+    linker
+        .func_wrap(
+            "env",
+            "execute_action",
+            |mut caller: Caller<'_, PluginHostState>, json_ptr: i32, json_len: i32| -> i32 {
+                let action_json = match read_guest_string(&mut caller, json_ptr, json_len) {
+                    Ok(s) => s,
+                    Err(code) => return code,
+                };
+                let permissions = caller.data().permissions.clone();
+                let resp = plugin_api::api_execute_action(&permissions, &action_json);
+                if resp.success {
+                    host_result::OK
+                } else {
+                    host_result::PERMISSION_DENIED
+                }
+            },
+        )
+        .map_err(|e| format!("Failed to register execute_action: {}", e))?;
+
+    Ok(())
+}
 
 /// Plugin manifest declaring name, version, and required permissions.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -85,12 +332,14 @@ pub struct PluginInstance {
     /// Plugin metadata
     pub manifest: PluginManifest,
     /// Wasmtime store for this plugin
-    store: Store<()>,
+    store: Store<PluginHostState>,
     /// Wasmtime instance
     instance: Instance,
     /// Current lifecycle state
     pub state: PluginState,
-    /// Granted permissions
+    /// Granted permissions — the intersection of what the manifest requested
+    /// and what the user actually approved at load time. May be a strict
+    /// subset of `manifest.permissions`.
     permissions: Vec<Permission>,
     /// Execution counter for debugging
     exec_count: u64,
@@ -103,6 +352,13 @@ impl PluginInstance {
     /// * `manifest` - Plugin metadata with permissions declaration
     /// * `wasm_path` - Path to .wasm file
     /// * `config` - Initialization configuration
+    /// * `granted_permissions` - Permissions the user actually approved for
+    ///   this load (see [`PluginManager::load_plugin`]). Only permissions
+    ///   that are both requested by the manifest *and* present here are
+    ///   granted — this is the boundary the host functions registered on the
+    ///   plugin's [`wasmtime::Linker`] enforce, so an unapproved permission
+    ///   is never reachable from guest code regardless of what the manifest
+    ///   claims.
     ///
     /// # Returns
     /// Initialized PluginInstance in Loaded state
@@ -115,7 +371,15 @@ impl PluginInstance {
         manifest: PluginManifest,
         wasm_path: &Path,
         _config: &PluginConfig,
+        granted_permissions: &[Permission],
     ) -> Result<Self, String> {
+        let granted: Vec<Permission> = manifest
+            .permissions
+            .iter()
+            .filter(|p| granted_permissions.contains(p))
+            .copied()
+            .collect();
+
         // Create WASM runtime
         let engine = Engine::default();
 
@@ -126,10 +390,16 @@ impl PluginInstance {
         let module = Module::new(&engine, &wasm_bytes)
             .map_err(|e| format!("Failed to load WASM module: {}", e))?;
 
-        let mut store = Store::new(&engine, ());
-        let linker = Linker::new(&engine);
+        let host_state = PluginHostState {
+            plugin_name: manifest.name.clone(),
+            permissions: granted.clone(),
+        };
+        let mut store = Store::new(&engine, host_state);
+        let mut linker: Linker<PluginHostState> = Linker::new(&engine);
+        register_host_functions(&mut linker)?;
 
-        // Instantiate module (minimal setup - full API in plugin_api.rs)
+        // Instantiate module against the permission-checked host-function
+        // surface registered above.
         let instance = linker
             .instantiate(&mut store, &module)
             .map_err(|e| format!("Failed to instantiate module: {}", e))?;
@@ -139,14 +409,16 @@ impl PluginInstance {
             store,
             instance,
             state: PluginState::Loaded,
-            permissions: Vec::new(),
+            permissions: granted,
             exec_count: 0,
         })
     }
 
-    /// Initialize plugin with configuration and validate permissions.
+    /// Initialize plugin with configuration.
     ///
-    /// Moves to `Ready` state if successful.
+    /// Moves to `Ready` state if successful. Permissions were already fixed
+    /// at [`PluginInstance::load`] time — this step only runs the plugin's
+    /// own `plugin_init()` export, it does not grant anything further.
     pub fn initialize(&mut self, _config: &PluginConfig) -> Result<(), String> {
         if self.state != PluginState::Loaded {
             return Err(format!(
@@ -166,9 +438,6 @@ impl PluginInstance {
                 .map_err(|e| format!("Plugin init failed: {}", e))?;
         }
 
-        // Grant declared permissions
-        self.permissions = self.manifest.permissions.clone();
-
         self.state = PluginState::Ready;
         Ok(())
     }
@@ -176,6 +445,42 @@ impl PluginInstance {
     /// Check if plugin has specific permission.
     pub fn has_permission(&self, perm: Permission) -> bool {
         self.permissions.contains(&perm)
+    }
+
+    /// Permissions actually granted to this instance (manifest request ∩
+    /// user approval at load time) — may be fewer than `manifest.permissions`.
+    pub fn granted_permissions(&self) -> &[Permission] {
+        &self.permissions
+    }
+
+    /// Call a zero-argument WASM export that returns `i32` and return its raw
+    /// result. Unlike [`PluginInstance::execute`] (which always reports
+    /// `exec_count` and discards the export's own return value), this
+    /// surfaces exactly what the guest returned — needed to verify host
+    /// functions like `get_constant`/`log_message` actually gave back the
+    /// permission-check result the guest observed.
+    pub fn call_i32_export(&mut self, name: &str) -> Result<i32, String> {
+        let func = self
+            .instance
+            .get_typed_func::<(), i32>(&mut self.store, name)
+            .map_err(|e| format!("Export '{}' not found or wrong signature: {}", name, e))?;
+        func.call(&mut self.store, ())
+            .map_err(|e| format!("Call to '{}' failed: {}", name, e))
+    }
+
+    /// Read `len` bytes from the plugin's exported linear memory at `offset`.
+    /// Lets tests verify a host function wrote its result where the guest
+    /// expected it.
+    pub fn read_memory(&mut self, offset: usize, len: usize) -> Result<Vec<u8>, String> {
+        let memory = self
+            .instance
+            .get_memory(&mut self.store, "memory")
+            .ok_or_else(|| "Plugin has no exported memory".to_string())?;
+        let mut buf = vec![0u8; len];
+        memory
+            .read(&self.store, offset, &mut buf)
+            .map_err(|e| format!("Memory read failed: {}", e))?;
+        Ok(buf)
     }
 
     /// Execute plugin function, returning execution count.
@@ -258,10 +563,18 @@ impl PluginManager {
     }
 
     /// Load a plugin from WASM file.
+    ///
+    /// `approved_permissions` is the set of permissions the user actually
+    /// consented to grant (e.g. via a load-time confirmation dialog) — the
+    /// plugin ends up with the intersection of this set and whatever its own
+    /// manifest requests. A manifest requesting `WriteConstants` that the
+    /// user did not approve simply doesn't get it, silently and safely,
+    /// rather than being auto-granted.
     pub fn load_plugin(
         &mut self,
         manifest: PluginManifest,
         wasm_path: &Path,
+        approved_permissions: &[Permission],
     ) -> Result<String, String> {
         let name = manifest.name.clone();
 
@@ -269,7 +582,8 @@ impl PluginManager {
             return Err(format!("Plugin '{}' already loaded", name));
         }
 
-        let mut plugin = PluginInstance::load(manifest, wasm_path, &self.config)?;
+        let mut plugin =
+            PluginInstance::load(manifest, wasm_path, &self.config, approved_permissions)?;
         plugin.initialize(&self.config)?;
 
         self.plugins.insert(name.clone(), plugin);

--- a/crates/libretune-core/tests/plugin_api.rs
+++ b/crates/libretune-core/tests/plugin_api.rs
@@ -4,24 +4,21 @@
 //!
 //! # Test fixture invariant
 //!
-//! [`create_test_context()`] builds a [`PluginManager`] with **no plugins
-//! registered**, so every `check_permission(...)` call returns `false`.
-//! This is why every permission-guarded host function below is expected to be
-//! denied — the fixture proves the guard rejects *unknown* plugins without the
-//! caller having to set up a permissions table.
+//! Permission-guarded host functions take the calling plugin's *granted*
+//! permission set directly (`&[Permission]`), not a shared [`PluginManager`]
+//! lookup — see [`libretune_core::plugin_system`]'s host-function wiring for
+//! why (avoids re-entrant locking from inside a WASM call). Passing `&[]`
+//! below is the "unregistered/no-grant" case; passing the specific
+//! `Permission` variant is the "granted" case.
 
 use libretune_core::plugin_api::*;
 use libretune_core::plugin_system::*;
 
 /// Build an API context wrapping an empty [`PluginManager`].
 ///
-/// No plugin is registered, so `PluginManager::check_permission` always
-/// returns `false`. Every permission-guarded host function (table/constant
-/// access, channel subscription, action execution) will therefore report
-/// [`ApiResponse::permission_denied`] regardless of the plugin name passed in.
-/// Only `api_log_message` (which intentionally bypasses the permission gate)
-/// and `api_get_plugin_info` (which fails with "not found" instead) succeed
-/// differently for an unregistered plugin name.
+/// Only used by [`api_get_plugin_info`], which still looks a plugin up by
+/// name in the manager (it reports on a *different* plugin's info, not the
+/// caller's own permissions, so it legitimately needs the manager).
 fn create_test_context() -> PluginApiContext {
     let config = PluginConfig {
         data_dir: "/tmp/libretune_plugins".to_string(),
@@ -62,80 +59,77 @@ fn test_api_context_initialization() {
 
 #[test]
 fn test_api_get_table_data_permission_check() {
-    let ctx = create_test_context();
-
-    // "restricted_plugin" is not registered, so it lacks ReadTables and must
-    // be rejected before any table data is read.
-    let resp = api_get_table_data(&ctx, "restricted_plugin", "veTable1", 0, 0);
+    // No permissions granted: must be rejected before any table data is read.
+    let resp = api_get_table_data(&[], "veTable1", 0, 0);
     assert!(!resp.success);
     assert!(resp.error.contains("Permission"));
 }
 
 #[test]
-fn test_api_get_constant_permission_check() {
-    let ctx = create_test_context();
+fn test_api_get_table_data_granted() {
+    let resp = api_get_table_data(&[Permission::ReadTables], "veTable1", 0, 0);
+    assert!(resp.success);
+}
 
-    // Constants are covered by ReadTables (see api_get_constant docs); an
-    // unregistered plugin lacks it and must be rejected.
-    let resp = api_get_constant(&ctx, "restricted_plugin", "rpmMin");
+#[test]
+fn test_api_get_constant_permission_check() {
+    // Constants are covered by ReadTables (see api_get_constant docs); no
+    // grant means the call must be rejected.
+    let resp = api_get_constant(&[], "rpmMin");
     assert!(!resp.success);
 }
 
 #[test]
 fn test_api_set_constant_permission_check() {
-    let ctx = create_test_context();
-
-    // Writes are a distinct permission from reads: "readonly_plugin" lacks
-    // WriteConstants, so the byte payload must never reach the tune cache.
-    let resp = api_set_constant(&ctx, "readonly_plugin", "rpmMin", &[0, 0, 0, 0]);
+    // Writes are a distinct permission from reads: ReadTables alone must not
+    // satisfy WriteConstants, so the byte payload must never reach the tune cache.
+    let resp = api_set_constant(&[Permission::ReadTables], "rpmMin", &[0, 0, 0, 0]);
     assert!(!resp.success);
     assert!(resp.error.contains("WriteConstants"));
 }
 
 #[test]
-fn test_api_subscribe_channel_permission_check() {
-    let ctx = create_test_context();
+fn test_api_set_constant_granted() {
+    let resp = api_set_constant(&[Permission::WriteConstants], "rpmMin", &[0, 0, 0, 0]);
+    assert!(resp.success);
+}
 
-    // "limited_plugin" holds no SubscribeChannels grant, so it cannot register
-    // a realtime subscription and must be rejected up front.
-    let resp = api_subscribe_channel(&ctx, "limited_plugin", "RPM");
+#[test]
+fn test_api_subscribe_channel_permission_check() {
+    // No SubscribeChannels grant: cannot register a realtime subscription and
+    // must be rejected up front.
+    let resp = api_subscribe_channel(&[], "RPM");
     assert!(!resp.success);
 }
 
 #[test]
 fn test_api_get_channel_value_permission_check() {
-    let ctx = create_test_context();
-
     // Reading a subscribed channel value re-checks SubscribeChannels, so even
-    // a guessed channel_id (42) must be rejected for an unregistered plugin.
-    let resp = api_get_channel_value(&ctx, "limited_plugin", 42);
+    // a guessed channel_id (42) must be rejected without the grant.
+    let resp = api_get_channel_value(&[], 42);
     assert!(!resp.success);
 }
 
 #[test]
 fn test_api_execute_action_permission_check() {
-    let ctx = create_test_context();
-
-    // "noaccess_plugin" lacks ExecuteActions, so the JSON action payload must
-    // be rejected before any command is parsed or dispatched.
-    let resp = api_execute_action(&ctx, "noaccess_plugin", "{}");
+    // No ExecuteActions grant: the JSON action payload must be rejected
+    // before any command is parsed or dispatched.
+    let resp = api_execute_action(&[], "{}");
     assert!(!resp.success);
     assert!(resp.error.contains("ExecuteActions"));
 }
 
 #[test]
 fn test_api_log_message_always_allowed() {
-    let ctx = create_test_context();
-
     // Logging deliberately bypasses the permission gate — it is the one host
-    // function any plugin may call, so an unregistered plugin still succeeds.
-    let resp = api_log_message(&ctx, "test_plugin", 1, "Info message");
+    // function any plugin may call regardless of grants.
+    let resp = api_log_message("test_plugin", 1, "Info message");
     assert!(resp.success);
 
-    let resp = api_log_message(&ctx, "test_plugin", 3, "Error message");
+    let resp = api_log_message("test_plugin", 3, "Error message");
     assert!(resp.success);
 
-    let resp = api_log_message(&ctx, "another", 0, "Debug");
+    let resp = api_log_message("another", 0, "Debug");
     assert!(resp.success);
 }
 
@@ -232,26 +226,22 @@ fn test_api_response_error_only() {
 
 #[test]
 fn test_multiple_log_messages() {
-    let ctx = create_test_context();
-
     // Each call is independent and permission-free, so a rapid burst of logs
     // must all succeed (no rate limit or dedup at this layer).
     for i in 0..5 {
         let msg = format!("Log message {}", i);
-        let resp = api_log_message(&ctx, "test", 1, msg);
+        let resp = api_log_message("test", 1, msg);
         assert!(resp.success);
     }
 }
 
 #[test]
 fn test_api_permission_enforcement_consistency() {
-    let ctx = create_test_context();
-
-    // Denial must be uniform across calls: the same unregistered plugin is
-    // rejected regardless of which table/cell it targets, confirming the guard
-    // is keyed on permissions and not on the specific request.
-    let resp1 = api_get_table_data(&ctx, "test_plugin", "table1", 0, 0);
-    let resp2 = api_get_table_data(&ctx, "test_plugin", "table2", 5, 5);
+    // Denial must be uniform across calls: an empty grant set is rejected
+    // regardless of which table/cell it targets, confirming the guard is
+    // keyed on the permission set and not on the specific request.
+    let resp1 = api_get_table_data(&[], "table1", 0, 0);
+    let resp2 = api_get_table_data(&[], "table2", 5, 5);
 
     assert!(!resp1.success);
     assert!(!resp2.success);
@@ -261,13 +251,11 @@ fn test_api_permission_enforcement_consistency() {
 
 #[test]
 fn test_log_message_multiple_plugins() {
-    let ctx = create_test_context();
-
     // Logging state is never shared between plugin names, so three distinct
-    // (unregistered) plugins can each emit a log without interference.
-    let resp1 = api_log_message(&ctx, "plugin_a", 0, "From A");
-    let resp2 = api_log_message(&ctx, "plugin_b", 1, "From B");
-    let resp3 = api_log_message(&ctx, "plugin_c", 2, "From C");
+    // plugins can each emit a log without interference.
+    let resp1 = api_log_message("plugin_a", 0, "From A");
+    let resp2 = api_log_message("plugin_b", 1, "From B");
+    let resp3 = api_log_message("plugin_c", 2, "From C");
 
     assert!(resp1.success);
     assert!(resp2.success);

--- a/crates/libretune-core/tests/plugin_system.rs
+++ b/crates/libretune-core/tests/plugin_system.rs
@@ -66,7 +66,7 @@ fn test_load_instantiates_real_wasm_module() {
     let manifest = create_test_manifest();
     let config = create_test_config();
 
-    let instance = PluginInstance::load(manifest, wasm_file.path(), &config);
+    let instance = PluginInstance::load(manifest, wasm_file.path(), &config, &[]);
     assert!(
         instance.is_ok(),
         "expected a trivial empty module to load and instantiate cleanly: {:?}",
@@ -328,6 +328,294 @@ fn test_permission_bits() {
     }
 
     assert!(!perms.contains(&Permission::ExecuteActions));
+}
+
+// --- Host-function wiring tests -------------------------------------------
+//
+// The tests above exercise the manifest/permission/lifecycle data types in
+// isolation. These exercise the actual boundary a WASM guest crosses to call
+// back into the host: real WAT modules that import `env.*` functions, get
+// instantiated against the real `Linker`, and are driven through
+// `PluginInstance::call_i32_export`/`read_memory` to confirm the permission
+// check and memory marshaling genuinely happen, not just compile.
+
+/// Build and instantiate a `PluginInstance` from inline WAT text.
+fn load_wat(wat: &str, manifest: PluginManifest, approved: &[Permission]) -> PluginInstance {
+    use std::io::Write;
+    let mut wasm_file = tempfile::Builder::new()
+        .suffix(".wasm")
+        .tempfile()
+        .expect("failed to create temp wasm file");
+    wasm_file
+        .write_all(wat.as_bytes())
+        .expect("failed to write test module");
+
+    let config = create_test_config();
+    let mut instance = PluginInstance::load(manifest, wasm_file.path(), &config, approved)
+        .unwrap_or_else(|e| panic!("failed to load WAT module: {e}\n{wat}"));
+    instance.initialize(&config).expect("failed to initialize");
+    instance
+}
+
+fn manifest_requesting(permissions: Vec<Permission>) -> PluginManifest {
+    PluginManifest {
+        name: "wat_test_plugin".to_string(),
+        version: "1.0.0".to_string(),
+        description: "inline WAT test fixture".to_string(),
+        author: "Test".to_string(),
+        permissions,
+    }
+}
+
+#[test]
+fn log_message_requires_no_permission_and_reaches_the_host() {
+    // "hello from plugin" is 17 bytes, written at offset 0 via the data segment.
+    let wat = r#"
+        (module
+            (import "env" "log_message" (func $log_message (param i32 i32 i32) (result i32)))
+            (memory (export "memory") 1)
+            (data (i32.const 0) "hello from plugin")
+            (func (export "plugin_execute") (result i32)
+                (call $log_message (i32.const 1) (i32.const 0) (i32.const 17))
+            )
+        )
+    "#;
+    let mut instance = load_wat(wat, manifest_requesting(vec![]), &[]);
+    let result = instance
+        .call_i32_export("plugin_execute")
+        .expect("call failed");
+    assert_eq!(
+        result, 0,
+        "log_message should succeed with zero permissions granted"
+    );
+}
+
+#[test]
+fn get_constant_denied_without_read_tables_permission() {
+    let wat = r#"
+        (module
+            (import "env" "get_constant" (func $get_constant (param i32 i32 i32) (result i32)))
+            (memory (export "memory") 1)
+            (data (i32.const 0) "rpm")
+            (func (export "plugin_execute") (result i32)
+                (call $get_constant (i32.const 0) (i32.const 3) (i32.const 100))
+            )
+        )
+    "#;
+    // Manifest requests ReadTables, but the user approves nothing.
+    let mut instance = load_wat(wat, manifest_requesting(vec![Permission::ReadTables]), &[]);
+    let result = instance
+        .call_i32_export("plugin_execute")
+        .expect("call failed");
+    assert_eq!(
+        result, -1,
+        "expected PERMISSION_DENIED when ReadTables wasn't approved"
+    );
+}
+
+#[test]
+fn get_constant_succeeds_and_writes_result_when_approved() {
+    let wat = r#"
+        (module
+            (import "env" "get_constant" (func $get_constant (param i32 i32 i32) (result i32)))
+            (memory (export "memory") 1)
+            (data (i32.const 0) "rpm")
+            (func (export "plugin_execute") (result i32)
+                (call $get_constant (i32.const 0) (i32.const 3) (i32.const 100))
+            )
+        )
+    "#;
+    let mut instance = load_wat(
+        wat,
+        manifest_requesting(vec![Permission::ReadTables]),
+        &[Permission::ReadTables],
+    );
+    let result = instance
+        .call_i32_export("plugin_execute")
+        .expect("call failed");
+    assert_eq!(result, 0, "expected OK once ReadTables is approved");
+
+    // The host function must have written its 4-byte placeholder value at
+    // the out_ptr the guest supplied (offset 100).
+    let written = instance.read_memory(100, 4).expect("memory read failed");
+    assert_eq!(written.len(), 4);
+}
+
+#[test]
+fn set_constant_denied_without_write_constants_permission() {
+    let wat = r#"
+        (module
+            (import "env" "set_constant" (func $set_constant (param i32 i32 f32) (result i32)))
+            (memory (export "memory") 1)
+            (data (i32.const 0) "rpm")
+            (func (export "plugin_execute") (result i32)
+                (call $set_constant (i32.const 0) (i32.const 3) (f32.const 1500))
+            )
+        )
+    "#;
+    // Approve ReadTables (an unrelated permission) to prove it doesn't leak
+    // into a WriteConstants grant.
+    let mut instance = load_wat(
+        wat,
+        manifest_requesting(vec![Permission::WriteConstants]),
+        &[Permission::ReadTables],
+    );
+    let result = instance
+        .call_i32_export("plugin_execute")
+        .expect("call failed");
+    assert_eq!(
+        result, -1,
+        "expected PERMISSION_DENIED without WriteConstants"
+    );
+}
+
+#[test]
+fn set_constant_succeeds_when_approved() {
+    let wat = r#"
+        (module
+            (import "env" "set_constant" (func $set_constant (param i32 i32 f32) (result i32)))
+            (memory (export "memory") 1)
+            (data (i32.const 0) "rpm")
+            (func (export "plugin_execute") (result i32)
+                (call $set_constant (i32.const 0) (i32.const 3) (f32.const 1500))
+            )
+        )
+    "#;
+    let mut instance = load_wat(
+        wat,
+        manifest_requesting(vec![Permission::WriteConstants]),
+        &[Permission::WriteConstants],
+    );
+    let result = instance
+        .call_i32_export("plugin_execute")
+        .expect("call failed");
+    assert_eq!(result, 0);
+}
+
+#[test]
+fn manifest_cannot_self_grant_beyond_what_was_approved() {
+    // Manifest declares all four permissions; user approves only ReadTables.
+    // A guest calling execute_action (ExecuteActions) must still be denied.
+    let wat = r#"
+        (module
+            (import "env" "execute_action" (func $execute_action (param i32 i32) (result i32)))
+            (memory (export "memory") 1)
+            (data (i32.const 0) "{}")
+            (func (export "plugin_execute") (result i32)
+                (call $execute_action (i32.const 0) (i32.const 2))
+            )
+        )
+    "#;
+    let mut instance = load_wat(
+        wat,
+        manifest_requesting(vec![
+            Permission::ReadTables,
+            Permission::WriteConstants,
+            Permission::SubscribeChannels,
+            Permission::ExecuteActions,
+        ]),
+        &[Permission::ReadTables],
+    );
+    assert_eq!(instance.granted_permissions(), &[Permission::ReadTables]);
+    let result = instance
+        .call_i32_export("plugin_execute")
+        .expect("call failed");
+    assert_eq!(
+        result, -1,
+        "self-declaring ExecuteActions in the manifest must not grant it without approval"
+    );
+}
+
+#[test]
+fn oversized_guest_string_length_is_rejected_without_touching_memory() {
+    // Length far larger than MAX_GUEST_STRING_LEN (64 KiB) must be rejected
+    // up front rather than attempting an out-of-bounds memory read.
+    let wat = r#"
+        (module
+            (import "env" "log_message" (func $log_message (param i32 i32 i32) (result i32)))
+            (memory (export "memory") 1)
+            (func (export "plugin_execute") (result i32)
+                (call $log_message (i32.const 1) (i32.const 0) (i32.const 1000000))
+            )
+        )
+    "#;
+    let mut instance = load_wat(wat, manifest_requesting(vec![]), &[]);
+    let result = instance
+        .call_i32_export("plugin_execute")
+        .expect("call failed");
+    assert_eq!(
+        result, -2,
+        "oversized length must be rejected as invalid args"
+    );
+}
+
+#[test]
+fn negative_pointer_is_rejected() {
+    let wat = r#"
+        (module
+            (import "env" "log_message" (func $log_message (param i32 i32 i32) (result i32)))
+            (memory (export "memory") 1)
+            (func (export "plugin_execute") (result i32)
+                (call $log_message (i32.const 1) (i32.const -1) (i32.const 5))
+            )
+        )
+    "#;
+    let mut instance = load_wat(wat, manifest_requesting(vec![]), &[]);
+    let result = instance
+        .call_i32_export("plugin_execute")
+        .expect("call failed");
+    assert_eq!(
+        result, -2,
+        "negative pointer must be rejected as invalid args"
+    );
+}
+
+#[test]
+fn subscribe_channel_and_get_channel_value_round_trip_with_permission() {
+    let wat = r#"
+        (module
+            (import "env" "subscribe_channel" (func $subscribe_channel (param i32 i32 i32) (result i32)))
+            (import "env" "get_channel_value" (func $get_channel_value (param i32 i32) (result i32)))
+            (memory (export "memory") 1)
+            (data (i32.const 0) "RPM")
+            (func (export "subscribe") (result i32)
+                (call $subscribe_channel (i32.const 0) (i32.const 3) (i32.const 100))
+            )
+            (func (export "plugin_execute") (result i32)
+                (call $get_channel_value (i32.const 0) (i32.const 104))
+            )
+        )
+    "#;
+    let mut instance = load_wat(
+        wat,
+        manifest_requesting(vec![Permission::SubscribeChannels]),
+        &[Permission::SubscribeChannels],
+    );
+    let sub_result = instance.call_i32_export("subscribe").expect("call failed");
+    assert_eq!(sub_result, 0);
+    let value_result = instance
+        .call_i32_export("plugin_execute")
+        .expect("call failed");
+    assert_eq!(value_result, 0);
+}
+
+#[test]
+fn get_table_data_denied_without_read_tables_permission() {
+    let wat = r#"
+        (module
+            (import "env" "get_table_data" (func $get_table_data (param i32 i32 i32 i32 i32) (result i32)))
+            (memory (export "memory") 1)
+            (data (i32.const 0) "veTable1")
+            (func (export "plugin_execute") (result i32)
+                (call $get_table_data (i32.const 0) (i32.const 8) (i32.const 0) (i32.const 0) (i32.const 100))
+            )
+        )
+    "#;
+    let mut instance = load_wat(wat, manifest_requesting(vec![]), &[]);
+    let result = instance
+        .call_i32_export("plugin_execute")
+        .expect("call failed");
+    assert_eq!(result, -1);
 }
 
 #[test]


### PR DESCRIPTION
## Description
The WASM plugin permission system had two structural gaps: the permission-checked
host API (`plugin_api.rs`) was never registered on the wasmtime `Linker`, so no
plugin could actually call back into the host at all — the whole permission system
gated access to nothing reachable. Separately, granted permissions were taken
verbatim from a self-declared manifest with zero user consent step. This PR closes
both.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues
None filed — found via a permission-enforcement audit of the plugin system.

## Changes Made
- Register all seven `plugin_api.rs` functions as real host-function imports under
  the `env` module via wasmtime's `Linker`, with bounds-checked guest memory
  marshaling (string/byte read+write, capped length, negative-pointer rejection).
- Refactor `plugin_api.rs`'s permission checks to take the calling plugin's granted
  permissions directly (`&[Permission]`) instead of locking a shared `PluginManager`
  — avoids lock re-entrancy if a host function is ever called from inside code that
  already holds that lock.
- `PluginManager::load_plugin`/`PluginInstance::load` now take an
  `approved_permissions` set; only the intersection of what the manifest requests
  and what's approved is ever granted, fixed at load time in both the instance and
  its WASM `Store` data.
- Tauri command `load_wasm_plugin` accepts `approved_permissions` from the frontend;
  `PluginPanel.tsx` now shows a consent dialog (checkboxes, default unchecked)
  before loading instead of silently granting `ReadTables`.
- Add WAT-based integration tests exercising the host functions end-to-end
  (granted/denied paths, memory marshaling, oversized/negative pointer rejection,
  manifest-cannot-self-grant-beyond-approval).

## Testing
- [x] I have tested these changes locally
- [x] New and existing tests pass (`cargo test`)
- [ ] The UI works correctly with these changes

## Checklist
- [x] Code compiles without errors
- [x] No new clippy warnings (`cargo clippy`)
- [x] Code is formatted (`cargo fmt`)
- [x] TypeScript compiles without errors (`npx tsc --noEmit`)
- [ ] Documentation updated if needed
- [x] Commit messages follow conventional format

## Screenshots (if applicable)
N/A — see `PluginPanel.tsx`/`.css` diff for the new consent dialog markup/styles.

---
Note: `App.integration.test.tsx`'s "Auto" packet-mode test failed once in the full
suite (a pre-existing `act()`-warning race, unrelated to this diff) but passed
consistently in 2 isolated reruns — documented flake seen in prior PRs (#98).
