### PR TITLE
fix(dashboard-designer): stop resize fixed-edge drift once minSize is…

### DIFF
--- a/crates/libretune-app/src/components/dashboards/designer/__tests__/useDesignerDragResize.test.ts
+++ b/crates/libretune-app/src/components/dashboards/designer/__tests__/useDesignerDragResize.test.ts
@@ -1,0 +1,190 @@
+import { act } from 'react';
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useDesignerDragResize } from '../useDesignerDragResize';
+import type { DashComponent, DashFile } from '../../dashTypes';
+
+// Minimal gauge fixture: only the fields the drag/resize hook actually reads
+// (id, relative_x/y/width/height) need real values. Cast covers the rest of
+// TsGaugeConfig's many display/appearance fields, which this hook never
+// touches — it only ever spreads `...c.Gauge`.
+function makeGauge(overrides: Record<string, unknown> = {}): DashComponent {
+  return {
+    Gauge: {
+      id: 'g1',
+      relative_x: 0.3,
+      relative_y: 0.3,
+      relative_width: 0.2,
+      relative_height: 0.2,
+      ...overrides,
+    },
+  } as unknown as DashComponent;
+}
+
+function makeDashFile(component: DashComponent): DashFile {
+  return {
+    bibliography: {},
+    version_info: {},
+    gauge_cluster: {
+      components: [component],
+    },
+  } as unknown as DashFile;
+}
+
+function makeContainerRef(width: number, height: number) {
+  return {
+    current: {
+      getBoundingClientRect: () => ({
+        width,
+        height,
+        top: 0,
+        left: 0,
+        right: width,
+        bottom: height,
+        x: 0,
+        y: 0,
+        toJSON() {
+          return this;
+        },
+      }),
+    },
+  } as unknown as React.RefObject<HTMLDivElement>;
+}
+
+describe('useDesignerDragResize', () => {
+  it('keeps the right edge fixed when a west-handle drag shrinks past the minimum size', () => {
+    // Regression test: startRelativeX=0.3, startWidth=0.2, so the right edge
+    // (the fixed point for a west-handle resize) is at 0.5. Before the fix,
+    // dragging the west handle far enough right that width would clamp to
+    // minSize (0.05) still moved newX from the raw unclamped delta, so the
+    // right edge drifted from 0.5 to 0.60+ instead of staying put.
+    const gauge = makeGauge();
+    const dashFile = makeDashFile(gauge);
+    const onDashFileChange = vi.fn();
+    const containerRef = makeContainerRef(1000, 1000);
+
+    const { result } = renderHook(() =>
+      useDesignerDragResize({
+        dashFile,
+        containerRef,
+        snapToGrid: (v) => v,
+        pushHistory: vi.fn(),
+        onDashFileChange,
+        onSelectGauge: vi.fn(),
+      }),
+    );
+
+    act(() => {
+      result.current.onResizeMouseDown(
+        {
+          clientX: 500,
+          clientY: 500,
+          preventDefault: () => {},
+          stopPropagation: () => {},
+        } as unknown as React.MouseEvent,
+        'w',
+        'g1',
+        gauge,
+      );
+    });
+
+    // deltaX = (750 - 500) / 1000 = 0.25 → past the point where
+    // startWidth (0.2) - deltaX would go negative.
+    act(() => {
+      window.dispatchEvent(new MouseEvent('mousemove', { clientX: 750, clientY: 500 }));
+    });
+
+    expect(onDashFileChange).toHaveBeenCalled();
+    const lastCall = onDashFileChange.mock.calls[onDashFileChange.mock.calls.length - 1][0] as DashFile;
+    const updatedGauge = lastCall.gauge_cluster.components[0] as { Gauge: { relative_x: number; relative_width: number } };
+
+    expect(updatedGauge.Gauge.relative_width).toBeCloseTo(0.05, 5);
+    // Right edge must stay at the original 0.3 + 0.2 = 0.5, not drift.
+    expect(updatedGauge.Gauge.relative_x + updatedGauge.Gauge.relative_width).toBeCloseTo(0.5, 5);
+  });
+
+  it('keeps the bottom edge fixed when a north-handle drag shrinks past the minimum size', () => {
+    const gauge = makeGauge();
+    const dashFile = makeDashFile(gauge);
+    const onDashFileChange = vi.fn();
+    const containerRef = makeContainerRef(1000, 1000);
+
+    const { result } = renderHook(() =>
+      useDesignerDragResize({
+        dashFile,
+        containerRef,
+        snapToGrid: (v) => v,
+        pushHistory: vi.fn(),
+        onDashFileChange,
+        onSelectGauge: vi.fn(),
+      }),
+    );
+
+    act(() => {
+      result.current.onResizeMouseDown(
+        {
+          clientX: 500,
+          clientY: 500,
+          preventDefault: () => {},
+          stopPropagation: () => {},
+        } as unknown as React.MouseEvent,
+        'n',
+        'g1',
+        gauge,
+      );
+    });
+
+    act(() => {
+      window.dispatchEvent(new MouseEvent('mousemove', { clientX: 500, clientY: 750 }));
+    });
+
+    const lastCall = onDashFileChange.mock.calls[onDashFileChange.mock.calls.length - 1][0] as DashFile;
+    const updatedGauge = lastCall.gauge_cluster.components[0] as { Gauge: { relative_y: number; relative_height: number } };
+
+    expect(updatedGauge.Gauge.relative_height).toBeCloseTo(0.05, 5);
+    expect(updatedGauge.Gauge.relative_y + updatedGauge.Gauge.relative_height).toBeCloseTo(0.5, 5);
+  });
+
+  it('east-handle resize is unaffected (no x movement, sanity check)', () => {
+    const gauge = makeGauge();
+    const dashFile = makeDashFile(gauge);
+    const onDashFileChange = vi.fn();
+    const containerRef = makeContainerRef(1000, 1000);
+
+    const { result } = renderHook(() =>
+      useDesignerDragResize({
+        dashFile,
+        containerRef,
+        snapToGrid: (v) => v,
+        pushHistory: vi.fn(),
+        onDashFileChange,
+        onSelectGauge: vi.fn(),
+      }),
+    );
+
+    act(() => {
+      result.current.onResizeMouseDown(
+        {
+          clientX: 500,
+          clientY: 500,
+          preventDefault: () => {},
+          stopPropagation: () => {},
+        } as unknown as React.MouseEvent,
+        'e',
+        'g1',
+        gauge,
+      );
+    });
+
+    act(() => {
+      window.dispatchEvent(new MouseEvent('mousemove', { clientX: 250, clientY: 500 }));
+    });
+
+    const lastCall = onDashFileChange.mock.calls[onDashFileChange.mock.calls.length - 1][0] as DashFile;
+    const updatedGauge = lastCall.gauge_cluster.components[0] as { Gauge: { relative_x: number; relative_width: number } };
+
+    expect(updatedGauge.Gauge.relative_width).toBeCloseTo(0.05, 5);
+    // Left edge (x) must stay exactly where it started for an east drag.
+    expect(updatedGauge.Gauge.relative_x).toBeCloseTo(0.3, 5);
+  });
+});

