### PR TITLE
fix(settings): missing update_setting arms, empty AI provider, batch save performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,44 @@ relevant.
 
 ## [Unreleased]
 
+### 2026-07-31 — Dashboard validation loop + Settings save performance/reliability
+
+Fixes a runaway backend loop that starved the UI, plus several Settings-save
+correctness and performance issues that surfaced once the loop was resolved.
+
+#### Fixed
+- **Infinite `validate_dashboard` loop** — `useGaugeRangeSync`'s INI/definition
+  change effect listed `dashFile` and `syncGaugeRanges` (both derived from
+  `dashFile`) as deps alongside `syncToken`. Syncing creates a new `dashFile`
+  object → recreates `syncGaugeRanges` → retriggers the effect (syncToken stays
+  > 0 after a `definition:loaded`/`ini:changed` event) → re-sync → infinite loop.
+  The runaway `validate_dashboard` calls saturated the Tauri IPC, so Settings
+  Apply's `await invoke('update_setting')` calls never resolved, leaving
+  Apply/OK permanently disabled. Fix: the INI-change effect now depends on
+  `syncToken` ONLY, reading the latest sync fn/flags/dashFile from a ref.
+- **"Some settings failed to save" error** — the backend `update_setting` match
+  was missing arms for `auto_commit_on_save`, `commit_message_format`,
+  `fome_fast_comms_enabled`, `auto_record_enabled`, `key_on_threshold_rpm`, and
+  `key_off_timeout_sec`; each hit the `_ => Err("Unknown setting")` catch-all.
+  Added all six arms (and extracted the match into a shared `apply_setting`
+  helper used by both the single and batch commands, so this can't regress).
+- **AI assistant reported "not configured"** — `ai_provider` was saving empty.
+  Leftover from the earlier `Settings::default()` corruption bug, the stored
+  `""` made the Provider dropdown render blank (no matching option), so the user
+  never selected one. `configured` requires a non-empty provider + model, so it
+  falsely reported unconfigured. Frontend now coerces empty `ai_provider` to
+  `'openai'` on load; `agent_status` treats empty provider as `'openai'`
+  defensively.
+
+#### Changed
+- **Batched Settings save (performance)** — the Settings dialog previously made
+  ~30 sequential `update_setting` calls on Apply/OK, each doing a full disk
+  read + write cycle (~60 file operations, several seconds on Windows). Added a
+  new `update_settings` (plural) command that loads settings once, applies all
+  key/value pairs to one in-memory struct, and saves once — reducing I/O to a
+  single read + write. `saveSettings` now sends all settings in one batched
+  invoke. Save is now near-instant.
+
 ### 2026-07-31 — Menu i18n fix, menu-bar grouping, settings search
 
 Closes [#72 ([BUG] Languages)](https://github.com/RallyPat/LibreTune/issues/72)

--- a/crates/libretune-app/src-tauri/src/commands/agent.rs
+++ b/crates/libretune-app/src-tauri/src/commands/agent.rs
@@ -206,7 +206,11 @@ pub async fn agent_status(app: tauri::AppHandle) -> Result<AgentStatus, String> 
     let s = crate::load_settings(&app);
     // Treat an empty provider as the default ("openai") so the configured-flag
     // isn't falsely false for setups that only set a base URL + key + model.
-    let provider = if s.ai_provider.is_empty() { "openai".to_string() } else { s.ai_provider.clone() };
+    let provider = if s.ai_provider.is_empty() {
+        "openai".to_string()
+    } else {
+        s.ai_provider.clone()
+    };
     Ok(AgentStatus {
         enabled: s.ai_assistant_enabled,
         risk_acknowledged: s.ai_risk_acknowledged,

--- a/crates/libretune-app/src-tauri/src/commands/agent.rs
+++ b/crates/libretune-app/src-tauri/src/commands/agent.rs
@@ -204,15 +204,18 @@ fn default_authority() -> AutoTuneAuthorityLimits {
 #[tauri::command]
 pub async fn agent_status(app: tauri::AppHandle) -> Result<AgentStatus, String> {
     let s = crate::load_settings(&app);
+    // Treat an empty provider as the default ("openai") so the configured-flag
+    // isn't falsely false for setups that only set a base URL + key + model.
+    let provider = if s.ai_provider.is_empty() { "openai".to_string() } else { s.ai_provider.clone() };
     Ok(AgentStatus {
         enabled: s.ai_assistant_enabled,
         risk_acknowledged: s.ai_risk_acknowledged,
-        provider: s.ai_provider.clone(),
+        provider: provider.clone(),
         model: s.ai_model.clone(),
         capability_tier: s.ai_capability_tier.clone(),
         // Configured if both provider and model are non-empty (key is optional
         // for local providers, so we don't require it).
-        configured: !s.ai_provider.is_empty() && !s.ai_model.is_empty(),
+        configured: !provider.is_empty() && !s.ai_model.is_empty(),
     })
 }
 

--- a/crates/libretune-app/src-tauri/src/commands/settings.rs
+++ b/crates/libretune-app/src-tauri/src/commands/settings.rs
@@ -9,17 +9,12 @@ pub async fn get_settings(app: tauri::AppHandle) -> Result<Settings, String> {
     Ok(load_settings(&app))
 }
 
-/// Update a single setting
-#[tauri::command]
-pub async fn update_setting(
-    app: tauri::AppHandle,
-    key: String,
-    value: String,
-) -> Result<(), String> {
-    let mut settings = load_settings(&app);
-
-    match key.as_str() {
-        "units_system" => settings.units_system = value,
+/// Apply a single key/value to a `Settings` struct in place (no disk I/O).
+/// Shared by `update_setting` (single) and `update_settings` (batch) so the
+/// match logic stays in one place.
+fn apply_setting(settings: &mut Settings, key: &str, value: &str) -> Result<(), String> {
+    match key {
+        "units_system" => settings.units_system = value.to_string(),
         "auto_burn_on_close" => {
             settings.auto_burn_on_close = value.parse().map_err(|_| "Invalid boolean value")?
         }
@@ -33,20 +28,20 @@ pub async fn update_setting(
         "auto_sync_gauge_ranges" => {
             settings.auto_sync_gauge_ranges = value.parse().map_err(|_| "Invalid boolean value")?
         }
-        "indicator_column_count" => settings.indicator_column_count = value,
+        "indicator_column_count" => settings.indicator_column_count = value.to_string(),
         "indicator_fill_empty" => {
             settings.indicator_fill_empty = value.parse().map_err(|_| "Invalid boolean value")?
         }
-        "indicator_text_fit" => settings.indicator_text_fit = value,
+        "indicator_text_fit" => settings.indicator_text_fit = value.to_string(),
         // Status bar channels (JSON array)
         "status_bar_channels" => {
-            settings.status_bar_channels = serde_json::from_str(&value)
+            settings.status_bar_channels = serde_json::from_str(value)
                 .map_err(|e| format!("Invalid JSON for status_bar_channels: {}", e))?
         }
         // Heatmap scheme settings
-        "heatmap_value_scheme" => settings.heatmap_value_scheme = value,
-        "heatmap_change_scheme" => settings.heatmap_change_scheme = value,
-        "heatmap_coverage_scheme" => settings.heatmap_coverage_scheme = value,
+        "heatmap_value_scheme" => settings.heatmap_value_scheme = value.to_string(),
+        "heatmap_change_scheme" => settings.heatmap_change_scheme = value.to_string(),
+        "heatmap_coverage_scheme" => settings.heatmap_coverage_scheme = value.to_string(),
         // Help icon visibility
         "show_all_help_icons" => {
             settings.show_all_help_icons = value.parse().map_err(|_| "Invalid boolean value")?
@@ -64,10 +59,10 @@ pub async fn update_setting(
                 value.parse().map_err(|_| "Invalid number value")?
         }
         "runtime_packet_mode" => {
-            settings.runtime_packet_mode = value;
+            settings.runtime_packet_mode = value.to_string();
         }
         "last_serial_port" => {
-            settings.last_serial_port = if value.is_empty() { None } else { Some(value) }
+            settings.last_serial_port = if value.is_empty() { None } else { Some(value.to_string()) }
         }
         "auto_reconnect_after_controller_command" => {
             settings.auto_reconnect_after_controller_command =
@@ -87,17 +82,17 @@ pub async fn update_setting(
             settings.show_ecu_menus_in_menubar =
                 value.parse().map_err(|_| "Invalid boolean value")?
         }
-        "table_cursor_color" => settings.table_cursor_color = value,
-        "table_trail_color" => settings.table_trail_color = value,
+        "table_cursor_color" => settings.table_cursor_color = value.to_string(),
+        "table_trail_color" => settings.table_trail_color = value.to_string(),
         "table_trail_fade_sec" => {
             settings.table_trail_fade_sec = value.parse().map_err(|_| "Invalid number")?
         }
         // Session persistence
         "last_project_path" => {
-            settings.last_project_path = if value.is_empty() { None } else { Some(value) }
+            settings.last_project_path = if value.is_empty() { None } else { Some(value.to_string()) }
         }
         "last_active_tab" => {
-            settings.last_active_tab = if value.is_empty() { None } else { Some(value) }
+            settings.last_active_tab = if value.is_empty() { None } else { Some(value.to_string()) }
         }
         // UI layout state.
         "sidebar_visible" => {
@@ -107,16 +102,16 @@ pub async fn update_setting(
             settings.agent_panel_visible = value.parse().map_err(|_| "Invalid boolean value")?
         }
         "sidebar_expanded_ids" => {
-            settings.sidebar_expanded_ids = if value.is_empty() { None } else { Some(value) }
+            settings.sidebar_expanded_ids = if value.is_empty() { None } else { Some(value.to_string()) }
         }
         "selected_dashboard" => {
-            settings.selected_dashboard = if value.is_empty() { None } else { Some(value) }
+            settings.selected_dashboard = if value.is_empty() { None } else { Some(value.to_string()) }
         }
         "open_tabs" => {
             // Store the JSON blob as-is; the frontend parses it.
-            settings.open_tabs = if value.is_empty() { None } else { Some(value) }
+            settings.open_tabs = if value.is_empty() { None } else { Some(value.to_string()) }
         }
-        "language" => settings.language = if value.is_empty() { None } else { Some(value) },
+        "language" => settings.language = if value.is_empty() { None } else { Some(value.to_string()) },
 
         // --- AI Assistant settings (all keys must have arms; see repo memory
         // about the latent auto_commit_on_save bug). ---
@@ -140,25 +135,81 @@ pub async fn update_setting(
                 settings.ai_risk_acknowledged = false;
                 settings.ai_assistant_enabled = false;
             }
-            settings.ai_provider = value;
+            settings.ai_provider = value.to_string();
         }
-        "ai_base_url" => settings.ai_base_url = value,
+        "ai_base_url" => settings.ai_base_url = value.to_string(),
         "ai_api_key" => {
             // Changing the key invalidates the prior risk ack boundary.
             if value != settings.ai_api_key {
                 settings.ai_risk_acknowledged = false;
                 settings.ai_assistant_enabled = false;
             }
-            settings.ai_api_key = value;
+            settings.ai_api_key = value.to_string();
         }
-        "ai_model" => settings.ai_model = value,
-        "ai_capability_tier" => settings.ai_capability_tier = value,
+        "ai_model" => settings.ai_model = value.to_string(),
+        "ai_capability_tier" => settings.ai_capability_tier = value.to_string(),
+        // Version control settings
+        "auto_commit_on_save" => settings.auto_commit_on_save = value.to_string(),
+        "commit_message_format" => settings.commit_message_format = value.to_string(),
+        // FOME fast comms toggle
+        "fome_fast_comms_enabled" => {
+            settings.fome_fast_comms_enabled = value.parse().map_err(|_| "Invalid boolean value")?
+        }
+        // Auto-record (data logging) settings
+        "auto_record_enabled" => {
+            settings.auto_record_enabled = value.parse().map_err(|_| "Invalid boolean value")?
+        }
+        "key_on_threshold_rpm" => {
+            settings.key_on_threshold_rpm = value.parse().map_err(|_| "Invalid number value")?
+        }
+        "key_off_timeout_sec" => {
+            settings.key_off_timeout_sec = value.parse().map_err(|_| "Invalid number value")?
+        }
         _ => return Err(format!("Unknown setting: {}", key)),
     }
+    Ok(())
+}
 
+/// Update a single setting
+#[tauri::command]
+pub async fn update_setting(
+    app: tauri::AppHandle,
+    key: String,
+    value: String,
+) -> Result<(), String> {
+    let mut settings = load_settings(&app);
+    apply_setting(&mut settings, &key, &value)?;
     save_settings(&app, &settings);
     let _ = app.emit("settings:changed", key.clone());
     Ok(())
+}
+
+/// Update multiple settings in a SINGLE load + save cycle. Much faster than
+/// calling `update_setting` repeatedly (which re-reads and re-writes the
+/// settings file on every call). Used by the Settings dialog's Apply/OK to
+/// avoid the multi-second delay from ~30 sequential disk writes.
+#[tauri::command]
+pub async fn update_settings(
+    app: tauri::AppHandle,
+    updates: Vec<(String, String)>,
+) -> Result<(), String> {
+    let mut settings = load_settings(&app);
+    let mut errors: Vec<String> = Vec::new();
+    let mut changed_keys: Vec<String> = Vec::new();
+    for (key, value) in &updates {
+        match apply_setting(&mut settings, key, value) {
+            Ok(()) => changed_keys.push(key.clone()),
+            Err(e) => errors.push(format!("{}: {}", key, e)),
+        }
+    }
+    save_settings(&app, &settings);
+    // Notify listeners that settings changed (one event rather than N).
+    let _ = app.emit("settings:changed", "__batch__");
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors.join("\n"))
+    }
 }
 
 /// Update custom heatmap color stops for a context

--- a/crates/libretune-app/src-tauri/src/commands/settings.rs
+++ b/crates/libretune-app/src-tauri/src/commands/settings.rs
@@ -62,7 +62,11 @@ fn apply_setting(settings: &mut Settings, key: &str, value: &str) -> Result<(), 
             settings.runtime_packet_mode = value.to_string();
         }
         "last_serial_port" => {
-            settings.last_serial_port = if value.is_empty() { None } else { Some(value.to_string()) }
+            settings.last_serial_port = if value.is_empty() {
+                None
+            } else {
+                Some(value.to_string())
+            }
         }
         "auto_reconnect_after_controller_command" => {
             settings.auto_reconnect_after_controller_command =
@@ -89,10 +93,18 @@ fn apply_setting(settings: &mut Settings, key: &str, value: &str) -> Result<(), 
         }
         // Session persistence
         "last_project_path" => {
-            settings.last_project_path = if value.is_empty() { None } else { Some(value.to_string()) }
+            settings.last_project_path = if value.is_empty() {
+                None
+            } else {
+                Some(value.to_string())
+            }
         }
         "last_active_tab" => {
-            settings.last_active_tab = if value.is_empty() { None } else { Some(value.to_string()) }
+            settings.last_active_tab = if value.is_empty() {
+                None
+            } else {
+                Some(value.to_string())
+            }
         }
         // UI layout state.
         "sidebar_visible" => {
@@ -102,16 +114,34 @@ fn apply_setting(settings: &mut Settings, key: &str, value: &str) -> Result<(), 
             settings.agent_panel_visible = value.parse().map_err(|_| "Invalid boolean value")?
         }
         "sidebar_expanded_ids" => {
-            settings.sidebar_expanded_ids = if value.is_empty() { None } else { Some(value.to_string()) }
+            settings.sidebar_expanded_ids = if value.is_empty() {
+                None
+            } else {
+                Some(value.to_string())
+            }
         }
         "selected_dashboard" => {
-            settings.selected_dashboard = if value.is_empty() { None } else { Some(value.to_string()) }
+            settings.selected_dashboard = if value.is_empty() {
+                None
+            } else {
+                Some(value.to_string())
+            }
         }
         "open_tabs" => {
             // Store the JSON blob as-is; the frontend parses it.
-            settings.open_tabs = if value.is_empty() { None } else { Some(value.to_string()) }
+            settings.open_tabs = if value.is_empty() {
+                None
+            } else {
+                Some(value.to_string())
+            }
         }
-        "language" => settings.language = if value.is_empty() { None } else { Some(value.to_string()) },
+        "language" => {
+            settings.language = if value.is_empty() {
+                None
+            } else {
+                Some(value.to_string())
+            }
+        }
 
         // --- AI Assistant settings (all keys must have arms; see repo memory
         // about the latent auto_commit_on_save bug). ---

--- a/crates/libretune-app/src-tauri/src/lib.rs
+++ b/crates/libretune-app/src-tauri/src/lib.rs
@@ -140,7 +140,9 @@ use commands::restore_points::{
     create_restore_point, delete_restore_point, list_restore_points, load_restore_point,
 };
 use commands::save_tune::{save_tune, save_tune_as};
-use commands::settings::{get_settings, update_heatmap_custom_stops, update_setting, update_settings};
+use commands::settings::{
+    get_settings, update_heatmap_custom_stops, update_setting, update_settings,
+};
 use commands::start_autotune::start_autotune;
 use commands::sync_ecu_data::sync_ecu_data;
 use commands::system::{get_build_info, get_serial_ports};

--- a/crates/libretune-app/src-tauri/src/lib.rs
+++ b/crates/libretune-app/src-tauri/src/lib.rs
@@ -140,7 +140,7 @@ use commands::restore_points::{
     create_restore_point, delete_restore_point, list_restore_points, load_restore_point,
 };
 use commands::save_tune::{save_tune, save_tune_as};
-use commands::settings::{get_settings, update_heatmap_custom_stops, update_setting};
+use commands::settings::{get_settings, update_heatmap_custom_stops, update_setting, update_settings};
 use commands::start_autotune::start_autotune;
 use commands::sync_ecu_data::sync_ecu_data;
 use commands::system::{get_build_info, get_serial_ports};
@@ -425,6 +425,7 @@ pub fn run() {
             // Settings commands
             get_settings,
             update_setting,
+            update_settings,
             get_hotkey_bindings,
             save_hotkey_bindings,
             mark_onboarding_completed,

--- a/crates/libretune-app/src/components/tuner-ui/__tests__/SettingsDialog.test.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/__tests__/SettingsDialog.test.tsx
@@ -57,15 +57,22 @@ describe('SettingsDialog', () => {
     const applyBtn = screen.getByText('Apply');
     await userEvent.click(applyBtn);
 
-    // Ensure update_setting called with runtime_packet_mode and that it matches the select's value
+    // Settings are now saved in a single batched `update_settings` call
+    // (one disk read + write on the backend) rather than ~30 sequential
+    // `update_setting` calls. Assert the batch includes the expected pairs.
     const expectedMode = runtimeSelect.value;
     await waitFor(() => {
-      expect(invoke).toHaveBeenCalledWith('update_setting', { key: 'runtime_packet_mode', value: expectedMode });
+      const calls = (invoke as unknown as any).mock.calls.filter((c: any[]) => c[0] === 'update_settings');
+      expect(calls.length).toBeGreaterThan(0);
+      const updates = calls[calls.length - 1][1].updates as [string, string][];
+      expect(updates).toContainEqual(['runtime_packet_mode', expectedMode]);
     });
 
-    // Also ensure auto_reconnect setting is saved
+    // Also ensure auto_reconnect setting is in the batch
     await waitFor(() => {
-      expect(invoke).toHaveBeenCalledWith('update_setting', { key: 'auto_reconnect_after_controller_command', value: 'false' });
+      const calls = (invoke as unknown as any).mock.calls.filter((c: any[]) => c[0] === 'update_settings');
+      const updates = calls[calls.length - 1][1].updates as [string, string][];
+      expect(updates).toContainEqual(['auto_reconnect_after_controller_command', 'false']);
     });
 
     // Flush once more so any state update Apply triggers after its last

--- a/crates/libretune-app/src/components/tuner-ui/dialogs/SettingsDialog.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/dialogs/SettingsDialog.tsx
@@ -183,7 +183,12 @@ export function SettingsDialog({ isOpen, onClose, theme, onThemeChange, onSettin
         // AI assistant settings
         if (settings.ai_assistant_enabled !== undefined) setAiEnabled(settings.ai_assistant_enabled);
         if (settings.ai_risk_acknowledged !== undefined) setAiRiskAcked(settings.ai_risk_acknowledged);
-        if (settings.ai_provider !== undefined) setAiProvider(settings.ai_provider);
+        if (settings.ai_provider !== undefined) {
+          // Coerce empty/blank provider to the default so the dropdown always
+          // shows a valid selection (older settings files could store "").
+          const p = settings.ai_provider as string;
+          setAiProvider(p && p.trim() ? p : 'openai');
+        }
         if (settings.ai_base_url !== undefined) setAiBaseUrl(settings.ai_base_url);
         if (settings.ai_api_key !== undefined) setAiApiKey(settings.ai_api_key);
         if (settings.ai_model !== undefined) setAiModel(settings.ai_model);
@@ -418,24 +423,15 @@ export function SettingsDialog({ isOpen, onClose, theme, onThemeChange, onSettin
     }
   }, [currentProject]);
 
-  // Persist all settings to the backend WITHOUT closing the dialog. Each
-  // setting is saved independently so one failure cannot silently abort the
-  // rest (this was the root cause of the GLM/z.ai info not saving — a thrown
-  // invoke aborted the whole sequence). Returns the list of per-setting
-  // errors (empty on full success).
+  // Persist all settings to the backend WITHOUT closing the dialog. Sends all
+  // settings in a SINGLE batched `update_settings` call (one disk read + one
+  // disk write on the backend) instead of ~30 sequential `update_setting`
+  // calls (which each did a full read+write cycle and took several seconds).
+  // Returns the list of per-setting errors (empty on full success).
   const saveSettings = useCallback(async (): Promise<string[]> => {
     setSaveStatus('saving');
     setSaveError(null);
     const errors: string[] = [];
-    // Helper: invoke update_setting, capturing any error instead of letting
-    // it abort the whole save.
-    const set = async (key: string, value: string) => {
-      try {
-        await invoke('update_setting', { key, value });
-      } catch (e) {
-        errors.push(`${key}: ${String(e)}`);
-      }
-    };
 
     // Wrap the whole save body so saveStatus can NEVER get stuck at 'saving'
     // (which would leave Apply/OK permanently disabled). Any unexpected throw
@@ -456,66 +452,70 @@ export function SettingsDialog({ isOpen, onClose, theme, onThemeChange, onSettin
       try {
         localStorage.setItem(LANGUAGE_STORAGE_KEY, localLanguage);
       } catch { /* ignore */ }
-      await set('language', localLanguage);
-      // Update units setting
+
+      // Build the batch of [key, value] pairs. Order matters for the AI
+      // assistant settings: provider/key are listed before risk-ack/enable so
+      // the backend's enable-guard (which requires risk-ack) sees the ack
+      // applied in the same in-memory cycle. Provider/key changes reset the
+      // ack on the backend side; the ack/enable pairs after them re-set it.
+      const updates: [string, string][] = [
+        ['language', localLanguage],
+        // Update units setting (normalize invalid to metric)
+        ['units_system', (localUnits !== 'metric' && localUnits !== 'imperial') ? 'metric' : localUnits],
+        ['auto_burn_on_close', autoBurnOnClose.toString()],
+        ['status_bar_channels', JSON.stringify(statusBarChannels)],
+        ['indicator_column_count', indicatorColumnCount],
+        ['indicator_fill_empty', indicatorFillEmpty.toString()],
+        ['indicator_text_fit', indicatorTextFit],
+        ['heatmap_value_scheme', heatmapValueScheme],
+        ['heatmap_change_scheme', heatmapChangeScheme],
+        ['heatmap_coverage_scheme', heatmapCoverageScheme],
+        ['gauge_snap_to_grid', gaugeSnapToGrid.toString()],
+        ['gauge_free_move', gaugeFreeMove.toString()],
+        ['gauge_lock', gaugeLock.toString()],
+        ['auto_sync_gauge_ranges', autoSyncGaugeRanges.toString()],
+        ['auto_commit_on_save', autoCommitOnSave],
+        ['commit_message_format', commitMessageFormat],
+        ['runtime_packet_mode', runtimePacketMode],
+        ['ai_provider', aiProvider],
+        ['ai_base_url', aiBaseUrl],
+        ['ai_api_key', aiApiKey],
+        ['ai_model', aiModel],
+        ['ai_capability_tier', aiCapabilityTier],
+        ['ai_risk_acknowledged', aiRiskAcked.toString()],
+        ['ai_assistant_enabled', aiEnabled.toString()],
+        ['auto_reconnect_after_controller_command', autoReconnectAfterControllerCommand.toString()],
+        ['auto_reconnect_after_firmware', autoReconnectAfterFirmware.toString()],
+        ['auto_record_enabled', autoRecordEnabled.toString()],
+        ['key_on_threshold_rpm', keyOnThresholdRpm.toString()],
+        ['key_off_timeout_sec', keyOffTimeoutSec.toString()],
+        ['alert_large_change_enabled', alertLargeChangeEnabled.toString()],
+        ['alert_large_change_abs', alertLargeChangeAbs.toString()],
+        ['alert_large_change_percent', alertLargeChangePercent.toString()],
+      ];
+
+      // Send the entire batch in one call (1 load + 1 save on the backend).
+      try {
+        await invoke('update_settings', { updates });
+      } catch (e) {
+        // The backend returns a newline-joined list of "key: error" for any
+        // individual failures. Split them back into the errors array.
+        errors.push(...String(e).split('\n').filter(Boolean));
+      }
+
+      // Normalize units state if it was coerced
       if (localUnits !== 'metric' && localUnits !== 'imperial') {
         setLocalUnits('metric');
-        await set('units_system', 'metric');
-      } else {
-        await set('units_system', localUnits);
       }
-      // Update auto-burn setting
-      await set('auto_burn_on_close', autoBurnOnClose.toString());
-      // Update status bar channels
-      await set('status_bar_channels', JSON.stringify(statusBarChannels));
-      // Update indicator panel settings
-      await set('indicator_column_count', indicatorColumnCount);
-      await set('indicator_fill_empty', indicatorFillEmpty.toString());
-      await set('indicator_text_fit', indicatorTextFit);
-      // Update heatmap settings
-      await set('heatmap_value_scheme', heatmapValueScheme);
-      await set('heatmap_change_scheme', heatmapChangeScheme);
-      await set('heatmap_coverage_scheme', heatmapCoverageScheme);
-      // Update gauge settings
-      await set('gauge_snap_to_grid', gaugeSnapToGrid.toString());
-      await set('gauge_free_move', gaugeFreeMove.toString());
-      await set('gauge_lock', gaugeLock.toString());
-      await set('auto_sync_gauge_ranges', autoSyncGaugeRanges.toString());
-      // Update version control settings
-      await set('auto_commit_on_save', autoCommitOnSave);
-      await set('commit_message_format', commitMessageFormat);
-      // Update runtime packet mode
-      await set('runtime_packet_mode', runtimePacketMode);
-      // Update AI assistant settings. Order matters: provider/key first, then
-      // capability tier, then ack, then enable — so the backend's enable-guard
-      // (which requires risk-ack) sees the ack we just sent. Provider/key
-      // changes reset the ack on the backend side; we re-send it afterwards.
-      await set('ai_provider', aiProvider);
-      await set('ai_base_url', aiBaseUrl);
-      await set('ai_api_key', aiApiKey);
-      await set('ai_model', aiModel);
-      await set('ai_capability_tier', aiCapabilityTier);
-      await set('ai_risk_acknowledged', aiRiskAcked.toString());
-      await set('ai_assistant_enabled', aiEnabled.toString());
-      await set('auto_reconnect_after_controller_command', autoReconnectAfterControllerCommand.toString());
-      await set('auto_reconnect_after_firmware', autoReconnectAfterFirmware.toString());
-      // Update auto-record settings
-      await set('auto_record_enabled', autoRecordEnabled.toString());
-      await set('key_on_threshold_rpm', keyOnThresholdRpm.toString());
-      await set('key_off_timeout_sec', keyOffTimeoutSec.toString());
-      // Update alert rules settings
-      await set('alert_large_change_enabled', alertLargeChangeEnabled.toString());
-      await set('alert_large_change_abs', alertLargeChangeAbs.toString());
-      await set('alert_large_change_percent', alertLargeChangePercent.toString());
 
-      // Update hotkey bindings
+      // Hotkey bindings (separate command, not part of the settings struct)
       try {
         await invoke('save_hotkey_bindings', { bindings: hotkeyBindings });
       } catch (e) {
         errors.push(`hotkey_bindings: ${String(e)}`);
       }
 
-      // Update project-specific settings
+      // Project-specific settings
       if (currentProject) {
         try {
           await invoke('update_project_auto_connect', { autoConnect });


### PR DESCRIPTION
## Summary

Follow-up fixes for Settings saving that surfaced after PR #102 (the dashboard-loop fix) made Apply/OK actually run to completion. Three issues, all in the save path:

## 1. "Some settings failed to save" error

The backend `update_setting` match was **missing arms** for 6 keys the frontend sends:
- `auto_commit_on_save`
- `commit_message_format`
- `fome_fast_comms_enabled`
- `auto_record_enabled`
- `key_on_threshold_rpm`
- `key_off_timeout_sec`

Each hit the `_ => Err("Unknown setting")` catch-all, so Apply showed "Some settings failed to save". Added all six arms.

To prevent this class of bug recurring, the giant match was **extracted into a shared `apply_setting(&mut settings, key, value)` helper** used by both the single and batch commands — so the key list lives in exactly one place.

## 2. AI assistant reported "not configured"

`agent_status` reports `configured = !provider.is_empty() && !model.is_empty()`. The user's `ai_provider` was saving as **empty** — a leftover from the earlier `Settings::default()` corruption bug (PR #101) — which made the Provider dropdown render blank (no option matches `""`), so the user never selected one. With `ai_model` set but `ai_provider` empty, `configured` was false.

Fixes:
- **Frontend**: coerce empty `ai_provider` → `'openai'` on load, so the dropdown always shows a valid selection.
- **Backend** (`agent_status`): treat empty provider as `'openai'` defensively.

## 3. Apply/OK took several seconds (performance)

`saveSettings` made ~30 sequential `update_setting` calls, each doing a **full disk read + write cycle** (load → mutate one field → save → emit) — ~60 file operations on Windows, adding up to several seconds.

**New `update_settings` (plural) command**: loads settings **once**, applies all key/value pairs to one in-memory struct (via the shared `apply_setting` helper), and saves **once**. The frontend now sends all settings in a single batched `invoke('update_settings', { updates })`. Save is now near-instant (2 file ops instead of ~60).

The AI settings ordering (provider/key before risk-ack/enable) is preserved because the batch is applied in array order to the same struct, so the backend's enable-guard still sees the ack.

## Verification
- `cargo check -p libretune-app` — clean
- `npm run typecheck` — passes
- `npx vitest run` — 17 files / 106 tests pass (updated the SettingsDialog Apply test for the batched call)

## Files
- `src-tauri/src/commands/settings.rs` — extracted `apply_setting`; added `update_settings` batch command + the 6 missing arms
- `src-tauri/src/lib.rs` — registered `update_settings`
- `src-tauri/src/commands/agent.rs` — empty-provider coercion in `agent_status`
- `components/tuner-ui/dialogs/SettingsDialog.tsx` — batched `saveSettings` (one invoke); ai_provider coercion on load
- `components/tuner-ui/__tests__/SettingsDialog.test.tsx` — updated Apply assertions for the batched call
- `CHANGELOG.md` — new entry
