### PR TITLE
fix(autotune): show connection status, block Start when disconnected

### DIFF
--- a/crates/libretune-app/src/PopOutWindow.tsx
+++ b/crates/libretune-app/src/PopOutWindow.tsx
@@ -414,6 +414,7 @@ export default function PopOutWindow() {
           <AutoTune
             tableName={(popOutData.data as string) || ''}
             onClose={handleClose}
+            isConnected={isConnected}
           />
         );
       

--- a/crates/libretune-app/src/components/TabContentRouter.tsx
+++ b/crates/libretune-app/src/components/TabContentRouter.tsx
@@ -217,6 +217,7 @@ export function TabContentRouter(props: TabContentRouterProps) {
         <AutoTune
           tableName={(content.data as string) || ""}
           onClose={() => handleTabClose("autotune")}
+          isConnected={status.state === "Connected"}
         />
       );
     case "datalog":

--- a/crates/libretune-app/src/components/tuner-ui/AutoTune.css
+++ b/crates/libretune-app/src/components/tuner-ui/AutoTune.css
@@ -58,8 +58,20 @@
 
 .autotune-header h2 {
   margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
   font-size: 16px;
   font-weight: 600;
+}
+
+.autotune-disconnected-badge {
+  background: var(--error);
+  color: white;
+  padding: 2px 8px;
+  border-radius: 3px;
+  font-size: 10px;
+  font-weight: bold;
 }
 
 .autotune-table-selector {

--- a/crates/libretune-app/src/components/tuner-ui/AutoTune.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/AutoTune.tsx
@@ -34,6 +34,7 @@ import { invoke } from '@tauri-apps/api/core';
 import { open, save } from '@tauri-apps/plugin-dialog';
 import { valueToHeatmapColor } from '../../utils/heatmapColors';
 import { TuneHealthCard } from './TuneHealth';
+import { useToast } from '../../contexts/ToastContext';
 import './AutoTune.css';
 
 // =============================================================================
@@ -151,6 +152,8 @@ interface AutoTuneProps {
   tableName?: string;
   /** Callback when component is closed */
   onClose?: () => void;
+  /** Whether the app currently has a live ECU connection */
+  isConnected: boolean;
 }
 
 interface VeAnalyzeConfig {
@@ -165,7 +168,9 @@ interface VeAnalyzeConfig {
 // AutoTune Component
 // =============================================================================
 
-export function AutoTune({ tableName: initialTableName = '', onClose }: AutoTuneProps) {
+export function AutoTune({ tableName: initialTableName = '', onClose, isConnected }: AutoTuneProps) {
+  const { showToast } = useToast();
+
   // State
   const [isRunning, setIsRunning] = useState(false);
   const [selectedTable, setSelectedTable] = useState(initialTableName);
@@ -460,6 +465,10 @@ export function AutoTune({ tableName: initialTableName = '', onClose }: AutoTune
   }, [tableData]);
 
   const startAutoTune = useCallback(async () => {
+    if (!isConnected) {
+      showToast('Connect to the ECU to start AutoTune — it needs live data to generate recommendations.', 'warning');
+      return;
+    }
     try {
       await invoke('start_autotune', {
         tableName: selectedTable,
@@ -480,7 +489,7 @@ export function AutoTune({ tableName: initialTableName = '', onClose }: AutoTune
     } catch (e) {
       setError(`Failed to start AutoTune: ${e}`);
     }
-  }, [selectedTable, secondaryTableEnabled, secondaryTable, loadSource, settings, filters, authority, targetAfrTable, lambdaDelayTable, strictLambdaMatch]);
+  }, [isConnected, showToast, selectedTable, secondaryTableEnabled, secondaryTable, loadSource, settings, filters, authority, targetAfrTable, lambdaDelayTable, strictLambdaMatch]);
 
   const stopAutoTune = useCallback(async () => {
     try {
@@ -621,7 +630,10 @@ export function AutoTune({ tableName: initialTableName = '', onClose }: AutoTune
       {/* Header */}
       <div className="autotune-header">
         <div className="autotune-title-row">
-          <h2>AutoTune</h2>
+          <h2>
+            AutoTune
+            {!isConnected && <span className="autotune-disconnected-badge">DISCONNECTED</span>}
+          </h2>
           <div className="autotune-table-selectors">
             <div className="autotune-table-group">
               <label>Primary:</label>
@@ -683,7 +695,12 @@ export function AutoTune({ tableName: initialTableName = '', onClose }: AutoTune
               <Square size={14} fill="currentColor" /> Stop
             </button>
           ) : (
-            <button onClick={startAutoTune} className="autotune-start">
+            <button
+              onClick={startAutoTune}
+              className="autotune-start"
+              disabled={!isConnected}
+              title={isConnected ? undefined : 'Connect to the ECU to start AutoTune'}
+            >
               <Play size={14} fill="currentColor" /> Start
             </button>
           )}

--- a/crates/libretune-app/src/components/tuner-ui/__tests__/AutoTune.test.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/__tests__/AutoTune.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+
+vi.mock('@tauri-apps/plugin-dialog', () => ({ open: vi.fn(), save: vi.fn() }));
+
+import { invoke } from '@tauri-apps/api/core';
+import { ToastProvider } from '../../../contexts/ToastContext';
+import { AutoTune } from '../AutoTune';
+
+const TABLE_DATA = {
+  name: 'veTable1Tbl',
+  title: 'VE Table',
+  x_bins: [1000, 2000],
+  y_bins: [20, 80],
+  z_values: [
+    [50, 60],
+    [70, 80],
+  ],
+  x_output_channel: 'rpm',
+  y_output_channel: 'map',
+};
+
+function mockInvoke() {
+  (invoke as unknown as any).mockImplementation((cmd: string) => {
+    if (cmd === 'get_ve_analyze_config') return Promise.resolve(null);
+    if (cmd === 'get_tables') return Promise.resolve([{ name: 'veTable1Tbl', title: 'VE Table' }]);
+    if (cmd === 'get_table_data') return Promise.resolve(TABLE_DATA);
+    if (cmd === 'get_available_channels') return Promise.resolve([]);
+    return Promise.resolve();
+  });
+}
+
+// Regression test: AutoTune previously had no isConnected awareness at all
+// (TabContentRouter.tsx never passed it, unlike every other connection-aware
+// component). Clicking Start while disconnected silently called
+// start_autotune anyway -- it "succeeded" but no live data ever streamed in,
+// so nothing visible ever happened, matching GitHub issue #132 ("when I hit
+// Start, nothing happens -- it is as if it isn't connected").
+describe('AutoTune connection awareness', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockInvoke();
+  });
+
+  it('disables Start and shows a DISCONNECTED badge when not connected', async () => {
+    render(
+      <ToastProvider>
+        <AutoTune tableName="veTable1Tbl" isConnected={false} />
+      </ToastProvider>
+    );
+
+    await waitFor(() => expect(screen.getByText('DISCONNECTED')).toBeInTheDocument());
+
+    const startBtn = screen.getByRole('button', { name: /start/i });
+    expect(startBtn).toBeDisabled();
+
+    (invoke as unknown as any).mockClear();
+    await userEvent.click(startBtn);
+    expect(invoke).not.toHaveBeenCalledWith('start_autotune', expect.anything());
+  });
+
+  it('enables Start and calls start_autotune when connected', async () => {
+    render(
+      <ToastProvider>
+        <AutoTune tableName="veTable1Tbl" isConnected={true} />
+      </ToastProvider>
+    );
+
+    await waitFor(() => expect(screen.queryByText('DISCONNECTED')).not.toBeInTheDocument());
+
+    const startBtn = screen.getByRole('button', { name: /start/i });
+    expect(startBtn).not.toBeDisabled();
+
+    await userEvent.click(startBtn);
+    await waitFor(() =>
+      expect(invoke).toHaveBeenCalledWith('start_autotune', expect.objectContaining({ tableName: 'veTable1Tbl' }))
+    );
+  });
+});


### PR DESCRIPTION
## Description
AutoTune never received an `isConnected` prop — every other connection-aware component in the app (dashboard, EcuConsole, LuaConsole) gets one from `TabContentRouter`, but AutoTune was missed. `start_autotune` only reads cached ECU definition/tune data with no live-connection check, so clicking Start while disconnected silently "succeeded" — `isRunning` flipped to `true`, but no real data ever streamed in. From the outside that's indistinguishable from a broken app.

This is related to #132 ("Start" appears to do nothing) but **does not close it** — see the Testing section below.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues
Related to #132 — addresses part of it, does not close it.

## Changes Made
- `AutoTune` now takes `isConnected: boolean`, passed from `TabContentRouter` the same way as every other connection-aware component (`status.state === "Connected"`).
- Start is disabled (with an explanatory tooltip) while disconnected, and shows a toast warning as a backup guard if triggered anyway — mirrors `LuaConsole`'s existing pattern exactly.
- Added a "DISCONNECTED" badge next to the AutoTune title, same styling convention as `LuaConsole`'s.
- 2 new regression tests in `AutoTune.test.tsx`.

## Testing
- [x] I have tested these changes locally
- [x] New and existing tests pass (`cargo test`)
- [x] The UI works correctly with these changes

Verified the new tests fail against the pre-fix component (no `isConnected` awareness existed at all) before confirming they pass post-fix. Manually rebuilt and confirmed the DISCONNECTED badge and disabled Start button appear correctly while disconnected.

**Important scope note on #132**: that issue actually bundles three separate things — (1) Start appearing to do nothing, (2) no TPS/Alpha-N load-source option (only MAP/MAF exist), and (3) the Y-axis not showing correct TPS values. This PR only fixes (1). If the reporter genuinely wasn't connected, this resolves their exact symptom. But if they *were* connected and using a TPS-based VE table, (2) and (3) are the real underlying problem — the backend's `AutoTuneLoadSource` enum only has `Map`/`Maf`, there's no concept of TPS/Alpha-N as a load axis anywhere in the load-bin or cell-attribution logic. Adding that is a meaningfully-sized feature addition, not a wiring fix, so it's intentionally out of scope here — happy to discuss it separately (Discord / issue) before anyone takes a run at it.

## Checklist
- [x] Code compiles without errors
- [x] No new clippy warnings (`cargo clippy`)
- [x] Code is formatted (`cargo fmt`)
- [x] TypeScript compiles without errors (`npx tsc --noEmit`)
- [ ] Documentation updated if needed
- [x] Commit messages follow conventional format

## Screenshots (if applicable)
AutoTune header now shows a "DISCONNECTED" badge and a disabled Start button when there's no live ECU connection.