### PR TITLE
fix(layer-panel): stop hide/show from destroying a real enabled_condi…

### DIFF
--- a/crates/libretune-app/src/components/dashboards/designer/LayerPanel.tsx
+++ b/crates/libretune-app/src/components/dashboards/designer/LayerPanel.tsx
@@ -4,11 +4,21 @@
  * Lists every component on the dashboard and lets the user:
  *  - select/focus a component (single-click)
  *  - reorder z-stack (▲/▼ buttons; later index = drawn on top)
- *  - toggle visibility via an `enabled_condition` of "false" / cleared
+ *  - toggle visibility via `enabled_condition`
  *  - delete
  *
  * Z-ordering uses the array order in `gauge_cluster.components` since
  * the dashboard renders strictly in that sequence.
+ *
+ * `enabled_condition` is also a real, user-facing field (set via
+ * PropertyEditor's "Enabled Condition" input, e.g. "hasLambdaSensor" or
+ * "rpm > 0") for conditional visibility at runtime. The Hide/Show toggle
+ * here reuses that same field as a simple boolean by overwriting it to the
+ * literal string "false" — so hiding a component that already had a real
+ * condition must stash the original away first (round-tripped through
+ * `extra_attrs`, same mechanism PropertyEditor's TrendSeriesEditor uses for
+ * its own non-schema fields) and restore it on Show, instead of silently
+ * destroying it.
  */
 
 import { DashFile, DashComponent, isGauge, isIndicator } from '../dashTypes';
@@ -38,19 +48,50 @@ function componentKind(c: DashComponent): string {
   return '';
 }
 
