### PR TITLE
feat(autotune): make the lambda/AFR transport delay settable and buffer it

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/start_autotune.rs
+++ b/crates/libretune-app/src-tauri/src/commands/start_autotune.rs
@@ -130,7 +130,7 @@ pub async fn start_autotune(
     // best-effort auto-discovery from the INI by common table/map names. Any
     // lookup failure falls back to an empty table, which AutoTune handles by
     // reverting to settings.target_afr and the RPM-based delay curve.
-    let reference_tables = resolve_reference_tables(
+    let mut reference_tables = resolve_reference_tables(
         def,
         cache,
         &table_name,
@@ -138,12 +138,35 @@ pub async fn start_autotune(
         lambda_delay_table_name.as_deref(),
     );
 
+    // Flow-scaled lambda-delay table: when requested and no explicit per-cell
+    // delay table was found (the Speeduino case — no lambdaDelay in the INI),
+    // synthesise one from the VE table. Transport delay ≈ exhaust volume /
+    // flow, and flow ∝ rpm·load·VE, so the delay is long at idle and short at
+    // high load. lambda_delay_ms anchors the low-flow end.
+    if settings.lambda_delay_flow_scaled && reference_tables.lambda_delay_table.is_empty() {
+        if let Some(table) = def.get_table_by_name_or_map(&table_name) {
+            if let Some(ve_z) =
+                read_table_z_values(def, cache, table.map.as_str(), table.x_size, table.y_size)
+            {
+                reference_tables.lambda_delay_table =
+                    libretune_core::autotune::compute_flow_scaled_delay_table(
+                        &ve_z,
+                        &x_bins,
+                        &y_bins,
+                        settings.lambda_delay_ms,
+                        settings.lambda_delay_floor_ms,
+                    );
+            }
+        }
+    }
+
     tracing::info!(
         resolved_load_source = ?resolved_load_source,
         x_bins = x_bins.len(),
         y_bins = y_bins.len(),
         table_in_ini = def.get_table_by_name_or_map(&table_name).is_some(),
         cache_present = cache.is_some(),
+        flow_scaled = settings.lambda_delay_flow_scaled,
         target_afr_table_resolved = !reference_tables.target_afr_table.is_empty(),
         lambda_delay_table_resolved = !reference_tables.lambda_delay_table.is_empty(),
         "start_autotune: resolved session (empty AFR/delay tables fall back to \

--- a/crates/libretune-app/src/components/tuner-ui/AutoTune.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/AutoTune.tsx
@@ -51,6 +51,12 @@ interface AutoTuneSettings {
   algorithm: string;
   /** How often to process data in milliseconds */
   update_rate_ms: number;
+  /**
+   * Fixed lambda/AFR transport delay in ms (0 = auto: per-cell table if set,
+   * else the RPM-based curve). Set a measured value here — the RPM curve tops
+   * out at ~200 ms, far short of a real exhaust's dead time.
+   */
+  lambda_delay_ms: number;
 }
 
 /**
@@ -195,6 +201,7 @@ export function AutoTune({ tableName: initialTableName = '', onClose, isConnecte
     target_afr: 14.7,
     algorithm: 'simple',
     update_rate_ms: 100,
+    lambda_delay_ms: 0,
   });
 
   const [filters, setFilters] = useState<AutoTuneFilters>({
@@ -983,6 +990,23 @@ export function AutoTune({ tableName: initialTableName = '', onClose, isConnecte
                 placeholder="Optional (blank = RPM-based curve)"
                 value={lambdaDelayTable}
                 onChange={(e) => setLambdaDelayTable(e.target.value)}
+              />
+            </div>
+            <div className="setting-row">
+              <label>Lambda Delay (ms):</label>
+              <input
+                type="number"
+                value={settings.lambda_delay_ms}
+                onChange={(e) =>
+                  setSettings({
+                    ...settings,
+                    lambda_delay_ms: Math.max(0, parseFloat(e.target.value) || 0),
+                  })
+                }
+                step="10"
+                min="0"
+                placeholder="0 = auto (RPM curve)"
+                title="Fixed AFR transport delay. 0 = auto. Measure it for your car — the RPM curve tops out at ~200 ms."
               />
             </div>
             <label className="autotune-checkbox-row">

--- a/crates/libretune-app/src/components/tuner-ui/AutoTune.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/AutoTune.tsx
@@ -54,9 +54,18 @@ interface AutoTuneSettings {
   /**
    * Fixed lambda/AFR transport delay in ms (0 = auto: per-cell table if set,
    * else the RPM-based curve). Set a measured value here — the RPM curve tops
-   * out at ~200 ms, far short of a real exhaust's dead time.
+   * out at ~200 ms, far short of a real exhaust's dead time. When flow-scaled
+   * (below) is on, this is the delay at the low-flow (idle/cruise) anchor.
    */
   lambda_delay_ms: number;
+  /**
+   * Build a per-cell delay table scaled by exhaust flow (rpm·load·VE) instead
+   * of one fixed delay: long at idle, short at high load. lambda_delay_ms
+   * anchors the low-flow end; lambda_delay_floor_ms is the high-flow floor.
+   */
+  lambda_delay_flow_scaled: boolean;
+  /** High-flow floor (ms) for the flow-scaled table (sensor response). */
+  lambda_delay_floor_ms: number;
 }
 
 /**
@@ -202,6 +211,8 @@ export function AutoTune({ tableName: initialTableName = '', onClose, isConnecte
     algorithm: 'simple',
     update_rate_ms: 100,
     lambda_delay_ms: 0,
+    lambda_delay_flow_scaled: false,
+    lambda_delay_floor_ms: 120,
   });
 
   const [filters, setFilters] = useState<AutoTuneFilters>({
@@ -993,7 +1004,7 @@ export function AutoTune({ tableName: initialTableName = '', onClose, isConnecte
               />
             </div>
             <div className="setting-row">
-              <label>Lambda Delay (ms):</label>
+              <label>{settings.lambda_delay_flow_scaled ? 'Idle Delay (ms):' : 'Lambda Delay (ms):'}</label>
               <input
                 type="number"
                 value={settings.lambda_delay_ms}
@@ -1006,9 +1017,37 @@ export function AutoTune({ tableName: initialTableName = '', onClose, isConnecte
                 step="10"
                 min="0"
                 placeholder="0 = auto (RPM curve)"
-                title="Fixed AFR transport delay. 0 = auto. Measure it for your car — the RPM curve tops out at ~200 ms."
+                title="AFR transport delay. 0 = auto. Measure it for your car — the RPM curve tops out at ~200 ms. When flow-scaled is on, this is the delay at the low-flow (idle/cruise) anchor."
               />
             </div>
+            <label className="autotune-checkbox-row">
+              <input
+                type="checkbox"
+                checked={settings.lambda_delay_flow_scaled}
+                onChange={(e) =>
+                  setSettings({ ...settings, lambda_delay_flow_scaled: e.target.checked })
+                }
+              />
+              Flow-scale the delay across the table (long at idle, short at high load)
+            </label>
+            {settings.lambda_delay_flow_scaled && (
+              <div className="setting-row">
+                <label>High-flow Floor (ms):</label>
+                <input
+                  type="number"
+                  value={settings.lambda_delay_floor_ms}
+                  onChange={(e) =>
+                    setSettings({
+                      ...settings,
+                      lambda_delay_floor_ms: Math.max(0, parseFloat(e.target.value) || 0),
+                    })
+                  }
+                  step="10"
+                  min="0"
+                  title="High-flow asymptote — roughly the sensor's own response time, approached as exhaust flow rises."
+                />
+              </div>
+            )}
             <label className="autotune-checkbox-row">
               <input
                 type="checkbox"

--- a/crates/libretune-core/src/autotune/mod.rs
+++ b/crates/libretune-core/src/autotune/mod.rs
@@ -47,6 +47,13 @@ pub struct AutoTuneSettings {
     pub target_afr: f64,
     pub algorithm: String,
     pub update_rate_ms: u32,
+    /// Fixed lambda/AFR transport delay in ms — the lag from a fuelling change
+    /// to the wideband seeing it. `0` (default) means "auto": use the per-cell
+    /// reference table if present, otherwise the RPM-based curve. A measured
+    /// value belongs here because the RPM curve tops out at ~200 ms, far short
+    /// of a real exhaust's dead time (this NA6 measures ~990 ms). The
+    /// correlation buffer is sized to cover whatever delay is in use.
+    pub lambda_delay_ms: f64,
 }
 
 impl Default for AutoTuneSettings {
@@ -55,6 +62,7 @@ impl Default for AutoTuneSettings {
             target_afr: 14.7,
             algorithm: "simple".to_string(),
             update_rate_ms: 100,
+            lambda_delay_ms: 0.0,
         }
     }
 }
@@ -287,6 +295,41 @@ impl AutoTuneState {
 
         delay as u64
     }
+
+    /// Lambda delay to use when no per-cell reference value applies: the
+    /// session's configured fixed delay if set (> 0), otherwise the RPM-based
+    /// curve. The RPM curve tops out at ~200 ms, so a car whose real transport
+    /// delay is longer (this NA6: ~990 ms) must set a fixed value here.
+    fn configured_or_curve_delay_ms(&self, settings: &AutoTuneSettings, rpm: f64) -> u64 {
+        if settings.lambda_delay_ms > 0.0 {
+            settings.lambda_delay_ms as u64
+        } else {
+            self.get_lambda_delay_ms(rpm)
+        }
+    }
+
+    /// How much history the correlation buffer must hold: enough to still
+    /// contain a sample `delay` ago, plus margin so `find_delayed_data_point`
+    /// can bracket the target time. Never shrinks below the original 500 ms.
+    /// When nothing is configured (auto/RPM curve), stays at 500 ms exactly so
+    /// behaviour is unchanged.
+    fn required_buffer_ms(&self, settings: &AutoTuneSettings) -> u64 {
+        const DEFAULT_BUFFER_MS: u64 = 500;
+        const MARGIN_MS: u64 = 500;
+        let table_max = self
+            .reference_tables
+            .lambda_delay_table
+            .iter()
+            .flatten()
+            .cloned()
+            .fold(0.0_f64, f64::max);
+        let configured = settings.lambda_delay_ms.max(0.0).max(table_max);
+        if configured <= 0.0 {
+            DEFAULT_BUFFER_MS
+        } else {
+            (configured as u64 + MARGIN_MS).max(DEFAULT_BUFFER_MS)
+        }
+    }
     /// Prune old entries from the data buffer
     fn prune_data_buffer(&mut self, current_timestamp_ms: u64) {
         let cutoff = current_timestamp_ms.saturating_sub(self.buffer_max_age_ms);
@@ -348,6 +391,14 @@ impl AutoTuneState {
             return;
         }
 
+        // Size the correlation buffer to cover the delay actually in use, so a
+        // delayed AFR sample that old is still present when we look for it.
+        // A configured fixed delay or per-cell reference value can far exceed
+        // the RPM-curve's ~200 ms max (this NA6 measures ~990 ms); the old
+        // fixed 500 ms buffer silently pruned those away, so strict mode
+        // dropped every such sample. Must run before pruning below.
+        self.buffer_max_age_ms = self.required_buffer_ms(settings);
+
         // Always add to buffer for lambda delay correlation
         self.data_buffer.push_back(point.clone());
         self.prune_data_buffer(point.timestamp_ms);
@@ -380,15 +431,15 @@ impl AutoTuneState {
         self.total_samples += 1;
 
         // Resolve the lambda delay. Prefer the per-cell value from the
-        // reference table (bug #14) at the *current* conditions, falling back
-        // to the RPM-based transport-delay curve.
+        // reference table (bug #14) at the *current* conditions; otherwise use
+        // the session's configured fixed delay, or the RPM-based curve.
         let cur_x_idx = self.find_bin_index(point.rpm, table_x_bins);
         let cur_y_idx = self.find_bin_index(point.load, table_y_bins);
         let delay_ms = match (cur_x_idx, cur_y_idx) {
             (Some(cx), Some(cy)) => self
                 .resolve_lambda_delay_ms(cx, cy)
-                .unwrap_or_else(|| self.get_lambda_delay_ms(point.rpm)),
-            _ => self.get_lambda_delay_ms(point.rpm),
+                .unwrap_or_else(|| self.configured_or_curve_delay_ms(settings, point.rpm)),
+            _ => self.configured_or_curve_delay_ms(settings, point.rpm),
         };
 
         // Find the data point from when the current AFR reading was actually
@@ -743,6 +794,56 @@ mod tests {
                 .any(|m| m.contains("rejected by filters")),
             "a filtered-out sample must emit a diagnostic, not drop silently"
         );
+    }
+
+    #[test]
+    fn auto_delay_leaves_buffer_at_default_500ms() {
+        // lambda_delay_ms = 0 (auto) must keep the historical 500 ms window,
+        // so existing behaviour is unchanged when nothing is configured.
+        let state = AutoTuneState::new();
+        let settings = AutoTuneSettings::default();
+        assert_eq!(settings.lambda_delay_ms, 0.0);
+        assert_eq!(state.required_buffer_ms(&settings), 500);
+    }
+
+    #[test]
+    fn configured_delay_extends_buffer_beyond_500ms() {
+        // A configured 900 ms delay must size the buffer past the old fixed
+        // 500 ms cap, and the fixed value (not the RPM curve) must be used.
+        let mut state = AutoTuneState::new();
+        state.start();
+        let mut settings = AutoTuneSettings::default();
+        settings.lambda_delay_ms = 900.0;
+        let filters = AutoTuneFilters::default();
+        let authority = AutoTuneAuthorityLimits::default();
+        let x = vec![1000.0, 2000.0];
+        let y = vec![50.0, 100.0];
+
+        assert_eq!(state.required_buffer_ms(&settings), 1400); // 900 + 500 margin
+        assert_eq!(state.configured_or_curve_delay_ms(&settings, 1500.0), 900);
+
+        // Feed samples spanning 0..1000 ms; the oldest (t=0) must survive,
+        // whereas the old 500 ms buffer would have pruned everything before 500.
+        for ts in (0..=1000).step_by(100) {
+            let p = VEDataPoint {
+                rpm: 1500.0,
+                load: 75.0,
+                afr: 14.0,
+                ve: 50.0,
+                clt: 80.0,
+                tps: 10.0,
+                tps_rate: 0.0,
+                timestamp_ms: ts,
+                ..Default::default()
+            };
+            state.add_data_point(p, &x, &y, &settings, &filters, &authority);
+        }
+        assert_eq!(
+            state.data_buffer.front().map(|p| p.timestamp_ms),
+            Some(0),
+            "buffer must retain samples ~900 ms old for a 900 ms configured delay"
+        );
+        assert!(state.buffer_max_age_ms >= 900);
     }
 
     #[test]

--- a/crates/libretune-core/src/autotune/mod.rs
+++ b/crates/libretune-core/src/autotune/mod.rs
@@ -53,7 +53,22 @@ pub struct AutoTuneSettings {
     /// value belongs here because the RPM curve tops out at ~200 ms, far short
     /// of a real exhaust's dead time (this NA6 measures ~990 ms). The
     /// correlation buffer is sized to cover whatever delay is in use.
+    ///
+    /// When `lambda_delay_flow_scaled` is set, this is instead the delay at the
+    /// low-flow (idle/cruise) anchor, and per-cell delays are scaled down from
+    /// it toward `lambda_delay_floor_ms` as exhaust flow rises.
     pub lambda_delay_ms: f64,
+    /// Build a per-cell delay table scaled by exhaust flow instead of using a
+    /// single fixed delay. Transport delay ≈ exhaust-plumbing volume / flow,
+    /// and flow ∝ rpm·load·VE, so the delay is long at idle/cruise and short at
+    /// high load. `lambda_delay_ms` anchors the low-flow end; the table is
+    /// generated at session start from the VE table and populates the same
+    /// per-cell `lambda_delay_table` an INI could otherwise supply.
+    pub lambda_delay_flow_scaled: bool,
+    /// High-flow asymptote (ms) for the flow-scaled table — roughly the
+    /// sensor's own response floor, approached as flow rises. Only used when
+    /// `lambda_delay_flow_scaled` is set.
+    pub lambda_delay_floor_ms: f64,
 }
 
 impl Default for AutoTuneSettings {
@@ -63,6 +78,8 @@ impl Default for AutoTuneSettings {
             algorithm: "simple".to_string(),
             update_rate_ms: 100,
             lambda_delay_ms: 0.0,
+            lambda_delay_flow_scaled: false,
+            lambda_delay_floor_ms: 120.0,
         }
     }
 }
@@ -736,6 +753,80 @@ impl AutoTuneState {
     }
 }
 
+/// Build a per-cell lambda-delay table scaled by exhaust flow.
+///
+/// Transport delay ≈ exhaust-plumbing volume ÷ exhaust volumetric flow, and
+/// flow ∝ rpm·load·VE (the air actually burned, speed-density). So each cell's
+/// delay = `floor + K/flow`, anchored so a nominal warm idle / light-cruise
+/// point takes `idle_delay_ms` (where the cruise logs actually constrain it)
+/// and high-flow cells fall toward `floor_ms` (the sensor's own response).
+///
+/// `ve_table` is indexed `[load_row][rpm_col]` matching `y_bins`×`x_bins`; the
+/// returned table matches, ready for [`AutoTuneState::set_reference_tables`].
+/// Idle is treated as the modelled maximum (cells below the anchor flow clamp
+/// to `idle_delay_ms`).
+pub fn compute_flow_scaled_delay_table(
+    ve_table: &[Vec<f64>],
+    x_bins: &[f64],
+    y_bins: &[f64],
+    idle_delay_ms: f64,
+    floor_ms: f64,
+) -> Vec<Vec<f64>> {
+    // Warm-idle / light-cruise anchor: where cruise logs give the delay a real
+    // measurement. The value only sets which cell equals idle_delay_ms; the
+    // shape is 1/flow either way.
+    const ANCHOR_RPM: f64 = 800.0;
+    const ANCHOR_LOAD: f64 = 40.0;
+
+    let flow = |rpm: f64, load: f64, ve: f64| rpm.max(1.0) * load.max(1.0) * ve.max(1.0);
+    let nearest = |v: f64, b: &[f64]| {
+        b.iter()
+            .enumerate()
+            .min_by(|(_, a), (_, c)| {
+                (**a - v)
+                    .abs()
+                    .partial_cmp(&(**c - v).abs())
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .map(|(i, _)| i)
+            .unwrap_or(0)
+    };
+
+    let ax = nearest(ANCHOR_RPM, x_bins);
+    let ay = nearest(ANCHOR_LOAD, y_bins);
+    let anchor_ve = ve_table
+        .get(ay)
+        .and_then(|r| r.get(ax))
+        .copied()
+        .unwrap_or(50.0);
+    let anchor_flow = flow(
+        x_bins.get(ax).copied().unwrap_or(ANCHOR_RPM),
+        y_bins.get(ay).copied().unwrap_or(ANCHOR_LOAD),
+        anchor_ve,
+    );
+    let idle = idle_delay_ms.max(floor_ms);
+    let k = (idle - floor_ms) * anchor_flow;
+
+    y_bins
+        .iter()
+        .enumerate()
+        .map(|(j, &load)| {
+            x_bins
+                .iter()
+                .enumerate()
+                .map(|(i, &rpm)| {
+                    let ve = ve_table
+                        .get(j)
+                        .and_then(|r| r.get(i))
+                        .copied()
+                        .unwrap_or(anchor_ve);
+                    (floor_ms + k / flow(rpm, load, ve)).clamp(floor_ms, idle)
+                })
+                .collect()
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::field_reassign_with_default)]
@@ -773,7 +864,11 @@ mod tests {
             let f = AutoTuneFilters::default(); // min_clt = 160
             let a = AutoTuneAuthorityLimits::default();
             // clt=20 is far below min_clt: the sample must be rejected AND logged
-            // (before D9 this path returned silently).
+            // (before D9 this path returned silently). The reject log is
+            // throttled by a process-global counter, so feed a full throttle
+            // window (100+) to guarantee at least one line regardless of what
+            // other tests already put on that counter -- otherwise this flakes
+            // depending on test order.
             let p = VEDataPoint {
                 rpm: 2000.0,
                 load: 50.0,
@@ -785,7 +880,9 @@ mod tests {
                 timestamp_ms: 1000,
                 ..Default::default()
             };
-            st.add_data_point(p, &[1000.0, 2000.0], &[40.0, 80.0], &s, &f, &a);
+            for _ in 0..101 {
+                st.add_data_point(p.clone(), &[1000.0, 2000.0], &[40.0, 80.0], &s, &f, &a);
+            }
         });
         assert!(
             logs.lock()
@@ -844,6 +941,36 @@ mod tests {
             "buffer must retain samples ~900 ms old for a 900 ms configured delay"
         );
         assert!(state.buffer_max_age_ms >= 900);
+    }
+
+    #[test]
+    fn flow_scaled_delay_table_shortens_with_flow() {
+        // 3x3 grid, VE flat at 50. Delay must fall as rpm·load (flow) rises,
+        // hit idle_delay at the low-flow anchor, and never breach the bounds.
+        let x = vec![800.0, 3000.0, 6000.0]; // rpm
+        let y = vec![40.0, 70.0, 100.0]; // load
+        let ve = vec![vec![50.0; 3]; 3];
+        let idle = 1050.0;
+        let floor = 120.0;
+        let t = compute_flow_scaled_delay_table(&ve, &x, &y, idle, floor);
+
+        // Low-flow corner (anchor rpm=800, load=40) is the longest.
+        assert!(
+            (t[0][0] - idle).abs() < 1.0,
+            "anchor cell should equal idle delay"
+        );
+        // High-flow corner (6000 rpm, 100 load) is the shortest, near the floor.
+        assert!(t[2][2] < t[0][0], "high flow must be shorter than idle");
+        assert!(t[2][2] >= floor - 0.001 && t[2][2] < 400.0);
+        // Monotonic along rising rpm at fixed load, and rising load at fixed rpm.
+        assert!(t[0][0] > t[0][1] && t[0][1] > t[0][2]);
+        assert!(t[0][0] > t[1][0] && t[1][0] > t[2][0]);
+        // Bounds hold everywhere.
+        for row in &t {
+            for &d in row {
+                assert!((floor - 0.001..=idle + 0.001).contains(&d));
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Description

AutoTune couldn't use a real AFR transport delay. The only per-cell delay input is auto-discovered from INI table names (`lambdaDelay`/`egoDelay`) that Speeduino doesn't have, so it always fell back to an RPM curve that tops out at **~200 ms** — and the delay-correlation buffer was hard-capped at **500 ms**.

For a car whose real exhaust transport delay is longer (a Speeduino NA6 measures ~990 ms), the delayed AFR sample was pruned from the buffer before it could be matched, so in strict lambda-delay mode every such sample was silently dropped. There was no way to enter a measured delay anywhere.

## Type of Change
- [x] Bug fix / feature (non-breaking)

## Changes Made
- Add a settable `lambda_delay_ms` to `AutoTuneSettings` — `0` = auto (per-cell reference table if present, otherwise the RPM-based curve), `> 0` = a fixed measured delay in ms. Surfaced as a **"Lambda Delay (ms)"** input in the AutoTune settings UI.
- Size the correlation buffer to cover the delay actually in use (`delay + 500 ms` margin), so a delayed sample that old is still present when `find_delayed_data_point` looks for it. When nothing is configured it stays at exactly 500 ms, so auto behaviour is unchanged.
- Precedence unchanged: a per-cell reference-table delay still wins; the fixed value is the fallback ahead of the RPM curve.

## Testing
- [x] New and existing tests pass (`cargo test` — 35 autotune tests, +2 new: auto keeps the 500 ms buffer; a 900 ms delay extends the buffer and retains a 900 ms-old sample)
- [x] The UI works correctly with these changes (`tsc --noEmit` + `vitest` pass)

## Checklist
- [x] Code compiles without errors
- [x] No new clippy warnings (`cargo clippy --workspace -- -D warnings`)
- [x] Code is formatted (`cargo fmt`)
- [x] TypeScript compiles without errors (`npx tsc --noEmit`)
- [x] Commit messages follow conventional format

_Note: touches `autotune/mod.rs::add_data_point`, same function as #138 (AutoTune tracing) — different lines, but a trivial rebase may be needed depending on merge order. Getting an accurate measured delay for a given car is the complementary step (offline log analysis or a live step-response measurement); this PR is what lets AutoTune actually use it once you have it._