### PR TITLE
fix(dash): remove implicit 50px min size from template-generated tiles

### DIFF
--- a/crates/libretune-core/src/dash/templates.rs
+++ b/crates/libretune-core/src/dash/templates.rs
@@ -983,6 +983,13 @@ fn log_stat_tile(spec: LogStatSpec) -> DashComponent {
         critical_color: LT_CRITICAL_COLOR,
         border_width: 1,
         font_size_adjustment: -1,
+        // These tiles are laid out densely by relative percentage; a nonzero
+        // shortest_size (GaugeConfig::default's fallback for parsing legacy
+        // files that omit the field) would force a pixel floor that fights
+        // that layout at smaller dashboard sizes, overflowing into
+        // neighboring tiles. See useDesignerDrop.ts's own default of 0 for
+        // freshly-placed, percentage-driven gauges.
+        shortest_size: 0,
         ..Default::default()
     }))
 }
@@ -1009,6 +1016,7 @@ fn log_sparkline(spec: LogSparkSpec) -> DashComponent {
         critical_color: LT_CRITICAL_COLOR,
         show_history: true,
         border_width: 1,
+        shortest_size: 0, // see log_stat_tile's comment
         ..Default::default()
     }))
 }
@@ -1059,6 +1067,7 @@ fn log_multi_trend(
         critical_color: LT_CRITICAL_COLOR,
         extra_attrs: log_series_attrs(extra),
         border_width: 1,
+        shortest_size: 0, // see log_stat_tile's comment
         ..Default::default()
     }))
 }
@@ -1864,4 +1873,34 @@ pub fn create_telemetry_live_dashboard() -> DashFile {
 /// Backward-compatible alias — the old "F1 Telemetry" name pointed here.
 pub fn create_f1_telemetry_dashboard() -> DashFile {
     create_telemetry_live_dashboard()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression test: log_stat_tile/log_sparkline/log_multi_trend all rely
+    /// on `..Default::default()`, which sets shortest_size to 50 (a fallback
+    /// meant for parsing legacy files that omit the field, see
+    /// dash/types.rs's GaugeConfig::default). Left unset, that 50px floor
+    /// overrides these tiles' relative_width/height at smaller dashboard
+    /// sizes, forcing them to overflow their allotted box and overlap
+    /// neighboring tiles -- invisible on a large/maximized window (where
+    /// their percentage-based size already exceeds 50px), but reproducible
+    /// on any smaller one.
+    #[test]
+    fn test_telemetry_live_dashboard_tiles_have_no_shortest_size_floor() {
+        let dash = create_telemetry_live_dashboard();
+        for component in &dash.gauge_cluster.components {
+            if let DashComponent::Gauge(gauge) = component {
+                assert_eq!(
+                    gauge.shortest_size, 0,
+                    "component '{}' has a nonzero shortest_size, which clamps \
+                     it to a pixel floor that fights its relative-percentage \
+                     layout at smaller dashboard sizes",
+                    gauge.id
+                );
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Description
Fixes a dashboard layout bug where gauge tiles overlap once the app window is shrunk below maximized. Every tile in the built-in "Telemetry Live" dashboard (and the other built-in templates) was inheriting an implicit 50px minimum size from `GaugeConfig::default()`, which fights the tiles' relative-percentage layout once their computed size drops below 50px.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues
None filed — found during manual testing.

## Changes Made
- `log_stat_tile`, `log_sparkline`, and `log_multi_trend` in `templates.rs` now explicitly set `shortest_size: 0` instead of inheriting the `50` default meant for parsing legacy files that omit the field.
- Added a regression test asserting every component in `create_telemetry_live_dashboard()` has `shortest_size == 0`.

## Testing
- [x] I have tested these changes locally
- [x] New and existing tests pass (`cargo test`)
- [x] The UI works correctly with these changes

Reproduced by shrinking the app window down from maximized — at large window sizes each tile's percentage-based size already exceeds 50px so the bug is invisible, but at smaller sizes some tiles get forced to their 50px floor and overflow into the tile below. Verified the regression test fails against the pre-fix code and passes after the fix. Manually confirmed the overlap is gone after regenerating the dashboard from the fixed template and shrinking the window to the previously-broken size.

Note: this only affects newly-generated dashboard files. Anyone with an already-saved "Telemetry Live.ltdash.xml" (etc.) won't see the fix until that file is regenerated, since the app intentionally never overwrites an existing dashboard file with its built-in default.

## Checklist
- [x] Code compiles without errors
- [x] No new clippy warnings (`cargo clippy`)
- [x] Code is formatted (`cargo fmt`)
- [x] TypeScript compiles without errors (`npx tsc --noEmit`)
- [ ] Documentation updated if needed
- [x] Commit messages follow conventional format

## Screenshots (if applicable)
Before: gauge tiles overlap when the window is shrunk below maximized.
After: tiles render cleanly at any window size.