### PR TITLE
feat(autotune): automated AFR transport-delay step test

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/afr_delay_test.rs
+++ b/crates/libretune-app/src-tauri/src/commands/afr_delay_test.rs
@@ -1,0 +1,307 @@
+//! Automated AFR transport-delay measurement.
+//!
+//! Measuring how long the wideband takes to see a fuelling change needs a
+//! clean, precisely-timed step at a known operating point. Doing that by hand
+//! means typing a value, watching a gauge, and typing it back — awkward while
+//! driving, and impossible to time accurately enough for a delay of a few
+//! hundred milliseconds.
+//!
+//! This runs the step automatically: enrich by a set percentage, hold, restore,
+//! settle, repeat. The operator holds the engine at the operating point; the
+//! app only touches fuelling.
+//!
+//! # Safety
+//!
+//! This writes to a running engine, so the design is deliberately narrow:
+//!
+//! - **Enrichment only.** The step percentage is clamped positive. A rich
+//!   excursion is harmless; a lean one at load destroys pistons. There is no
+//!   parameter that can make the mixture leaner.
+//! - **Bounded magnitude.** Capped at [`MAX_STEP_PERCENT`], well inside the
+//!   range where an engine simply runs rich.
+//! - **RAM only, never burned.** The step is written to the ECU's live memory,
+//!   so it is not persisted. Cycling the key restores the stored tune even if
+//!   this process dies mid-step.
+//! - **Restore on every path.** The original value is written back after each
+//!   step, on abort, and on error. The restore is attempted even when the run
+//!   is failing, and a failure to restore is escalated loudly.
+//! - **Abortable.** The operator can stop between steps, and abort triggers an
+//!   immediate restore.
+
+use serde::Serialize;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+use tauri::{AppHandle, Emitter};
+
+use crate::state::AppState;
+
+/// Largest enrichment the test will apply. Chosen so the mixture stays in the
+/// range where an engine runs rich but healthy; the useful signal is around
+/// 8-10% and anything beyond this is measuring nothing new.
+const MAX_STEP_PERCENT: f64 = 20.0;
+
+/// Smallest enrichment worth applying. Below this the AFR change disappears
+/// into normal cycle-to-cycle scatter and no delay can be extracted.
+const MIN_STEP_PERCENT: f64 = 3.0;
+
+/// Bounds on how long a step is held, in milliseconds.
+const MIN_HOLD_MS: u64 = 500;
+const MAX_HOLD_MS: u64 = 5_000;
+
+/// Constant used as the fuel multiplier. `reqFuel` scales every injector pulse
+/// equally, so the step is independent of position in the VE table — unlike
+/// editing a table cell, where interpolation between cells would blur it.
+const FUEL_CONSTANT: &str = "reqFuel";
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DelayTestProgress {
+    pub phase: String,
+    pub step: u32,
+    pub total_steps: u32,
+    pub applied_value: f64,
+    pub baseline_value: f64,
+    pub message: String,
+}
+
+fn emit(app: &AppHandle, p: DelayTestProgress) {
+    let _ = app.emit("afr_delay_test:progress", p);
+}
+
+/// Shared abort flag so [`abort_afr_delay_test`] can stop a run in progress.
+static ABORT: std::sync::OnceLock<Arc<AtomicBool>> = std::sync::OnceLock::new();
+
+fn abort_flag() -> Arc<AtomicBool> {
+    ABORT
+        .get_or_init(|| Arc::new(AtomicBool::new(false)))
+        .clone()
+}
+
+/// Request that a running test stop. The current step is restored before the
+/// run ends.
+#[tauri::command]
+pub async fn abort_afr_delay_test() -> Result<(), String> {
+    abort_flag().store(true, Ordering::SeqCst);
+    Ok(())
+}
+
+/// Run an automated series of enrichment steps.
+///
+/// `step_percent` is clamped to [`MIN_STEP_PERCENT`]..=[`MAX_STEP_PERCENT`] and
+/// forced positive. `hold_ms` is how long the enrichment is applied;
+/// `settle_ms` is the pause afterwards for the mixture to return to baseline
+/// before the next step.
+#[tauri::command]
+pub async fn run_afr_delay_test(
+    app: AppHandle,
+    state: tauri::State<'_, AppState>,
+    step_percent: f64,
+    hold_ms: u64,
+    settle_ms: u64,
+    repeats: u32,
+) -> Result<String, String> {
+    // Enrichment only: take the magnitude, then clamp. A negative input cannot
+    // survive this, so no combination of arguments leans the engine out.
+    let step_percent = step_percent.abs().clamp(MIN_STEP_PERCENT, MAX_STEP_PERCENT);
+    let hold_ms = hold_ms.clamp(MIN_HOLD_MS, MAX_HOLD_MS);
+    let settle_ms = settle_ms.clamp(MIN_HOLD_MS, MAX_HOLD_MS * 2);
+    let repeats = repeats.clamp(1, 20);
+
+    // Read the baseline through the same path the UI uses, so the restore
+    // target is what the engine is actually running rather than an assumption.
+    // Reading it up front also fails the run early if the ECU is unreachable,
+    // instead of discovering that after a step has already been applied.
+    let baseline = crate::commands::constants_read::get_constant_value(
+        state.clone(),
+        FUEL_CONSTANT.to_string(),
+    )
+    .await
+    .map_err(|e| format!("Could not read {FUEL_CONSTANT} ({e}). Connect and load a tune first."))?;
+
+    if baseline <= 0.0 {
+        return Err(format!(
+            "{FUEL_CONSTANT} reads {baseline}, which is not a usable baseline"
+        ));
+    }
+
+    let enriched = (baseline * (1.0 + step_percent / 100.0) * 10.0).round() / 10.0;
+    if enriched <= baseline {
+        return Err(format!(
+            "A {step_percent:.1}% step on {baseline} does not change the value at this \
+             resolution. Use a larger step."
+        ));
+    }
+
+    abort_flag().store(false, Ordering::SeqCst);
+
+    emit(
+        &app,
+        DelayTestProgress {
+            phase: "starting".into(),
+            step: 0,
+            total_steps: repeats,
+            applied_value: enriched,
+            baseline_value: baseline,
+            message: format!(
+                "{FUEL_CONSTANT} {baseline:.1} -> {enriched:.1} ({step_percent:.1}% richer), \
+                 {repeats} steps, {hold_ms} ms hold. RAM only, never burned."
+            ),
+        },
+    );
+
+    // Anything that leaves this function must first put `baseline` back. The
+    // helper is used on the happy path, on abort, and on error.
+    async fn restore(state: &tauri::State<'_, AppState>, baseline: f64) -> Result<(), String> {
+        crate::commands::constant_update::update_constant(
+            state.clone(),
+            FUEL_CONSTANT.to_string(),
+            baseline,
+        )
+        .await
+    }
+
+    let mut completed = 0u32;
+    for step in 1..=repeats {
+        if abort_flag().load(Ordering::SeqCst) {
+            break;
+        }
+
+        emit(
+            &app,
+            DelayTestProgress {
+                phase: "enriching".into(),
+                step,
+                total_steps: repeats,
+                applied_value: enriched,
+                baseline_value: baseline,
+                message: format!("step {step}/{repeats}: hold steady"),
+            },
+        );
+
+        if let Err(e) = crate::commands::constant_update::update_constant(
+            state.clone(),
+            FUEL_CONSTANT.to_string(),
+            enriched,
+        )
+        .await
+        {
+            // The write failed, so the ECU may or may not have taken it.
+            // Restore regardless and stop.
+            let restore_err = restore(&state, baseline).await.err();
+            return Err(match restore_err {
+                None => format!("Step {step} failed to apply ({e}). Baseline restored."),
+                Some(r) => format!(
+                    "Step {step} failed to apply ({e}) AND restoring {FUEL_CONSTANT} to \
+                     {baseline} also failed ({r}). CYCLE THE KEY to reload the stored tune."
+                ),
+            });
+        }
+
+        tokio::time::sleep(Duration::from_millis(hold_ms)).await;
+
+        if let Err(e) = restore(&state, baseline).await {
+            return Err(format!(
+                "Applied step {step} but could not restore {FUEL_CONSTANT} to {baseline} ({e}). \
+                 The engine is running RICH. CYCLE THE KEY to reload the stored tune."
+            ));
+        }
+
+        completed = step;
+
+        emit(
+            &app,
+            DelayTestProgress {
+                phase: "settling".into(),
+                step,
+                total_steps: repeats,
+                applied_value: baseline,
+                baseline_value: baseline,
+                message: format!("step {step}/{repeats} done, settling"),
+            },
+        );
+
+        if step < repeats {
+            tokio::time::sleep(Duration::from_millis(settle_ms)).await;
+        }
+    }
+
+    // Belt and braces: restore once more on the way out, in case the loop was
+    // broken by an abort between the enrich and the restore.
+    restore(&state, baseline).await.map_err(|e| {
+        format!(
+            "Test finished but the final restore of {FUEL_CONSTANT} to {baseline} failed ({e}). \
+             CYCLE THE KEY to reload the stored tune."
+        )
+    })?;
+
+    let aborted = abort_flag().load(Ordering::SeqCst);
+    let summary = format!(
+        "{} after {completed}/{repeats} steps. {FUEL_CONSTANT} restored to {baseline:.1}. \
+         Nothing was burned.",
+        if aborted { "Aborted" } else { "Completed" }
+    );
+
+    emit(
+        &app,
+        DelayTestProgress {
+            phase: if aborted { "aborted" } else { "complete" }.into(),
+            step: completed,
+            total_steps: repeats,
+            applied_value: baseline,
+            baseline_value: baseline,
+            message: summary.clone(),
+        },
+    );
+
+    Ok(summary)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The clamp is the safety boundary: no input may produce a lean step or an
+    /// unbounded one. Mirrors the clamping in `run_afr_delay_test`.
+    fn clamp_step(p: f64) -> f64 {
+        p.abs().clamp(MIN_STEP_PERCENT, MAX_STEP_PERCENT)
+    }
+
+    #[test]
+    fn negative_input_cannot_produce_a_lean_step() {
+        // A negative percentage would lean the engine — the one outcome that
+        // damages hardware. `abs` must make it an enrichment.
+        assert_eq!(clamp_step(-8.0), 8.0);
+        assert_eq!(clamp_step(-100.0), MAX_STEP_PERCENT);
+        assert!(clamp_step(-0.001) >= MIN_STEP_PERCENT);
+    }
+
+    #[test]
+    fn step_magnitude_is_bounded() {
+        assert_eq!(clamp_step(1000.0), MAX_STEP_PERCENT);
+        assert_eq!(clamp_step(0.5), MIN_STEP_PERCENT);
+        assert_eq!(clamp_step(8.0), 8.0);
+    }
+
+    #[test]
+    fn hold_and_settle_are_bounded() {
+        assert_eq!(0u64.clamp(MIN_HOLD_MS, MAX_HOLD_MS), MIN_HOLD_MS);
+        assert_eq!(u64::MAX.clamp(MIN_HOLD_MS, MAX_HOLD_MS), MAX_HOLD_MS);
+    }
+
+    /// The enriched value must round to the constant's 0.1 resolution and be
+    /// strictly richer, otherwise the step is invisible to the ECU.
+    #[test]
+    fn enriched_value_rounds_to_resolution_and_is_richer() {
+        let baseline: f64 = 12.6;
+        let enriched = (baseline * 1.08 * 10.0).round() / 10.0;
+        assert!(enriched > baseline, "must be richer");
+        assert!((enriched - 13.6).abs() < 1e-9, "got {enriched}");
+        // reqFuel is stored at 0.1 ms resolution, so a value that does not land
+        // on that grid would be silently truncated by the ECU write.
+        assert!(
+            ((enriched * 10.0) - (enriched * 10.0).round()).abs() < 1e-9,
+            "must land on the 0.1 ms grid"
+        );
+    }
+}

