### PR TITLE
fix(datalog): read TunerStudio .msl logs instead of silently loading nothing

### DIFF
--- a/crates/libretune-app/src/components/tuner-ui/DataLogView.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/DataLogView.tsx
@@ -7,6 +7,7 @@ import { useChannels, useRealtimeStore } from '../../stores/realtimeStore';
 import { useGraphLogStore, exportGraphLogSetup, importGraphLogSetup } from '../../stores/graphLogStore';
 import LoggerStatsPanel from './LoggerStatsPanel';
 import GraphLog, { GraphSample } from './GraphLog';
+import { parseLogFile } from '../../utils/parseLogFile';
 import './DataLogView.css';
 
 /** Hard cap on samples kept in the frontend; the oldest are dropped beyond it. */
@@ -209,6 +210,9 @@ export const DataLogView: React.FC = () => {
   const [playbackPosition, setPlaybackPosition] = useState(0); // 0-1
   const [playbackSpeed, setPlaybackSpeed] = useState<PlaybackSpeed>(1);
   const [loadedFileName, setLoadedFileName] = useState<string | null>(null);
+  // Surfaced in the UI when a chosen log yields no rows — otherwise the Load
+  // button appears to do nothing.
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [showStats, setShowStats] = useState(false);
   const [chartMode, setChartMode] = useState<'graphlog' | 'overlay'>('graphlog');
   const [selectedStatsChannel, setSelectedStatsChannel] = useState<string | null>(null);
@@ -470,88 +474,12 @@ export const DataLogView: React.FC = () => {
   // 4180 parser) — it handles quoted fields with embedded commas via the
   // inQuotes toggle below, but does not handle escaped quotes ("") or CRLF
   // inside quotes. Datalogs from both apps are simple enough that this suffices.
-  const parseLogCsv = useCallback((content: string, _fileName: string): { 
-    data: { x: number; values: Record<string, number> }[];
-    channels: string[];
-  } => {
-    const lines = content.trim().split('\n');
-    if (lines.length < 2) return { data: [], channels: [] };
-    
-    // Parse header - handle both formats
-    const headerLine = lines[0];
-    const headers = headerLine.split(',').map(h => h.trim().replace(/^"|"$/g, ''));
-    
-    // Detect format: TunerStudio uses "Time" column, LibreTune uses "timestamp_ms"
-    const timeColIndex = headers.findIndex(h => 
-      h.toLowerCase() === 'time' || 
-      h.toLowerCase() === 'timestamp_ms' ||
-      h.toLowerCase() === 'timestamp'
-    );
-    
-    // Distinguishes the two formats so the timestamp can be unit-normalized.
-    const isTunerStudioFormat = headers.some(h => h.toLowerCase() === 'time');
-    const channels = headers.filter((_, i) => i !== timeColIndex);
-    
-    const data: { x: number; values: Record<string, number> }[] = [];
-    
-    for (let i = 1; i < lines.length; i++) {
-      const line = lines[i].trim();
-      if (!line) continue;
-      
-      // Minimal quoted-CSV state machine: toggle inQuotes on each '"' so that
-      // commas inside quoted fields don't split the field. Anything else is
-      // accumulated into the current field.
-      const values: string[] = [];
-      let current = '';
-      let inQuotes = false;
-      for (const char of line) {
-        if (char === '"') {
-          inQuotes = !inQuotes;
-        } else if (char === ',' && !inQuotes) {
-          values.push(current.trim());
-          current = '';
-        } else {
-          current += char;
-        }
-      }
-      values.push(current.trim());
-      
-      if (values.length < headers.length) continue;
-      
-      // Parse timestamp, normalizing both formats to milliseconds.
-      let timestamp: number;
-      if (timeColIndex >= 0) {
-        const timeStr = values[timeColIndex];
-        if (isTunerStudioFormat) {
-          // TunerStudio format: seconds with decimals
-          timestamp = parseFloat(timeStr) * 1000;
-        } else {
-          // LibreTune format: milliseconds
-          timestamp = parseFloat(timeStr);
-        }
-      } else {
-        // No time column - use index * 100ms
-        timestamp = (i - 1) * 100;
-      }
-      
-      if (isNaN(timestamp)) continue;
-      
-      const entry: Record<string, number> = {};
-      let channelIdx = 0;
-      for (let j = 0; j < headers.length; j++) {
-        if (j === timeColIndex) continue;
-        const val = parseFloat(values[j]);
-        if (!isNaN(val)) {
-          entry[channels[channelIdx]] = val;
-        }
-        channelIdx++;
-      }
-      
-      data.push({ x: timestamp, values: entry });
-    }
-    
-    return { data, channels };
-  }, []);
+  // Parsing lives in `utils/parseLogFile` so it can be unit-tested against
+  // real .msl and .csv fixtures without mounting this component.
+  const parseLogCsv = useCallback(
+    (content: string, _fileName: string) => parseLogFile(content),
+    []
+  );
   
   const handleLoadLog = useCallback(async () => {
     try {
@@ -571,9 +499,16 @@ export const DataLogView: React.FC = () => {
       const { data, channels } = parseLogCsv(content, fileName);
       
       if (data.length === 0) {
+        // Previously this only reached the console, so picking an unreadable
+        // log looked like the button had done nothing at all.
         console.error('No valid data found in log file');
+        setLoadError(
+          `Could not read any data from "${fileName}". ` +
+          `Supported formats are TunerStudio .msl and comma-separated .csv logs.`
+        );
         return;
       }
+      setLoadError(null);
       
       // Switch to playback mode
       setLogData(data);
@@ -703,6 +638,11 @@ export const DataLogView: React.FC = () => {
           {loadedFileName && (
             <span className="loaded-file" title={loadedFileName}>
               {loadedFileName.length > 25 ? '...' + loadedFileName.slice(-22) : loadedFileName}
+            </span>
+          )}
+          {loadError && (
+            <span className="load-error" role="alert" title={loadError}>
+              {loadError}
             </span>
           )}
         </div>

--- a/crates/libretune-app/src/utils/__tests__/parseLogFile.test.ts
+++ b/crates/libretune-app/src/utils/__tests__/parseLogFile.test.ts
@@ -1,0 +1,92 @@
+//! Tests for the recorded-datalog parser.
+//!
+//! The `.msl` cases encode the shape of real TunerStudio exports: a preamble
+//! before the header, a units row after it, tab delimiters, timestamps that
+//! are neither zero-based nor monotonic, and enum channels emitting strings in
+//! otherwise numeric columns. Each fixture below exists because a parser that
+//! assumed otherwise silently produced an empty log.
+
+import { describe, it, expect } from 'vitest';
+import { parseLogFile } from '../parseLogFile';
+
+/**
+ * A minimal but structurally faithful `.msl`: two preamble lines, a `#`
+ * separator, a tab-separated header, a units row, then data. `Time` is in
+ * seconds and negative, as it is in logs exported from a longer `.mlg`.
+ */
+const MSL_FIXTURE = [
+  '"speeduino 202501: Speeduino 2025.01.4"',
+  '"Capture Date: Sat Sep 20 12:10:33 BST 2025, File author: TunerStudio MS version 3.2.05"',
+  '#',
+  'Time\tRPM\tMAP\tAFR\tDFCO',
+  's\trpm\tkpa\tO2\t',
+  '-11923.118\t1450\t38.0\t14.7\tOff',
+  '-11923.050\t1502\t41.5\t14.6\tOff',
+  '-11922.921\t1610\t44.0\t13.9\tOn',
+].join('\n');
+
+const CSV_FIXTURE = [
+  'timestamp_ms,RPM,MAP,AFR',
+  '0,1450,38.0,14.7',
+  '100,1502,41.5,14.6',
+].join('\n');
+
+describe('parseLogFile — TunerStudio .msl', () => {
+  it('skips the preamble and units row and reads every data sample', () => {
+    const { data, channels } = parseLogFile(MSL_FIXTURE);
+
+    // Three data rows — the units row must not be counted as a sample, which
+    // is what an off-by-one in the preamble skip would produce.
+    expect(data).toHaveLength(3);
+    expect(channels).toEqual(['RPM', 'MAP', 'AFR', 'DFCO']);
+  });
+
+  it('parses tab-delimited fields rather than treating the row as one column', () => {
+    const { data } = parseLogFile(MSL_FIXTURE);
+    expect(data[0].values.RPM).toBe(1450);
+    expect(data[0].values.MAP).toBeCloseTo(38.0);
+    expect(data[2].values.AFR).toBeCloseTo(13.9);
+  });
+
+  it('preserves negative, non-zero-based timestamps and converts seconds to ms', () => {
+    const { data } = parseLogFile(MSL_FIXTURE);
+    // Real exports carry offsets relative to the original recording, so the
+    // parser must not normalise, clamp, or reject them.
+    expect(data[0].x).toBeCloseTo(-11923118);
+    expect(data[2].x).toBeCloseTo(-11922921);
+    // Duration must come from the range, never from `x` starting at zero.
+    expect(data[2].x - data[0].x).toBeCloseTo(197);
+  });
+
+  it('keeps numeric fields on a row where an enum channel logs a string', () => {
+    const { data } = parseLogFile(MSL_FIXTURE);
+    // `DFCO` is `Off`/`On`; the row must survive with its numeric channels
+    // intact rather than being discarded wholesale.
+    expect(data[0].values.RPM).toBe(1450);
+    expect(data[0].values.DFCO).toBeUndefined();
+  });
+});
+
+describe('parseLogFile — LibreTune .csv', () => {
+  it('still parses comma-separated logs with a millisecond timestamp', () => {
+    const { data, channels } = parseLogFile(CSV_FIXTURE);
+    expect(channels).toEqual(['RPM', 'MAP', 'AFR']);
+    expect(data).toHaveLength(2);
+    // `timestamp_ms` is already milliseconds and must not be scaled again.
+    expect(data[0].x).toBe(0);
+    expect(data[1].x).toBe(100);
+  });
+});
+
+describe('parseLogFile — malformed input', () => {
+  it('returns no data for content with no recognisable header', () => {
+    // The caller surfaces this to the user; silently returning an empty log
+    // is what made a failed load look like the button had done nothing.
+    const { data } = parseLogFile('not a log\njust text\n');
+    expect(data).toHaveLength(0);
+  });
+
+  it('returns no data for an empty file', () => {
+    expect(parseLogFile('').data).toHaveLength(0);
+  });
+});

--- a/crates/libretune-app/src/utils/parseLogFile.ts
+++ b/crates/libretune-app/src/utils/parseLogFile.ts
@@ -1,0 +1,191 @@
+/**
+ * Parser for recorded datalog files.
+ *
+ * Handles the two text formats the Load dialog offers:
+ *
+ * - **LibreTune CSV** — comma-separated, header on the first line, a
+ *   `timestamp_ms` column in milliseconds.
+ * - **TunerStudio `.msl`** — TAB-separated, and prefixed with a preamble that
+ *   must be skipped before the real header:
+ *
+ *   ```
+ *   "speeduino 202501: Speeduino 2025.01.4"      <- ECU signature
+ *   "Capture Date: ..., File author: ..."        <- capture metadata
+ *   #                                            <- separator
+ *   Time<TAB>SecL<TAB>RPM<TAB>...                <- real header
+ *   s<TAB>sec<TAB>rpm<TAB>...                    <- units row, NOT data
+ *   <data rows>
+ *   ```
+ *
+ * Rather than hard-coding those line offsets (TunerStudio's preamble length is
+ * not guaranteed), the header is located by scanning the first few lines for
+ * one that splits into multiple fields and carries a recognised time column.
+ *
+ * Two properties of real `.msl` exports drive the remaining decisions:
+ *
+ * - **Timestamps are not necessarily zero-based, positive, or monotonic.** A
+ *   log exported from a longer `.mlg` recording carries offsets relative to
+ *   the *original* recording, so values can be large and negative, and the
+ *   first row may be a `0.0` marker that precedes them. Callers must derive
+ *   duration from the data range rather than assuming `x` starts at zero.
+ * - **Enum channels emit strings** (`Off` / `On`) in otherwise numeric
+ *   columns, so a field that fails to parse is skipped individually instead of
+ *   discarding the whole sample.
+ */
+
+/** One parsed sample: `x` is the timestamp in milliseconds. */
+export interface LogSample {
+  x: number;
+  values: Record<string, number>;
+}
+
+export interface ParsedLog {
+  data: LogSample[];
+  channels: string[];
+}
+
+/** Header names accepted as the time column, lower-cased. */
+const TIME_COLUMN_NAMES = ['time', 'timestamp_ms', 'timestamp'];
+
+/** How far into the file to look for the header before giving up. */
+const MAX_HEADER_SCAN_LINES = 10;
+
+/** Fallback spacing when a log has no time column at all. */
+const FALLBACK_SAMPLE_INTERVAL_MS = 100;
+
+function splitFields(line: string, delimiter: string): string[] {
+  return line.split(delimiter).map(f => f.trim().replace(/^"|"$/g, ''));
+}
+
+function isTimeColumn(name: string): boolean {
+  return TIME_COLUMN_NAMES.includes(name.toLowerCase());
+}
+
+/**
+ * Split one data row, honouring quoted fields so a delimiter inside quotes
+ * does not split the field.
+ */
+function splitRow(line: string, delimiter: string): string[] {
+  const values: string[] = [];
+  let current = '';
+  let inQuotes = false;
+
+  for (const char of line) {
+    if (char === '"') {
+      inQuotes = !inQuotes;
+    } else if (char === delimiter && !inQuotes) {
+      values.push(current.trim());
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+  values.push(current.trim());
+
+  return values;
+}
+
+/**
+ * Parse a recorded log. Returns empty `data` when no header or no readable
+ * rows could be found, which callers should surface to the user rather than
+ * treating as an empty log.
+ */
+export function parseLogFile(content: string): ParsedLog {
+  const lines = content.trim().split('\n');
+  if (lines.length < 2) return { data: [], channels: [] };
+
+  // Locate the header and infer the delimiter together: the first line that
+  // splits into multiple fields and contains a time column wins. Tab is tried
+  // first so a `.msl` whose preamble happens to contain a comma is not
+  // mistaken for CSV.
+  let headerIdx = -1;
+  let delimiter = ',';
+  outer: for (let i = 0; i < Math.min(lines.length, MAX_HEADER_SCAN_LINES); i++) {
+    for (const candidate of ['\t', ',']) {
+      const fields = splitFields(lines[i], candidate);
+      if (fields.length > 1 && fields.some(isTimeColumn)) {
+        headerIdx = i;
+        delimiter = candidate;
+        break outer;
+      }
+    }
+  }
+
+  // No time column anywhere: fall back to treating line 0 as a CSV header so
+  // headerless-but-tabular logs still load, with synthesised timestamps.
+  if (headerIdx === -1) {
+    headerIdx = 0;
+    delimiter = lines[0].includes('\t') ? '\t' : ',';
+  }
+
+  const headers = splitFields(lines[headerIdx], delimiter);
+  const timeColIndex = headers.findIndex(isTimeColumn);
+
+  // `Time` is in seconds (TunerStudio); `timestamp_ms` is already milliseconds.
+  const timeIsSeconds =
+    timeColIndex >= 0 && headers[timeColIndex].toLowerCase() === 'time';
+
+  // `.msl` follows the header with a units row (`s`, `rpm`, `kpa`, blank for
+  // bitfields). Detect it by the time column failing to parse as a number,
+  // which no real data row does.
+  let firstDataIdx = headerIdx + 1;
+  if (timeColIndex >= 0 && firstDataIdx < lines.length) {
+    const next = splitFields(lines[firstDataIdx], delimiter);
+    if (next.length > 1 && Number.isNaN(parseFloat(next[timeColIndex]))) {
+      firstDataIdx++;
+    }
+  }
+
+  const channels = headers.filter((_, i) => i !== timeColIndex);
+  const data: LogSample[] = [];
+
+  for (let i = firstDataIdx; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (!line) continue;
+
+    const values = splitRow(line, delimiter);
+    if (values.length < headers.length) continue;
+
+    let timestamp: number;
+    if (timeColIndex >= 0) {
+      timestamp = parseFloat(values[timeColIndex]);
+      if (timeIsSeconds) timestamp *= 1000;
+    } else {
+      timestamp = (i - firstDataIdx) * FALLBACK_SAMPLE_INTERVAL_MS;
+    }
+    if (Number.isNaN(timestamp)) continue;
+
+    const entry: Record<string, number> = {};
+    let channelIdx = 0;
+    for (let j = 0; j < headers.length; j++) {
+      if (j === timeColIndex) continue;
+      // Enum channels log `Off`/`On` in numeric columns; skip just that field.
+      const val = parseFloat(values[j]);
+      if (!Number.isNaN(val)) entry[channels[channelIdx]] = val;
+      channelIdx++;
+    }
+
+    // A row that yielded no numeric field is not a sample — this is what
+    // arbitrary text degrades into, and emitting it would make an unreadable
+    // file look like a log with content.
+    if (Object.keys(entry).length === 0) continue;
+
+    data.push({ x: timestamp, values: entry });
+  }
+
+  // Order by timestamp so playback and charting advance monotonically.
+  //
+  // Real exports are not reliably ordered. One observed TunerStudio `.msl`
+  // (an export from a longer `.mlg`) carries a genuine first sample — 44
+  // populated channels — stamped `0.000`, while every subsequent row uses an
+  // offset near -11923s relative to the original recording. That single row is
+  // real data, so it is kept rather than discarded on a timestamp heuristic;
+  // sorting simply stops it from making the series jump backwards.
+  //
+  // Consumers must therefore derive duration from the min/max of `x` and
+  // tolerate a large gap between the first and second samples. An outlier like
+  // this makes a nominal-18.7-minute log span ~199 minutes end to end.
+  data.sort((a, b) => a.x - b.x);
+
+  return { data, channels };
+}


### PR DESCRIPTION
## Description

The Load dialog in Data Logging offers `csv`, `msl` and `log`, but the parser split every line on commas and treated line 1 as the header. A `.msl` opens with a preamble, so line 1 is the ECU signature string: it produced a single bogus column, no time column, and zero samples.

The failure was silent. The empty result only reached `console.error`, so choosing a `.msl` looked like the button had done nothing at all.

`.msl` differs from CSV in four ways, all now handled:

- TAB delimited, not comma
- a preamble before the header (signature, capture date, `#`)
- a units row after the header (`s`, `rpm`, `kpa`, blank for bitfields)
- enum channels emit strings (`Off` / `On`) in otherwise numeric columns

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues
No existing issue — found while trying to open a TunerStudio log exported from a Speeduino project.

## Changes Made
- Moved parsing out of a `useCallback` inside `DataLogView` into `utils/parseLogFile.ts`, so it can be tested without mounting the component. Behaviour for existing LibreTune CSV logs is unchanged.
- The header is located by scanning the first few lines for one that splits into multiple fields and carries a recognised time column, rather than assuming a fixed offset — TunerStudio's preamble length is not guaranteed.
- The delimiter is inferred from that same match, tab tried first.
- The units row is detected by its time field failing to parse, which no real data row does.
- Non-numeric fields are skipped individually, so an enum column does not discard the whole sample.
- A failed load now surfaces in the UI instead of only the console.
- Samples are sorted by timestamp (see below).

## Testing
- [x] I have tested these changes locally
- [x] New and existing tests pass (`cargo test`)
- [x] The UI works correctly with these changes

`./scripts/pre-push.sh` passes end to end: cargo build, cargo tests, build-info test, clippy (no warnings), `npm ci`, TypeScript check, frontend build, frontend tests, and Rust formatting.

7 new unit tests, each encoding a specific failure mode rather than restating the implementation.

Verified against a real 4.8 MB `.msl` (16,853 samples, 76 channels, Speeduino 2025.01) exported from TunerStudio: parses correctly with values matching the source. Previously it parsed to nothing.

## Checklist
- [x] Code compiles without errors
- [x] No new clippy warnings (`cargo clippy`)
- [x] Code is formatted (`cargo fmt`)
- [x] TypeScript compiles without errors (`npx tsc --noEmit`)
- [ ] Documentation updated if needed — no user-facing docs describe this behaviour
- [x] Commit messages follow conventional format

## Two properties of real exports worth recording

Both were found in a live Speeduino log rather than by reading a spec, and both are documented in the module header:

**Timestamps are neither zero-based, positive, nor monotonic.** A `.msl` exported from a longer `.mlg` carries offsets relative to the *original* recording, so values are large and negative. In the file used here they run from −11923.118 to −10799.227 seconds. A parser computing `duration = last − first` gets a sensible number only by accident.

**That same file's first row is a genuine sample** — 44 populated channels, RPM 972 — stamped `0.000` while every other row sits near −11923. It is real engine data with what looks like a placeholder timestamp.

I kept that row rather than dropping it on a timestamp heuristic, since discarding real data to make a duration look tidy seemed the worse trade. Samples are sorted by timestamp so playback stays monotonic, and the docs note that consumers must derive duration from the range and tolerate the gap. The visible consequence is that this particular log reports a ~199 minute span for what is really 18.7 minutes of driving.

If you would rather such a row were discarded, that is an easy change — I did not want to make that call unilaterally, since it means throwing away logged engine data.
