### PR TITLE
fix(designer-drop): keep dropped gauges fully on-canvas near the edges

### DIFF
--- a/crates/libretune-app/src/components/dashboards/designer/__tests__/useDesignerDrop.test.ts
+++ b/crates/libretune-app/src/components/dashboards/designer/__tests__/useDesignerDrop.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { clampDropPosition } from '../useDesignerDrop';
+
+describe('clampDropPosition', () => {
+  it('centers a drop in the middle of the canvas without hitting either bound', () => {
+    const { relX, relY } = clampDropPosition(0.5, 0.5);
+    expect(relX).toBeCloseTo(0.4, 5);
+    expect(relY).toBeCloseTo(0.4, 5);
+  });
+
+  it('keeps the gauge fully on-canvas when dropped at the right/bottom edge', () => {
+    // Regression test: a drop right at the canvas edge (raw relX/relY = 1)
+    // previously clamped the near edge to 0.9 regardless of the gauge's
+    // 0.2 width/height, leaving the far edge at 1.1 -- 10% off-canvas.
+    const { relX, relY } = clampDropPosition(1, 1);
+    const DEFAULT_DROP_SIZE = 0.2;
+    expect(relX).toBeCloseTo(1 - DEFAULT_DROP_SIZE, 5);
+    expect(relY).toBeCloseTo(1 - DEFAULT_DROP_SIZE, 5);
+    // The far edge must not exceed the canvas.
+    expect(relX + DEFAULT_DROP_SIZE).toBeLessThanOrEqual(1);
+    expect(relY + DEFAULT_DROP_SIZE).toBeLessThanOrEqual(1);
+  });
+
+  it('keeps the gauge fully on-canvas when dropped at the left/top edge', () => {
+    const { relX, relY } = clampDropPosition(0, 0);
+    expect(relX).toBe(0);
+    expect(relY).toBe(0);
+  });
+
+  it('never produces a negative position for a drop just inside the edge', () => {
+    const { relX, relY } = clampDropPosition(0.05, 0.05);
+    expect(relX).toBeGreaterThanOrEqual(0);
+    expect(relY).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/crates/libretune-app/src/components/dashboards/designer/useDesignerDrop.ts
+++ b/crates/libretune-app/src/components/dashboards/designer/useDesignerDrop.ts
@@ -8,6 +8,27 @@ interface ChannelInfo {
   translate: number;
 }
 
+/** Default size for a gauge created by a canvas drop (both painter-tile and
+ * channel drops go through `createDefaultGaugeFromChannel`, which hardcodes
+ * this same size). Shared so the drop-position clamp in `onDrop` can derive
+ * its bounds from the actual size instead of a magic number that can drift
+ * out of sync with it. */
+const DEFAULT_DROP_SIZE = 0.2;
+
+/**
+ * Center a raw cursor-relative drop position on a DEFAULT_DROP_SIZE-sized
+ * gauge, then clamp so the gauge's far edge (not just its near edge) stays
+ * on-canvas. Extracted as a pure function so the clamping math is directly
+ * unit-testable without simulating a full DragEvent.
+ */
+export function clampDropPosition(rawRelX: number, rawRelY: number): { relX: number; relY: number } {
+  const halfSize = DEFAULT_DROP_SIZE / 2;
+  return {
+    relX: Math.max(0, Math.min(1 - DEFAULT_DROP_SIZE, rawRelX - halfSize)),
+    relY: Math.max(0, Math.min(1 - DEFAULT_DROP_SIZE, rawRelY - halfSize)),
+  };
+}
+
 /**
  * Build a default `TsGaugeConfig` populated from a channel drop event,
  * using INI-derived metadata when available.
@@ -67,8 +88,8 @@ export function createDefaultGaugeFromChannel(
     minor_ticks: 0,
     relative_x: relX,
     relative_y: relY,
-    relative_width: 0.2,
-    relative_height: 0.2,
+    relative_width: DEFAULT_DROP_SIZE,
+    relative_height: DEFAULT_DROP_SIZE,
     border_width: 1,
     shortest_size: 0,
     shape_locked_to_aspect: false,
@@ -130,12 +151,10 @@ export function useDesignerDrop({
       if (!dashFile) return;
 
       const rect = e.currentTarget.getBoundingClientRect();
-      let relX = (e.clientX - rect.left) / rect.width;
-      let relY = (e.clientY - rect.top) / rect.height;
+      const rawRelX = (e.clientX - rect.left) / rect.width;
+      const rawRelY = (e.clientY - rect.top) / rect.height;
 
-      // Offset to roughly center on cursor
-      relX = Math.max(0, Math.min(0.9, relX - 0.1));
-      relY = Math.max(0, Math.min(0.9, relY - 0.1));
+      let { relX, relY } = clampDropPosition(rawRelX, rawRelY);
 
       if (gridSnap > 0) {
         relX = snapToGrid(relX);


### PR DESCRIPTION
## Description
Every gauge created by a canvas drop (painter-tile or channel drop, both via `createDefaultGaugeFromChannel`) is hardcoded to `relative_width`/`relative_height` 0.2. The drop handler centered the new gauge on the cursor (subtracting half-size, 0.1) then clamped the result to a magic `0.9` — bounding the gauge's *near* edge, not its far edge. Dropping near the right or bottom of the canvas (raw cursor position close to 1.0) clamped the near edge to 0.9, putting the far edge at 1.1 — 10% of the gauge hanging off the canvas. Grid-snap doesn't correct this either, it only rounds, it doesn't reclamp to bounds. Same bug shape as the earlier resize-edge-drift fix (#116): a fixed bound not accounting for the element's actual size.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues
None filed — found during an internal audit of the dashboard designer's drag/drop logic.

## Changes Made
- Extracted a shared `DEFAULT_DROP_SIZE` constant, used by both the gauge's own width/height and the clamp bound, so they can't drift apart the way `0.9`/`0.2` already had.
- Extracted a pure `clampDropPosition` helper, clamping to `1 - DEFAULT_DROP_SIZE` instead of the magic `0.9`, so the clamping math is directly unit-testable without simulating a full `DragEvent`.

## Testing
- [x] I have tested these changes locally
- [x] New and existing tests pass (`cargo test` / frontend `vitest`) — 4 new tests. Verified against the old bounds directly: temporarily reverted `clampDropPosition`'s body to the old `Math.min(0.9, ...)` logic and reran — the edge-drop test failed with exactly the predicted `0.9` vs `0.8` mismatch, confirming the test catches the real bug, before restoring the fix. `npx tsc --noEmit` clean. Full `pre-push.sh` green, 136 tests, zero flakes this run.
- [ ] The UI works correctly with these changes — verified via unit tests on the extracted pure function; didn't drag-and-drop a real channel near the canvas edge in the running app.

## Checklist
- [x] Code compiles without errors
- [x] No new clippy warnings (`cargo clippy`) — no Rust changes in this PR
- [x] Code is formatted (`cargo fmt`) — no Rust changes in this PR
- [x] TypeScript compiles without errors (`npx tsc --noEmit`)
- [ ] Documentation updated if needed — n/a, internal interaction logic
- [x] Commit messages follow conventional format