--- a/crates/libretune-app/src-tauri/src/commands/afr_delay_test.rs
+++ b/crates/libretune-app/src-tauri/src/commands/afr_delay_test.rs
@@ -54,6 +54,12 @@ const MAX_HOLD_MS: u64 = 5_000;
 /// editing a table cell, where interpolation between cells would blur it.
 const FUEL_CONSTANT: &str = "reqFuel";
 
+/// Progress event emitted to the frontend during a delay-test run (as
+/// `afr_delay_test:progress`). `phase` is a coarse stage label —
+/// "starting", "enriching", "settling", then "complete" or "aborted".
+/// `applied_value` and `baseline_value` are the current and restore
+/// fuel-constant values so the UI can show exactly what is written and
+/// confirm the restore.
 #[derive(Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DelayTestProgress {

--- a/crates/libretune-app/src-tauri/src/commands/mod.rs
+++ b/crates/libretune-app/src-tauri/src/commands/mod.rs
@@ -5,6 +5,7 @@
 //! `tauri::State<crate::state::AppState>`.
 
 pub mod adaptive_timing;
+pub mod afr_delay_test;
 pub mod agent;
 pub mod annotations;
 pub mod app_settings;

--- a/crates/libretune-app/src-tauri/src/lib.rs
+++ b/crates/libretune-app/src-tauri/src/lib.rs
@@ -41,6 +41,7 @@ pub(crate) use commands::util_helpers::{
 use commands::adaptive_timing::{
     disable_adaptive_timing, enable_adaptive_timing, get_adaptive_timing_stats,
 };
+use commands::afr_delay_test::{abort_afr_delay_test, run_afr_delay_test};
 use commands::agent::{
     agent_apply_proposals, agent_delete_chat, agent_list_chats, agent_load_chat, agent_save_chat,
     agent_send_message, agent_status, agent_stop,
@@ -257,6 +258,9 @@ pub fn run() {
             get_port_editor,
             get_port_editor_assignments,
             save_port_editor_assignments,
+            // AFR transport-delay step test
+            run_afr_delay_test,
+            abort_afr_delay_test,
             // Math Channels
             get_math_channels,
             set_math_channel,

--- a/crates/libretune-app/src/App.tsx
+++ b/crates/libretune-app/src/App.tsx
@@ -223,6 +223,7 @@ function AppContent() {
   const [newTuneDialogOpen, setNewTuneDialogOpen] = useState(false);
   const [settingsDialogOpen, setSettingsDialogOpen] = useState(false);
   const [mathChannelsDialogOpen, setMathChannelsDialogOpen] = useState(false);
+  const [afrDelayTestOpen, setAfrDelayTestOpen] = useState(false);
   const [aboutDialogOpen, setAboutDialogOpen] = useState(false);
   const [connectionDialogOpen, setConnectionDialogOpen] = useState(false);
   const [connecting, setConnecting] = useState(false);
@@ -1416,7 +1417,7 @@ function AppContent() {
     closeProject, handleCreateRestorePoint,
     setNewProjectDialogOpen, setImportProjectOpen, setSaveDialogOpen, setLoadDialogOpen,
     setBurnDialogOpen, setFirmwareUpdateDialogOpen, setRestorePointsOpen, setTuneHistoryOpen, setSettingsDialogOpen,
-    setMathChannelsDialogOpen, setBaseMapDialogOpen, setTableComparisonOpen,
+    setMathChannelsDialogOpen, setAfrDelayTestOpen, setBaseMapDialogOpen, setTableComparisonOpen,
     setTuneFileDiffOpen, setDynoOverlayOpen, setPluginPanelOpen, agentPanelVisible, setAgentPanelVisible, setConnectionDialogOpen,
     setUserManualOpen, setUserManualSection, setAboutDialogOpen, setSidebarVisible,
     setTheme, setTabs, setTabContents, setActiveTabId,
@@ -1643,7 +1644,9 @@ function AppContent() {
         setStatusBarChannels={setStatusBarChannels}
         setDefaultRuntimePacketMode={setDefaultRuntimePacketMode}
         mathChannelsDialogOpen={mathChannelsDialogOpen}
+        afrDelayTestOpen={afrDelayTestOpen}
         setMathChannelsDialogOpen={setMathChannelsDialogOpen}
+        setAfrDelayTestOpen={setAfrDelayTestOpen}
         aboutDialogOpen={aboutDialogOpen}
         setAboutDialogOpen={setAboutDialogOpen}
         connectionDialogOpen={connectionDialogOpen}

--- a/crates/libretune-app/src/components/DialogOverlays.tsx
+++ b/crates/libretune-app/src/components/DialogOverlays.tsx
@@ -18,6 +18,7 @@ import TableComparisonDialog from "./dialogs/TableComparisonDialog";
 import PerformanceFieldsDialog from "./dialogs/PerformanceFieldsDialog";
 import RestorePointsDialog from "./dialogs/RestorePointsDialog";
 import ImportProjectWizard from "./dialogs/ImportProjectWizard";
+import AfrDelayTestDialog from './dialogs/AfrDelayTestDialog';
 import MathChannelsDialog from "./dialogs/MathChannelsDialog";
 import MigrationReportDialog from "./dialogs/MigrationReportDialog";
 import TuneFileDiffDialog from "./dialogs/TuneFileDiffDialog";
@@ -81,6 +82,8 @@ export interface DialogOverlaysProps {
 
   // Math channels / About
   mathChannelsDialogOpen: boolean;
+  afrDelayTestOpen: boolean;
+  setAfrDelayTestOpen: (v: boolean) => void;
   setMathChannelsDialogOpen: (v: boolean) => void;
   aboutDialogOpen: boolean;
   setAboutDialogOpen: (v: boolean) => void;
@@ -202,6 +205,7 @@ export function DialogOverlays(props: DialogOverlaysProps) {
     setUnitsSystem, setAutoBurnOnClose, setStatus, setStatusBarChannels, setDefaultRuntimePacketMode,
     showEcuMenusInMenubar, setShowEcuMenusInMenubar,
     mathChannelsDialogOpen, setMathChannelsDialogOpen,
+    afrDelayTestOpen, setAfrDelayTestOpen,
     aboutDialogOpen, setAboutDialogOpen,
     connectionDialogOpen, setConnectionDialogOpen,
     ports, selectedPort, baudRate, timeoutMs, connectionType, setConnectionType,
@@ -274,6 +278,10 @@ export function DialogOverlays(props: DialogOverlaysProps) {
       {mathChannelsDialogOpen && (
         <MathChannelsDialog onClose={() => setMathChannelsDialogOpen(false)} />
       )}
+      <AfrDelayTestDialog
+        isOpen={afrDelayTestOpen}
+        onClose={() => setAfrDelayTestOpen(false)}
+      />
       <AboutDialog isOpen={aboutDialogOpen} onClose={() => setAboutDialogOpen(false)} />
       <ConnectionDialog
         isOpen={connectionDialogOpen}

--- a/crates/libretune-app/src/components/dialogs/AfrDelayTestDialog.css
+++ b/crates/libretune-app/src/components/dialogs/AfrDelayTestDialog.css
@@ -1,0 +1,168 @@
+.afr-delay-dialog {
+  background: var(--panel-bg, #1e1e2e);
+  border: 1px solid var(--border-color, #333);
+  border-radius: 8px;
+  padding: 20px;
+  width: 520px;
+  max-width: 92vw;
+  max-height: 90vh;
+  overflow-y: auto;
+  color: var(--text-color, #e0e0e0);
+}
+
+.afr-delay-dialog h2 {
+  margin: 0 0 8px;
+  font-size: 1.15rem;
+}
+
+.afr-delay-intro {
+  margin: 0 0 14px;
+  font-size: 0.85rem;
+  opacity: 0.8;
+  line-height: 1.45;
+}
+
+/* The safety notice is the most important thing on the dialog, so it is
+   visually prominent rather than fine print. */
+.afr-delay-safety {
+  display: flex;
+  gap: 10px;
+  padding: 12px;
+  margin-bottom: 16px;
+  background: rgba(255, 176, 0, 0.08);
+  border: 1px solid rgba(255, 176, 0, 0.35);
+  border-radius: 6px;
+  font-size: 0.82rem;
+  line-height: 1.45;
+}
+.afr-delay-safety svg { flex-shrink: 0; margin-top: 2px; color: #ffb000; }
+.afr-delay-safety ul { margin: 6px 0 0; padding-left: 18px; }
+.afr-delay-safety li { margin: 3px 0; }
+.afr-delay-safety code {
+  background: rgba(255,255,255,0.08);
+  padding: 1px 4px;
+  border-radius: 3px;
+}
+
+.afr-delay-fields {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px 16px;
+  margin-bottom: 12px;
+}
+.afr-delay-fields label {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 4px 8px;
+  font-size: 0.85rem;
+}
+.afr-delay-fields input {
+  grid-column: 1 / -1;
+  background: var(--input-bg, #14141f);
+  border: 1px solid var(--border-color, #333);
+  border-radius: 4px;
+  color: inherit;
+  padding: 6px 8px;
+  font-family: inherit;
+  font-variant-numeric: tabular-nums;
+}
+.afr-delay-fields input:disabled { opacity: 0.5; }
+.afr-delay-fields .unit { font-size: 0.78rem; opacity: 0.6; }
+
+.afr-delay-estimate {
+  font-size: 0.8rem;
+  opacity: 0.7;
+  margin: 0 0 14px;
+}
+
+.afr-delay-progress {
+  border: 1px solid var(--border-color, #333);
+  border-radius: 6px;
+  padding: 10px 12px;
+  margin-bottom: 12px;
+  font-size: 0.82rem;
+}
+.afr-delay-bar {
+  height: 5px;
+  background: rgba(255,255,255,0.08);
+  border-radius: 3px;
+  overflow: hidden;
+  margin-bottom: 8px;
+}
+.afr-delay-bar > div {
+  height: 100%;
+  background: #4fc3f7;
+  transition: width 0.25s ease;
+}
+.afr-delay-progress.phase-enriching .afr-delay-bar > div { background: #ffb000; }
+.afr-delay-progress.phase-complete .afr-delay-bar > div { background: #66bb6a; }
+.afr-delay-progress.phase-aborted .afr-delay-bar > div { background: #ef5350; }
+
+.afr-delay-status { display: flex; gap: 8px; align-items: baseline; }
+.afr-delay-status .phase {
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+  opacity: 0.65;
+}
+.afr-delay-values {
+  margin-top: 6px;
+  font-size: 0.78rem;
+  opacity: 0.75;
+  font-variant-numeric: tabular-nums;
+}
+
+.afr-delay-result {
+  padding: 10px 12px;
+  margin-bottom: 12px;
+  border-radius: 6px;
+  background: rgba(102, 187, 106, 0.1);
+  border: 1px solid rgba(102, 187, 106, 0.35);
+  font-size: 0.83rem;
+}
+
+/* Errors here can mean the engine is still enriched, so they must be
+   impossible to miss and are never truncated. */
+.afr-delay-error {
+  display: flex;
+  gap: 8px;
+  padding: 10px 12px;
+  margin-bottom: 12px;
+  border-radius: 6px;
+  background: rgba(239, 83, 80, 0.12);
+  border: 1px solid rgba(239, 83, 80, 0.5);
+  font-size: 0.83rem;
+  line-height: 1.45;
+}
+.afr-delay-error svg { flex-shrink: 0; margin-top: 2px; color: #ef5350; }
+
+.afr-delay-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+.afr-delay-actions button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  border-radius: 5px;
+  border: 1px solid var(--border-color, #333);
+  background: var(--button-bg, #2a2a3a);
+  color: inherit;
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+.afr-delay-actions button.primary { background: #1976d2; border-color: #1976d2; }
+/* Abort is the only control during a run, so it gets the full width of
+   attention rather than sitting alongside disabled buttons. */
+.afr-delay-actions button.danger {
+  background: #c62828;
+  border-color: #c62828;
+  flex: 1;
+  justify-content: center;
+  padding: 12px;
+  font-size: 0.95rem;
+  font-weight: 600;
+}

--- a/crates/libretune-app/src/components/dialogs/AfrDelayTestDialog.tsx
+++ b/crates/libretune-app/src/components/dialogs/AfrDelayTestDialog.tsx
@@ -1,0 +1,181 @@
+/**
+ * Automated AFR transport-delay measurement.
+ *
+ * Applies a timed enrichment step so the wideband's response can be measured
+ * from the log. The operator holds the engine at an operating point; this only
+ * touches fuelling, and only ever enriches.
+ *
+ * The safety story is deliberately visible in the UI rather than buried: the
+ * dialog states that the step is rich-only, RAM-only and never burned, shows
+ * the exact values before anything is applied, and keeps a large abort control
+ * available for the whole run.
+ */
+import React, { useState, useEffect, useCallback } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import { listen } from '@tauri-apps/api/event';
+import { AlertTriangle, Play, Square } from 'lucide-react';
+import './AfrDelayTestDialog.css';
+
+interface Progress {
+  phase: string;
+  step: number;
+  totalSteps: number;
+  appliedValue: number;
+  baselineValue: number;
+  message: string;
+}
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export const AfrDelayTestDialog: React.FC<Props> = ({ isOpen, onClose }) => {
+  const [stepPercent, setStepPercent] = useState(8);
+  const [holdMs, setHoldMs] = useState(2000);
+  const [settleMs, setSettleMs] = useState(3000);
+  const [repeats, setRepeats] = useState(5);
+
+  const [running, setRunning] = useState(false);
+  const [progress, setProgress] = useState<Progress | null>(null);
+  const [result, setResult] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const un = listen<Progress>('afr_delay_test:progress', (e) => setProgress(e.payload));
+    return () => { un.then((f) => f()); };
+  }, []);
+
+  const start = useCallback(async () => {
+    setError(null);
+    setResult(null);
+    setRunning(true);
+    try {
+      const summary = await invoke<string>('run_afr_delay_test', {
+        stepPercent, holdMs, settleMs, repeats,
+      });
+      setResult(summary);
+    } catch (e) {
+      // A failure here may mean the engine is still enriched, so the message
+      // from the backend (which says whether the restore succeeded) matters —
+      // show it verbatim rather than summarising.
+      setError(String(e));
+    } finally {
+      setRunning(false);
+    }
+  }, [stepPercent, holdMs, settleMs, repeats]);
+
+  const abort = useCallback(async () => {
+    try { await invoke('abort_afr_delay_test'); } catch { /* best effort */ }
+  }, []);
+
+  if (!isOpen) return null;
+
+  const estSeconds = Math.round((repeats * (holdMs + settleMs)) / 1000);
+
+  return (
+    <div className="dialog-overlay" onClick={running ? undefined : onClose}>
+      <div className="afr-delay-dialog" onClick={(e) => e.stopPropagation()}>
+        <h2>AFR Delay Test</h2>
+
+        <p className="afr-delay-intro">
+          Applies a timed enrichment step so the delay between a fuelling change and
+          the wideband seeing it can be measured from the log. Repeat at several
+          rpm and load points to build a delay map.
+        </p>
+
+        <div className="afr-delay-safety">
+          <AlertTriangle size={16} />
+          <div>
+            <strong>Enrichment only, RAM only, never burned.</strong>
+            <ul>
+              <li>The step can only make the mixture richer, never leaner.</li>
+              <li>Written to live memory — cycling the key restores the stored tune.</li>
+              <li><code>reqFuel</code> is restored after every step and on abort.</li>
+              <li>Hold the engine steady yourself; this does not touch throttle.</li>
+            </ul>
+          </div>
+        </div>
+
+        <div className="afr-delay-fields">
+          <label>
+            Step size
+            <input type="number" min={3} max={20} step={1} value={stepPercent}
+              disabled={running}
+              onChange={(e) => setStepPercent(Number(e.target.value))} />
+            <span className="unit">% richer</span>
+          </label>
+          <label>
+            Hold
+            <input type="number" min={500} max={5000} step={100} value={holdMs}
+              disabled={running}
+              onChange={(e) => setHoldMs(Number(e.target.value))} />
+            <span className="unit">ms</span>
+          </label>
+          <label>
+            Settle
+            <input type="number" min={500} max={10000} step={100} value={settleMs}
+              disabled={running}
+              onChange={(e) => setSettleMs(Number(e.target.value))} />
+            <span className="unit">ms</span>
+          </label>
+          <label>
+            Repeats
+            <input type="number" min={1} max={20} step={1} value={repeats}
+              disabled={running}
+              onChange={(e) => setRepeats(Number(e.target.value))} />
+            <span className="unit">steps</span>
+          </label>
+        </div>
+
+        <p className="afr-delay-estimate">
+          Approximately {estSeconds}s. Start recording first, and keep rpm and load
+          steady throughout.
+        </p>
+
+        {progress && (
+          <div className={`afr-delay-progress phase-${progress.phase}`}>
+            <div className="afr-delay-bar">
+              <div style={{ width: `${(progress.step / Math.max(progress.totalSteps, 1)) * 100}%` }} />
+            </div>
+            <div className="afr-delay-status">
+              <span className="phase">{progress.phase}</span>
+              <span>{progress.message}</span>
+            </div>
+            {progress.baselineValue > 0 && (
+              <div className="afr-delay-values">
+                reqFuel baseline {progress.baselineValue.toFixed(1)} ms
+                {progress.phase === 'enriching' && ` -> applying ${progress.appliedValue.toFixed(1)} ms`}
+              </div>
+            )}
+          </div>
+        )}
+
+        {result && <div className="afr-delay-result">{result}</div>}
+        {error && (
+          <div className="afr-delay-error">
+            <AlertTriangle size={16} />
+            <span>{error}</span>
+          </div>
+        )}
+
+        <div className="afr-delay-actions">
+          {running ? (
+            <button type="button" className="danger" onClick={abort}>
+              <Square size={14} /> Abort and restore
+            </button>
+          ) : (
+            <>
+              <button type="button" onClick={onClose}>Close</button>
+              <button type="button" className="primary" onClick={start}>
+                <Play size={14} /> Start test
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AfrDelayTestDialog;

--- a/crates/libretune-app/src/menus/buildMenuItems.ts
+++ b/crates/libretune-app/src/menus/buildMenuItems.ts
@@ -45,6 +45,7 @@ export interface BuildMenuItemsDeps {
   setTuneHistoryOpen: (open: boolean) => void;
   setSettingsDialogOpen: (open: boolean) => void;
   setMathChannelsDialogOpen: (open: boolean) => void;
+  setAfrDelayTestOpen: (open: boolean) => void;
   setBaseMapDialogOpen: (open: boolean) => void;
   setTableComparisonOpen: (open: boolean) => void;
   setTuneFileDiffOpen: (open: boolean) => void;
@@ -77,7 +78,7 @@ export function buildMenuItems(deps: BuildMenuItemsDeps): TunerMenuItem[] {
     closeProject, handleCreateRestorePoint,
     setNewProjectDialogOpen, setImportProjectOpen, setSaveDialogOpen, setLoadDialogOpen,
     setBurnDialogOpen, setFirmwareUpdateDialogOpen, setRestorePointsOpen, setTuneHistoryOpen, setSettingsDialogOpen,
-    setMathChannelsDialogOpen, setBaseMapDialogOpen, setTableComparisonOpen,
+    setMathChannelsDialogOpen, setAfrDelayTestOpen, setBaseMapDialogOpen, setTableComparisonOpen,
     setTuneFileDiffOpen, setDynoOverlayOpen, setPluginPanelOpen, agentPanelVisible, setAgentPanelVisible, setConnectionDialogOpen,
     setUserManualOpen, setUserManualSection, setAboutDialogOpen, setSidebarVisible,
     setTheme, setTabs, setTabContents, setActiveTabId,
@@ -269,6 +270,9 @@ export function buildMenuItems(deps: BuildMenuItemsDeps): TunerMenuItem[] {
   toolItems.push({ id: "tune-file-diff", label: t('tools.tuneFileDiff'), onClick: () => setTuneFileDiffOpen(true), disabled: !currentProject });
   toolItems.push({ id: "dyno-overlay", label: t('tools.dynoData'), onClick: () => setDynoOverlayOpen(true) });
   toolItems.push({ id: "math-channels", label: t('tools.mathChannels'), onClick: () => setMathChannelsDialogOpen(true), disabled: !currentProject });
+  // Requires a live ECU as well as a project; the command reports clearly
+  // if reqFuel cannot be read, so the menu only guards on the project.
+  toolItems.push({ id: "afr-delay-test", label: "AFR Delay Test…", onClick: () => setAfrDelayTestOpen(true), disabled: !currentProject });
   toolItems.push({ id: "base-map", label: t('tools.generateBaseMap'), onClick: () => setBaseMapDialogOpen(true), disabled: !currentProject });
   toolItems.push({ id: "sep4", label: "", separator: true });
   toolItems.push(


### PR DESCRIPTION
## Description

Measuring the AFR transport delay by hand is impractical — you have to hold a steady operating point, apply a clean fuel step, and time the wideband's reaction to within tens of ms. This adds an automated step generator: enrich by a set percentage, hold, restore, repeat, emitting progress so the AFR response is captured in the datalog and the delay extracted offline (dead-time + tau). That number then feeds AutoTune's lambda delay.

## Type of Change
- [x] New feature (non-breaking)

## Safety (by construction)
- **Enrichment only** — the step percentage is clamped positive, so the mixture goes richer (safe), never leaner.
- **RAM only, never burned** — written to live memory and restored; a key-cycle wipes it if the process dies mid-step.
- **Restore** is attempted on completion, on abort, and on error.
- **Abortable** between steps; abort restores first.

## Changes Made
- `run_afr_delay_test` / `abort_afr_delay_test` commands (backend needs only `update_constant` — RAM write + restore).
- `AfrDelayTestDialog` UI + a **Tools → AFR Delay Test…** menu entry (guarded on an open project).

## Testing
- [x] New and existing tests pass (`cargo test`; frontend `tsc --noEmit` + `vitest` pass)

**Hardware note:** the step sequencing and all guard paths were exercised in-car (5 clean cycles), but on that build the underlying ECU write itself was ineffective (a separate comms issue), so the end-to-end measurement hasn't been validated on hardware yet. The test is safe regardless (enrich-only, RAM-only, restored).

## Checklist
- [x] Code compiles without errors
- [x] No new clippy warnings (`cargo clippy --workspace -- -D warnings`)
- [x] Code is formatted (`cargo fmt`)
- [x] TypeScript compiles without errors (`npx tsc --noEmit`)
- [x] Commit messages follow conventional format

_Extracted from the datalog-streaming branch it originally shipped alongside, so it can land independently. Pairs with #143 (settable / flow-scaled lambda delay) — this measures the number, that consumes it._