### PR TITLE
fix(dash): honour TunerStudio's ShowHistory as the peak-hold flag

### DIFF
--- a/crates/libretune-core/src/dash/parser.rs
+++ b/crates/libretune-core/src/dash/parser.rs
@@ -613,7 +613,15 @@ fn set_gauge_property(gauge: &mut GaugeConfig, prop: &str, value: &str) {
                 Some(value.to_string())
             }
         }
-        "ShowHistory" => gauge.show_history = value.parse().unwrap_or(false),
+        // `ShowHistory` is TunerStudio's peak-hold flag; the format has no
+        // separate `PeakHold` property. Drive `peak_hold` from it so an
+        // imported cluster keeps the peak markers it was authored with.
+        // `show_history` retains the raw parsed value.
+        "ShowHistory" => {
+            let show_history = value.parse().unwrap_or(false);
+            gauge.show_history = show_history;
+            gauge.peak_hold = show_history;
+        }
         "HistoryValue" => gauge.history_value = value.parse().unwrap_or(0.0),
         "HistoryDelay" => gauge.history_delay = value.parse().unwrap_or(15000),
         "NeedleSmoothing" => gauge.needle_smoothing = value.parse().unwrap_or(1),
@@ -749,6 +757,93 @@ mod tests {
             assert_eq!(gauge.gauge_painter, GaugePainter::AnalogGauge);
         } else {
             panic!("Expected Gauge component");
+        }
+    }
+
+    /// TunerStudio stores the peak-hold flag as `ShowHistory`; the `.dash`
+    /// format has no `PeakHold` property. Parsing must drive `peak_hold` from
+    /// it, otherwise every imported cluster loses the peak markers it was
+    /// authored with (404 of the gauges TunerStudio itself ships set it).
+    #[test]
+    fn test_show_history_drives_peak_hold() {
+        let dash_with = |show_history: &str| {
+            format!(
+                r#"<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<dsh xmlns="http://www.EFIAnalytics.com/:dsh">
+    <bibliography author="Test" company="TestCo" writeDate="2025-01-01"/>
+    <versionInfo fileFormat="3.0" firmwareSignature="speeduino"/>
+    <gaugeCluster antiAliasing="true" clusterBackgroundColor="-16777216">
+        <dashComp type="Gauge">
+            <Title type="String">RPM</Title>
+            <OutputChannel type="String">rpm</OutputChannel>
+            <GaugePainter type="GaugePainter">Analog Gauge</GaugePainter>
+            <ShowHistory type="boolean">{show_history}</ShowHistory>
+        </dashComp>
+    </gaugeCluster>
+</dsh>"#
+            )
+        };
+
+        let gauge_from = |xml: &str| {
+            let mut dash = parse_dash_file(xml).expect("parse");
+            match dash.gauge_cluster.components.remove(0) {
+                DashComponent::Gauge(g) => *g,
+                _ => panic!("Expected Gauge component"),
+            }
+        };
+
+        let enabled = gauge_from(&dash_with("true"));
+        assert!(
+            enabled.peak_hold,
+            "ShowHistory=true must enable peak_hold, otherwise the renderer never draws the marker"
+        );
+        assert!(enabled.show_history, "raw value retained for round-trip");
+
+        let disabled = gauge_from(&dash_with("false"));
+        assert!(
+            !disabled.peak_hold,
+            "ShowHistory=false must not enable peak_hold"
+        );
+    }
+
+    /// A cluster edited in LibreTune must write the user's peak-hold choice
+    /// back as `ShowHistory`, so it survives a round-trip through TunerStudio.
+    #[test]
+    fn test_peak_hold_round_trips_as_show_history() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<dsh xmlns="http://www.EFIAnalytics.com/:dsh">
+    <bibliography author="Test" company="TestCo" writeDate="2025-01-01"/>
+    <versionInfo fileFormat="3.0" firmwareSignature="speeduino"/>
+    <gaugeCluster antiAliasing="true" clusterBackgroundColor="-16777216">
+        <dashComp type="Gauge">
+            <Title type="String">RPM</Title>
+            <OutputChannel type="String">rpm</OutputChannel>
+            <GaugePainter type="GaugePainter">Analog Gauge</GaugePainter>
+            <ShowHistory type="boolean">false</ShowHistory>
+        </dashComp>
+    </gaugeCluster>
+</dsh>"#;
+
+        // Simulate the designer's peak-hold checkbox being ticked.
+        let mut dash = parse_dash_file(xml).expect("parse");
+        match dash.gauge_cluster.components[0] {
+            DashComponent::Gauge(ref mut g) => g.peak_hold = true,
+            _ => panic!("Expected Gauge component"),
+        }
+
+        let written = crate::dash::writer::write_dash_file(&dash).expect("write");
+        assert!(
+            written.contains("<ShowHistory type=\"boolean\">true</ShowHistory>"),
+            "peak_hold=true must serialise as ShowHistory=true, got:\n{written}"
+        );
+
+        let mut reparsed = parse_dash_file(&written).expect("reparse");
+        match reparsed.gauge_cluster.components.remove(0) {
+            DashComponent::Gauge(g) => assert!(
+                g.peak_hold,
+                "peak_hold must survive a write/parse round-trip"
+            ),
+            _ => panic!("Expected Gauge component"),
         }
     }
 

