### PR TITLE
Fix/ini parser lastoffset bits string size

### DIFF
--- a/crates/libretune-core/src/ini/parser.rs
+++ b/crates/libretune-core/src/ini/parser.rs
@@ -1143,9 +1143,15 @@ fn parse_constants_entry(
     if let Some(mut constant) =
         parse_constant_line(clean_key, value, *current_page, *last_offset, help_text)
     {
-        // Update last_offset for next constant (offset + size in bytes)
-        let size = constant.data_type.size_bytes() as u16 * constant.shape.element_count() as u16;
-        *last_offset = constant.offset + size;
+        // Update last_offset for next constant (offset + size in bytes).
+        // Use Constant::size_bytes(), not a hand-rolled data_type * element_count
+        // calculation -- that duplicate used to disagree with it for two cases:
+        // bits fields are packed (0 extra bytes; the raw DataType::size_bytes()
+        // of 1 would wrongly burn a byte per bit field), and string fields need
+        // their length in bytes (the raw DataType::size_bytes() of 0 for
+        // "variable size" would wrongly advance by 0, aliasing whatever field
+        // came next onto the string's own bytes).
+        *last_offset = constant.offset + constant.size_bytes() as u16;
 
         // Resolve $references in bit_options
         if !constant.bit_options.is_empty() {
@@ -3765,5 +3771,69 @@ constOnPage0 = scalar, U16, 0, "ms", 1, 0, 0, 100, 1
     assert_eq!(
         c.page, 0,
         "INI 'page = 0' should remain as internal page 0 (saturating_sub prevents underflow)"
+    );
+}
+
+#[test]
+fn test_last_offset_after_bits_field_does_not_advance() {
+    // Regression test: bits fields are packed (they don't take their own
+    // byte), so lastOffset on the field right after a bits field must
+    // resolve to the SAME offset as that bits field, not offset+1.
+    let content = r#"
+[MegaTune]
+signature = "test 1.0"
+queryCommand = "Q"
+
+[TunerStudio]
+nPages = 1
+pageSize = 256
+
+[Constants]
+page = 1
+flagsByte = bits, U08, 100, [0:3], "A", "B"
+afterBits = scalar, U08, lastOffset, "counts", 1.0, 0.0, 0, 255, 0
+"#;
+
+    let def = parse_ini(content).expect("Should parse successfully");
+
+    let flags = def.constants.get("flagsByte").expect("flagsByte should exist");
+    assert_eq!(flags.offset, 100);
+
+    let after = def.constants.get("afterBits").expect("afterBits should exist");
+    assert_eq!(
+        after.offset, 100,
+        "a field right after a bits field must share its offset (bits are packed), not offset+1"
+    );
+}
+
+#[test]
+fn test_last_offset_after_string_field_advances_by_its_length() {
+    // Regression test: a string field's byte footprint is its declared
+    // length, so lastOffset on the field right after it must resolve to
+    // offset + length -- not alias onto the string's own bytes.
+    let content = r#"
+[MegaTune]
+signature = "test 1.0"
+queryCommand = "Q"
+
+[TunerStudio]
+nPages = 1
+pageSize = 256
+
+[Constants]
+page = 1
+vehicleName = string, ASCII, 200, 16
+afterString = scalar, U08, lastOffset, "counts", 1.0, 0.0, 0, 255, 0
+"#;
+
+    let def = parse_ini(content).expect("Should parse successfully");
+
+    let name = def.constants.get("vehicleName").expect("vehicleName should exist");
+    assert_eq!(name.offset, 200);
+
+    let after = def.constants.get("afterString").expect("afterString should exist");
+    assert_eq!(
+        after.offset, 216,
+        "a field right after a 16-byte string must start at offset+16 (200+16), not alias the string's own bytes"
     );
 }

--- a/crates/libretune-core/src/ini/parser.rs
+++ b/crates/libretune-core/src/ini/parser.rs
@@ -3796,10 +3796,16 @@ afterBits = scalar, U08, lastOffset, "counts", 1.0, 0.0, 0, 255, 0
 
     let def = parse_ini(content).expect("Should parse successfully");
 
-    let flags = def.constants.get("flagsByte").expect("flagsByte should exist");
+    let flags = def
+        .constants
+        .get("flagsByte")
+        .expect("flagsByte should exist");
     assert_eq!(flags.offset, 100);
 
-    let after = def.constants.get("afterBits").expect("afterBits should exist");
+    let after = def
+        .constants
+        .get("afterBits")
+        .expect("afterBits should exist");
     assert_eq!(
         after.offset, 100,
         "a field right after a bits field must share its offset (bits are packed), not offset+1"
@@ -3828,10 +3834,16 @@ afterString = scalar, U08, lastOffset, "counts", 1.0, 0.0, 0, 255, 0
 
     let def = parse_ini(content).expect("Should parse successfully");
 
-    let name = def.constants.get("vehicleName").expect("vehicleName should exist");
+    let name = def
+        .constants
+        .get("vehicleName")
+        .expect("vehicleName should exist");
     assert_eq!(name.offset, 200);
 
-    let after = def.constants.get("afterString").expect("afterString should exist");
+    let after = def
+        .constants
+        .get("afterString")
+        .expect("afterString should exist");
     assert_eq!(
         after.offset, 216,
         "a field right after a 16-byte string must start at offset+16 (200+16), not alias the string's own bytes"


### PR DESCRIPTION
## Description
`parse_constants_entry` tracked the running offset counter (used to resolve the `lastOffset` keyword on the next constant) with its own inline calculation — `data_type.size_bytes() * shape.element_count()` — instead of calling `Constant::size_bytes()`, which already exists and already handles `bits` and `string` fields specially. The two disagreed:

- **bits fields** are packed (multiple bit fields commonly share one byte), so `Constant::size_bytes()` correctly returns 0 for them. The inline calc used `DataType::size_bytes()` directly, which returns 1 for `Bits` (grouped with `U08`/`S08`) — so a field using `lastOffset` right after a bits field landed one byte too far, not on the byte it was meant to share.
- **string fields** need their declared length in bytes, which `Constant::size_bytes()` returns via `shape.element_count()`. The inline calc used `DataType::size_bytes()` directly, which returns 0 for `String` ("variable size") — so a field using `lastOffset` right after a string field landed on the exact same offset as the string, aliasing onto its own bytes instead of the length past it.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues
None filed — found during an internal audit of the INI parser core.

## Changes Made
- `parse_constants_entry` now calls `constant.size_bytes()` instead of duplicating (and diverging from) its logic.

## Testing
- [x] I have tested these changes locally
- [x] New and existing tests pass (`cargo test`) — 2 new regression tests, both verified against the pre-fix calculation directly: temporarily reverted to the old inline formula and reran — both failed with exactly the predicted wrong offsets (101 vs 100 for the bits case, 200 vs 216 for the string case) — before restoring the fix. Full `ini` module test suite (63 tests) still green, no regressions. Full `pre-push.sh` green.
- [ ] The UI works correctly with these changes — this is parser-layer logic verified via unit tests on synthetic INI content; I checked the app's own bundled `demo.ini` and it never actually uses the `lastOffset` keyword, so I can't demonstrate this specific defect firing on real shipped data. It's a real, verified defect in the code regardless, reachable by any INI (including other-ECU-vendor ones this app supports) that uses `lastOffset` near a `bits` or `string` field.

## Checklist
- [x] Code compiles without errors
- [x] No new clippy warnings (`cargo clippy`)
- [x] Code is formatted (`cargo fmt`)
- [x] TypeScript compiles without errors (`npx tsc --noEmit`) — no frontend changes in this PR
- [ ] Documentation updated if needed — n/a, internal parser behavior
- [x] Commit messages follow conventional format
