### PR TITLE
fix(plugin_system): make execute_action's return code honest, fix sta…

### DIFF
--- a/crates/libretune-core/src/plugin_api.rs
+++ b/crates/libretune-core/src/plugin_api.rs
@@ -247,7 +247,13 @@ pub fn api_get_constant(
 /// * `value_bytes` - Raw bytes to write
 ///
 /// # Returns
-/// ApiResponse with success or error
+/// ApiResponse indicating whether the write is authorized. This function
+/// only checks permission — it does not write anything itself. The actual
+/// write happens after the plugin's synchronous run finishes: the caller
+/// (`plugin_system`'s `set_constant` host function) records a
+/// `PluginProposal::SetConstant` on success here, and `execute_wasm_plugin`
+/// applies it afterward via the real `update_constant` command, the same
+/// path a user-driven edit takes.
 pub fn api_set_constant(
     granted: &[Permission],
     _constant_name: &str,
@@ -257,7 +263,6 @@ pub fn api_set_constant(
         return ApiResponse::permission_denied("WriteConstants");
     }
 
-    // Implementation would write to tune cache
     ApiResponse::ok_empty()
 }
 
@@ -329,13 +334,20 @@ pub fn api_get_channel_value(
 /// * `action_json` - JSON-encoded action data
 ///
 /// # Returns
-/// ApiResponse with execution result or error
+/// ApiResponse indicating whether the permission check passed — **not**
+/// whether the action was executed. LibreTune's action-scripting engine
+/// (`action_scripting::Action`/`ActionPlayer`) is validation-only today,
+/// with no generic "run this one action now" dispatcher to call into, so
+/// nothing here ever actually executes the action. The caller
+/// (`plugin_system`'s `execute_action` host function) reflects this
+/// honestly at the wire level: it returns `host_result::ACCEPTED_NOT_EXECUTED`
+/// rather than `host_result::OK` on this path, so a plugin can't mistake
+/// "permission granted, proposal recorded" for "actually ran."
 pub fn api_execute_action(granted: &[Permission], _action_json: &str) -> ApiResponse {
     if !granted.contains(&Permission::ExecuteActions) {
         return ApiResponse::permission_denied("ExecuteActions");
     }
 
-    // Implementation would parse JSON and execute action
     ApiResponse::ok_empty()
 }
 

--- a/crates/libretune-core/src/plugin_system.rs
+++ b/crates/libretune-core/src/plugin_system.rs
@@ -44,6 +44,12 @@ mod host_result {
     /// Permission was held, but the requested table/constant/channel/id
     /// doesn't exist in this run's data snapshot.
     pub const NOT_FOUND: i32 = -3;
+    /// Permission was held and the request was recorded, but it will never
+    /// actually run — currently only returned by `execute_action`, since
+    /// LibreTune's action-scripting engine has no dispatcher to call into.
+    /// Deliberately not `OK`, so a plugin can't mistake "accepted" for
+    /// "executed".
+    pub const ACCEPTED_NOT_EXECUTED: i32 = 1;
 }
 
 /// A single table's current axis bins and cell values, captured for one
@@ -392,7 +398,9 @@ fn register_host_functions(linker: &mut Linker<PluginHostState>) -> Result<(), S
                     .data_mut()
                     .proposals
                     .push(PluginProposal::ExecuteAction { action_json });
-                host_result::OK
+                // Deliberately not host_result::OK — see ACCEPTED_NOT_EXECUTED's
+                // doc comment. The proposal is recorded, not run.
+                host_result::ACCEPTED_NOT_EXECUTED
             },
         )
         .map_err(|e| format!("Failed to register execute_action: {}", e))?;

--- a/crates/libretune-core/tests/plugin_system.rs
+++ b/crates/libretune-core/tests/plugin_system.rs
@@ -581,7 +581,7 @@ fn set_constant_records_a_proposal_instead_of_writing_directly() {
 }
 
 #[test]
-fn execute_action_records_an_unapplied_proposal() {
+fn execute_action_records_an_unapplied_proposal_and_says_so() {
     let wat = r#"
         (module
             (import "env" "execute_action" (func $execute_action (param i32 i32) (result i32)))
@@ -600,7 +600,19 @@ fn execute_action_records_an_unapplied_proposal() {
     let result = instance
         .execute(PluginDataSnapshot::default())
         .expect("execute failed");
-    assert_eq!(result.result_code, Some(0));
+    // Must NOT be host_result::OK (0) — the whole point is that a plugin
+    // can tell "recorded" apart from "actually ran". See
+    // host_result::ACCEPTED_NOT_EXECUTED's doc comment.
+    assert_eq!(
+        result.result_code,
+        Some(1),
+        "execute_action must return ACCEPTED_NOT_EXECUTED, not OK, since nothing actually executes"
+    );
+    assert_ne!(
+        result.result_code,
+        Some(0),
+        "a plugin must never see success (0) for an action that will never run"
+    );
     assert_eq!(
         result.proposals,
         vec![PluginProposal::ExecuteAction {


### PR DESCRIPTION
## Description
Follow-up to the two already-merged plugin PRs. A post-merge completeness
audit found one real remaining gap: `execute_action` returned
`host_result::OK` (0) — the same code as a genuinely successful call — even
though nothing ever actually executes the action (LibreTune's
action-scripting engine has no "run this one action now" dispatcher to call
into). A plugin's own code had no way to distinguish "recorded" from
"actually ran."

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues
Direct follow-up to #105.

## Changes Made
- Added `host_result::ACCEPTED_NOT_EXECUTED` (1), returned by
  `execute_action` instead of `OK`. A test now asserts a plugin can never
  see `0` for an action, since nothing executes it.
- Fixed a stale comment on `api_set_constant` ("Implementation would write
  to tune cache") that was backwards from reality — that write genuinely
  happens now, via the proposal recorded here and applied afterward by
  `execute_wasm_plugin`'s `update_constant` call.
- Updated both functions' doc comments to describe what actually happens
  end-to-end, not just what each function does in isolation.

## Testing
- [x] I have tested these changes locally
- [x] New and existing tests pass (`cargo test`)
- [ ] The UI works correctly with these changes
  <!-- Backend-only change, no UI-visible surface — the return code isn't
       exposed anywhere in PluginPanel.tsx today. -->

## Checklist
- [x] Code compiles without errors
- [x] No new clippy warnings (`cargo clippy`)
- [x] Code is formatted (`cargo fmt`)
- [x] TypeScript compiles without errors (`npx tsc --noEmit`)
- [ ] Documentation updated if needed
  <!-- Same pre-existing plugin-system.md gap noted in prior PRs, tracked
       separately. -->
- [x] Commit messages follow conventional format

## Screenshots (if applicable)
N/A — backend-only change.

