### PR TITLE
fix: deleting a project fails with "Project not found"

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/project_misc.rs
+++ b/crates/libretune-app/src-tauri/src/commands/project_misc.rs
@@ -2,6 +2,7 @@
 
 use crate::paths::get_projects_dir;
 use crate::state::AppState;
+use libretune_core::project::Project;
 use libretune_core::tune::TuneFile;
 
 /// Get info about an MSQ file without fully loading it (for the open dialog preview)
@@ -83,8 +84,21 @@ pub async fn delete_project(
     state: tauri::State<'_, AppState>,
     project_name: String,
 ) -> Result<(), String> {
-    let projects_dir = get_projects_dir(&app);
-    let project_path = projects_dir.join(&project_name);
+    // Resolve the project by the name it records, not by assuming its directory
+    // is named after it. `Project::create` sanitises the display name for the
+    // filesystem, and a project directory can be copied or renamed on disk, so
+    // the folder name and `project.json`'s `name` are not always equal.
+    // `list_projects` already reports both, and the UI lists projects from it,
+    // so resolving through it deletes exactly what the user selected.
+    //
+    // Fall back to the old name-joined path if the project is not in the list
+    // (e.g. an unreadable `project.json`), preserving the previous behaviour.
+    let project_path = Project::list_projects()
+        .map_err(|e| format!("Failed to list projects: {}", e))?
+        .into_iter()
+        .find(|p| p.name == project_name)
+        .map(|p| p.path)
+        .unwrap_or_else(|| get_projects_dir(&app).join(&project_name));
 
     if !project_path.exists() {
         return Err(format!("Project '{}' not found", project_name));

--- a/crates/libretune-app/src-tauri/src/commands/project_misc.rs
+++ b/crates/libretune-app/src-tauri/src/commands/project_misc.rs
@@ -93,12 +93,22 @@ pub async fn delete_project(
     //
     // Fall back to the old name-joined path if the project is not in the list
     // (e.g. an unreadable `project.json`), preserving the previous behaviour.
-    let project_path = Project::list_projects()
-        .map_err(|e| format!("Failed to list projects: {}", e))?
-        .into_iter()
-        .find(|p| p.name == project_name)
-        .map(|p| p.path)
-        .unwrap_or_else(|| get_projects_dir(&app).join(&project_name));
+    if project_name.trim().is_empty()
+        || !std::path::Path::new(&project_name)
+            .components()
+            .all(|c| matches!(c, std::path::Component::Normal(_)))
+    {
+        return Err("Invalid project name".to_string());
+    }
+
+    let project_path = match Project::list_projects() {
+        Ok(projects) => projects
+            .into_iter()
+            .find(|p| p.name == project_name)
+            .map(|p| p.path)
+            .unwrap_or_else(|| get_projects_dir(&app).join(&project_name)),
+        Err(_) => get_projects_dir(&app).join(&project_name),
+    };
 
     if !project_path.exists() {
         return Err(format!("Project '{}' not found", project_name));

--- a/crates/libretune-app/src-tauri/src/paths.rs
+++ b/crates/libretune-app/src-tauri/src/paths.rs
@@ -17,8 +17,19 @@ pub fn get_app_data_dir(app: &tauri::AppHandle) -> PathBuf {
 }
 
 /// Get the projects directory (cross-platform).
+///
+/// Projects are created and imported by `libretune-core`, which resolves this
+/// location via [`Project::projects_dir`] (`~/Documents/LibreTuneProjects`).
+/// Defer to that same function so the app and core cannot disagree about where
+/// projects live — this previously returned `<app_data_dir>/projects`, a
+/// directory no code path ever creates, which made `delete_project` fail with
+/// "Project not found" for every project.
+///
+/// Falls back to the app data dir only if the core lookup fails (e.g. no home
+/// directory can be determined), preserving the previous behaviour as a last
+/// resort.
 pub fn get_projects_dir(app: &tauri::AppHandle) -> PathBuf {
-    get_app_data_dir(app).join("projects")
+    Project::projects_dir().unwrap_or_else(|_| get_app_data_dir(app).join("projects"))
 }
 
 /// Get the definitions directory (cross-platform).


### PR DESCRIPTION
Fixes #68.

Deleting a project always failed with `Project '<name>' not found`. There turned out to be **two independent causes** of the same symptom; both are fixed here, and both were confirmed by manual UI testing on Windows.

### 1. The app looked in a directory that never exists

`paths::get_projects_dir()` returned `<app_data_dir>/projects`, but projects are created and imported by `libretune-core` via `Project::projects_dir()` → `~/Documents/LibreTuneProjects`.

Nothing in the codebase ever creates `<app_data_dir>/projects`, so the existence check in `delete_project` could never pass, and it returned early before reaching `remove_dir_all`. This affected every project on every platform.

Observed at runtime by calling the real core code:

```
created/imported to : ~/Documents/LibreTuneProjects/NA6_SPEEDUINO   exists: true
delete searched     : <app_data_dir>/projects/NA6_SPEEDUINO        exists: false
```

Fixed by deferring to `Project::projects_dir()` so the app and core cannot disagree, keeping the previous path as a fallback if the core lookup fails.

### 2. The path was re-derived from the display name

`delete_project` joined the raw `project_name` to the projects directory, assuming a project's folder is always named after it. It isn't: `Project::create` sanitises the display name into a `safe_name` for the filesystem, and a project directory can be copied or renamed on disk while `project.json` retains the original `name`.

When the two differ, the derived path doesn't exist and deletion fails with the same message, from a different cause.

Fixed by resolving through `Project::list_projects()`, which already reports both the recorded `name` and the actual `path`, and is what the UI lists from — so delete now removes exactly the project the user selected. Falls back to the old name-joined path when the project isn't listed (e.g. an unreadable `project.json`).

### Verification

Built a local debug build and tested through the UI:

| Case | Before | After |
|---|---|---|
| Folder name matches recorded name | "Project not found" | deletes, directory removed |
| Folder `NA6_TESTCOPY`, recorded name `NA6_SPEEDUINO` | "Project not found" | deletes, directory removed |

The second case still failed after fix 1 alone, which is what surfaced the second cause.

`cargo check -p libretune-app` and `cargo fmt --check` are clean.

### Notes

- No unit test: `get_projects_dir` takes a `tauri::AppHandle`, which isn't practical to construct in a unit test. Happy to add coverage if you can suggest a workable approach.
- `commands/dash_files.rs` calls the same `get_projects_dir` and resolved project-scoped dashboards against the same non-existent directory, so it is affected by fix 1. That path was not exercised during testing and is not claimed as verified.
