### PR TITLE
Allow offline table resize; block on signature mismatch.

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/signature_helpers.rs
+++ b/crates/libretune-app/src-tauri/src/commands/signature_helpers.rs
@@ -128,9 +128,7 @@ pub(crate) fn compare_signatures_with_prefix(
 
 /// True when an ECU is connected and its signature fully mismatches the loaded INI.
 /// Offline (no connection) is never treated as a mismatch.
-pub(crate) async fn connected_signature_is_mismatch(
-    state: &tauri::State<'_, AppState>,
-) -> bool {
+pub(crate) async fn connected_signature_is_mismatch(state: &tauri::State<'_, AppState>) -> bool {
     let ecu_sig = {
         let conn_guard = state.connection.lock().await;
         match conn_guard.as_ref().and_then(|c| c.signature()) {
@@ -142,11 +140,8 @@ pub(crate) async fn connected_signature_is_mismatch(
     let Some(def) = def_guard.as_ref() else {
         return false;
     };
-    compare_signatures_with_prefix(
-        &ecu_sig,
-        &def.signature,
-        def.signature_prefix.as_deref(),
-    ) == SignatureMatchType::Mismatch
+    compare_signatures_with_prefix(&ecu_sig, &def.signature, def.signature_prefix.as_deref())
+        == SignatureMatchType::Mismatch
 }
 
 /// Block dangerous table-size changes when ECU/INI signatures disagree.

--- a/crates/libretune-app/src-tauri/src/commands/signature_helpers.rs
+++ b/crates/libretune-app/src-tauri/src/commands/signature_helpers.rs
@@ -126,6 +126,41 @@ pub(crate) fn compare_signatures_with_prefix(
     SignatureMatchType::Mismatch
 }
 
+/// True when an ECU is connected and its signature fully mismatches the loaded INI.
+/// Offline (no connection) is never treated as a mismatch.
+pub(crate) async fn connected_signature_is_mismatch(
+    state: &tauri::State<'_, AppState>,
+) -> bool {
+    let ecu_sig = {
+        let conn_guard = state.connection.lock().await;
+        match conn_guard.as_ref().and_then(|c| c.signature()) {
+            Some(s) => s.to_string(),
+            None => return false,
+        }
+    };
+    let def_guard = state.definition.lock().await;
+    let Some(def) = def_guard.as_ref() else {
+        return false;
+    };
+    compare_signatures_with_prefix(
+        &ecu_sig,
+        &def.signature,
+        def.signature_prefix.as_deref(),
+    ) == SignatureMatchType::Mismatch
+}
+
+/// Block dangerous table-size changes when ECU/INI signatures disagree.
+pub(crate) async fn assert_resize_allowed(
+    state: &tauri::State<'_, AppState>,
+) -> Result<(), String> {
+    if connected_signature_is_mismatch(state).await {
+        return Err(
+            "Cannot resize tables while the ECU signature does not match the loaded INI".into(),
+        );
+    }
+    Ok(())
+}
+
 /// Build a shallow SignatureMismatchInfo (without resolving matching INIs) for testing
 #[allow(dead_code)]
 pub(crate) fn build_shallow_mismatch_info(

--- a/crates/libretune-app/src-tauri/src/commands/table_internals.rs
+++ b/crates/libretune-app/src-tauri/src/commands/table_internals.rs
@@ -221,6 +221,16 @@ pub(crate) async fn get_table_data_internal(
         (x_bins_full, y_bins_full, z_values, None)
     };
 
+    let size_info = if let Some(mut dto) = size_dto {
+        // Hide Set Size when a connected ECU fully mismatches the INI.
+        if crate::commands::signature_helpers::connected_signature_is_mismatch(state).await {
+            dto.resizable = false;
+        }
+        Some(dto)
+    } else {
+        None
+    };
+
     Ok(TableData {
         name: table_name_out,
         title: table_title,
@@ -231,7 +241,7 @@ pub(crate) async fn get_table_data_internal(
         y_axis_name: clean_axis_label(&y_label),
         x_output_channel,
         y_output_channel,
-        size_info: size_dto,
+        size_info,
     })
 }
 

--- a/crates/libretune-app/src-tauri/src/commands/table_ops.rs
+++ b/crates/libretune-app/src-tauri/src/commands/table_ops.rs
@@ -71,7 +71,8 @@ pub async fn rebin_table(
 }
 
 /// Resize a TunerStudio dynamically sized table (and all tables sharing its
-/// row/col count scalars). Requires a live ECU connection.
+/// row/col count scalars). Works offline (tune RAM/file only); burns when connected.
+/// Blocked when a connected ECU signature fully mismatches the loaded INI.
 #[tauri::command]
 pub async fn resize_table_size(
     app: tauri::AppHandle,
@@ -80,9 +81,7 @@ pub async fn resize_table_size(
     new_cols: usize,
     new_rows: usize,
 ) -> Result<TableData, String> {
-    if state.connection.lock().await.is_none() {
-        return Err("ECU must be connected to resize the table".into());
-    }
+    crate::commands::signature_helpers::assert_resize_allowed(&state).await?;
 
     let (cols_const, rows_const, shared_tables, x_first, y_first) = {
         let def_guard = state.definition.lock().await;
@@ -155,8 +154,12 @@ pub async fn resize_table_size(
     update_constant(state.clone(), cols_const, new_cols as f64).await?;
     update_constant(state.clone(), rows_const, new_rows as f64).await?;
 
-    let burn = crate::commands::tune_io::burn_to_ecu(app, state.clone()).await;
-    burn.map_err(|e| format!("Resized in RAM but burn failed: {}", e))?;
+    let connected = state.connection.lock().await.is_some();
+    if connected {
+        crate::commands::tune_io::burn_to_ecu(app, state.clone())
+            .await
+            .map_err(|e| format!("Resized in RAM but burn failed: {}", e))?;
+    }
 
     get_table_data_internal(&state, &table_name).await
 }

--- a/crates/libretune-app/src/components/dialogs/SetTableSizeDialog.tsx
+++ b/crates/libretune-app/src/components/dialogs/SetTableSizeDialog.tsx
@@ -57,7 +57,9 @@ export default function SetTableSizeDialog({
       <Dialog.Body>
         <p style={{ marginTop: 0 }}>
           Resize this table (and any tables that share its axes). Axes are regenerated between the
-          current endpoints and Z values are interpolated. ECU must stay connected.
+          current endpoints and Z values are interpolated. Works offline (saved to the tune); when
+          connected, changes are written and burned. Disabled if the ECU signature does not match
+          the INI.
         </p>
         <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '12px' }}>
           <label>

--- a/crates/libretune-app/src/components/tables/TableEditor2D.tsx
+++ b/crates/libretune-app/src/components/tables/TableEditor2D.tsx
@@ -900,7 +900,7 @@ export default function TableEditor2D({
       setRebinDialog({ show: false, newXBins: result.x_bins, newYBins: result.y_bins });
       onValuesChange?.(result.z_values);
       setSetSizeOpen(false);
-      showToast(`Table resized to ${rows}×${cols}`, 'success');
+      showToast(`Table resized to ${rows}x${cols}`, 'success');
     } catch (err) {
       handleOperationError('Set table size', err);
     } finally {


### PR DESCRIPTION
Resize writes the tune locally when disconnected and burns only when connected. Hide/reject Set Size if a connected ECU fully mismatches the INI.
initially i opted for online only but now you can resize either offline or online (ecu disconnected or connected)