### PR TITLE
fix(migration): detect page/offset relocation in migration report

### DIFF
--- a/crates/libretune-app/src/components/dialogs/MigrationReportDialog.tsx
+++ b/crates/libretune-app/src/components/dialogs/MigrationReportDialog.tsx
@@ -13,6 +13,7 @@ import {
   Minus,
   RefreshCw,
   Scale,
+  Move,
   ChevronDown,
   ChevronRight,
   Check,
@@ -25,6 +26,8 @@ export interface ConstantChange {
   name: string;
   old_type?: string;
   new_type?: string;
+  old_page?: number;
+  new_page?: number;
   old_scale?: number;
   new_scale?: number;
   old_offset?: number;
@@ -38,6 +41,7 @@ export interface MigrationReport {
   missing_in_ini: string[];
   type_changed: ConstantChange[];
   scale_changed: ConstantChange[];
+  location_changed: ConstantChange[];
   can_auto_migrate: boolean;
   requires_user_review: boolean;
   severity: "none" | "low" | "medium" | "high";
@@ -257,6 +261,40 @@ export default function MigrationReportDialog({
                           <span className="change-detail">
                             scale: {c.old_scale?.toFixed(4)} →{" "}
                             {c.new_scale?.toFixed(4)}
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+              )}
+
+              {/* Location changes (page/offset moved, type/scale unchanged) */}
+              {report.location_changed.length > 0 && (
+                <div className="migration-section info">
+                  <button
+                    className="section-header"
+                    onClick={() => toggleSection("location")}
+                  >
+                    {expandedSections.has("location") ? (
+                      <ChevronDown size={16} />
+                    ) : (
+                      <ChevronRight size={16} />
+                    )}
+                    <Move size={16} className="section-icon" />
+                    <span className="section-title">
+                      Storage Location Changed ({report.location_changed.length})
+                    </span>
+                    <span className="section-badge info">Handled Automatically</span>
+                  </button>
+                  {expandedSections.has("location") && (
+                    <ul className="change-list">
+                      {report.location_changed.map((c) => (
+                        <li key={c.name}>
+                          <code>{c.name}</code>
+                          <span className="change-detail">
+                            page {c.old_page}/offset {c.old_offset} → page {c.new_page}
+                            /offset {c.new_offset}
                           </span>
                         </li>
                       ))}

--- a/crates/libretune-core/src/tune/migration.rs
+++ b/crates/libretune-core/src/tune/migration.rs
@@ -23,6 +23,12 @@ pub struct MigrationReport {
     /// Constants whose scale/translate changed (may affect values)
     pub scale_changed: Vec<ConstantChange>,
 
+    /// Constants whose page/offset moved but type and scale/translate are
+    /// unchanged. The app already applies constants by name against the
+    /// current definition's page/offset, so this doesn't affect the values
+    /// that get written — it's purely informational.
+    pub location_changed: Vec<ConstantChange>,
+
     /// True if all changes can be auto-migrated safely
     pub can_auto_migrate: bool,
 
@@ -65,6 +71,7 @@ impl MigrationReport {
             missing_in_ini: Vec::new(),
             type_changed: Vec::new(),
             scale_changed: Vec::new(),
+            location_changed: Vec::new(),
             can_auto_migrate: true,
             requires_user_review: false,
             severity: "none".to_string(),
@@ -77,6 +84,7 @@ impl MigrationReport {
             || !self.missing_in_ini.is_empty()
             || !self.type_changed.is_empty()
             || !self.scale_changed.is_empty()
+            || !self.location_changed.is_empty()
     }
 
     /// Get a summary of the changes
@@ -94,6 +102,9 @@ impl MigrationReport {
         }
         if !self.scale_changed.is_empty() {
             parts.push(format!("{} scale changes", self.scale_changed.len()));
+        }
+        if !self.location_changed.is_empty() {
+            parts.push(format!("{} location changes", self.location_changed.len()));
         }
 
         if parts.is_empty() {
@@ -176,6 +187,26 @@ pub fn compare_manifests(
                     ),
                 });
             }
+            // Check if page/offset moved (type and scale/translate unchanged)
+            else if entry.page != current.page || entry.offset != current.offset {
+                report.location_changed.push(ConstantChange {
+                    name: entry.name.clone(),
+                    old_type: entry.data_type.clone(),
+                    old_page: entry.page,
+                    old_offset: entry.offset,
+                    old_scale: entry.scale,
+                    old_translate: entry.translate,
+                    new_type: current_type,
+                    new_page: current.page,
+                    new_offset: current.offset,
+                    new_scale: current.scale,
+                    new_translate: current.translate,
+                    change_description: format!(
+                        "Moved from page {} offset {} to page {} offset {}",
+                        entry.page, entry.offset, current.page, current.offset
+                    ),
+                });
+            }
         } else {
             // Constant was in tune but not in current INI
             report.missing_in_ini.push(entry.name.clone());
@@ -191,8 +222,10 @@ pub fn compare_manifests(
         report.requires_user_review = true;
         report.can_auto_migrate = true;
         report.severity = "medium".to_string();
-    } else if !report.missing_in_tune.is_empty() {
-        // Only new constants - can auto-apply defaults
+    } else if !report.missing_in_tune.is_empty() || !report.location_changed.is_empty() {
+        // Only new constants and/or page/offset moves - values are either
+        // defaulted or already applied correctly by name, so this can
+        // auto-migrate without review.
         report.can_auto_migrate = true;
         report.requires_user_review = false;
         report.severity = "low".to_string();
@@ -225,5 +258,84 @@ mod tests {
         let summary = report.summary();
         assert!(summary.contains("2 new constants"));
         assert!(summary.contains("1 removed constants"));
+    }
+
+    #[test]
+    fn test_location_change_detected_when_type_and_scale_unchanged() {
+        // Regression test: a constant whose page/offset moved between INI
+        // versions, with type and scale/translate unchanged, must not be
+        // silently invisible to the report.
+        use crate::ini::Constant;
+
+        let manifest = vec![ConstantManifestEntry {
+            name: "egoCorrection".to_string(),
+            data_type: "U08".to_string(),
+            page: 3,
+            offset: 50,
+            scale: 1.0,
+            translate: 0.0,
+        }];
+
+        let mut def = EcuDefinition::default();
+        def.constants.insert(
+            "egoCorrection".to_string(),
+            Constant {
+                name: "egoCorrection".to_string(),
+                page: 5,
+                offset: 100,
+                ..Constant::default()
+            },
+        );
+
+        let report = compare_manifests(&manifest, &def);
+
+        assert!(report.has_changes());
+        assert_eq!(report.location_changed.len(), 1);
+        assert!(report.type_changed.is_empty());
+        assert!(report.scale_changed.is_empty());
+        assert_eq!(report.severity, "low");
+        assert!(report.can_auto_migrate);
+        assert!(!report.requires_user_review);
+
+        let change = &report.location_changed[0];
+        assert_eq!(change.old_page, 3);
+        assert_eq!(change.old_offset, 50);
+        assert_eq!(change.new_page, 5);
+        assert_eq!(change.new_offset, 100);
+    }
+
+    #[test]
+    fn test_type_change_takes_precedence_over_location_change() {
+        // If type AND location both changed, the constant should be
+        // classified as a type change (higher severity), not a location
+        // change — matching the existing type-vs-scale precedence.
+        use crate::ini::{Constant, DataType};
+
+        let manifest = vec![ConstantManifestEntry {
+            name: "rpmLimit".to_string(),
+            data_type: "U08".to_string(),
+            page: 3,
+            offset: 50,
+            scale: 1.0,
+            translate: 0.0,
+        }];
+
+        let mut def = EcuDefinition::default();
+        def.constants.insert(
+            "rpmLimit".to_string(),
+            Constant {
+                name: "rpmLimit".to_string(),
+                page: 5,
+                offset: 100,
+                data_type: DataType::U16,
+                ..Constant::default()
+            },
+        );
+
+        let report = compare_manifests(&manifest, &def);
+
+        assert_eq!(report.type_changed.len(), 1);
+        assert!(report.location_changed.is_empty());
+        assert_eq!(report.severity, "high");
     }
 }


### PR DESCRIPTION
## Description
Fixes a gap in the tune migration report where a constant's storage
location (page/offset) moving between INI versions went completely
undetected, even though the underlying data structures were clearly
built to track it.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues
None filed — found via code audit.

## Changes Made
- `compare_manifests()` checked a saved tune manifest against the current
  INI for type changes and scale/translate changes, but never compared
  `page`/`offset` — despite `ConstantManifestEntry` and `ConstantChange`
  both already carrying page/offset fields for exactly this purpose. A
  constant that only moved location (type and scale unchanged) produced
  zero diff entries — not even a neutral "no changes" result, it was
  simply invisible.
- Added a `location_changed: Vec<ConstantChange>` bucket to
  `MigrationReport`, populated with the same precedence as the existing
  type-vs-scale check (type change wins, then scale, then location-only).
  Classified as low severity / auto-migratable, since it's genuinely low
  risk: `load_tune`'s constant-application logic already re-derives
  page/offset from the *current* definition by name on every load, so
  tune values land in the right place regardless of what this report
  says — the gap was purely informational.
- Wired the new bucket through `has_changes()` and `summary()`.
- Added a "Storage Location Changed" section to
  `MigrationReportDialog.tsx`, and added `old_page`/`new_page` to the TS
  `ConstantChange` interface, which was missing them even though the Rust
  struct always had them.

## Testing
- [x] I have tested these changes locally
- [x] New and existing tests pass (`cargo test`)
- [ ] The UI works correctly with these changes

Added 2 unit tests in `migration.rs`: one proving a page/offset-only move
is now detected and classified as low-severity/auto-migratable, one
proving type changes still take precedence over location changes when
both occur on the same constant (matching the existing type-vs-scale
precedence). Full `./scripts/pre-push.sh` run: all checks passed cleanly
(314 Rust unit tests, up from 312 before this change; no flakes this
run).

## Checklist
- [x] Code compiles without errors
- [x] No new clippy warnings (`cargo clippy`)
- [x] Code is formatted (`cargo fmt`)
- [x] TypeScript compiles without errors (`npx tsc --noEmit`)
- [ ] Documentation updated if needed
- [x] Commit messages follow conventional format
