### PR TITLE
fix(ini): treat lastOffset as an overlay, not an advancing counter

### DIFF
--- a/crates/libretune-core/src/ini/parser.rs
+++ b/crates/libretune-core/src/ini/parser.rs
@@ -1141,15 +1141,15 @@ fn parse_constants_entry(
     if let Some(mut constant) =
         parse_constant_line(clean_key, value, *current_page, *last_offset, help_text)
     {
-        // Update last_offset for next constant (offset + size in bytes).
-        // Use Constant::size_bytes(), not a hand-rolled data_type * element_count
-        // calculation -- that duplicate used to disagree with it for two cases:
-        // bits fields are packed (0 extra bytes; the raw DataType::size_bytes()
-        // of 1 would wrongly burn a byte per bit field), and string fields need
-        // their length in bytes (the raw DataType::size_bytes() of 0 for
-        // "variable size" would wrongly advance by 0, aliasing whatever field
-        // came next onto the string's own bytes).
-        *last_offset = constant.offset + constant.size_bytes() as u16;
+        // Record this constant's own offset so a following `lastOffset` field
+        // resolves to it. TunerStudio's `lastOffset` keyword means "reuse the
+        // previous variable's offset" -- its purpose is overlaying two scalings
+        // on the same bytes (e.g. an AFR view and a Lambda view of one fuel
+        // target: `afrTable`/`lambdaTable`, `ego_min_afr`/`ego_min_lambda`).
+        // It must NOT advance by the field's size; doing so aliased Speeduino's
+        // `afrTable` onto `rpmBinsAFR` (both at offset 256 on page 5) and read
+        // past the page end.
+        *last_offset = constant.offset;
 
         // Resolve $references in bit_options
         if !constant.bit_options.is_empty() {
@@ -3941,9 +3941,10 @@ constOnPage0 = scalar, U16, 0, "ms", 1, 0, 0, 100, 1
 
 #[test]
 fn test_last_offset_after_bits_field_does_not_advance() {
-    // Regression test: bits fields are packed (they don't take their own
-    // byte), so lastOffset on the field right after a bits field must
-    // resolve to the SAME offset as that bits field, not offset+1.
+    // Regression test: lastOffset reuses the previous constant's offset, so a
+    // field right after a bits field shares that field's offset. (A bits field
+    // is also packed into the same byte as its neighbours, so overlaying it is
+    // the intended behaviour here.)
     let content = r#"
 [MegaTune]
 signature = "test 1.0"
@@ -3978,10 +3979,14 @@ afterBits = scalar, U08, lastOffset, "counts", 1.0, 0.0, 0, 255, 0
 }
 
 #[test]
-fn test_last_offset_after_string_field_advances_by_its_length() {
-    // Regression test: a string field's byte footprint is its declared
-    // length, so lastOffset on the field right after it must resolve to
-    // offset + length -- not alias onto the string's own bytes.
+fn test_last_offset_overlays_previous_constant_not_advance() {
+    // `lastOffset` means "reuse the previous variable's offset", so two
+    // constants can present the same bytes under different scalings. This is
+    // Speeduino's page-5 fuel-target layout: `afrTable` overlays `lambdaTable`
+    // (a 256-byte 16x16 table at offset 0), and the real bin arrays follow at
+    // their own explicit offsets. If `lastOffset` wrongly advanced by the
+    // table size, `afrTable` would land at 256 -- on top of `rpmBinsAFR` and
+    // past the page end -- which is the in-car "AFR/lambda table wrong" bug.
     let content = r#"
 [MegaTune]
 signature = "test 1.0"
@@ -3989,28 +3994,76 @@ queryCommand = "Q"
 
 [TunerStudio]
 nPages = 1
-pageSize = 256
+pageSize = 288
 
 [Constants]
 page = 1
-vehicleName = string, ASCII, 200, 16
-afterString = scalar, U08, lastOffset, "counts", 1.0, 0.0, 0, 255, 0
+lambdaTable = array, U08, 0, [16x16], "Lambda", 0.1, 0.0, 0.0, 2.0, 3
+afrTable    = array, U08, lastOffset, [16x16], "AFR", 0.1, 0.0, 7, 25.5, 1
+rpmBinsAFR  = array, U08, 256, [16], "RPM", 100.0, 0.0, 100, 25500, 0
 "#;
 
     let def = parse_ini(content).expect("Should parse successfully");
 
-    let name = def
+    let lambda = def
         .constants
-        .get("vehicleName")
-        .expect("vehicleName should exist");
-    assert_eq!(name.offset, 200);
+        .get("lambdaTable")
+        .expect("lambdaTable should exist");
+    assert_eq!(lambda.offset, 0);
 
-    let after = def
+    let afr = def
         .constants
-        .get("afterString")
-        .expect("afterString should exist");
+        .get("afrTable")
+        .expect("afrTable should exist");
     assert_eq!(
-        after.offset, 216,
-        "a field right after a 16-byte string must start at offset+16 (200+16), not alias the string's own bytes"
+        afr.offset, 0,
+        "afrTable must overlay lambdaTable at the same offset (0), not advance to 256"
+    );
+
+    // A constant with an explicit offset after a lastOffset overlay is
+    // unaffected: it still starts exactly where the INI declares.
+    let rpm = def
+        .constants
+        .get("rpmBinsAFR")
+        .expect("rpmBinsAFR should exist");
+    assert_eq!(rpm.offset, 256);
+}
+
+#[test]
+fn test_last_offset_overlays_consecutive_scalar_pairs() {
+    // Speeduino's page-6 layout uses lastOffset for AFR/Lambda scalar pairs:
+    // each `*_lambda` overlays the `*_afr` byte directly before it. The next
+    // pair then advances via its own explicit offset. Verifies overlay does
+    // not "stick" across an explicitly-offset constant.
+    let content = r#"
+[MegaTune]
+signature = "test 1.0"
+queryCommand = "Q"
+
+[TunerStudio]
+nPages = 1
+pageSize = 16
+
+[Constants]
+page = 1
+ego_min_afr    = scalar, U08, 8, "AFR", 0.1, 0, 7, 25, 1
+ego_min_lambda = scalar, U08, lastOffset, "Lambda", 0.068, 0, 0.5, 1.7, 3
+ego_max_afr    = scalar, U08, 9, "AFR", 0.1, 0, 7, 25, 1
+ego_max_lambda = scalar, U08, lastOffset, "Lambda", 0.068, 0, 0.5, 1.7, 3
+"#;
+
+    let def = parse_ini(content).expect("Should parse successfully");
+
+    assert_eq!(def.constants.get("ego_min_afr").unwrap().offset, 8);
+    assert_eq!(
+        def.constants.get("ego_min_lambda").unwrap().offset,
+        8,
+        "ego_min_lambda must overlay ego_min_afr at offset 8"
+    );
+    assert_eq!(def.constants.get("ego_max_afr").unwrap().offset, 9);
+    assert_eq!(
+        def.constants.get("ego_max_lambda").unwrap().offset,
+        9,
+        "ego_max_lambda must overlay ego_max_afr at offset 9, not chain from the previous overlay"
     );
 }


### PR DESCRIPTION
## Description

TunerStudio's `lastOffset` keyword means *"reuse the previous variable's offset"* — its purpose is overlaying two scalings on the same ECU bytes (an AFR view and a Lambda view of one fuel target). The parser instead advanced the running offset by the previous field's size.

On Speeduino's real `mainController.ini` this put `afrTable` at offset 256 — landing on top of `rpmBinsAFR` (also 256) and reading past the end of page 5. In-car this showed as the AFR and lambda tables displaying RPM-bin bytes.

Confirmed against every `lastOffset` use in the Speeduino INI — all are AFR/Lambda overlay pairs sharing one offset:

| Previous constant | `lastOffset` constant | Shared offset |
|---|---|---|
| `lambdaTable` @ 0 (256 B) | `afrTable` | 0 |
| `ego_min_afr` @ 8 | `ego_min_lambda` | 8 |
| `ego_max_afr` @ 9 | `ego_max_lambda` | 9 |
| `afrProtectDeviationLambda` @ 189 | `afrProtectDeviation` | 189 |
| `n2o_maxAFR` @ 79 | `n2o_maxLambda` | 79 |

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made
- `parse_constants_entry` now records the constant's own offset as `last_offset` instead of `offset + size_bytes`, so a following `lastOffset` field overlays it.
- Replaced the string-advance regression test (which encoded the wrong advancing model against a field pairing that occurs in no real INI) with two overlay tests built from the real page-5 (`afrTable`/`lambdaTable`) and page-6 (`ego_min/max_afr` vs `_lambda`) layouts.

## Testing
- [x] I have tested these changes locally
- [x] New and existing tests pass (`cargo test` — 329 core tests, incl. 2 new overlay tests)

## Checklist
- [x] Code compiles without errors
- [x] No new clippy warnings (`cargo clippy --workspace -- -D warnings`)
- [x] Code is formatted (`cargo fmt`)
- [x] Commit messages follow conventional format