### PR TITLE
feat(datalog): count realtime samples dropped to logger lock contention

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/data_logging.rs
+++ b/crates/libretune-app/src-tauri/src/commands/data_logging.rs
@@ -126,6 +126,12 @@ pub async fn start_logging(
     }
     logger.start();
 
+    // Reset the dropped-sample counter for this session and mark recording
+    // active so the stream tick counts (rather than silently swallows) any
+    // sample it can't hand to the logger while the lock is busy (D10).
+    crate::state::LOGGER_SAMPLES_DROPPED.store(0, std::sync::atomic::Ordering::Relaxed);
+    crate::state::LOGGER_RECORDING.store(true, std::sync::atomic::Ordering::Relaxed);
+
     Ok(())
 }
 
@@ -133,6 +139,7 @@ pub async fn start_logging(
 pub async fn stop_logging(state: tauri::State<'_, AppState>) -> Result<(), String> {
     let mut logger = state.data_logger.lock().await;
     logger.stop();
+    crate::state::LOGGER_RECORDING.store(false, std::sync::atomic::Ordering::Relaxed);
     Ok(())
 }
 

--- a/crates/libretune-app/src-tauri/src/commands/realtime_stream.rs
+++ b/crates/libretune-app/src-tauri/src/commands/realtime_stream.rs
@@ -164,6 +164,20 @@ pub(crate) fn apply_channel_aliases(data: &mut HashMap<String, f64>) {
 
 /// Feed the current realtime snapshot to the data logger when a recording is
 /// active. The logger applies its own sample-rate limiting in `record()`.
+/// Record that a realtime sample couldn't be handed to the logger because its
+/// lock was busy. Counts the drop (D10) only while a recording is actually
+/// active, so ordinary idle contention isn't counted. Returns whether it was
+/// counted — split out so the gating can be unit-tested without a full stream.
+pub(crate) fn note_dropped_log_sample() -> bool {
+    use std::sync::atomic::Ordering::Relaxed;
+    if crate::state::LOGGER_RECORDING.load(Relaxed) {
+        crate::state::LOGGER_SAMPLES_DROPPED.fetch_add(1, Relaxed);
+        true
+    } else {
+        false
+    }
+}
+
 pub(crate) async fn feed_data_logger(app_state: &AppState, data: &HashMap<String, f64>) {
     // try_lock: never stall the stream tick on logger contention
     let mut logger = match app_state.data_logger.try_lock() {
@@ -171,12 +185,8 @@ pub(crate) async fn feed_data_logger(app_state: &AppState, data: &HashMap<String
         Err(_) => {
             // The lock is held elsewhere. If a recording is active this tick's
             // sample is lost -- count it so the loss is visible instead of
-            // silent (D10). When not recording the drop is harmless, so don't
-            // inflate the counter.
-            if crate::state::LOGGER_RECORDING.load(std::sync::atomic::Ordering::Relaxed) {
-                crate::state::LOGGER_SAMPLES_DROPPED
-                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-            }
+            // silent (D10). When not recording the drop is harmless.
+            note_dropped_log_sample();
             return;
         }
     };
@@ -827,6 +837,30 @@ pub async fn start_realtime_stream(
 
     *task_guard = Some(handle);
     Ok(())
+}
+
+#[cfg(test)]
+mod dropped_sample_tests {
+    use super::note_dropped_log_sample;
+    use crate::state::LOGGER_RECORDING;
+    use std::sync::atomic::Ordering::Relaxed;
+
+    #[test]
+    fn drop_counted_only_while_recording() {
+        // Gate on the return value (deterministic per call) rather than the
+        // process-global counter, so the test can't race another test's drops.
+        LOGGER_RECORDING.store(false, Relaxed);
+        assert!(
+            !note_dropped_log_sample(),
+            "idle logger contention is not a lost sample"
+        );
+        LOGGER_RECORDING.store(true, Relaxed);
+        assert!(
+            note_dropped_log_sample(),
+            "a drop while recording must be counted (D10)"
+        );
+        LOGGER_RECORDING.store(false, Relaxed); // leave the global clean
+    }
 }
 
 #[cfg(test)]

--- a/crates/libretune-app/src-tauri/src/commands/realtime_stream.rs
+++ b/crates/libretune-app/src-tauri/src/commands/realtime_stream.rs
@@ -168,7 +168,17 @@ pub(crate) async fn feed_data_logger(app_state: &AppState, data: &HashMap<String
     // try_lock: never stall the stream tick on logger contention
     let mut logger = match app_state.data_logger.try_lock() {
         Ok(l) => l,
-        Err(_) => return,
+        Err(_) => {
+            // The lock is held elsewhere. If a recording is active this tick's
+            // sample is lost -- count it so the loss is visible instead of
+            // silent (D10). When not recording the drop is harmless, so don't
+            // inflate the counter.
+            if crate::state::LOGGER_RECORDING.load(std::sync::atomic::Ordering::Relaxed) {
+                crate::state::LOGGER_SAMPLES_DROPPED
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            }
+            return;
+        }
     };
     if !logger.is_recording() {
         return;
@@ -487,6 +497,8 @@ pub async fn start_realtime_stream(
                 transfer_reason: mode_reason,
                 interval_ms: interval,
                 started_at_ms: chrono::Utc::now().timestamp_millis(),
+                samples_dropped: crate::state::LOGGER_SAMPLES_DROPPED
+                    .load(std::sync::atomic::Ordering::Relaxed),
             };
         }
 
@@ -806,6 +818,8 @@ pub async fn start_realtime_stream(
                     stats.ticks_success = local_ticks_success;
                     stats.ticks_skipped = local_ticks_skipped;
                     stats.ticks_error = local_ticks_error;
+                    stats.samples_dropped = crate::state::LOGGER_SAMPLES_DROPPED
+                        .load(std::sync::atomic::Ordering::Relaxed);
                 }
             }
         }

--- a/crates/libretune-app/src-tauri/src/state.rs
+++ b/crates/libretune-app/src-tauri/src/state.rs
@@ -98,7 +98,25 @@ pub struct StreamStats {
     pub transfer_reason: String,
     pub interval_ms: u64,
     pub started_at_ms: i64,
+    /// Realtime snapshots that could not be handed to the data logger because
+    /// its lock was held elsewhere while a recording was active. A nonzero
+    /// value means the saved log is missing samples (see [`LOGGER_SAMPLES_DROPPED`]).
+    pub samples_dropped: u64,
 }
+
+/// Count of realtime samples dropped because the data-logger lock was busy on a
+/// stream tick while recording (D10). The stream tick feeds the logger with
+/// `try_lock` so it never stalls; before this counter those drops were silent.
+/// Read into [`StreamStats::samples_dropped`] and reset when a recording starts.
+pub static LOGGER_SAMPLES_DROPPED: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
+/// Whether a data-logging recording is currently active. Set by the start/stop
+/// logging commands so the stream tick can tell a genuinely dropped sample
+/// (lock busy *while recording*) from ordinary idle contention, without paying
+/// for the data-logger lock on the hot path.
+pub static LOGGER_RECORDING: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]

--- a/crates/libretune-app/src/components/diagnostics/OutputChannelStatus.tsx
+++ b/crates/libretune-app/src/components/diagnostics/OutputChannelStatus.tsx
@@ -26,6 +26,7 @@ interface StreamStats {
   transferReason: string;
   intervalMs: number;
   startedAtMs: number;
+  samplesDropped?: number;
 }
 
 interface OutputChannelStatusData {
@@ -59,6 +60,7 @@ interface MetricsPayload {
     transferReason: string;
     intervalMs: number;
     startedAtMs: number;
+    samplesDropped?: number;
   };
 }
 
@@ -286,6 +288,12 @@ export function OutputChannelStatus() {
               <span className="och-live-value">{formatUptime(liveStream.startedAtMs)}</span>
               <span className="och-live-unit">uptime</span>
             </div>
+            {(liveStream.samplesDropped ?? 0) > 0 && (
+              <div className="och-live-stat">
+                <span className="och-live-value och-error">{liveStream.samplesDropped!.toLocaleString()}</span>
+                <span className="och-live-unit">log samples dropped</span>
+              </div>
+            )}
           </div>
         </div>
 


### PR DESCRIPTION
## Description

The stream tick feeds the data logger with `try_lock` so it never stalls on contention, but a failed lock silently discarded the sample. When AutoTune is open this was observed to degrade or kill active logging, with no record of how much was lost.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made
- Track dropped samples in a counter, gated on an actual recording being active (set by start/stop logging) so idle contention isn't counted; reset per session.
- Surface it in `StreamStats` and show it in the Output Channel Status diagnostics when nonzero.

Turns a silent, unverifiable loss into a visible number.

## Testing
- [x] New and existing tests pass (`cargo test`)
- [x] The UI works correctly with these changes (TypeScript type-checks; frontend unit tests pass)

## Checklist
- [x] Code compiles without errors
- [x] No new clippy warnings (`cargo clippy --workspace -- -D warnings`)
- [x] Code is formatted (`cargo fmt`)
- [x] TypeScript compiles without errors (`npx tsc --noEmit`)
- [x] Commit messages follow conventional format