### PR TITLE
feat(autotune): add tracing across the AutoTune path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2396,6 +2396,7 @@ dependencies = [
  "tauri-plugin-window-state",
  "tempfile",
  "tokio",
+ "tracing",
  "tracing-subscriber",
 ]
 

--- a/crates/libretune-app/src-tauri/Cargo.toml
+++ b/crates/libretune-app/src-tauri/Cargo.toml
@@ -31,6 +31,7 @@ tokio = { workspace = true }
 tauri-plugin-dialog = "2"
 chrono = { workspace = true }
 byteorder = "1"
+tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 [dev-dependencies]

--- a/crates/libretune-app/src-tauri/src/commands/autotune_misc.rs
+++ b/crates/libretune-app/src-tauri/src/commands/autotune_misc.rs
@@ -73,6 +73,11 @@ mod tests {
 #[tauri::command]
 pub async fn stop_autotune(state: tauri::State<'_, AppState>) -> Result<(), String> {
     let mut guard = state.autotune_state.lock().await;
+    tracing::info!(
+        accepted_samples = guard.total_samples(),
+        cells_with_recommendations = guard.recommendations.len(),
+        "stop_autotune: stopping (recommendations retained until cleared)"
+    );
     guard.stop();
 
     let mut secondary_guard = state.autotune_secondary_state.lock().await;
@@ -206,8 +211,14 @@ pub async fn send_autotune_recommendations(
         guard.get_recommendations()
     };
     if recs.is_empty() {
+        tracing::info!(table = %table_name, "send_autotune_recommendations: nothing to send (no recommendations accumulated)");
         return Err("No recommendations to send".to_string());
     }
+    tracing::info!(
+        table = %table_name,
+        recommendations = recs.len(),
+        "send_autotune_recommendations: applying to ECU RAM"
+    );
 
     // Snapshot what we need from the definition, then drop the lock before
     // doing any ECU I/O below — holding it across the read/write round-trip
@@ -305,6 +316,11 @@ pub async fn send_autotune_recommendations(
 
     conn.write_memory(write_params).map_err(|e| e.to_string())?;
 
+    tracing::info!(
+        table = %table_name,
+        cells_written = recs.len(),
+        "send_autotune_recommendations: written to ECU RAM (burn separately to persist)"
+    );
     Ok(())
 }
 
@@ -355,8 +371,10 @@ pub async fn burn_autotune_recommendations(
 
     let params = libretune_core::protocol::commands::BurnParams { can_id: 0, page };
 
+    tracing::info!(table = %table_name, page, "burn_autotune_recommendations: burning page to ECU flash");
     conn.burn(params).map_err(|e| e.to_string())?;
 
+    tracing::info!(table = %table_name, page, "burn_autotune_recommendations: burn complete");
     Ok(())
 }
 

--- a/crates/libretune-app/src-tauri/src/commands/start_autotune.rs
+++ b/crates/libretune-app/src-tauri/src/commands/start_autotune.rs
@@ -22,9 +22,22 @@ pub async fn start_autotune(
     lambda_delay_table_name: Option<String>,
     strict_lambda_match: Option<bool>,
 ) -> Result<(), String> {
+    tracing::info!(
+        table = %table_name,
+        secondary = ?secondary_table_name,
+        requested_load_source = ?load_source,
+        target_afr = settings.target_afr,
+        target_afr_table = ?target_afr_table_name,
+        lambda_delay_table = ?lambda_delay_table_name,
+        "start_autotune: requested"
+    );
+
     // Get the table definition to extract bin values
     let def_guard = state.definition.lock().await;
-    let def = def_guard.as_ref().ok_or("No ECU definition loaded")?;
+    let def = def_guard.as_ref().ok_or_else(|| {
+        tracing::warn!("start_autotune: no ECU definition loaded — cannot start");
+        "No ECU definition loaded".to_string()
+    })?;
     let definition_signature = def.signature.clone();
     let cache_guard = state.tune_cache.lock().await;
     let cache = cache_guard.as_ref();
@@ -125,6 +138,18 @@ pub async fn start_autotune(
         lambda_delay_table_name.as_deref(),
     );
 
+    tracing::info!(
+        resolved_load_source = ?resolved_load_source,
+        x_bins = x_bins.len(),
+        y_bins = y_bins.len(),
+        table_in_ini = def.get_table_by_name_or_map(&table_name).is_some(),
+        cache_present = cache.is_some(),
+        target_afr_table_resolved = !reference_tables.target_afr_table.is_empty(),
+        lambda_delay_table_resolved = !reference_tables.lambda_delay_table.is_empty(),
+        "start_autotune: resolved session (empty AFR/delay tables fall back to \
+         settings.target_afr / RPM-based delay)"
+    );
+
     drop(cache_guard);
     drop(def_guard);
 
@@ -163,6 +188,11 @@ pub async fn start_autotune(
     } else {
         secondary_guard.stop();
     }
+    tracing::info!(
+        table = %table_name,
+        secondary_running = secondary_table_name.is_some(),
+        "start_autotune: session started"
+    );
     Ok(())
 }
 /// Read axis bin values from a constant definition

--- a/crates/libretune-core/src/autotune/mod.rs
+++ b/crates/libretune-core/src/autotune/mod.rs
@@ -327,6 +327,13 @@ impl AutoTuneState {
         }
     }
 
+    /// Number of samples that passed the filters this session — the
+    /// denominator behind each cell's hit percentage. Exposed for diagnostics
+    /// (e.g. logging how much data a session actually accepted).
+    pub fn total_samples(&self) -> u64 {
+        self.total_samples
+    }
+
     pub fn add_data_point(
         &mut self,
         point: VEDataPoint,
@@ -345,6 +352,25 @@ impl AutoTuneState {
         self.prune_data_buffer(point.timestamp_ms);
 
         if !self.passes_filters(&point, filters) {
+            // Throttled so a full drive doesn't flood the log, but enough to
+            // show *why* AutoTune "does nothing": compare these against the
+            // active filter thresholds (a warm-up CLT below min_clt and a
+            // tip-in TPS rate above max_tps_rate are the usual culprits).
+            static REJECTS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+            let n = REJECTS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            if n < 5 || n.is_multiple_of(100) {
+                tracing::debug!(
+                    rpm = point.rpm,
+                    clt = point.clt,
+                    tps_rate = point.tps_rate,
+                    min_rpm = filters.min_rpm,
+                    max_rpm = filters.max_rpm,
+                    min_clt = filters.min_clt,
+                    max_tps_rate = filters.max_tps_rate,
+                    rejected_so_far = n + 1,
+                    "AutoTune: sample rejected by filters"
+                );
+            }
             return;
         }
 
@@ -381,6 +407,21 @@ impl AutoTuneState {
             Some(hp) => hp,
             None => {
                 if self.strict_lambda_match {
+                    // Strict mode (the default) silently dropped these before,
+                    // a common reason accepted-sample counts stay near zero on
+                    // an otherwise-valid session. Throttled to stay readable.
+                    static NO_DELAY: std::sync::atomic::AtomicU64 =
+                        std::sync::atomic::AtomicU64::new(0);
+                    let n = NO_DELAY.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    if n < 5 || n.is_multiple_of(100) {
+                        tracing::debug!(
+                            timestamp_ms = point.timestamp_ms,
+                            delay_ms,
+                            dropped_so_far = n + 1,
+                            "AutoTune: sample dropped (strict lambda-delay: no delayed \
+                             buffer match at target delay)"
+                        );
+                    }
                     return;
                 }
                 tracing::warn!(
@@ -462,6 +503,27 @@ impl AutoTuneState {
         } else {
             0.0
         };
+
+        // Periodic proof-of-life: shows AutoTune is accepting samples and how
+        // the current cell's recommendation is evolving. Capturing these ends
+        // the `current_recs` borrow so `self` can be read for the summary.
+        let (rec_begin, rec_value, rec_hits) = (
+            current_recs.beginning_value,
+            current_recs.recommended_value,
+            current_recs.hit_count,
+        );
+        if self.total_samples.is_multiple_of(50) {
+            tracing::debug!(
+                total_accepted = self.total_samples,
+                cells_touched = self.recommendations.len(),
+                cell_x = cell_x_idx,
+                cell_y = cell_y_idx,
+                begin_ve = rec_begin,
+                recommended_ve = rec_value,
+                cell_hits = rec_hits,
+                "AutoTune: accepted sample"
+            );
+        }
     }
 
     /// Apply authority limits to clamp the recommended VE change

--- a/crates/libretune-core/src/autotune/mod.rs
+++ b/crates/libretune-core/src/autotune/mod.rs
@@ -689,6 +689,61 @@ mod tests {
     #![allow(clippy::field_reassign_with_default)]
     use super::*;
 
+    /// Captures `tracing` event messages into a shared Vec so a test can assert
+    /// that a specific diagnostic actually fired (the whole point of D9: these
+    /// drop paths used to be silent).
+    #[derive(Clone, Default)]
+    struct LogCapture(std::sync::Arc<std::sync::Mutex<Vec<String>>>);
+    impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for LogCapture {
+        fn on_event(&self, e: &tracing::Event<'_>, _c: tracing_subscriber::layer::Context<'_, S>) {
+            struct V(std::sync::Arc<std::sync::Mutex<Vec<String>>>);
+            impl tracing::field::Visit for V {
+                fn record_debug(&mut self, f: &tracing::field::Field, v: &dyn std::fmt::Debug) {
+                    if f.name() == "message" {
+                        self.0.lock().unwrap().push(format!("{v:?}"));
+                    }
+                }
+            }
+            e.record(&mut V(self.0.clone()));
+        }
+    }
+
+    #[test]
+    fn filter_rejected_sample_is_logged_not_silent() {
+        use tracing_subscriber::layer::SubscriberExt;
+        let cap = LogCapture::default();
+        let logs = cap.0.clone();
+        let sub = tracing_subscriber::registry().with(cap);
+        tracing::subscriber::with_default(sub, || {
+            let mut st = AutoTuneState::new();
+            st.start();
+            let s = AutoTuneSettings::default();
+            let f = AutoTuneFilters::default(); // min_clt = 160
+            let a = AutoTuneAuthorityLimits::default();
+            // clt=20 is far below min_clt: the sample must be rejected AND logged
+            // (before D9 this path returned silently).
+            let p = VEDataPoint {
+                rpm: 2000.0,
+                load: 50.0,
+                afr: 14.0,
+                ve: 50.0,
+                clt: 20.0,
+                tps: 5.0,
+                tps_rate: 0.0,
+                timestamp_ms: 1000,
+                ..Default::default()
+            };
+            st.add_data_point(p, &[1000.0, 2000.0], &[40.0, 80.0], &s, &f, &a);
+        });
+        assert!(
+            logs.lock()
+                .unwrap()
+                .iter()
+                .any(|m| m.contains("rejected by filters")),
+            "a filtered-out sample must emit a diagnostic, not drop silently"
+        );
+    }
+
     #[test]
     fn custom_filter_allows_matching_point() {
         let state = AutoTuneState::default();


### PR DESCRIPTION
## Description

AutoTune previously emitted **zero** log lines even under full debug (`RUST_LOG=...libretune_core=debug,libretune_app=debug`), so "it does nothing" was undiagnosable. This adds tracing at the points that actually decide whether it works.

Notably, in strict lambda-delay mode (the default) samples with no delayed-buffer match were dropped by a **silent** `return` — a common reason accepted-sample counts stay near zero on an otherwise-valid session. That path (and the filter-reject path) now log throttled diagnostics.

## Type of Change
- [x] New feature (non-breaking change that adds functionality) — observability only, no behaviour change

## Changes Made
- `start_autotune`: logs the requested session, resolved load source and bin counts, and whether the Target-AFR / lambda-delay reference tables resolved or fell back to defaults.
- `AutoTuneState::add_data_point` (core): throttled logs for the two previously-silent drop paths — filter rejects (with the thresholds, so a coolant-below-`min_clt` or saturated-TPS cause is visible) and strict lambda-delay no-match — plus a periodic accepted-sample summary.
- `stop`/`send`/`burn`: log session totals, apply-to-RAM, and burn-to-flash.
- Adds `tracing` to the app crate's deps (the workspace already provides it; the crate only pulled in `tracing-subscriber` before) and a `total_samples()` accessor on `AutoTuneState`.

## Testing
- [x] New and existing tests pass (`cargo test` — 33 autotune tests + workspace)

## Checklist
- [x] Code compiles without errors
- [x] No new clippy warnings (`cargo clippy --workspace -- -D warnings`)
- [x] Code is formatted (`cargo fmt`)
- [x] Commit messages follow conventional format

_Note: adds `tracing = { workspace = true }` to the app crate `Cargo.toml`, same one line as #(webview-console-capture PR) — trivial overlap._