--- a/crates/libretune-app/src/components/dashboards/designer/useDesignerDragResize.ts
+++ b/crates/libretune-app/src/components/dashboards/designer/useDesignerDragResize.ts
@@ -199,19 +199,27 @@ export function useDesignerDragResize({
         // would drift. Same mirror logic for s (bottom) vs n (top).
         const handle = resizeState.handle;
         if (handle.includes('e')) newWidth = snapToGrid(resizeState.startWidth + deltaX);
-        if (handle.includes('w')) {
-          newWidth = snapToGrid(resizeState.startWidth - deltaX);
-          newX = snapToGrid(resizeState.startRelativeX + deltaX);
-        }
+        if (handle.includes('w')) newWidth = snapToGrid(resizeState.startWidth - deltaX);
         if (handle.includes('s')) newHeight = snapToGrid(resizeState.startHeight + deltaY);
-        if (handle.includes('n')) {
-          newHeight = snapToGrid(resizeState.startHeight - deltaY);
-          newY = snapToGrid(resizeState.startRelativeY + deltaY);
-        }
+        if (handle.includes('n')) newHeight = snapToGrid(resizeState.startHeight - deltaY);
 
         const minSize = 0.05;
         newWidth = Math.max(minSize, newWidth);
         newHeight = Math.max(minSize, newHeight);
+
+        // Derive x/y from the already-floor-clamped width/height instead of
+        // from the raw mouse delta, so the fixed edge (right edge for a west
+        // drag, bottom edge for a north drag) never drifts once minSize is
+        // hit. Computing x from the unclamped delta let the right/bottom edge
+        // keep sliding with the mouse even after width/height pinned at the
+        // floor, since x and width stopped moving in lockstep at that point.
+        if (handle.includes('w')) {
+          newX = snapToGrid(resizeState.startRelativeX + resizeState.startWidth - newWidth);
+        }
+        if (handle.includes('n')) {
+          newY = snapToGrid(resizeState.startRelativeY + resizeState.startHeight - newHeight);
+        }
+
         newX = Math.max(0, Math.min(1 - newWidth, newX));
         newY = Math.max(0, Math.min(1 - newHeight, newY));
 


### PR DESCRIPTION
## Description
Dragging a west or north resize handle far enough that width/height would shrink below `minSize` (0.05) still computed the gauge's new x/y position from the raw, unclamped mouse delta — but that value was computed *before* the minSize floor got applied to width/height. Once size pinned at the floor, position kept tracking the mouse anyway, so the edge that's supposed to stay fixed during a west/north drag (the right edge for west, bottom edge for north) visibly slid instead of staying anchored.

Verified with concrete numbers before fixing: `startRelativeX=0.3`, `startWidth=0.2` → the right edge should stay at 0.5 for the whole west-handle drag. Dragging past the point where width would go negative clamped width to 0.05 but left x tracking the mouse, producing a right edge of 0.60 — a drift that kept growing the further you dragged past the floor. East/south handles are unaffected since they never touch x/y, only width/height.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues
None filed — found during an internal audit of the dashboard designer's drag/resize logic.

## Changes Made
- `useDesignerDragResize.ts`: restructured the mousemove handler to compute `newWidth`/`newHeight` (including the minSize floor clamp) fully first, then derive `newX`/`newY` from the already-clamped size (`start position + start size - new size`) instead of from the raw delta. The fixed edge is exact by construction regardless of where minSize clamps.
- Pure logic change — no UI layout or markup touched, no change in behavior for any drag that doesn't hit the size floor.

## Testing
- [x] I have tested these changes locally
- [x] New and existing tests pass (`cargo test` / frontend `vitest`) — 3 new tests in `useDesignerDragResize.test.ts` (first test file for this hook): west-handle and north-handle regression tests, both confirmed via `git stash` to genuinely fail against the pre-fix code with the exact hand-computed drift value, then confirmed to pass against the fix; plus an east-handle sanity check proving that handle was never affected. Full `pre-push.sh` green, zero flakes, 117 tests total (up 3).
- [ ] The UI works correctly with these changes — verified via unit tests simulating the mouse events directly (mocked container `getBoundingClientRect`, dispatched real `mousemove` events); didn't click through an actual resize drag in the running app.

## Checklist
- [x] Code compiles without errors
- [x] No new clippy warnings (`cargo clippy`) — no Rust changes in this PR
- [x] Code is formatted (`cargo fmt`) — no Rust changes in this PR
- [x] TypeScript compiles without errors (`npx tsc --noEmit`)
- [ ] Documentation updated if needed — n/a, internal interaction logic, nothing user-facing to document
- [x] Commit messages follow conventional format

