### PR TITLE
feat(diagnostics): forward webview console errors into the Rust log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2396,6 +2396,7 @@ dependencies = [
  "tauri-plugin-window-state",
  "tempfile",
  "tokio",
+ "tracing",
  "tracing-subscriber",
 ]
 

--- a/crates/libretune-app/src-tauri/Cargo.toml
+++ b/crates/libretune-app/src-tauri/Cargo.toml
@@ -31,6 +31,7 @@ tokio = { workspace = true }
 tauri-plugin-dialog = "2"
 chrono = { workspace = true }
 byteorder = "1"
+tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 [dev-dependencies]

--- a/crates/libretune-app/src-tauri/src/commands/mod.rs
+++ b/crates/libretune-app/src-tauri/src/commands/mod.rs
@@ -77,3 +77,4 @@ pub mod types;
 pub mod update_project_ini;
 pub mod util_helpers;
 pub mod wasm_plugin;
+pub mod webview_log;

--- a/crates/libretune-app/src-tauri/src/commands/webview_log.rs
+++ b/crates/libretune-app/src-tauri/src/commands/webview_log.rs
@@ -1,0 +1,22 @@
+//! Bridge for surfacing webview (frontend) console output in the Rust logs.
+//!
+//! The session logs capture Rust `tracing` only; webview `console.error`,
+//! uncaught exceptions and unhandled promise rejections are otherwise
+//! invisible. That blind spot is why frontend-side failures like the Engine
+//! Constants dialog silently not dispatching `update_constant` (D6) could not
+//! be diagnosed from a full-debug session. The frontend forwards its console
+//! errors/warnings and uncaught errors here so they land in the same log.
+
+/// Emit a message originating from the webview into the Rust `tracing` log,
+/// tagged so it is obviously frontend-sourced. `level` is the JS console level
+/// ("error", "warn", "log", "info", "debug"); anything else is treated as info.
+#[tauri::command]
+pub fn log_webview_message(level: String, message: String) {
+    match level.as_str() {
+        "error" => tracing::error!(target: "webview", "{message}"),
+        "warn" => tracing::warn!(target: "webview", "{message}"),
+        "debug" => tracing::debug!(target: "webview", "{message}"),
+        // "log"/"info"/unknown → info
+        _ => tracing::info!(target: "webview", "{message}"),
+    }
+}

--- a/crates/libretune-app/src-tauri/src/lib.rs
+++ b/crates/libretune-app/src-tauri/src/lib.rs
@@ -168,6 +168,7 @@ use commands::wasm_plugin::{
     execute_wasm_plugin, get_wasm_plugin_info, list_wasm_plugins, load_wasm_plugin,
     unload_wasm_plugin,
 };
+use commands::webview_log::log_webview_message;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -441,7 +442,8 @@ pub fn run() {
             unload_wasm_plugin,
             list_wasm_plugins,
             execute_wasm_plugin,
-            get_wasm_plugin_info
+            get_wasm_plugin_info,
+            log_webview_message
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/crates/libretune-app/src/__tests__/webviewConsoleCapture.test.ts
+++ b/crates/libretune-app/src/__tests__/webviewConsoleCapture.test.ts
@@ -1,0 +1,47 @@
+// Verifies the D6 diagnostics bridge: webview console errors/warnings are
+// forwarded to the Rust log via `log_webview_message`, WITHOUT suppressing the
+// original console output (so the browser devtools still show them too).
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import { invoke } from '@tauri-apps/api/core';
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn(() => Promise.resolve()) }));
+
+import { installWebviewConsoleCapture } from '../webviewConsoleCapture';
+
+const invokeMock = vi.mocked(invoke);
+// Stub the console BEFORE install so the capture wraps these (and we can assert
+// the original was still called). install() is idempotent and patches the
+// module-global console once, so this ordering matters.
+const errStub = vi.fn();
+const warnStub = vi.fn();
+
+beforeAll(() => {
+  console.error = errStub;
+  console.warn = warnStub;
+  installWebviewConsoleCapture();
+});
+beforeEach(() => {
+  invokeMock.mockClear();
+  errStub.mockClear();
+  warnStub.mockClear();
+});
+
+describe('webviewConsoleCapture', () => {
+  it('forwards console.error to log_webview_message and still calls the original', () => {
+    console.error('boom', 42);
+    expect(errStub).toHaveBeenCalled(); // output not swallowed
+    expect(invokeMock).toHaveBeenCalledWith('log_webview_message', {
+      level: 'error',
+      message: expect.stringContaining('boom'),
+    });
+  });
+
+  it('forwards console.warn at warn level', () => {
+    console.warn('heads up');
+    expect(warnStub).toHaveBeenCalled();
+    expect(invokeMock).toHaveBeenCalledWith('log_webview_message', {
+      level: 'warn',
+      message: expect.stringContaining('heads up'),
+    });
+  });
+});