--- a/crates/libretune-core/src/dash/types.rs
+++ b/crates/libretune-core/src/dash/types.rs
@@ -453,7 +453,8 @@ pub struct GaugeConfig {
     #[serde(default)]
     pub enabled_condition: Option<String>,
     /// Render a persistent peak-hold marker tracking the maximum observed
-    /// value (TS `peakHold`).
+    /// value. Serialised to and from TunerStudio's `ShowHistory` property —
+    /// the `.dash` format has no `PeakHold` of its own.
     #[serde(default)]
     pub peak_hold: bool,
     /// Hysteresis (in channel units) applied to warning/critical state

--- a/crates/libretune-core/src/dash/writer.rs
+++ b/crates/libretune-core/src/dash/writer.rs
@@ -319,7 +319,11 @@ fn write_gauge_component<W: Write>(
         write_string_property(writer, "NeedleImageFileName", "null")?;
     }
 
-    write_boolean_property(writer, "ShowHistory", gauge.show_history)?;
+    // Written from `peak_hold`, which is what the designer edits and what the
+    // renderer consults; `ShowHistory` is TunerStudio's name for the same
+    // flag, so a cluster edited here opens in TunerStudio with the peak
+    // markers the user actually set.
+    write_boolean_property(writer, "ShowHistory", gauge.peak_hold)?;
     write_double_property(writer, "HistoryValue", gauge.history_value)?;
     write_int_property(writer, "HistoryDelay", gauge.history_delay)?;
     write_int_property(writer, "NeedleSmoothing", gauge.needle_smoothing)?;


### PR DESCRIPTION
## Description

TunerStudio has no `PeakHold` property — `ShowHistory` is how the `.dash` format stores whether a gauge draws a peak-hold marker. LibreTune parsed `ShowHistory` into `gauge.show_history` and then never read it, while the renderer consulted `gauge.peak_hold`, a field that was never populated from the file at all: it defaulted to `false` and could only be set from LibreTune's own designer checkbox.

The peak-hold rendering itself is already fully implemented (`painters/analogGauge.ts`, plus the `peakValue` plumbing in `useGaugeRenderer.ts`) — only the wiring from the file was missing. So importing a TunerStudio cluster silently dropped every peak marker it was authored with.

Measured across 70 real `.dash` files — the 56 clusters TunerStudio ships in `TunerStudioMS/Dash/` plus 14 from a live Speeduino project — **567 of 1217 gauges (47%) declare `ShowHistory=true`**, and all 567 were losing their markers.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues
No existing issue — found while auditing `.dash` round-trip fidelity against real TunerStudio dashboards.

## Changes Made
- `dash/parser.rs` — `ShowHistory` now drives `peak_hold` as well as `show_history`, so an imported cluster keeps the peak markers it was authored with. The raw value is still retained in `show_history`.
- `dash/writer.rs` — `ShowHistory` is now written from `peak_hold`, which is what the designer edits and what the renderer consults, so a cluster edited in LibreTune round-trips back to TunerStudio with the setting the user actually chose.
- `dash/types.rs` — corrected the doc comment on `peak_hold`, which claimed it mapped to a TunerStudio property named `peakHold`; no such property exists in the format.
- Added two regression tests, both verified to fail without this change:
  - `test_show_history_drives_peak_hold`
  - `test_peak_hold_round_trips_as_show_history`

## Testing
- [x] I have tested these changes locally
- [x] New and existing tests pass (`cargo test`)
- [x] The UI works correctly with these changes

`./scripts/pre-push.sh` passes end to end: cargo build, cargo tests, build-info test, clippy (no warnings), `npm ci`, TypeScript check, frontend build, frontend tests, and Rust formatting.

Both new tests were confirmed to fail with the change reverted, so they genuinely cover the defect rather than merely passing alongside it.

Beyond the unit tests, the parser was run over all 70 real `.dash` files mentioned above (0 parse failures) to confirm the change takes effect on genuine TunerStudio dashboards rather than only on synthetic fixtures.

## Checklist
- [x] Code compiles without errors
- [x] No new clippy warnings (`cargo clippy`)
- [x] Code is formatted (`cargo fmt`)
- [x] TypeScript compiles without errors (`npx tsc --noEmit`)
- [ ] Documentation updated if needed — no user-facing docs describe this behaviour
- [x] Commit messages follow conventional format

## Notes for the reviewer

`peak_hold` and `show_history` now both exist and describe the same concept, which is a little redundant. I kept both to avoid changing the designer's data model in a bug-fix PR, but if you would prefer a single field I am happy to collapse them — `show_history` currently has no other reader.

While auditing this I also found seven further `.dash` gauge properties that are parsed, stored and written back but never applied by the renderer: `needle_smoothing`, `history_delay`, `history_value`, `face_angle`, `gauge_style`, `default_min` and `default_max`. `face_angle` in particular carries real geometry (values of 94, 180 and 360 degrees across the shipped clusters). I have deliberately left those out of this PR since applying them is a larger rendering conversation; happy to open an issue enumerating them if that would be useful.
