### PR TITLE
refactor(dash): collapse redundant show_history into peak_hold

### DIFF
--- a/crates/libretune-app/src/components/curves/CurveEditor.tsx
+++ b/crates/libretune-app/src/components/curves/CurveEditor.tsx
@@ -82,7 +82,7 @@ export function toTsGaugeConfig(gauge: SimpleGaugeInfo): TsGaugeConfig {
     antialiasing_on: true,
     background_image_file_name: null,
     needle_image_file_name: null,
-    show_history: false,
+    peak_hold: false,
     history_value: 0,
     history_delay: 0,
     needle_smoothing: 0,

--- a/crates/libretune-app/src/components/dashboards/dashTypes.ts
+++ b/crates/libretune-app/src/components/dashboards/dashTypes.ts
@@ -201,7 +201,6 @@ export interface TsGaugeConfig {
   needle_pivot_offset_y?: number;
 
   // History/tracking
-  show_history: boolean;
   history_value: number;
   history_delay: number;
   needle_smoothing: number;
@@ -217,7 +216,7 @@ export interface TsGaugeConfig {
   /** Optional INI expression that hides this gauge when false. */
   enabled_condition?: string | null;
   /** Render a persistent peak-hold marker tracking the maximum observed value. */
-  peak_hold?: boolean;
+  peak_hold: boolean;
   /** Hysteresis (in channel units) on warning/critical state transitions. */
   hysteresis?: number | null;
   /** Catch-all for un-modeled `.dash` attributes (round-trip safety). */

--- a/crates/libretune-app/src/components/dashboards/designer/useDesignerDrop.ts
+++ b/crates/libretune-app/src/components/dashboards/designer/useDesignerDrop.ts
@@ -96,7 +96,7 @@ export function createDefaultGaugeFromChannel(
     antialiasing_on: true,
     background_image_file_name: null,
     needle_image_file_name: null,
-    show_history: false,
+    peak_hold: false,
     history_value: 0,
     history_delay: 0,
     needle_smoothing: 0,

--- a/crates/libretune-app/src/components/dashboards/utils/defaultGauge.ts
+++ b/crates/libretune-app/src/components/dashboards/utils/defaultGauge.ts
@@ -67,7 +67,7 @@ export function buildDefaultGauge(opts: DefaultGaugeOptions): TsGaugeConfig {
     antialiasing_on: true,
     background_image_file_name: null,
     needle_image_file_name: null,
-    show_history: false,
+    peak_hold: false,
     history_value: 0,
     history_delay: 0,
     needle_smoothing: 0,

--- a/crates/libretune-app/src/components/gauges/painters/__tests__/lineGraph.test.ts
+++ b/crates/libretune-app/src/components/gauges/painters/__tests__/lineGraph.test.ts
@@ -86,7 +86,7 @@ const baseConfig: TsGaugeConfig = {
   antialiasing_on: true,
   background_image_file_name: null,
   needle_image_file_name: null,
-  show_history: true,
+  peak_hold: false,
   history_value: 0,
   history_delay: 0,
   needle_smoothing: 0,

--- a/crates/libretune-core/src/dash/parser.rs
+++ b/crates/libretune-core/src/dash/parser.rs
@@ -613,14 +613,11 @@ fn set_gauge_property(gauge: &mut GaugeConfig, prop: &str, value: &str) {
                 Some(value.to_string())
             }
         }
-        // `ShowHistory` is TunerStudio's peak-hold flag; the format has no
-        // separate `PeakHold` property. Drive `peak_hold` from it so an
-        // imported cluster keeps the peak markers it was authored with.
-        // `show_history` retains the raw parsed value.
+        // `ShowHistory` is TunerStudio's peak-hold flag; the `.dash` format
+        // has no separate `PeakHold` property, so drive `peak_hold` from it
+        // to keep the peak markers an imported cluster was authored with.
         "ShowHistory" => {
-            let show_history = value.parse().unwrap_or(false);
-            gauge.show_history = show_history;
-            gauge.peak_hold = show_history;
+            gauge.peak_hold = value.parse().unwrap_or(false);
         }
         "HistoryValue" => gauge.history_value = value.parse().unwrap_or(0.0),
         "HistoryDelay" => gauge.history_delay = value.parse().unwrap_or(15000),
@@ -797,7 +794,6 @@ mod tests {
             enabled.peak_hold,
             "ShowHistory=true must enable peak_hold, otherwise the renderer never draws the marker"
         );
-        assert!(enabled.show_history, "raw value retained for round-trip");
 
         let disabled = gauge_from(&dash_with("false"));
         assert!(

--- a/crates/libretune-core/src/dash/templates.rs
+++ b/crates/libretune-core/src/dash/templates.rs
@@ -692,7 +692,6 @@ pub fn create_tuning_dashboard() -> DashFile {
             trim_color: LT_TEXT_SECONDARY,
             warn_color: LT_WARN_COLOR,
             critical_color: LT_CRITICAL_COLOR,
-            show_history: true,
             ..Default::default()
         })));
 
@@ -1014,7 +1013,6 @@ fn log_sparkline(spec: LogSparkSpec) -> DashComponent {
         trim_color: LT_LOG_GRAY,
         warn_color: LT_WARN_COLOR,
         critical_color: LT_CRITICAL_COLOR,
-        show_history: true,
         border_width: 1,
         shortest_size: 0, // see log_stat_tile's comment
         ..Default::default()

--- a/crates/libretune-core/src/dash/types.rs
+++ b/crates/libretune-core/src/dash/types.rs
@@ -435,7 +435,6 @@ pub struct GaugeConfig {
     pub needle_image_offset_y: Option<f64>,
 
     // History/tracking
-    pub show_history: bool,
     pub history_value: f64,
     pub history_delay: i32,
     pub needle_smoothing: i32,
@@ -545,7 +544,6 @@ impl Default for GaugeConfig {
             needle_pivot_offset_y: None,
             needle_image_offset_x: None,
             needle_image_offset_y: None,
-            show_history: false,
             history_value: 0.0,
             history_delay: 15000,
             needle_smoothing: 1,


### PR DESCRIPTION
## Summary

Follow-up to #125 (by @aby312), collapsing the redundant `show_history` field into the single canonical `peak_hold` field that #125 introduced.

In #125, @aby312 added `peak_hold` as the live flag driving the peak-hold gauge marker, but deliberately kept the pre-existing `show_history` field to avoid changing the designer's data model in a bug-fix PR. They flagged this as redundant:

> `peak_hold` and `show_history` now both exist and describe the same concept, which is a little redundant. I kept both to avoid changing the designer's data model in a bug-fix PR, but if you would prefer a single field I am happy to collapse them — `show_history` currently has no other reader.

This PR takes up that suggestion.

## Why it's safe

Investigation confirmed `show_history` is **globally dead**:

- **No reader on either side.** The renderer reads only `peak_hold` (`gauges/painters/analogGauge.ts`); the designer edits only `peak_hold` (`PropertyEditor.tsx`); no painter reads `show_history`.
- **The XML writer already serializes from `peak_hold` only** (`writer.rs` → `<ShowHistory>`), so the TunerStudio XML round-trip was never dependent on `show_history`. The two `ShowHistory` round-trip tests continue to pass.
- **No JSON persistence path** — `DashFile`/`GaugeConfig` cross the Tauri IPC boundary transiently but are never cached to disk; pop-out windows don't carry gauge config. No data-loss risk.
- **LineGraph gauges** draw their trail unconditionally from the realtime history buffer and ignore both flags, so dropping `show_history: true` from the LineGraph templates is a no-op (kept `peak_hold: false` via `..Default::default()` — `true` would be semantically wrong for a line graph).

## Changes

**Rust (`libretune-core`)**
- `dash/types.rs` — removed `show_history` field + `Default` initializer.
- `dash/parser.rs` — `ShowHistory` parse arm now sets only `peak_hold`; dropped the now-invalid `show_history` test assertion.
- `dash/templates.rs` — removed `show_history: true` from two LineGraph templates.
- `dash/writer.rs` — no change (already serializes from `peak_hold`).

**Frontend (`libretune-app`)**
- `dashTypes.ts` — removed `show_history`; promoted `peak_hold` from optional to required `boolean`.
- `defaultGauge.ts` / `useDesignerDrop.ts` / `CurveEditor.tsx` — swapped `show_history: false` → `peak_hold: false` in default factories.
- `lineGraph.test.ts` — swapped `show_history: true` → `peak_hold: false` in fixture.

## Verification

- `cargo test -p libretune-core --lib dash::` — **14/14 pass**, including `test_show_history_drives_peak_hold` and `test_peak_hold_round_trips_as_show_history`.
- `cargo clippy -p libretune-core` — clean.
- `npm run typecheck` — clean.
- `npx vitest run lineGraph.test.ts` — **3/3 pass**.
- Runtime: app launched in demo mode; the `Telemetry Live` dashboard (built from the edited LineGraph templates) loads 42 components / 0 errors.

## Credit

This is the follow-up cleanup that @aby312 offered to do in #125. The design decision to collapse toward `peak_hold` (rather than `show_history`) follows directly from their analysis — `peak_hold` is the field the renderer reads, the designer edits, and the writer serializes.

Refs #125.
