### PR TITLE
fix(protocol): check ECU status code on write_memory instead of disca…

### DIFF
--- a/crates/libretune-core/src/protocol/connection.rs
+++ b/crates/libretune-core/src/protocol/connection.rs
@@ -127,6 +127,38 @@ fn strip_status_byte(payload: &[u8], expected_data_len: usize, label: &str) -> V
     }
 }
 
+/// Inspect a modern-protocol write response for an ECU-reported error status.
+///
+/// Per msEnvelope_1.0 §15.2, every reply frame's first payload byte is a
+/// response code. `write_memory` used to discard the response entirely once
+/// its CRC checked out, so a write the ECU rejected (out of range, flash
+/// locked, busy, settings refused) was silently reported to the rest of the
+/// app as a success. Mirrors the same status-byte check already used for
+/// console command ('E') responses in `send_console_command_modern`.
+///
+/// An empty payload is treated as success rather than an error: some
+/// ECU/INI combinations don't echo a status byte on write acks at all (the
+/// same leniency `strip_status_byte` already applies on the read side), and
+/// the CRC already confirmed the frame arrived intact.
+fn check_write_response_status(response: &Packet) -> Result<(), ProtocolError> {
+    let Some(&status) = response.payload.first() else {
+        return Ok(());
+    };
+    let code = super::ResponseCode::from_byte(status);
+    if !code.is_error() {
+        return Ok(());
+    }
+    let message = if code.carries_payload_message() && response.payload.len() > 1 {
+        String::from_utf8_lossy(&response.payload[1..]).into_owned()
+    } else {
+        code.message().to_string()
+    };
+    Err(ProtocolError::EcuStatusError {
+        code: status,
+        message,
+    })
+}
+
 /// Drain up to `remaining` bytes from the channel within `deadline`, discarding all data.
 ///
 /// Called after a partial-read timeout inside `send_packet` to flush the rest of the
@@ -1657,8 +1689,8 @@ impl Connection {
         let result = if self.use_modern_protocol {
             // Modern protocol: wrap in CRC packet
             let packet = Packet::new(cmd);
-            let _response = self.send_packet(packet)?;
-            Ok(())
+            let response = self.send_packet(packet)?;
+            check_write_response_status(&response)
         } else {
             // Legacy protocol: send raw command
             self.send_raw_command(&cmd)?;
@@ -2301,6 +2333,56 @@ mod tests {
         let conn = Connection::new(config);
         assert_eq!(conn.state(), ConnectionState::Disconnected);
         assert!(conn.signature().is_none());
+    }
+
+    #[test]
+    fn write_response_status_ok_on_empty_payload() {
+        // Some ECU/INI combos don't echo a status byte on write acks; the CRC
+        // already confirmed the frame arrived intact, so treat this as success
+        // rather than an error, matching strip_status_byte's read-side leniency.
+        let response = Packet::new(vec![]);
+        assert!(check_write_response_status(&response).is_ok());
+    }
+
+    #[test]
+    fn write_response_status_ok_on_success_code() {
+        let response = Packet::new(vec![0x00]); // ResponseCode::Ok
+        assert!(check_write_response_status(&response).is_ok());
+
+        let response = Packet::new(vec![0x00, 0xAB, 0xCD]); // Ok plus trailing echoed data
+        assert!(check_write_response_status(&response).is_ok());
+    }
+
+    #[test]
+    fn write_response_status_rejects_ecu_reported_error() {
+        // 0x84 = OutOfRange. Before this fix, write_memory discarded the
+        // response entirely and reported this write as Ok(()) regardless.
+        let response = Packet::new(vec![0x84]);
+        let err = check_write_response_status(&response).unwrap_err();
+        match err {
+            ProtocolError::EcuStatusError { code, message } => {
+                assert_eq!(code, 0x84);
+                assert_eq!(message, super::super::ResponseCode::OutOfRange.message());
+            }
+            other => panic!("expected EcuStatusError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn write_response_status_extracts_payload_message_for_generic_error() {
+        // 0x94 = GenericError, which per spec carries a user-readable message
+        // in the remaining payload bytes rather than using the default text.
+        let mut payload = vec![0x94];
+        payload.extend_from_slice(b"flash write failed");
+        let response = Packet::new(payload);
+        let err = check_write_response_status(&response).unwrap_err();
+        match err {
+            ProtocolError::EcuStatusError { code, message } => {
+                assert_eq!(code, 0x94);
+                assert_eq!(message, "flash write failed");
+            }
+            other => panic!("expected EcuStatusError, got {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Description
`write_memory` received and CRC-validated the ECU's response to every write, then discarded it completely — the modern-protocol branch bound it to `_response` and dropped it; the legacy branch didn't even bind it. Per msEnvelope_1.0 §15.2, every reply frame's first payload byte is a response code, and this codebase already has a full `ResponseCode` enum (`OutOfRange`, `FlashLocked`, `Busy`, `SettingsError`, etc.) plus an `EcuStatusError` variant — already used for console command ('E') responses, just never applied to writes. If the ECU rejected a write for any reason, `write_memory` still reported `Ok(())`: the UI shows the edit as saved and the in-memory tune cache updates as if it applied, but the ECU may never have accepted it.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues
None filed — found during an internal audit of the protocol/connection layer.

## Changes Made
- Added `check_write_response_status` (`connection.rs`), mirroring the exact pattern `send_console_command_modern` already uses for its own response: parse the status byte via `ResponseCode::from_byte`, treat an empty payload or non-error code as success, otherwise return `ProtocolError::EcuStatusError` with the payload-derived message for codes that carry one (0x03/0x94/0x95) or the default spec message otherwise.
- Wired it into `write_memory`'s modern-protocol branch only. Scoped deliberately: `response_code.rs` is explicitly scoped to the msEnvelope_1.0 spec, and `send_console_command_legacy` (the existing precedent for the legacy protocol) does no status-byte checking either — legacy is plain ASCII console text, not this binary status-code convention.
- Did not change `write_page`'s transient-error retry classification (matches "121"/timeout/semaphore substrings). Whether an `EcuStatusError` like `Busy` should also be retried is a separate policy decision, out of scope here.

## Testing
- [x] I have tested these changes locally
- [x] New and existing tests pass (`cargo test`) — 4 new unit tests on the extracted `check_write_response_status` (empty-payload and success-code pass-through, an `OutOfRange` rejection, and payload-derived-message extraction for `GenericError`). Full `pre-push.sh` green, zero flakes.
- [ ] The UI works correctly with these changes — this is protocol-layer logic verified via unit tests against synthetic response payloads; I didn't exercise this against a real ECU that actually returns an error status on write (would need hardware that rejects a specific write to reproduce end-to-end).

## Checklist
- [x] Code compiles without errors
- [x] No new clippy warnings (`cargo clippy`)
- [x] Code is formatted (`cargo fmt`)
- [x] TypeScript compiles without errors (`npx tsc --noEmit`) — no frontend changes in this PR
- [ ] Documentation updated if needed — n/a, internal protocol-layer behavior
- [x] Commit messages follow conventional format
