### PR TITLE
fix(scripts): make pre-push.sh actually fail when a piped check fails

### DIFF
--- a/scripts/pre-push.sh
+++ b/scripts/pre-push.sh
@@ -7,6 +7,8 @@
 # Or install as Git hook: ./scripts/pre-push.sh --install-hook
 
 set -e  # Exit on first error
+set -o pipefail  # A failing command upstream of a pipe (e.g. `cargo build | tee log`)
+                 # must fail the pipeline, not be masked by tee/tail's own success
 
 # Ensure we're in the repository root
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
## Description
`scripts/pre-push.sh` has `set -e` but no `set -o pipefail`. Five of its nine checks pipe their command through `tee`/`tail` for logging: `cargo build`, the `build_info` test, `cargo clippy`, `npx tsc --noEmit`, and `npm run build`. Without `pipefail`, bash's `if pipeline; then` only looks at the exit code of the *last* command in the pipe — `tee`/`tail` — and those almost always succeed regardless of whether the real command failed underneath them. So those five checks could never actually report failure: the script would print "✓ passed" and "Safe to push" even when the real command genuinely failed.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues
None filed — found while working on an unrelated fix (a TypeScript error the script claimed had passed, sitting right there in its own captured output).

## Changes Made
- Added `set -o pipefail` alongside the existing `set -e`, near the top of the script.

## Testing
- [x] I have tested these changes locally
- [x] New and existing tests pass (`cargo test`)
- [x] The UI works correctly with these changes

Verified two ways:
1. Isolated repro of the exact pattern: `if false | tee log; then` reports PASS without the fix, FAIL with it.
2. Reproduced the real scenario directly: injected a genuine TypeScript error into `App.tsx`, ran the actual `if npx tsc --noEmit | tee ...; then` block from this script — correctly reports FAIL with the fix applied, then reverted the injected error.

Also confirmed `set -e`'s if-condition exemption still holds (every pipe in this file is already the direct condition of an `if`), so the script still accumulates failures via `FAILED` and prints a full summary at the end instead of aborting on the first failure — unchanged from the original intended behavior, just now actually correct.

Ran the full script end-to-end on the current (clean) codebase afterward to confirm nothing regressed — all 9 checks still pass genuinely, not just by default.

## Checklist
- [x] Code compiles without errors
- [x] No new clippy warnings (`cargo clippy`)
- [x] Code is formatted (`cargo fmt`)
- [x] TypeScript compiles without errors (`npx tsc --noEmit`)
- [ ] Documentation updated if needed
- [x] Commit messages follow conventional format

## Screenshots (if applicable)
N/A — shell script logic fix, no UI change.