-function isHidden(c: DashComponent): boolean {
-  const cond = isGauge(c)
-    ? c.Gauge.enabled_condition
-    : isIndicator(c)
-      ? c.Indicator.enabled_condition
-      : null;
-  return cond?.trim().toLowerCase() === 'false';
+const HIDDEN_MARKER = 'false';
+const SAVED_CONDITION_KEY = 'lt_prev_enabled_condition';
+
+function getCondition(c: DashComponent): string | null {
+  if (isGauge(c)) return c.Gauge.enabled_condition ?? null;
+  if (isIndicator(c)) return c.Indicator.enabled_condition ?? null;
+  return null;
 }
 
-function withHidden(c: DashComponent, hidden: boolean): DashComponent {
-  const cond = hidden ? 'false' : null;
-  if (isGauge(c)) return { Gauge: { ...c.Gauge, enabled_condition: cond } };
-  if (isIndicator(c)) return { Indicator: { ...c.Indicator, enabled_condition: cond } };
+function getExtraAttrs(c: DashComponent): Record<string, string> {
+  if (isGauge(c)) return c.Gauge.extra_attrs ?? {};
+  if (isIndicator(c)) return c.Indicator.extra_attrs ?? {};
+  return {};
+}
+
+export function isHidden(c: DashComponent): boolean {
+  return getCondition(c)?.trim().toLowerCase() === HIDDEN_MARKER;
+}
+
+export function withHidden(c: DashComponent, hidden: boolean): DashComponent {
+  const currentCondition = getCondition(c);
+  const attrs = { ...getExtraAttrs(c) };
+
+  let nextCondition: string | null;
+  if (hidden) {
+    // Stash whatever real condition (if any) was set before overwriting it
+    // with the hide marker, so Show can restore it exactly instead of
+    // always resetting to "always visible". Skip this if it's already the
+    // hide marker (already hidden -- nothing new to preserve).
+    if (currentCondition?.trim().toLowerCase() !== HIDDEN_MARKER) {
+      if (currentCondition) {
+        attrs[SAVED_CONDITION_KEY] = currentCondition;
+      } else {
+        delete attrs[SAVED_CONDITION_KEY];
+      }
+    }
+    nextCondition = HIDDEN_MARKER;
+  } else {
+    nextCondition = attrs[SAVED_CONDITION_KEY] ?? null;
+    delete attrs[SAVED_CONDITION_KEY];
+  }
+
+  if (isGauge(c)) return { Gauge: { ...c.Gauge, enabled_condition: nextCondition, extra_attrs: attrs } };
+  if (isIndicator(c)) return { Indicator: { ...c.Indicator, enabled_condition: nextCondition, extra_attrs: attrs } };
   return c;
 }
 

--- a/crates/libretune-app/src/components/dashboards/designer/__tests__/LayerPanel.test.tsx
+++ b/crates/libretune-app/src/components/dashboards/designer/__tests__/LayerPanel.test.tsx
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import { isHidden, withHidden } from '../LayerPanel';
+import type { DashComponent } from '../../dashTypes';
+
+function makeGauge(overrides: Record<string, unknown> = {}): DashComponent {
+  return {
+    Gauge: {
+      id: 'g1',
+      ...overrides,
+    },
+  } as unknown as DashComponent;
+}
+
+function makeIndicator(overrides: Record<string, unknown> = {}): DashComponent {
+  return {
+    Indicator: {
+      id: 'i1',
+      ...overrides,
+    },
+  } as unknown as DashComponent;
+}
+
+describe('LayerPanel hide/show', () => {
+  it('hides a gauge with no prior condition and shows it again with no condition restored', () => {
+    const gauge = makeGauge({ enabled_condition: null });
+
+    const hidden = withHidden(gauge, true);
+    expect(isHidden(hidden)).toBe(true);
+    expect((hidden as { Gauge: { enabled_condition: string | null } }).Gauge.enabled_condition).toBe('false');
+
+    const shown = withHidden(hidden, false);
+    expect(isHidden(shown)).toBe(false);
+    expect((shown as { Gauge: { enabled_condition: string | null } }).Gauge.enabled_condition).toBeNull();
+  });
+
+  it('preserves a real enabled_condition across hide, and restores it exactly on show', () => {
+    // Regression test: before this fix, hiding a gauge that already had a
+    // real conditional-visibility expression (set via PropertyEditor)
+    // silently overwrote it with the literal "false", and showing it again
+    // reset it to null instead of the original expression -- permanently
+    // destroying it with no warning.
+    const gauge = makeGauge({ enabled_condition: 'rpm > 0' });
+
+    const hidden = withHidden(gauge, true);
+    expect(isHidden(hidden)).toBe(true);
+    const hiddenGauge = (hidden as { Gauge: { enabled_condition: string | null; extra_attrs: Record<string, string> } }).Gauge;
+    expect(hiddenGauge.enabled_condition).toBe('false');
+    // The original expression must survive somewhere, not be discarded.
+    expect(hiddenGauge.extra_attrs.lt_prev_enabled_condition).toBe('rpm > 0');
+
+    const shown = withHidden(hidden, false);
+    const shownGauge = (shown as { Gauge: { enabled_condition: string | null; extra_attrs: Record<string, string> } }).Gauge;
+    expect(isHidden(shown)).toBe(false);
+    // The real expression is restored exactly, not reset to null.
+    expect(shownGauge.enabled_condition).toBe('rpm > 0');
+    // The stash key doesn't linger around after being restored.
+    expect(shownGauge.extra_attrs.lt_prev_enabled_condition).toBeUndefined();
+  });
+
+  it('does the same preserve/restore for indicators', () => {
+    const indicator = makeIndicator({ enabled_condition: 'hasLambdaSensor' });
+
+    const hidden = withHidden(indicator, true);
+    const shown = withHidden(hidden, false);
+    const shownIndicator = (shown as { Indicator: { enabled_condition: string | null } }).Indicator;
+
+    expect(shownIndicator.enabled_condition).toBe('hasLambdaSensor');
+  });
+
+  it('hiding an already-hidden component does not clobber a previously-stashed condition', () => {
+    // If withHidden(true) is ever called twice in a row (e.g. a stale
+    // double-click), the second call must not treat the hide marker itself
+    // as "the real condition to preserve" and overwrite the actual stash.
+    const gauge = makeGauge({ enabled_condition: 'rpm > 0' });
+    const hiddenOnce = withHidden(gauge, true);
+    const hiddenTwice = withHidden(hiddenOnce, true);
+
+    const attrs = (hiddenTwice as { Gauge: { extra_attrs: Record<string, string> } }).Gauge.extra_attrs;
+    expect(attrs.lt_prev_enabled_condition).toBe('rpm > 0');
+
+    const shown = withHidden(hiddenTwice, false);
+    expect((shown as { Gauge: { enabled_condition: string | null } }).Gauge.enabled_condition).toBe('rpm > 0');
+  });
+
+  it('preserves other extra_attrs entries untouched (e.g. trend series config)', () => {
+    const gauge = makeGauge({
+      enabled_condition: 'rpm > 0',
+      extra_attrs: { lt_series2_channel: 'boost' },
+    });
+
+    const hidden = withHidden(gauge, true);
+    const shown = withHidden(hidden, false);
+    const attrs = (shown as { Gauge: { extra_attrs: Record<string, string> } }).Gauge.extra_attrs;
+
+    expect(attrs.lt_series2_channel).toBe('boost');
+    expect(attrs.lt_prev_enabled_condition).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Description
`enabled_condition` is a real, user-facing field (PropertyEditor's "Enabled Condition" input, e.g. `"hasLambdaSensor"` or `"rpm > 0"`) for conditional visibility at runtime, evaluated via `useEnabledCondition`/`evaluate_expression`. `LayerPanel.tsx`'s Hide/Show toggle reused that same field as a simple boolean: hiding unconditionally overwrote it to the literal string `"false"`, and showing again reset it to `null`. A gauge that already had a real condition set lost it permanently and irrecoverably the moment it was hidden — no warning, and un-hiding didn't restore it either.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues
None filed — found during an internal audit of the dashboard designer's layer panel.

## Changes Made
- `withHidden` now stashes whatever real condition was present before overwriting it with the hide marker, and restores it on Show. Uses the same `extra_attrs` round-trip mechanism `PropertyEditor`'s `TrendSeriesEditor` already uses for its own non-schema fields (`lt_series2_channel` etc.), now under `lt_prev_enabled_condition` — no schema change, and it survives the `.ltdash.xml` round trip the same way those fields do.
- Handles a double-hide call defensively (won't treat the hide marker itself as "the real condition to preserve" if called twice in a row) and leaves any other `extra_attrs` entries untouched.
- Exported `isHidden`/`withHidden` (previously module-private) for direct unit testing.

## Testing
- [x] I have tested these changes locally
- [x] New and existing tests pass (`cargo test` / frontend `vitest`) — 5 new tests, including the core preserve/restore round trip and the same for indicators. Verified precisely against the *pre-fix logic* (not just that it wasn't exported before): temporarily re-exported the old function bodies unchanged and reran the suite — 3 of 5 tests failed with exactly the predicted symptom (e.g. `expected null to be 'hasLambdaSensor'`), confirming the tests exercise the real behavioral bug. `npx tsc --noEmit` clean. Full `pre-push.sh`: hit the known `App.integration.test.tsx` "Auto" flake (unrelated to this change), confirmed via 3 isolated reruns, all passed.
- [ ] The UI works correctly with these changes — verified via unit tests on the extracted pure functions; didn't click through the actual Layer Panel hide/show buttons in the running app.

## Checklist
- [x] Code compiles without errors
- [x] No new clippy warnings (`cargo clippy`) — no Rust changes in this PR
- [x] Code is formatted (`cargo fmt`) — no Rust changes in this PR
- [x] TypeScript compiles without errors (`npx tsc --noEmit`)
- [ ] Documentation updated if needed — n/a, internal component behavior
- [x] Commit messages follow conventional format
