### PR TITLE
fix(core): route [DEBUG] output through tracing so RUST_LOG controls it

### DIFF
--- a/crates/libretune-core/src/ini/parser.rs
+++ b/crates/libretune-core/src/ini/parser.rs
@@ -149,7 +149,7 @@ fn parse_ini_internal(content: &str, ctx: &mut IncludeContext) -> Result<EcuDefi
         // Handle preprocessor directives (always processed regardless of condition)
         if let Some(stripped) = line.strip_prefix("#set ") {
             let symbol = stripped.trim().to_string();
-            eprintln!("[DEBUG] preprocessor: #set {}", symbol);
+            tracing::debug!("preprocessor: #set {}", symbol);
             ctx.defined_symbols.insert(symbol);
             i += 1;
             continue;
@@ -157,7 +157,7 @@ fn parse_ini_internal(content: &str, ctx: &mut IncludeContext) -> Result<EcuDefi
 
         if let Some(stripped) = line.strip_prefix("#unset ") {
             let symbol = stripped.trim();
-            eprintln!("[DEBUG] preprocessor: #unset {}", symbol);
+            tracing::debug!("preprocessor: #unset {}", symbol);
             ctx.defined_symbols.remove(symbol);
             i += 1;
             continue;
@@ -166,7 +166,7 @@ fn parse_ini_internal(content: &str, ctx: &mut IncludeContext) -> Result<EcuDefi
         if let Some(stripped) = line.strip_prefix("#if ") {
             let symbol = stripped.trim();
             let is_defined = ctx.defined_symbols.contains(symbol);
-            eprintln!("[DEBUG] preprocessor: #if {} -> {}", symbol, is_defined);
+            tracing::debug!("preprocessor: #if {} -> {}", symbol, is_defined);
             condition_stack.push(is_defined);
             i += 1;
             continue;
@@ -174,10 +174,7 @@ fn parse_ini_internal(content: &str, ctx: &mut IncludeContext) -> Result<EcuDefi
 
         if line == "#else" {
             if let Some(last) = condition_stack.last_mut() {
-                eprintln!(
-                    "[DEBUG] preprocessor: #else (was {}, now {})",
-                    *last, !*last
-                );
+                tracing::debug!("preprocessor: #else (was {}, now {})", *last, !*last);
                 *last = !*last;
             }
             i += 1;
@@ -185,7 +182,7 @@ fn parse_ini_internal(content: &str, ctx: &mut IncludeContext) -> Result<EcuDefi
         }
 
         if line == "#endif" {
-            eprintln!("[DEBUG] preprocessor: #endif");
+            tracing::debug!("preprocessor: #endif");
             condition_stack.pop();
             i += 1;
             continue;
@@ -294,9 +291,10 @@ fn parse_ini_internal(content: &str, ctx: &mut IncludeContext) -> Result<EcuDefi
             });
 
             if !conditions.is_empty() && !conditions_pass {
-                eprintln!(
-                    "[DEBUG] ini: section [{}] suppressed by unmet condition(s): {:?}",
-                    name, conditions
+                tracing::debug!(
+                    "ini: section [{}] suppressed by unmet condition(s): {:?}",
+                    name,
+                    conditions
                 );
                 current_section = String::new();
                 i += 1;
@@ -782,7 +780,7 @@ fn parse_megatune(def: &mut EcuDefinition, key: &str, value: &str) {
             def.signature_prefix = Some(value.trim_matches('"').to_string());
         }
         "querycommand" => {
-            eprintln!("[DEBUG] parse_megatune: queryCommand = {:?}", value);
+            tracing::debug!("parse_megatune: queryCommand = {:?}", value);
             def.query_command = value.trim_matches('"').to_string();
         }
         "versioninfo" => {
@@ -792,8 +790,8 @@ fn parse_megatune(def: &mut EcuDefinition, key: &str, value: &str) {
             // Strip potential comments
             let clean_val = value.split(';').next().unwrap_or("").trim();
             def.protocol.delay_after_port_open = clean_val.parse().unwrap_or(0);
-            eprintln!(
-                "[DEBUG] parse_megatune: delayAfterPortOpen = {}",
+            tracing::debug!(
+                "parse_megatune: delayAfterPortOpen = {}",
                 def.protocol.delay_after_port_open
             );
         }
@@ -812,8 +810,8 @@ fn parse_megatune(def: &mut EcuDefinition, key: &str, value: &str) {
         "ochblocksize" => {
             let clean_val = value.split(';').next().unwrap_or("").trim();
             def.protocol.och_block_size = clean_val.parse().unwrap_or(0);
-            eprintln!(
-                "[DEBUG] parse_megatune: ochBlockSize = {}",
+            tracing::debug!(
+                "parse_megatune: ochBlockSize = {}",
                 def.protocol.och_block_size
             );
         }
@@ -827,7 +825,7 @@ fn parse_megatune(def: &mut EcuDefinition, key: &str, value: &str) {
 
 /// Parse [TunerStudio] section entries (INI section name - keep as-is)
 fn parse_tunerstudio(def: &mut EcuDefinition, key: &str, value: &str) {
-    eprintln!("[DEBUG] parse_ts: key = {:?}, value = {:?}", key, value);
+    tracing::debug!("parse_ts: key = {:?}, value = {:?}", key, value);
     match key.to_lowercase().as_str() {
         "signature" => {
             def.signature = value.trim_matches('"').to_string();
@@ -884,8 +882,8 @@ fn parse_tunerstudio(def: &mut EcuDefinition, key: &str, value: &str) {
         "delayafterportopen" => {
             let clean_val = value.split(';').next().unwrap_or("").trim();
             def.protocol.delay_after_port_open = clean_val.parse().unwrap_or(0);
-            eprintln!(
-                "[DEBUG] parse_ts: delayAfterPortOpen = {}",
+            tracing::debug!(
+                "parse_ts: delayAfterPortOpen = {}",
                 def.protocol.delay_after_port_open
             );
         }
@@ -899,34 +897,31 @@ fn parse_tunerstudio(def: &mut EcuDefinition, key: &str, value: &str) {
         }
         "messageenvelopeformat" => {
             def.protocol.message_envelope_format = Some(value.trim_matches('"').to_string());
-            eprintln!(
-                "[DEBUG] parse_ts: messageEnvelopeFormat = {:?}",
+            tracing::debug!(
+                "parse_ts: messageEnvelopeFormat = {:?}",
                 def.protocol.message_envelope_format
             );
         }
         "maxunusedruntimerange" => {
             let clean_val = value.split(';').next().unwrap_or("").trim();
             def.protocol.max_unused_runtime_range = clean_val.parse().unwrap_or(0);
-            eprintln!(
-                "[DEBUG] parse_ts: maxUnusedRuntimeRange = {}",
+            tracing::debug!(
+                "parse_ts: maxUnusedRuntimeRange = {}",
                 def.protocol.max_unused_runtime_range
             );
         }
         "ochgetcommand" => {
             let clean_val = value.split(';').next().unwrap_or("").trim();
             def.protocol.och_get_command = Some(clean_val.trim_matches('"').to_string());
-            eprintln!(
-                "[DEBUG] parse_ts: ochGetCommand = {:?}",
+            tracing::debug!(
+                "parse_ts: ochGetCommand = {:?}",
                 def.protocol.och_get_command
             );
         }
         "ochblocksize" => {
             let clean_val = value.split(';').next().unwrap_or("").trim();
             def.protocol.och_block_size = clean_val.parse().unwrap_or(0);
-            eprintln!(
-                "[DEBUG] parse_ts: ochBlockSize = {}",
-                def.protocol.och_block_size
-            );
+            tracing::debug!("parse_ts: ochBlockSize = {}", def.protocol.och_block_size);
         }
         _ => {}
     }
@@ -960,8 +955,8 @@ fn parse_constants_entry(
         }
         "maxunusedruntimerange" => {
             def.protocol.max_unused_runtime_range = value.parse().unwrap_or(0);
-            eprintln!(
-                "[DEBUG] parse_constants: maxUnusedRuntimeRange = {}",
+            tracing::debug!(
+                "parse_constants: maxUnusedRuntimeRange = {}",
                 def.protocol.max_unused_runtime_range
             );
             return;
@@ -1269,16 +1264,13 @@ fn parse_burst_mode_entry(def: &mut EcuDefinition, key: &str, value: &str) {
         def.protocol.burst_get_command = Some(value.trim_matches('"').to_string());
     } else if key.eq_ignore_ascii_case("ochgetcommand") {
         let clean = value.trim_matches('"').to_string();
-        eprintln!(
-            "[DEBUG] parse_burst_mode_entry: ochGetCommand = {:?}",
-            clean
-        );
+        tracing::debug!("parse_burst_mode_entry: ochGetCommand = {:?}", clean);
         def.protocol.och_get_command = Some(clean);
     } else if key.eq_ignore_ascii_case("ochblocksize") {
         let clean = value.split(';').next().unwrap_or("").trim();
         def.protocol.och_block_size = clean.parse().unwrap_or(0);
-        eprintln!(
-            "[DEBUG] parse_burst_mode_entry: ochBlockSize = {}",
+        tracing::debug!(
+            "parse_burst_mode_entry: ochBlockSize = {}",
             def.protocol.och_block_size
         );
     }

--- a/crates/libretune-core/src/protocol/serial.rs
+++ b/crates/libretune-core/src/protocol/serial.rs
@@ -139,22 +139,16 @@ pub fn configure_port(port: &mut dyn SerialPort) -> Result<(), ProtocolError> {
     // Opening a serial port typically toggles DTR which triggers bootloader reset
     // Keeping DTR asserted prevents this and maintains stable connection
     if let Err(e) = port.write_data_terminal_ready(true) {
-        eprintln!(
-            "[DEBUG] configure_port: failed to set DTR high: {} (continuing)",
-            e
-        );
+        tracing::debug!("configure_port: failed to set DTR high: {} (continuing)", e);
     } else {
-        eprintln!("[DEBUG] configure_port: DTR set high");
+        tracing::debug!("configure_port: DTR set high");
     }
 
     // Set RTS high for proper flow control signaling
     if let Err(e) = port.write_request_to_send(true) {
-        eprintln!(
-            "[DEBUG] configure_port: failed to set RTS high: {} (continuing)",
-            e
-        );
+        tracing::debug!("configure_port: failed to set RTS high: {} (continuing)", e);
     } else {
-        eprintln!("[DEBUG] configure_port: RTS set high");
+        tracing::debug!("configure_port: RTS set high");
     }
 
     Ok(())

--- a/crates/libretune-core/src/tune/file.rs
+++ b/crates/libretune-core/src/tune/file.rs
@@ -770,9 +770,10 @@ impl TuneFile {
             }
         }
 
-        eprintln!(
-            "[DEBUG] parse_msq: Extracted {} constants and {} pcVariables from MSQ file",
-            constants_found, pcvars_found
+        tracing::debug!(
+            "parse_msq: Extracted {} constants and {} pcVariables from MSQ file",
+            constants_found,
+            pcvars_found
         );
 
         // If we found no constants and no signature, this isn't a valid MSQ


### PR DESCRIPTION
## Description

`libretune-app` initialises a `tracing` subscriber specifically so log verbosity is controlled by `RUST_LOG`, defaulting to `info` (`src-tauri/src/lib.rs`). Its own comment notes that dev builds "previously spammed". CONTRIBUTING.md documents this contract, including `RUST_LOG=error` to "quiet everything except errors".

23 call sites in `libretune-core` bypassed that entirely, writing straight to stderr with `eprintln!("[DEBUG] ...")`. Having no level filter, they print unconditionally — `RUST_LOG=error` does not silence them, which contradicts the documented behaviour.

The volume is not trivial. Parsing one real Speeduino `mainController.ini` emits **111 `[DEBUG]` lines** (one per `#if` / `#endif` / `#unset` directive), and every MSQ load adds another. That buries the `warn!` and `error!` output the subscriber exists to surface.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues
No existing issue — found while auditing parser output against real Speeduino INI and MSQ files.

## Changes Made
Converted every `[DEBUG]`-marked message to `tracing::debug!`, matching the pattern `libretune-core` already uses in `protocol/connection.rs` and `autotune/mod.rs`. The `[DEBUG] ` string prefix is dropped, since the log level now conveys it.

| File | Sites converted |
|---|---|
| `ini/parser.rs` | 18 |
| `protocol/serial.rs` | 4 |
| `tune/file.rs` | 1 |

Genuine warnings written with `eprintln!` were left alone — only messages explicitly marked `[DEBUG]` were converted. No message text or formatting arguments were otherwise altered.

## Testing
- [x] I have tested these changes locally
- [x] New and existing tests pass (`cargo test`)
- [x] The UI works correctly with these changes

`./scripts/pre-push.sh` passes end to end: cargo build, cargo tests, build-info test, clippy (no warnings), `npm ci`, TypeScript check, frontend build, frontend tests, and Rust formatting.

Verified behaviourally rather than only by compilation: loading 45 real `.msq` files previously emitted 45 `[DEBUG]` lines to stderr and now emits 0, with identical parse results (45/45 clean load → save → load round-trip, 0 differences). Parsing a real 469 KB Speeduino `mainController.ini` likewise drops from 111 `[DEBUG]` lines to 0 at the default `info` level.

Clippy warning count is unchanged at 11 before and after (all pre-existing, mostly in test code), so this introduces none.

## Checklist
- [x] Code compiles without errors
- [x] No new clippy warnings (`cargo clippy`)
- [x] Code is formatted (`cargo fmt`)
- [x] TypeScript compiles without errors (`npx tsc --noEmit`)
- [ ] Documentation updated if needed — CONTRIBUTING.md already documents the `RUST_LOG` behaviour this restores
- [x] Commit messages follow conventional format

## Unrelated observation while verifying

On one `./scripts/pre-push.sh` run, `src/__tests__/App.integration.test.tsx > shows packet mode and receives metrics when connected` failed on a `waitFor` timeout at line 109. It looks flaky rather than related to this change — this branch touches only Rust files, the test passes on unmodified `main`, it passed 5/5 in isolation on this branch, and a subsequent full pre-push run passed cleanly. It appears to surface only under full-suite concurrency.

Mentioning it because an intermittently failing integration test will redden CI for other contributors too. Happy to open a separate issue if that is useful.

## Notes for the reviewer

The messages are kept at `debug!` level to match their previous intent. If any of them are better as `trace!` — the per-directive preprocessor logging in `ini/parser.rs` is the most verbose group — that is an easy follow-up, and I am happy to adjust in this PR if you have a preference.