--- a/crates/libretune-app/src/main.tsx
+++ b/crates/libretune-app/src/main.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import ReactDOM from "react-dom/client";
+import { installWebviewConsoleCapture } from "./webviewConsoleCapture";
 import App from "./App";
 import PopOutWindow from "./PopOutWindow";
 import { LoadingProvider } from "./contexts/LoadingContext";
@@ -8,6 +9,10 @@ import { UnitPreferencesProvider } from "./contexts/useUnitPreferences";
 // Initialize i18next (side-effect: configures the global i18n instance).
 // Must be imported before any component that calls `useTranslation()`.
 import "./i18n";
+
+// Mirror webview console errors/warnings and uncaught errors into the Rust log
+// so frontend failures are visible in session logs (see webviewConsoleCapture).
+installWebviewConsoleCapture();
 
 /**
  * Root component that determines whether to render App or PopOutWindow

--- a/crates/libretune-app/src/webviewConsoleCapture.ts
+++ b/crates/libretune-app/src/webviewConsoleCapture.ts
@@ -1,0 +1,59 @@
+// Forward webview console errors/warnings and uncaught errors to the Rust
+// log via the `log_webview_message` command.
+//
+// The session logs capture Rust `tracing` only, so webview `console.error`,
+// uncaught exceptions and unhandled promise rejections are otherwise invisible
+// — the blind spot that made frontend-side failures like the Engine Constants
+// dialog silently not dispatching `update_constant` (D6) impossible to
+// diagnose from a full-debug session. This keeps the original console
+// behaviour intact and only *also* forwards to the backend.
+
+import { invoke } from "@tauri-apps/api/core";
+
+type Level = "error" | "warn" | "log" | "info" | "debug";
+
+function formatArg(arg: unknown): string {
+  if (arg instanceof Error) {
+    return arg.stack ? `${arg.message}\n${arg.stack}` : arg.message;
+  }
+  if (typeof arg === "string") return arg;
+  try {
+    return JSON.stringify(arg);
+  } catch {
+    return String(arg);
+  }
+}
+
+function forward(level: Level, message: string): void {
+  // Fire-and-forget; never let logging failures affect the app, and never
+  // recurse back into the patched console on error.
+  invoke("log_webview_message", { level, message }).catch(() => {});
+}
+
+let installed = false;
+
+/**
+ * Patch console.error/warn and install global error handlers so webview
+ * diagnostics reach the Rust log. Idempotent; safe to call once at startup.
+ */
+export function installWebviewConsoleCapture(): void {
+  if (installed) return;
+  installed = true;
+
+  for (const level of ["error", "warn"] as const) {
+    const original = console[level].bind(console);
+    console[level] = (...args: unknown[]) => {
+      original(...args);
+      forward(level, args.map(formatArg).join(" "));
+    };
+  }
+
+  window.addEventListener("error", (e) => {
+    const where = e.filename ? ` (${e.filename}:${e.lineno}:${e.colno})` : "";
+    forward("error", `Uncaught: ${e.message}${where}`);
+  });
+
+  window.addEventListener("unhandledrejection", (e) => {
+    forward("error", `Unhandled promise rejection: ${formatArg(e.reason)}`);
+  });
+}


### PR DESCRIPTION
## Description

Session logs capture Rust `tracing` only, so webview `console.error`/`warn`, uncaught exceptions and unhandled promise rejections were invisible. That blind spot makes frontend-side failures impossible to diagnose from a full-debug session — e.g. a dialog whose Tauri `invoke` throws before dispatching leaves no trace on the Rust side at all.

## Type of Change
- [x] New feature (non-breaking change that adds functionality) — diagnostics only

## Changes Made
- New `log_webview_message` command that emits into `tracing` tagged `target="webview"`.
- A small frontend module that patches `console.error`/`warn` and installs `window` `error` / `unhandledrejection` handlers, forwarding them without changing the original console behaviour. Installed first thing in `main.tsx`; fire-and-forget so logging can never affect the app.
- Adds `tracing` to the app crate's deps (workspace already provides it).

## Testing
- [x] New and existing tests pass (`cargo test`; frontend `tsc --noEmit` + `vitest` pass)
- [x] The UI works correctly with these changes (console behaviour preserved)

## Checklist
- [x] Code compiles without errors
- [x] No new clippy warnings (`cargo clippy --workspace -- -D warnings`)
- [x] Code is formatted (`cargo fmt`)
- [x] TypeScript compiles without errors (`npx tsc --noEmit`)
- [x] Commit messages follow conventional format

_Note: adds `tracing = { workspace = true }` to the app crate `Cargo.toml`, same one line as the AutoTune-tracing PR — trivial overlap._