### PR TITLE
Fix table editing operations and right-click selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,42 @@ relevant.
 
 ## [Unreleased]
 
+### 2026-08-01 — Table editing operations restored
+
+#### Fixed
+- **All table modifying operations failed silently-ish with "invalid args"** —
+  every table op in `TableEditor2D` (`set_cells_equal`, `scale_cells`,
+  `smooth_table`, `interpolate_cells`, `interpolate_linear`, `add_offset`,
+  `fill_region`, `rebin_table`) passed its `invoke` arguments in snake_case
+  (`table_name`, `selected_cells`, `scale_factor`, …). Tauri 2 expects
+  camelCase keys and converts them to the Rust `snake_case` parameters, so it
+  rejected every payload before the command body ran — e.g. *"invalid args
+  `tableName` for command `scale_cells`: command scale_cells missing required
+  key tableName"*. Scaling, smoothing, interpolation, fill and re-bin were all
+  dead. Plain cell edits/paste/undo kept working because `update_table_data`
+  was already using camelCase.
+- **`>` / `<` / `+` multiplied cell values instead of nudging them** — the
+  keyboard handler and toolbar buttons passed a raw multiplier (`1`, or `5`
+  with Ctrl) to `handleIncrease`/`handleDecrease`, which compute
+  `value * (1 ± amount)`. Pressing `>` doubled every selected cell and `+` made
+  it 11×. They now step by 1% (5% with Ctrl, 10% for `+`).
+- **Scale (`*` / toolbar) was a guaranteed no-op** — both entry points called
+  `handleScale(1.0)`. They now open a dialog prompting for the multiplier;
+  only the right-click menu previously supplied a real factor.
+- **Right-click context menu targeted the wrong cell** — `TableGrid` never
+  emitted the `data-x`/`data-y` attributes that `TableEditor2D`'s
+  `onContextMenu` handler read, so Lock/Unlock and the menu header always
+  resolved to cell `(0, 0)`. The handler also required the event target to
+  *be* the `.table-cell` element, but right-clicking the number hits the inner
+  value span, so the menu often didn't open at all. The cells now carry their
+  coordinates, the handler walks up with `closest()`, and a right-click
+  outside the current selection moves the selection to the clicked cell (the
+  menu's other actions all operate on the selection).
+
+#### Added
+- Regression tests asserting the `invoke` argument keys for each table
+  operation, so camelCase/snake_case drift can't silently break editing again.
+
 ### 2026-07-31 — Dashboard validation loop + Settings save performance/reliability
 
 Fixes a runaway backend loop that starved the UI, plus several Settings-save

--- a/crates/libretune-app/public/manual/technical/table-operations.md
+++ b/crates/libretune-app/public/manual/technical/table-operations.md
@@ -2,6 +2,26 @@
 
 LibreTune provides several mathematical operations for manipulating 2D and 3D table data. These operations are implemented in the core library for consistency and tested for correctness.
 
+## Editor Controls
+
+Select a cell or drag a rectangular selection before applying an operation.
+
+| Control | Action |
+| --- | --- |
+| `=` | Set selected cells to their average value |
+| `>` or `.` | Increase selected cells by 1% (`Ctrl`/`Cmd`: 5%) |
+| `<`, `,`, `-`, or `_` | Decrease selected cells by 1% (`Ctrl`/`Cmd`: 5%) |
+| `+` | Increase selected cells by 10% (`Ctrl`/`Cmd`: 50%) |
+| `*` | Open the scale-factor dialog |
+| `/` | Interpolate between the selected region's corner cells |
+| `s` | Smooth selected cells |
+| `Page Up` / `Page Down` | Add or subtract 0.1 (`Shift`: 1; `Ctrl`/`Cmd`: 0.05) |
+
+Scaling multiplies each selected value by the entered factor: use `1.05` for a
+5% increase or `0.95` for a 5% decrease. Right-clicking a cell opens the
+context menu for that cell; when it is outside the current selection, it
+becomes the active selection before an operation runs.
+
 ## Interpolation
 
 ### Bilinear Interpolation (2D Tables)

--- a/crates/libretune-app/src/components/tables/TableEditor2D.tsx
+++ b/crates/libretune-app/src/components/tables/TableEditor2D.tsx
@@ -7,6 +7,7 @@ import TableEditor3D from './TableEditor3D';
 import TableContextMenu from './TableContextMenu';
 import RebinDialog from '../dialogs/RebinDialog';
 import CellEditDialog from '../dialogs/CellEditDialog';
+import { Dialog, Button, FormField } from '../common';
 import LambdaPreviewTable from './LambdaPreviewTable';
 import { useHeatmapSettings } from '../../utils/useHeatmapSettings';
 import { useTableYAxisBottom, useTrailFadeSec } from '../../utils/useTableOrientation';
@@ -190,6 +191,11 @@ export default function TableEditor2D({
     row: 0,
     col: 0,
     value: 0,
+  });
+
+  const [scaleDialog, setScaleDialog] = useState<{ show: boolean; factor: string }>({
+    show: false,
+    factor: '1.05',
   });
 
   const [followMode, setFollowMode] = useState(true);
@@ -415,7 +421,8 @@ export default function TableEditor2D({
 
       const isCtrl = e.ctrlKey || e.metaKey;
       const isShift = e.shiftKey;
-      const multiplier = isCtrl ? 5 : 1; // Ctrl = 5x increment
+      // handleIncrease/handleDecrease take a fraction, not a multiplier.
+      const stepFraction = isCtrl ? 0.05 : 0.01;
       
       // Build composite key for Ctrl+key combinations
       const getKeyCombo = (key: string): string => {
@@ -496,22 +503,22 @@ export default function TableEditor2D({
       }
       if (matchesAction('table.increase') || ['>', '.', 'q'].includes(e.key)) {
         e.preventDefault();
-        handleIncrease(multiplier);
+        handleIncrease(stepFraction);
         return;
       }
       if (matchesAction('table.decrease') || ['<', ',', '-', '_'].includes(e.key)) {
         e.preventDefault();
-        handleDecrease(multiplier);
+        handleDecrease(stepFraction);
         return;
       }
       if (matchesAction('table.increaseMultiple') || e.key === '+') {
         e.preventDefault();
-        handleIncrease(10 * multiplier);
+        handleIncrease(10 * stepFraction);
         return;
       }
       if (matchesAction('table.scale') || e.key === '*') {
         e.preventDefault();
-        handleScale(1.0);
+        openScaleDialog();
         return;
       }
       if (matchesAction('table.interpolate') || e.key === '/') {
@@ -670,8 +677,8 @@ export default function TableEditor2D({
 
     try {
       const result = await invoke<TableOperationResult>('set_cells_equal', {
-        table_name,
-        selected_cells: selectedCellsPayload,
+        tableName: table_name,
+        selectedCells: selectedCellsPayload,
         value: avgValue
       });
       if (result && result.z_values) {
@@ -691,7 +698,7 @@ export default function TableEditor2D({
   };
 
   const handleScaleWrapper = () => {
-    handleScale(1.0);
+    openScaleDialog();
   };
 
   const handleContextMenuSetEqual = (_value: number) => {
@@ -730,9 +737,9 @@ export default function TableEditor2D({
     const previousValues = localZValues.map((row) => [...row]);
     try {
       const result = await invoke<TableOperationResult>('scale_cells', {
-        table_name,
-        selected_cells: selectedCellsPayload,
-        scale_factor: factor
+        tableName: table_name,
+        selectedCells: selectedCellsPayload,
+        scaleFactor: factor
       });
       if (result && result.z_values) {
         setLocalZValues(result.z_values);
@@ -745,12 +752,25 @@ export default function TableEditor2D({
     }
   };
 
+  const openScaleDialog = () => {
+    if (selectedCellsCoords.length === 0) return;
+    setContextMenu({ visible: false, x: 0, y: 0, value: 0 });
+    setScaleDialog(prev => ({ ...prev, show: true }));
+  };
+
+  const handleScaleDialogApply = () => {
+    const factor = parseFloat(scaleDialog.factor);
+    if (!Number.isFinite(factor)) return;
+    setScaleDialog(prev => ({ ...prev, show: false }));
+    handleScale(factor);
+  };
+
   const handleSmooth = async () => {
     const previousValues = localZValues.map((row) => [...row]);
     try {
       const result = await invoke<TableOperationResult>('smooth_table', {
-        table_name,
-        selected_cells: selectedCellsPayload,
+        tableName: table_name,
+        selectedCells: selectedCellsPayload,
         factor: 1.0
       });
       if (result && result.z_values) {
@@ -768,8 +788,8 @@ export default function TableEditor2D({
     const previousValues = localZValues.map((row) => [...row]);
     try {
       const result = await invoke<TableOperationResult>('interpolate_cells', {
-        table_name,
-        selected_cells: selectedCellsPayload
+        tableName: table_name,
+        selectedCells: selectedCellsPayload
       });
       if (result && result.z_values) {
         setLocalZValues(result.z_values);
@@ -786,8 +806,8 @@ export default function TableEditor2D({
     const previousValues = localZValues.map((row) => [...row]);
     try {
       const result = await invoke<TableOperationResult>('add_offset', {
-        table_name,
-        selected_cells: selectedCellsPayload,
+        tableName: table_name,
+        selectedCells: selectedCellsPayload,
         offset: offset
       });
       if (result && result.z_values) {
@@ -805,8 +825,8 @@ export default function TableEditor2D({
     const previousValues = localZValues.map((row) => [...row]);
     try {
       const result = await invoke<TableOperationResult>('interpolate_linear', {
-        table_name,
-        selected_cells: selectedCellsPayload,
+        tableName: table_name,
+        selectedCells: selectedCellsPayload,
         axis: axis
       });
       if (result && result.z_values) {
@@ -824,8 +844,8 @@ export default function TableEditor2D({
     const previousValues = localZValues.map((row) => [...row]);
     try {
       const result = await invoke<TableOperationResult>('fill_region', {
-        table_name,
-        selected_cells: selectedCellsPayload,
+        tableName: table_name,
+        selectedCells: selectedCellsPayload,
         direction: direction
       });
       if (result && result.z_values) {
@@ -852,10 +872,10 @@ export default function TableEditor2D({
 
     try {
       const result = await invoke<TableOperationResult>('rebin_table', {
-        table_name,
-        new_x_bins: newXBins,
-        new_y_bins: newYBins,
-        interpolate_z: interpolateZ
+        tableName: table_name,
+        newXBins: newXBins,
+        newYBins: newYBins,
+        interpolateZ: interpolateZ
       });
       if (result && result.z_values) {
         setLocalZValues(result.z_values);
@@ -1056,9 +1076,16 @@ export default function TableEditor2D({
     });
   };
 
-  const handleRightClick = (e: React.MouseEvent, x: number, y: number) => {
+  const handleRightClick = (e: React.MouseEvent, x: number, y: number, cell: HTMLElement) => {
     e.preventDefault();
-    const rect = (e.target as HTMLElement).getBoundingClientRect();
+
+    // Every menu action except lock/unlock operates on the selection, so a
+    // right-click outside it would silently target a different region.
+    if (!selectedCellsCoords.some(([sx, sy]) => sx === x && sy === y)) {
+      setSelectionRange({ start: [x, y], end: [x, y] });
+    }
+
+    const rect = cell.getBoundingClientRect();
     setContextMenu({
       visible: true,
       x,
@@ -1231,15 +1258,14 @@ export default function TableEditor2D({
       <div
         className={`editor-content${hasEmbeddedTableLiveReadout(table_name, x_output_channel, y_output_channel) ? ' editor-content--with-live' : ''}${isAfrTargetTable ? ' editor-content--with-lambda' : ''}`}
         onContextMenu={e => {
-          const target = e.target as HTMLElement;
-          if (target.classList.contains('table-cell')) {
-            const cell = target.closest('.table-cell') as HTMLElement;
-            if (cell) {
-              const x = parseInt(cell.dataset.x || '0');
-              const y = parseInt(cell.dataset.y || '0');
-              handleRightClick(e, x, y);
-            }
-          }
+          // The event target is usually the inner value span, so walk up to the cell.
+          const cell = (e.target as HTMLElement).closest('.table-cell') as HTMLElement | null;
+          if (!cell) return;
+          const x = Number(cell.dataset.x);
+          const y = Number(cell.dataset.y);
+          if (!Number.isInteger(x) || !Number.isInteger(y)) return;
+          if (!localZValues[y] || localZValues[y][x] === undefined) return;
+          handleRightClick(e, x, y, cell);
         }}
       >
         <TableGrid
@@ -1330,6 +1356,46 @@ export default function TableEditor2D({
         xAxisName={x_axis_name}
         yAxisName={y_axis_name}
       />
+
+      <Dialog
+        open={scaleDialog.show}
+        onClose={() => setScaleDialog(prev => ({ ...prev, show: false }))}
+        size="sm"
+        title="Scale Selected Cells"
+      >
+        <Dialog.Body>
+          <FormField
+            label="Multiplier"
+            help={`Applied to ${selectedCellsCoords.length} selected cell(s). 1.05 = +5%, 0.95 = -5%.`}
+          >
+            {id => (
+              <input
+                id={id}
+                type="number"
+                step="any"
+                autoFocus
+                value={scaleDialog.factor}
+                onChange={e => setScaleDialog(prev => ({ ...prev, factor: e.target.value }))}
+                onKeyDown={e => {
+                  if (e.key === 'Enter') handleScaleDialogApply();
+                }}
+              />
+            )}
+          </FormField>
+        </Dialog.Body>
+        <Dialog.Footer>
+          <Button variant="secondary" onClick={() => setScaleDialog(prev => ({ ...prev, show: false }))}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            onClick={handleScaleDialogApply}
+            disabled={!Number.isFinite(parseFloat(scaleDialog.factor))}
+          >
+            Apply
+          </Button>
+        </Dialog.Footer>
+      </Dialog>
     </div>
   );
 }

--- a/crates/libretune-app/src/components/tables/TableGrid.tsx
+++ b/crates/libretune-app/src/components/tables/TableGrid.tsx
@@ -514,6 +514,8 @@ export default function TableGrid({
                     ${isSelected ? 'selected' : ''} 
                     ${isLocked ? 'locked' : ''}
                   `}
+                  data-x={x}
+                  data-y={y}
                   style={getCellColor(value, x, y)}
                   onMouseDown={e => handleCellMouseDown(e, x, y)}
                   onDoubleClick={() => onCellDoubleClick?.(x, y)}

--- a/crates/libretune-app/src/components/tables/TableToolbar.tsx
+++ b/crates/libretune-app/src/components/tables/TableToolbar.tsx
@@ -74,16 +74,16 @@ export default function TableToolbar({
         </button>
         <button 
           className="ts-toolbar-btn" 
-          title="Increase by 1 (> or .)"
-          onClick={() => onIncrease(1)}
+          title="Increase by 1% (> or .)"
+          onClick={() => onIncrease(0.01)}
         >
           <Plus size={14} />
           <span className="ts-toolbar-key">&gt;</span>
         </button>
         <button 
           className="ts-toolbar-btn" 
-          title="Decrease by 1 (<)"
-          onClick={() => onDecrease(1)}
+          title="Decrease by 1% (<)"
+          onClick={() => onDecrease(0.01)}
         >
           <Minus size={14} />
           <span className="ts-toolbar-key">&lt;</span>

--- a/crates/libretune-app/src/components/tables/__tests__/TableEditor2D.operations.test.tsx
+++ b/crates/libretune-app/src/components/tables/__tests__/TableEditor2D.operations.test.tsx
@@ -1,0 +1,148 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { invoke } from '@tauri-apps/api/core';
+import TableEditor2D from '../TableEditor2D';
+import { ToastProvider } from '../../../contexts/ToastContext';
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
+
+const invokeMock = vi.mocked(invoke);
+
+const X_BINS = [500, 1000, 1500];
+const Y_BINS = [20, 40, 60];
+const Z_VALUES = [
+  [10, 11, 12],
+  [20, 21, 22],
+  [30, 31, 32],
+];
+
+/** Tauri 2 converts camelCase invoke keys to snake_case Rust params; sending
+ *  snake_case makes the command reject the payload before it ever runs. */
+const TABLE_OP_COMMANDS = new Set([
+  'set_cells_equal',
+  'scale_cells',
+  'smooth_table',
+  'interpolate_cells',
+  'interpolate_linear',
+  'add_offset',
+  'fill_region',
+  'rebin_table',
+]);
+
+function renderEditor() {
+  const result = render(
+    <ToastProvider>
+      <TableEditor2D
+        title="VE Table 1"
+        table_name="veTable1Tbl"
+        x_axis_name="RPM"
+        y_axis_name="MAP"
+        x_bins={X_BINS}
+        y_bins={Y_BINS}
+        z_values={Z_VALUES}
+      />
+    </ToastProvider>
+  );
+
+  // Operations no-op without a selection, so select the first cell.
+  const cells = result.container.querySelectorAll('.table-cell');
+  fireEvent.mouseDown(cells[0]);
+
+  return result;
+}
+
+function lastTableOpCall() {
+  const call = [...invokeMock.mock.calls].reverse().find(([cmd]) => TABLE_OP_COMMANDS.has(cmd as string));
+  if (!call) throw new Error('no table operation was invoked');
+  return { command: call[0] as string, args: (call[1] ?? {}) as Record<string, unknown> };
+}
+
+describe('TableEditor2D table operations', () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+    invokeMock.mockResolvedValue({
+      table_name: 'veTable1Tbl',
+      x_bins: X_BINS,
+      y_bins: Y_BINS,
+      z_values: Z_VALUES,
+    });
+  });
+
+  it('sends camelCase args for smooth', async () => {
+    renderEditor();
+    fireEvent.click(screen.getByTitle('Smooth selected cells (s)'));
+
+    await waitFor(() => expect(lastTableOpCall().command).toBe('smooth_table'));
+    expect(lastTableOpCall().args).toEqual({
+      tableName: 'veTable1Tbl',
+      selectedCells: [[0, 0]],
+      factor: 1.0,
+    });
+  });
+
+  it('sends camelCase args for interpolate', async () => {
+    renderEditor();
+    fireEvent.click(screen.getByTitle('Interpolate between corners (/)'));
+
+    await waitFor(() => expect(lastTableOpCall().command).toBe('interpolate_cells'));
+    expect(lastTableOpCall().args).toEqual({
+      tableName: 'veTable1Tbl',
+      selectedCells: [[0, 0]],
+    });
+  });
+
+  it('sends camelCase args for set equal', async () => {
+    renderEditor();
+    fireEvent.click(screen.getByTitle('Set Equal (=) - Set selected cells to average'));
+
+    await waitFor(() => expect(lastTableOpCall().command).toBe('set_cells_equal'));
+    expect(lastTableOpCall().args).toEqual({
+      tableName: 'veTable1Tbl',
+      selectedCells: [[0, 0]],
+      value: Z_VALUES[0][0],
+    });
+  });
+
+  it('prompts for a scale factor and sends camelCase args', async () => {
+    renderEditor();
+    fireEvent.click(screen.getByTitle('Scale selected cells (*)'));
+
+    const input = await screen.findByLabelText('Multiplier');
+    fireEvent.change(input, { target: { value: '1.1' } });
+    fireEvent.click(screen.getByText('Apply'));
+
+    await waitFor(() => expect(lastTableOpCall().command).toBe('scale_cells'));
+    expect(lastTableOpCall().args).toEqual({
+      tableName: 'veTable1Tbl',
+      selectedCells: [[0, 0]],
+      scaleFactor: 1.1,
+    });
+  });
+
+  it('nudges by a percentage rather than multiplying', () => {
+    const { container } = renderEditor();
+    fireEvent.click(screen.getByTitle('Increase by 1% (> or .)'));
+
+    const firstCell = container.querySelector('.table-cell .cell-value');
+    expect(firstCell?.textContent).toBe((Z_VALUES[0][0] * 1.01).toFixed(1));
+  });
+
+  it('resolves the right-clicked cell instead of defaulting to (0, 0)', async () => {
+    const { container } = renderEditor();
+
+    // Right-click the value span (the real event target) of cell x=1, y=1.
+    const cell = container.querySelectorAll('.table-cell')[4];
+    fireEvent.contextMenu(cell.querySelector('.cell-value')!);
+
+    expect(screen.getByText('Cell [1, 1]')).toBeInTheDocument();
+    expect(screen.getByText(`Val: ${Z_VALUES[1][1].toFixed(2)}`)).toBeInTheDocument();
+
+    // The menu acts on the selection, so it must have moved to the clicked cell.
+    fireEvent.click(screen.getByText('Set Equal'));
+    await waitFor(() => expect(lastTableOpCall().command).toBe('set_cells_equal'));
+    expect(lastTableOpCall().args).toEqual({
+      tableName: 'veTable1Tbl',
+      selectedCells: [[1, 1]],
+      value: Z_VALUES[1][1],
+    });
+  });
+});

--- a/docs/src/technical/table-operations.md
+++ b/docs/src/technical/table-operations.md
@@ -2,6 +2,26 @@
 
 LibreTune provides several mathematical operations for manipulating 2D and 3D table data. These operations are implemented in the core library for consistency and tested for correctness.
 
+## Editor Controls
+
+Select a cell or drag a rectangular selection before applying an operation.
+
+| Control | Action |
+| --- | --- |
+| `=` | Set selected cells to their average value |
+| `>` or `.` | Increase selected cells by 1% (`Ctrl`/`Cmd`: 5%) |
+| `<`, `,`, `-`, or `_` | Decrease selected cells by 1% (`Ctrl`/`Cmd`: 5%) |
+| `+` | Increase selected cells by 10% (`Ctrl`/`Cmd`: 50%) |
+| `*` | Open the scale-factor dialog |
+| `/` | Interpolate between the selected region's corner cells |
+| `s` | Smooth selected cells |
+| `Page Up` / `Page Down` | Add or subtract 0.1 (`Shift`: 1; `Ctrl`/`Cmd`: 0.05) |
+
+Scaling multiplies each selected value by the entered factor: use `1.05` for a
+5% increase or `0.95` for a 5% decrease. Right-clicking a cell opens the
+context menu for that cell; when it is outside the current selection, it
+becomes the active selection before an operation runs.
+
 ## Interpolation
 
 ### Bilinear Interpolation (2D Tables)


### PR DESCRIPTION
## Summary

- Restore all 2D table operations by sending Tauri 2 `invoke` arguments in camelCase.
- Correct percentage nudges and add a scale-factor dialog for `*` and the toolbar button.
- Fix right-click context menus so they resolve and select the actual clicked cell.
- Document table-editor controls in both bundled manual copies and add regression coverage.

## Root Cause

`TableEditor2D` passed `table_name`, `selected_cells`, and related snake_case
keys to Tauri commands. Tauri 2 requires camelCase JavaScript keys and maps
them to Rust snake_case parameters, so it rejected every table-operation
payload before the backend command executed.

## Validation

- `npm run typecheck`
- `npx vitest run` (112 tests passed)