### PR TITLE
Poc/speeduino firmware build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -67,6 +78,9 @@ name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "async-broadcast"
@@ -354,6 +368,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "bzip2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+dependencies = [
+ "bzip2-sys",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cairo-rs"
 version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -486,6 +519,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "cobs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -512,6 +555,12 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "convert_case"
@@ -734,6 +783,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6977c2a71ab1e0d1e62f966b411a498aa04c4dce47d93d52f8a360a06058922"
 
 [[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -868,6 +932,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deflate64"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
+
+[[package]]
 name = "deranged"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -875,6 +945,17 @@ checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -904,6 +985,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1214,6 +1296,16 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -1817,6 +1909,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2109,6 +2210,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "io-kit-sys"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2386,9 +2496,14 @@ dependencies = [
  "byteorder",
  "chrono",
  "dirs 5.0.1",
+ "flate2",
+ "futures-util",
  "libretune-core",
+ "regex",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "tar",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
@@ -2397,6 +2512,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing-subscriber",
+ "zip",
 ]
 
 [[package]]
@@ -2516,6 +2632,27 @@ checksum = "b3a8e7962a5368d5f264d045a5a255e90f9aa3fc1941ae15a8d2940d42cac671"
 dependencies = [
  "cc",
  "which",
+]
+
+[[package]]
+name = "lzma-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+dependencies = [
+ "byteorder",
+ "crc",
+]
+
+[[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -3121,6 +3258,16 @@ name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -3823,6 +3970,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -3842,12 +3990,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams 0.4.2",
  "web-sys",
  "webpki-roots",
 ]
@@ -3882,7 +4032,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -4289,6 +4439,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4573,6 +4734,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -5690,6 +5862,19 @@ dependencies = [
  "indexmap 2.14.0",
  "wasm-encoder 0.244.0",
  "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -6849,6 +7034,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
+]
+
+[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6984,6 +7188,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "zerotrie"
@@ -7019,10 +7237,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "aes",
+ "arbitrary",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "deflate64",
+ "displaydoc",
+ "flate2",
+ "getrandom 0.3.4",
+ "hmac",
+ "indexmap 2.14.0",
+ "lzma-rs",
+ "memchr",
+ "pbkdf2",
+ "sha1",
+ "thiserror 2.0.18",
+ "time",
+ "xz2",
+ "zeroize",
+ "zopfli",
+ "zstd",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4de98dfa5d5b7fef4ee834d0073d560c9ca7b6c46a71d058c48db7960f8cfaf7"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zstd"

--- a/crates/libretune-app/src-tauri/Cargo.toml
+++ b/crates/libretune-app/src-tauri/Cargo.toml
@@ -32,6 +32,14 @@ tauri-plugin-dialog = "2"
 chrono = { workspace = true }
 byteorder = "1"
 tracing-subscriber = { workspace = true }
+# Speeduino firmware build PoC (commands/speeduino_build.rs): downloading
+# arduino-cli/avrdude/Speeduino source releases and extracting their archives.
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
+futures-util = "0.3"
+zip = "2"
+tar = "0.4"
+flate2 = "1"
+regex = "1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/libretune-app/src-tauri/src/commands/demo.rs
+++ b/crates/libretune-app/src-tauri/src/commands/demo.rs
@@ -225,6 +225,7 @@ mod demo_mode_tests {
             math_channels: Mutex::new(Vec::new()),
             stream_stats: Mutex::new(StreamStats::default()),
             agent_task: Mutex::new(None),
+            speeduino_build_task: Mutex::new(None),
         };
 
         let dev_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))

--- a/crates/libretune-app/src-tauri/src/commands/mod.rs
+++ b/crates/libretune-app/src-tauri/src/commands/mod.rs
@@ -58,6 +58,7 @@ pub mod restore_points;
 pub mod save_tune;
 pub mod settings;
 pub mod signature_helpers;
+pub mod speeduino_build;
 pub mod start_autotune;
 pub mod sync_ecu_data;
 pub mod system;

--- a/crates/libretune-app/src-tauri/src/commands/realtime_stream.rs
+++ b/crates/libretune-app/src-tauri/src/commands/realtime_stream.rs
@@ -854,6 +854,7 @@ mod stale_definition_guard_tests {
             math_channels: Mutex::new(Vec::new()),
             stream_stats: Mutex::new(StreamStats::default()),
             agent_task: Mutex::new(None),
+            speeduino_build_task: Mutex::new(None),
         }
     }
 

--- a/crates/libretune-app/src-tauri/src/commands/speeduino_build.rs
+++ b/crates/libretune-app/src-tauri/src/commands/speeduino_build.rs
@@ -1,0 +1,942 @@
+//! Speeduino firmware build-from-source proof-of-concept.
+//!
+//! Unlike `firmware_update.rs` (STM32/rusEFI DFU/OpenBLT flashing of an
+//! already-built binary), Speeduino ships no pre-built `.hex` for its AVR
+//! boards -- this module downloads the firmware source, compiles it via an
+//! auto-fetched `arduino-cli`, and flashes the result. Scoped to the
+//! Arduino Mega 2560 (the standard Speeduino board) for this PoC; ESP32/
+//! Teensy/STM32 "Black" variants are not covered.
+//!
+//! Design ported from a proven, already-working reference: the user's own
+//! Speeduino Studio project's `ArduinoCliService`/`AvrdudeService`/
+//! `FirmwareReleaseService` (C#/.NET). Command shapes, GitHub API endpoints,
+//! and avrdude arguments mirror that implementation directly.
+//!
+//! Each `#[tauri::command]` is a thin wrapper around an `*_impl` function
+//! that takes a plain `base_dir: &Path` (instead of resolving it from an
+//! `AppHandle` internally) and `app: Option<&AppHandle>` (only used to emit
+//! progress/log events -- `None` skips emission). This keeps the real
+//! download/extract/compile logic callable from a plain integration test
+//! without needing a running Tauri app, which this project doesn't have a
+//! test harness for yet.
+
+use crate::paths::get_firmware_source_dir;
+use serde::Serialize;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use tauri::{AppHandle, Emitter};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+const AVR_MEGA_FQBN: &str = "arduino:avr:mega";
+const SPEEDUINO_REPO: &str = "noisymime/speeduino";
+const ARDUINO_CLI_REPO: &str = "arduino/arduino-cli";
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SpeeduinoToolchainInfo {
+    pub arduino_cli_path: Option<String>,
+    pub avr_core_installed: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SpeeduinoRelease {
+    pub version: String,
+    pub published_at: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SpeeduinoBuildResult {
+    pub success: bool,
+    pub hex_path: Option<String>,
+    pub log: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct SpeeduinoBuildLogEvent {
+    line: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct SpeeduinoDownloadProgressEvent {
+    received_bytes: u64,
+    total_bytes: u64,
+}
+
+fn push_log(app: Option<&AppHandle>, log: &mut Vec<String>, line: impl Into<String>) {
+    let line = line.into();
+    if let Some(app) = app {
+        let _ = app.emit(
+            "speeduino-build:log",
+            SpeeduinoBuildLogEvent { line: line.clone() },
+        );
+    }
+    log.push(line);
+}
+
+// ── Tool discovery ──────────────────────────────────────────────────────
+
+fn tools_dir(base_dir: &Path) -> PathBuf {
+    base_dir.join("tools")
+}
+
+fn arduino_cli_exe_name() -> &'static str {
+    if cfg!(windows) {
+        "arduino-cli.exe"
+    } else {
+        "arduino-cli"
+    }
+}
+
+fn avrdude_exe_name() -> &'static str {
+    if cfg!(windows) {
+        "avrdude.exe"
+    } else {
+        "avrdude"
+    }
+}
+
+/// Our own auto-downloaded copy (known-good) takes priority over PATH,
+/// matching the reference implementation's own precedence.
+fn find_in_tools_dir_or_path(base_dir: &Path, exe_name: &str) -> Option<PathBuf> {
+    let cached = tools_dir(base_dir).join(exe_name);
+    if cached.is_file() {
+        return Some(cached);
+    }
+    if let Ok(path_var) = std::env::var("PATH") {
+        for dir in std::env::split_paths(&path_var) {
+            let candidate = dir.join(exe_name);
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+fn find_arduino_cli(base_dir: &Path) -> Option<PathBuf> {
+    find_in_tools_dir_or_path(base_dir, arduino_cli_exe_name())
+}
+
+fn find_avrdude(base_dir: &Path) -> Option<PathBuf> {
+    find_in_tools_dir_or_path(base_dir, avrdude_exe_name())
+}
+
+async fn check_avr_core_installed(cli: &Path) -> bool {
+    let output = tokio::process::Command::new(cli)
+        .args(["core", "list"])
+        .output()
+        .await;
+    match output {
+        Ok(out) => String::from_utf8_lossy(&out.stdout).contains("arduino:avr"),
+        Err(_) => false,
+    }
+}
+
+// ── Streamed subprocess execution ───────────────────────────────────────
+
+/// Run a subprocess, emitting each stdout/stderr line as a
+/// `speeduino-build:log` event as it arrives (not after the process exits).
+async fn run_streamed(
+    app: Option<&AppHandle>,
+    exe: &Path,
+    args: &[&str],
+    cwd: Option<&Path>,
+    log: &mut Vec<String>,
+) -> Result<i32, String> {
+    let mut cmd = tokio::process::Command::new(exe);
+    cmd.args(args)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+    if let Some(dir) = cwd {
+        cmd.current_dir(dir);
+    }
+
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| format!("Failed to start {}: {e}", exe.display()))?;
+
+    let stdout = child.stdout.take().ok_or("Failed to capture stdout")?;
+    let stderr = child.stderr.take().ok_or("Failed to capture stderr")?;
+    let mut out_lines = BufReader::new(stdout).lines();
+    let mut err_lines = BufReader::new(stderr).lines();
+
+    let mut out_done = false;
+    let mut err_done = false;
+    loop {
+        tokio::select! {
+            line = out_lines.next_line(), if !out_done => {
+                match line {
+                    Ok(Some(l)) => push_log(app, log, l),
+                    _ => out_done = true,
+                }
+            }
+            line = err_lines.next_line(), if !err_done => {
+                match line {
+                    Ok(Some(l)) => push_log(app, log, l),
+                    _ => err_done = true,
+                }
+            }
+            status = child.wait(), if out_done && err_done => {
+                let status = status.map_err(|e| e.to_string())?;
+                return Ok(status.code().unwrap_or(-1));
+            }
+        }
+    }
+}
+
+// ── Downloads ────────────────────────────────────────────────────────────
+
+fn http_client() -> Result<reqwest::Client, String> {
+    reqwest::Client::builder()
+        .user_agent("LibreTune")
+        .build()
+        .map_err(|e| e.to_string())
+}
+
+async fn fetch_latest_release_json(
+    client: &reqwest::Client,
+    repo: &str,
+) -> Result<serde_json::Value, String> {
+    let url = format!("https://api.github.com/repos/{repo}/releases/latest");
+    let resp = client
+        .get(&url)
+        .header("Accept", "application/vnd.github+json")
+        .send()
+        .await
+        .map_err(|e| format!("Failed to fetch release info: {e}"))?;
+    if !resp.status().is_success() {
+        return Err(format!("GitHub API returned {}", resp.status()));
+    }
+    resp.json::<serde_json::Value>()
+        .await
+        .map_err(|e| format!("Failed to parse release JSON: {e}"))
+}
+
+async fn download_with_progress(
+    app: Option<&AppHandle>,
+    client: &reqwest::Client,
+    url: &str,
+    dest_path: &Path,
+) -> Result<(), String> {
+    use futures_util::StreamExt;
+
+    let response = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| format!("Download request failed: {e}"))?;
+    if !response.status().is_success() {
+        return Err(format!("Download failed: HTTP {}", response.status()));
+    }
+    let total_bytes = response.content_length().unwrap_or(0);
+    let mut received_bytes: u64 = 0;
+
+    if let Some(parent) = dest_path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| format!("Failed to create directory: {e}"))?;
+    }
+    let mut file = tokio::fs::File::create(dest_path)
+        .await
+        .map_err(|e| format!("Failed to create file: {e}"))?;
+
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|e| format!("Download error: {e}"))?;
+        file.write_all(&chunk)
+            .await
+            .map_err(|e| format!("Write error: {e}"))?;
+        received_bytes += chunk.len() as u64;
+        if let Some(app) = app {
+            let _ = app.emit(
+                "speeduino-build:download-progress",
+                SpeeduinoDownloadProgressEvent {
+                    received_bytes,
+                    total_bytes,
+                },
+            );
+        }
+    }
+    Ok(())
+}
+
+// ── Archive extraction ──────────────────────────────────────────────────
+
+/// Extract a single named binary from a zip archive (case-insensitive,
+/// ignoring any directory prefix) into `dest_dir`.
+fn extract_zip_binary(
+    archive_path: &Path,
+    binary_name: &str,
+    dest_dir: &Path,
+) -> Result<(), String> {
+    let file = std::fs::File::open(archive_path).map_err(|e| e.to_string())?;
+    let mut zip = zip::ZipArchive::new(file).map_err(|e| e.to_string())?;
+    for i in 0..zip.len() {
+        let mut entry = zip.by_index(i).map_err(|e| e.to_string())?;
+        let entry_name = entry
+            .name()
+            .rsplit(['/', '\\'])
+            .next()
+            .unwrap_or("")
+            .to_string();
+        if entry_name.eq_ignore_ascii_case(binary_name) {
+            let dest = dest_dir.join(binary_name);
+            let mut out = std::fs::File::create(&dest).map_err(|e| e.to_string())?;
+            std::io::copy(&mut entry, &mut out).map_err(|e| e.to_string())?;
+            return Ok(());
+        }
+    }
+    Err(format!("{binary_name} not found in archive"))
+}
+
+/// Extract a single named binary from a .tar.gz archive into `dest_dir`.
+fn extract_targz_binary(
+    archive_path: &Path,
+    binary_name: &str,
+    dest_dir: &Path,
+) -> Result<(), String> {
+    let file = std::fs::File::open(archive_path).map_err(|e| e.to_string())?;
+    let decoder = flate2::read::GzDecoder::new(file);
+    let mut archive = tar::Archive::new(decoder);
+    for entry in archive.entries().map_err(|e| e.to_string())? {
+        let mut entry = entry.map_err(|e| e.to_string())?;
+        let path = entry.path().map_err(|e| e.to_string())?.into_owned();
+        let entry_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+        if entry_name == binary_name {
+            let dest = dest_dir.join(binary_name);
+            let mut out = std::fs::File::create(&dest).map_err(|e| e.to_string())?;
+            std::io::copy(&mut entry, &mut out).map_err(|e| e.to_string())?;
+            return Ok(());
+        }
+    }
+    Err(format!("{binary_name} not found in archive"))
+}
+
+fn extract_zip_all(zip_path: &Path, dest_dir: &Path) -> Result<(), String> {
+    let file = std::fs::File::open(zip_path).map_err(|e| e.to_string())?;
+    let mut zip = zip::ZipArchive::new(file).map_err(|e| e.to_string())?;
+    zip.extract(dest_dir).map_err(|e| e.to_string())
+}
+
+#[cfg(unix)]
+fn mark_executable(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    if let Ok(meta) = std::fs::metadata(path) {
+        let mut perms = meta.permissions();
+        perms.set_mode(0o755);
+        let _ = std::fs::set_permissions(path, perms);
+    }
+}
+
+#[cfg(not(unix))]
+fn mark_executable(_path: &Path) {}
+
+// ── Locating the sketch inside downloaded source ────────────────────────
+
+/// Given an extracted Speeduino source tree, locate the sketch folder (the
+/// one containing `speeduino.ino`) that arduino-cli should compile. GitHub's
+/// release zip wraps everything in a single top-level "speeduino-<version>/"
+/// folder, inside which the .ino lives at "speeduino/speeduino.ino".
+fn find_sketch_root(extract_dir: &Path) -> Option<PathBuf> {
+    if let Some(top_level) = first_subdir(extract_dir) {
+        if let Some(found) = find_dir_containing_ino(&top_level) {
+            return Some(found);
+        }
+    }
+    find_dir_containing_ino(extract_dir)
+}
+
+fn first_subdir(dir: &Path) -> Option<PathBuf> {
+    let mut entries: Vec<PathBuf> = std::fs::read_dir(dir)
+        .ok()?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.is_dir())
+        .collect();
+    if entries.len() == 1 {
+        entries.pop()
+    } else {
+        None
+    }
+}
+
+fn find_dir_containing_ino(root: &Path) -> Option<PathBuf> {
+    if dir_has_ino(root) {
+        return Some(root.to_path_buf());
+    }
+    let entries = std::fs::read_dir(root).ok()?;
+    for entry in entries.filter_map(|e| e.ok()) {
+        let path = entry.path();
+        if path.is_dir() && dir_has_ino(&path) {
+            return Some(path);
+        }
+    }
+    None
+}
+
+fn dir_has_ino(dir: &Path) -> bool {
+    std::fs::read_dir(dir)
+        .map(|entries| {
+            entries
+                .filter_map(|e| e.ok())
+                .any(|e| e.path().extension().and_then(|s| s.to_str()) == Some("ino"))
+        })
+        .unwrap_or(false)
+}
+
+/// Extract Arduino library names from arduino-cli's "fatal error: X.h: No
+/// such file or directory" compile output, so they can be auto-installed via
+/// `arduino-cli lib install`.
+fn parse_missing_libraries(output: &str) -> Vec<String> {
+    let re = regex::Regex::new(r"fatal error: (\S+)\.h: No such file or directory").unwrap();
+    let mut seen = HashSet::new();
+    let mut result = Vec::new();
+    for cap in re.captures_iter(output) {
+        let header = &cap[1];
+        let lib_name = header
+            .rsplit(['/', '\\'])
+            .next()
+            .unwrap_or(header)
+            .to_string();
+        if seen.insert(lib_name.clone()) {
+            result.push(lib_name);
+        }
+    }
+    result
+}
+
+// ── Testable inner implementations ──────────────────────────────────────
+
+async fn get_speeduino_toolchain_info_impl(base_dir: &Path) -> SpeeduinoToolchainInfo {
+    let cli_path = find_arduino_cli(base_dir);
+    let avr_core_installed = match &cli_path {
+        Some(cli) => check_avr_core_installed(cli).await,
+        None => false,
+    };
+    SpeeduinoToolchainInfo {
+        arduino_cli_path: cli_path.map(|p| p.display().to_string()),
+        avr_core_installed,
+    }
+}
+
+async fn download_arduino_cli_impl(
+    base_dir: &Path,
+    app: Option<&AppHandle>,
+) -> Result<String, String> {
+    let client = http_client()?;
+    let release = fetch_latest_release_json(&client, ARDUINO_CLI_REPO).await?;
+    let assets = release["assets"]
+        .as_array()
+        .ok_or("No assets in arduino-cli release")?;
+
+    let (os_marker, is_zip): (&str, bool) = if cfg!(target_os = "windows") {
+        ("Windows_64bit", true)
+    } else if cfg!(target_os = "macos") {
+        ("macOS_64bit", false)
+    } else {
+        ("Linux_64bit", false)
+    };
+
+    let asset = assets
+        .iter()
+        .find(|a| {
+            a["name"]
+                .as_str()
+                .map(|n| n.contains(os_marker) && (n.ends_with(".zip") || n.ends_with(".tar.gz")))
+                .unwrap_or(false)
+        })
+        .ok_or_else(|| format!("Could not find a {os_marker} arduino-cli release asset"))?;
+
+    let download_url = asset["browser_download_url"]
+        .as_str()
+        .ok_or("Asset missing download URL")?;
+    let asset_name = asset["name"].as_str().unwrap_or("arduino-cli-download");
+
+    let dest_dir = tools_dir(base_dir);
+    std::fs::create_dir_all(&dest_dir).map_err(|e| e.to_string())?;
+    let archive_path = dest_dir.join(asset_name);
+
+    download_with_progress(app, &client, download_url, &archive_path).await?;
+
+    let final_name = arduino_cli_exe_name();
+    if is_zip {
+        extract_zip_binary(&archive_path, final_name, &dest_dir)?;
+    } else {
+        extract_targz_binary(&archive_path, final_name, &dest_dir)?;
+    }
+    let _ = std::fs::remove_file(&archive_path);
+
+    let final_path = dest_dir.join(final_name);
+    mark_executable(&final_path);
+    if !final_path.is_file() {
+        return Err("arduino-cli binary not found after extraction".to_string());
+    }
+    Ok(final_path.display().to_string())
+}
+
+async fn ensure_avr_core_impl(
+    base_dir: &Path,
+    app: Option<&AppHandle>,
+) -> Result<SpeeduinoBuildResult, String> {
+    let cli = find_arduino_cli(base_dir).ok_or("arduino-cli not found — download it first")?;
+    let mut log = Vec::new();
+    if check_avr_core_installed(&cli).await {
+        push_log(app, &mut log, "arduino:avr core already installed.");
+        return Ok(SpeeduinoBuildResult {
+            success: true,
+            hex_path: None,
+            log,
+        });
+    }
+    push_log(
+        app,
+        &mut log,
+        "Installing arduino:avr core (this may take a minute)...",
+    );
+    let exit_code = run_streamed(
+        app,
+        &cli,
+        &["core", "install", "arduino:avr"],
+        None,
+        &mut log,
+    )
+    .await?;
+    Ok(SpeeduinoBuildResult {
+        success: exit_code == 0,
+        hex_path: None,
+        log,
+    })
+}
+
+async fn download_speeduino_source_impl(
+    base_dir: &Path,
+    app: Option<&AppHandle>,
+    version: &str,
+) -> Result<String, String> {
+    let client = http_client()?;
+    let url = format!("https://github.com/{SPEEDUINO_REPO}/archive/refs/tags/{version}.zip");
+    std::fs::create_dir_all(base_dir).map_err(|e| e.to_string())?;
+    let zip_path = base_dir.join(format!("speeduino_{version}.zip"));
+
+    download_with_progress(app, &client, &url, &zip_path).await?;
+
+    let extract_dir = base_dir.join(format!("speeduino_{version}"));
+    if extract_dir.exists() {
+        std::fs::remove_dir_all(&extract_dir).map_err(|e| e.to_string())?;
+    }
+    extract_zip_all(&zip_path, &extract_dir)?;
+    let _ = std::fs::remove_file(&zip_path);
+
+    find_sketch_root(&extract_dir)
+        .map(|p| p.display().to_string())
+        .ok_or_else(|| {
+            "Could not locate the speeduino sketch folder in the downloaded source".to_string()
+        })
+}
+
+async fn compile_speeduino_firmware_impl(
+    base_dir: &Path,
+    app: Option<&AppHandle>,
+    sketch_path: &str,
+) -> Result<SpeeduinoBuildResult, String> {
+    let cli = find_arduino_cli(base_dir).ok_or("arduino-cli not found — download it first")?;
+    let build_dir = base_dir.join("build");
+    std::fs::create_dir_all(&build_dir).map_err(|e| e.to_string())?;
+    let build_dir_str = build_dir.display().to_string();
+
+    let mut log = Vec::new();
+    let mut exit_code = -1;
+
+    for attempt in 1..=10 {
+        push_log(
+            app,
+            &mut log,
+            if attempt == 1 {
+                "Compiling for Arduino Mega 2560...".to_string()
+            } else {
+                format!("Retrying compile (attempt {attempt})...")
+            },
+        );
+
+        let mut attempt_log = Vec::new();
+        exit_code = run_streamed(
+            app,
+            &cli,
+            &[
+                "compile",
+                "--fqbn",
+                AVR_MEGA_FQBN,
+                "--output-dir",
+                build_dir_str.as_str(),
+                sketch_path,
+            ],
+            None,
+            &mut attempt_log,
+        )
+        .await?;
+        log.extend(attempt_log.iter().cloned());
+
+        if exit_code == 0 {
+            break;
+        }
+
+        let missing = parse_missing_libraries(&attempt_log.join("\n"));
+        if missing.is_empty() {
+            push_log(
+                app,
+                &mut log,
+                "Compile failed — no missing libraries detected. See output above.",
+            );
+            break;
+        }
+
+        for lib_name in missing {
+            push_log(
+                app,
+                &mut log,
+                format!("Missing library detected: {lib_name}.h -> installing '{lib_name}'..."),
+            );
+            let mut lib_log = Vec::new();
+            let lib_exit = run_streamed(
+                app,
+                &cli,
+                &["lib", "install", lib_name.as_str()],
+                None,
+                &mut lib_log,
+            )
+            .await?;
+            log.extend(lib_log);
+            if lib_exit != 0 {
+                push_log(app, &mut log, format!("  Warning: could not auto-install '{lib_name}' — you may need to install it manually."));
+            }
+        }
+    }
+
+    let sketch_name = Path::new(sketch_path)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("speeduino");
+    let mut hex_path = build_dir.join(format!("{sketch_name}.ino.hex"));
+    if !hex_path.is_file() {
+        if let Some(found) = std::fs::read_dir(&build_dir).ok().and_then(|entries| {
+            entries
+                .filter_map(|e| e.ok())
+                .map(|e| e.path())
+                .find(|p| p.extension().and_then(|s| s.to_str()) == Some("hex"))
+        }) {
+            hex_path = found;
+        }
+    }
+
+    let success = exit_code == 0 && hex_path.is_file();
+    if success {
+        push_log(app, &mut log, format!("Compiled: {}", hex_path.display()));
+    }
+
+    Ok(SpeeduinoBuildResult {
+        success,
+        hex_path: success.then(|| hex_path.display().to_string()),
+        log,
+    })
+}
+
+async fn upload_speeduino_firmware_impl(
+    base_dir: &Path,
+    app: Option<&AppHandle>,
+    sketch_path: &str,
+    port: &str,
+) -> Result<SpeeduinoBuildResult, String> {
+    let build_dir = base_dir.join("build");
+    let mut log = Vec::new();
+
+    if let Some(cli) = find_arduino_cli(base_dir) {
+        push_log(
+            app,
+            &mut log,
+            format!("Uploading to {port} via arduino-cli..."),
+        );
+        let build_dir_str = build_dir.display().to_string();
+        let exit_code = run_streamed(
+            app,
+            &cli,
+            &[
+                "upload",
+                "--fqbn",
+                AVR_MEGA_FQBN,
+                "-p",
+                port,
+                "--input-dir",
+                build_dir_str.as_str(),
+                sketch_path,
+            ],
+            None,
+            &mut log,
+        )
+        .await?;
+        if exit_code == 0 {
+            push_log(app, &mut log, "Upload successful.");
+            return Ok(SpeeduinoBuildResult {
+                success: true,
+                hex_path: None,
+                log,
+            });
+        }
+        push_log(
+            app,
+            &mut log,
+            format!("arduino-cli upload failed (exit {exit_code}) — trying avrdude directly."),
+        );
+    } else {
+        push_log(
+            app,
+            &mut log,
+            "arduino-cli not found — trying avrdude directly.",
+        );
+    }
+
+    let avrdude = find_avrdude(base_dir)
+        .ok_or("Neither arduino-cli nor avrdude is available. Download arduino-cli first.")?;
+    let hex_path = std::fs::read_dir(&build_dir)
+        .map_err(|e| e.to_string())?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .find(|p| p.extension().and_then(|s| s.to_str()) == Some("hex"))
+        .ok_or("No compiled .hex found in the build directory")?;
+
+    let avrdude_dir = avrdude.parent().map(|p| p.to_path_buf());
+    let conf_path = avrdude_dir.as_ref().map(|d| d.join("avrdude.conf"));
+    let hex_str = hex_path.display().to_string();
+    let flash_arg = format!("flash:w:{hex_str}:i");
+    let conf_str = conf_path
+        .as_ref()
+        .filter(|c| c.is_file())
+        .map(|c| c.display().to_string());
+
+    let mut args: Vec<&str> = Vec::new();
+    if let Some(ref conf) = conf_str {
+        args.push("-C");
+        args.push(conf.as_str());
+    }
+    args.extend([
+        "-p",
+        "atmega2560",
+        "-c",
+        "wiring",
+        "-P",
+        port,
+        "-b",
+        "115200",
+        "-D",
+        "-U",
+        flash_arg.as_str(),
+        "-v",
+    ]);
+
+    push_log(
+        app,
+        &mut log,
+        format!("Running: avrdude {}", args.join(" ")),
+    );
+    let exit_code = run_streamed(app, &avrdude, &args, avrdude_dir.as_deref(), &mut log).await?;
+    let success = exit_code == 0;
+    push_log(
+        app,
+        &mut log,
+        if success {
+            "Flash successful.".to_string()
+        } else {
+            format!("Flash failed (exit {exit_code}).")
+        },
+    );
+
+    Ok(SpeeduinoBuildResult {
+        success,
+        hex_path: Some(hex_str),
+        log,
+    })
+}
+
+// ── Tauri commands (thin wrappers) ──────────────────────────────────────
+
+#[tauri::command]
+pub async fn get_speeduino_toolchain_info(
+    app: AppHandle,
+) -> Result<SpeeduinoToolchainInfo, String> {
+    Ok(get_speeduino_toolchain_info_impl(&get_firmware_source_dir(&app)).await)
+}
+
+#[tauri::command]
+pub async fn download_arduino_cli(app: AppHandle) -> Result<String, String> {
+    let base_dir = get_firmware_source_dir(&app);
+    download_arduino_cli_impl(&base_dir, Some(&app)).await
+}
+
+#[tauri::command]
+pub async fn ensure_avr_core(app: AppHandle) -> Result<SpeeduinoBuildResult, String> {
+    let base_dir = get_firmware_source_dir(&app);
+    ensure_avr_core_impl(&base_dir, Some(&app)).await
+}
+
+#[tauri::command]
+pub async fn check_latest_speeduino_release() -> Result<SpeeduinoRelease, String> {
+    let client = http_client()?;
+    let release = fetch_latest_release_json(&client, SPEEDUINO_REPO).await?;
+    Ok(SpeeduinoRelease {
+        version: release["tag_name"]
+            .as_str()
+            .unwrap_or("unknown")
+            .to_string(),
+        published_at: release["published_at"].as_str().unwrap_or("").to_string(),
+    })
+}
+
+#[tauri::command]
+pub async fn download_speeduino_source(app: AppHandle, version: String) -> Result<String, String> {
+    let base_dir = get_firmware_source_dir(&app);
+    download_speeduino_source_impl(&base_dir, Some(&app), &version).await
+}
+
+#[tauri::command]
+pub async fn compile_speeduino_firmware(
+    app: AppHandle,
+    sketch_path: String,
+) -> Result<SpeeduinoBuildResult, String> {
+    let base_dir = get_firmware_source_dir(&app);
+    compile_speeduino_firmware_impl(&base_dir, Some(&app), &sketch_path).await
+}
+
+#[tauri::command]
+pub async fn upload_speeduino_firmware(
+    app: AppHandle,
+    sketch_path: String,
+    port: String,
+) -> Result<SpeeduinoBuildResult, String> {
+    let base_dir = get_firmware_source_dir(&app);
+    upload_speeduino_firmware_impl(&base_dir, Some(&app), &sketch_path, &port).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_missing_libraries_extracts_names_without_path_or_extension() {
+        let output = "\
+src/speeduino.ino:12:10: fatal error: PID_v1.h: No such file or directory
+ #include <PID_v1.h>
+          ^~~~~~~~~~
+compilation terminated.
+";
+        let missing = parse_missing_libraries(output);
+        assert_eq!(missing, vec!["PID_v1".to_string()]);
+    }
+
+    #[test]
+    fn test_parse_missing_libraries_dedupes_and_strips_directory_prefix() {
+        let output = "\
+fatal error: some/nested/Wire.h: No such file or directory
+fatal error: Wire.h: No such file or directory
+";
+        let missing = parse_missing_libraries(output);
+        assert_eq!(missing, vec!["Wire".to_string()]);
+    }
+
+    #[test]
+    fn test_parse_missing_libraries_returns_empty_when_no_match() {
+        let output = "Sketch uses 45000 bytes of program storage space.\n";
+        assert!(parse_missing_libraries(output).is_empty());
+    }
+
+    #[test]
+    fn test_find_sketch_root_locates_ino_inside_github_release_layout() {
+        let tmp = tempfile::tempdir().unwrap();
+        let extract_dir = tmp.path().join("extracted");
+        let top_level = extract_dir.join("speeduino-202501.7");
+        let sketch_dir = top_level.join("speeduino");
+        std::fs::create_dir_all(&sketch_dir).unwrap();
+        std::fs::write(sketch_dir.join("speeduino.ino"), "// sketch").unwrap();
+        // A sibling non-sketch top-level file/dir to make sure the walk isn't
+        // fooled by the first directory entry alone.
+        std::fs::create_dir_all(top_level.join("reference")).unwrap();
+
+        let found = find_sketch_root(&extract_dir).expect("should find the sketch dir");
+        assert_eq!(found, sketch_dir);
+    }
+
+    #[test]
+    fn test_find_sketch_root_returns_none_when_no_ino_anywhere() {
+        let tmp = tempfile::tempdir().unwrap();
+        let extract_dir = tmp.path().join("extracted");
+        std::fs::create_dir_all(extract_dir.join("speeduino-202501.7").join("docs")).unwrap();
+
+        assert!(find_sketch_root(&extract_dir).is_none());
+    }
+
+    // ── Real, network-dependent integration test ────────────────────────
+    // Ignored by default (slow: real downloads + a real ~1-2 min AVR
+    // compile). Run explicitly with:
+    //   cargo test -p libretune-app --lib speeduino_build::tests::test_real_download_and_compile -- --ignored --nocapture
+    // Proves the actual shipped download/extract/compile logic works
+    // end-to-end against the real arduino-cli and Speeduino GitHub releases,
+    // not just that the code compiles.
+    #[test]
+    #[ignore]
+    fn test_real_download_and_compile_produces_a_hex() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let tmp = tempfile::tempdir().unwrap();
+            let base_dir = tmp.path();
+
+            println!("== Downloading arduino-cli ==");
+            let cli_path = download_arduino_cli_impl(base_dir, None)
+                .await
+                .expect("arduino-cli download should succeed");
+            println!("arduino-cli at: {cli_path}");
+            assert!(Path::new(&cli_path).is_file());
+
+            println!("== Ensuring arduino:avr core ==");
+            let core_result = ensure_avr_core_impl(base_dir, None)
+                .await
+                .expect("core install should not error");
+            for line in &core_result.log {
+                println!("{line}");
+            }
+            assert!(core_result.success, "avr core install should succeed");
+
+            println!("== Checking latest Speeduino release ==");
+            let client = http_client().unwrap();
+            let release = fetch_latest_release_json(&client, SPEEDUINO_REPO)
+                .await
+                .expect("should fetch latest release");
+            let version = release["tag_name"].as_str().unwrap().to_string();
+            println!("Latest Speeduino release: {version}");
+
+            println!("== Downloading Speeduino source {version} ==");
+            let sketch_path = download_speeduino_source_impl(base_dir, None, &version)
+                .await
+                .expect("source download should succeed");
+            println!("Sketch at: {sketch_path}");
+            assert!(Path::new(&sketch_path).is_dir());
+
+            println!("== Compiling for Arduino Mega 2560 ==");
+            let build_result = compile_speeduino_firmware_impl(base_dir, None, &sketch_path)
+                .await
+                .expect("compile should not error");
+            for line in &build_result.log {
+                println!("{line}");
+            }
+            assert!(build_result.success, "compile should succeed");
+            let hex_path = build_result
+                .hex_path
+                .expect("should have a hex path on success");
+            println!("Compiled hex: {hex_path}");
+            assert!(
+                Path::new(&hex_path).is_file(),
+                "hex file should actually exist"
+            );
+            let hex_size = std::fs::metadata(&hex_path).unwrap().len();
+            println!("Hex file size: {hex_size} bytes");
+            assert!(
+                hex_size > 1000,
+                "hex file should be a real, non-trivial firmware image"
+            );
+        });
+    }
+}

--- a/crates/libretune-app/src-tauri/src/commands/speeduino_build.rs
+++ b/crates/libretune-app/src-tauri/src/commands/speeduino_build.rs
@@ -20,7 +20,9 @@
 //! without needing a running Tauri app, which this project doesn't have a
 //! test harness for yet.
 
+use crate::commands::metrics::stop_metrics_task;
 use crate::paths::get_firmware_source_dir;
+use crate::state::AppState;
 use serde::Serialize;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
@@ -805,11 +807,37 @@ pub async fn compile_speeduino_firmware(
 #[tauri::command]
 pub async fn upload_speeduino_firmware(
     app: AppHandle,
+    state: tauri::State<'_, AppState>,
     sketch_path: String,
     port: String,
 ) -> Result<SpeeduinoBuildResult, String> {
+    // Release LibreTune's own tuning connection first -- if it's still
+    // holding the serial port open, avrdude/arduino-cli will fail to open
+    // it for flashing. Mirrors firmware_update.rs's update_ecu_firmware.
+    let mut log = Vec::new();
+    if state.connection.lock().await.is_some() {
+        push_log(
+            Some(&app),
+            &mut log,
+            "Releasing the active ECU connection before flashing…",
+        );
+        stop_metrics_task(state.clone()).await;
+        {
+            let mut task_guard = state.streaming_task.lock().await;
+            if let Some(handle) = task_guard.take() {
+                handle.abort();
+            }
+        }
+        *state.connection.lock().await = None;
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    }
+
     let base_dir = get_firmware_source_dir(&app);
-    upload_speeduino_firmware_impl(&base_dir, Some(&app), &sketch_path, &port).await
+    let mut result =
+        upload_speeduino_firmware_impl(&base_dir, Some(&app), &sketch_path, &port).await?;
+    log.append(&mut result.log);
+    result.log = log;
+    Ok(result)
 }
 
 #[cfg(test)]

--- a/crates/libretune-app/src-tauri/src/lib.rs
+++ b/crates/libretune-app/src-tauri/src/lib.rs
@@ -143,6 +143,11 @@ use commands::save_tune::{save_tune, save_tune_as};
 use commands::settings::{
     get_settings, update_heatmap_custom_stops, update_setting, update_settings,
 };
+use commands::speeduino_build::{
+    check_latest_speeduino_release, compile_speeduino_firmware, download_arduino_cli,
+    download_speeduino_source, ensure_avr_core, get_speeduino_toolchain_info,
+    upload_speeduino_firmware,
+};
 use commands::start_autotune::start_autotune;
 use commands::sync_ecu_data::sync_ecu_data;
 use commands::system::{get_build_info, get_serial_ports};
@@ -216,6 +221,7 @@ pub fn run() {
             math_channels: Mutex::new(Vec::new()),
             stream_stats: Mutex::new(StreamStats::default()),
             agent_task: Mutex::new(None),
+            speeduino_build_task: Mutex::new(None),
         })
         .invoke_handler(tauri::generate_handler![
             get_serial_ports,
@@ -339,6 +345,13 @@ pub fn run() {
             update_ecu_firmware,
             recover_ecu_firmware_dfu,
             release_serial_port_blockers,
+            get_speeduino_toolchain_info,
+            download_arduino_cli,
+            ensure_avr_core,
+            check_latest_speeduino_release,
+            download_speeduino_source,
+            compile_speeduino_firmware,
+            upload_speeduino_firmware,
             use_project_tune,
             use_ecu_tune,
             mark_tune_modified,

--- a/crates/libretune-app/src-tauri/src/paths.rs
+++ b/crates/libretune-app/src-tauri/src/paths.rs
@@ -47,6 +47,13 @@ pub fn get_dashboards_dir(app: &tauri::AppHandle) -> PathBuf {
     get_app_data_dir(app).join("dashboards")
 }
 
+/// Get the firmware-source-and-build-tools directory (cross-platform).
+/// Holds downloaded Speeduino firmware source, compiled build output, and the
+/// auto-fetched arduino-cli/avrdude toolchain binaries.
+pub fn get_firmware_source_dir(app: &tauri::AppHandle) -> PathBuf {
+    get_app_data_dir(app).join("firmware-source")
+}
+
 /// Project-relative path to the port editor JSON store.
 pub fn get_port_editor_store_path(project: &Project) -> PathBuf {
     project.path.join("projectCfg").join("port_editor.json")

--- a/crates/libretune-app/src-tauri/src/state.rs
+++ b/crates/libretune-app/src-tauri/src/state.rs
@@ -190,6 +190,11 @@ pub struct AppState {
     /// JoinHandle for the currently-running AI assistant turn (if any).
     /// Aborted by `agent_stop` to cancel an in-flight LLM request.
     pub agent_task: Mutex<Option<tokio::task::JoinHandle<()>>>,
+    /// Reserved for a future cancel-in-progress-build command; not yet
+    /// populated by commands/speeduino_build.rs's compile/upload commands,
+    /// which currently run to completion directly.
+    #[allow(dead_code)]
+    pub speeduino_build_task: Mutex<Option<tokio::task::JoinHandle<()>>>,
 }
 
 #[derive(Clone, Debug)]

--- a/crates/libretune-app/src-tauri/src/tests.rs
+++ b/crates/libretune-app/src-tauri/src/tests.rs
@@ -135,6 +135,7 @@ mod concurrency_tests {
             math_channels: Mutex::new(Vec::new()),
             stream_stats: Mutex::new(StreamStats::default()),
             agent_task: Mutex::new(None),
+            speeduino_build_task: Mutex::new(None),
         });
 
         // Simulate execute_controller_command pattern: lock def -> sleep -> lock conn
@@ -214,6 +215,7 @@ mod concurrency_tests {
             math_channels: Mutex::new(Vec::new()),
             stream_stats: Mutex::new(StreamStats::default()),
             agent_task: Mutex::new(None),
+            speeduino_build_task: Mutex::new(None),
         })
     }
 
@@ -445,6 +447,7 @@ signature = "Speeduino 2023-04"
             math_channels: Mutex::new(Vec::new()),
             stream_stats: Mutex::new(StreamStats::default()),
             agent_task: Mutex::new(None),
+            speeduino_build_task: Mutex::new(None),
         };
 
         let matches = find_matching_inis_from_state(&state, "Speeduino 2023-05").await;
@@ -514,6 +517,7 @@ signature = "Speeduino 2023-04"
             math_channels: Mutex::new(Vec::new()),
             stream_stats: Mutex::new(StreamStats::default()),
             agent_task: Mutex::new(None),
+            speeduino_build_task: Mutex::new(None),
         };
 
         let matches = find_matching_inis_from_state(&state, "Speeduino 2023-05").await;
@@ -586,6 +590,7 @@ signature = "Speeduino 2023-04"
             math_channels: Mutex::new(Vec::new()),
             stream_stats: Mutex::new(StreamStats::default()),
             agent_task: Mutex::new(None),
+            speeduino_build_task: Mutex::new(None),
         };
 
         // Partial match case
@@ -670,6 +675,7 @@ signature = "Speeduino 2023-04"
             math_channels: Mutex::new(Vec::new()),
             stream_stats: Mutex::new(StreamStats::default()),
             agent_task: Mutex::new(None),
+            speeduino_build_task: Mutex::new(None),
         };
 
         // Install factory returning a partial matching signature

--- a/crates/libretune-app/src/App.tsx
+++ b/crates/libretune-app/src/App.tsx
@@ -220,6 +220,7 @@ function AppContent() {
   const [loadDialogOpen, setLoadDialogOpen] = useState(false);
   const [burnDialogOpen, setBurnDialogOpen] = useState(false);
   const [firmwareUpdateDialogOpen, setFirmwareUpdateDialogOpen] = useState(false);
+  const [speeduinoBuildDialogOpen, setSpeeduinoBuildDialogOpen] = useState(false);
   const [newTuneDialogOpen, setNewTuneDialogOpen] = useState(false);
   const [settingsDialogOpen, setSettingsDialogOpen] = useState(false);
   const [mathChannelsDialogOpen, setMathChannelsDialogOpen] = useState(false);
@@ -1415,7 +1416,7 @@ function AppContent() {
     sidebarVisible, showEcuMenus: showEcuMenusInMenubar, tabs, openTarget, handleStdTarget, openHelpTopic, showToast,
     closeProject, handleCreateRestorePoint,
     setNewProjectDialogOpen, setImportProjectOpen, setSaveDialogOpen, setLoadDialogOpen,
-    setBurnDialogOpen, setFirmwareUpdateDialogOpen, setRestorePointsOpen, setTuneHistoryOpen, setSettingsDialogOpen,
+    setBurnDialogOpen, setFirmwareUpdateDialogOpen, setSpeeduinoBuildDialogOpen, setRestorePointsOpen, setTuneHistoryOpen, setSettingsDialogOpen,
     setMathChannelsDialogOpen, setBaseMapDialogOpen, setTableComparisonOpen,
     setTuneFileDiffOpen, setDynoOverlayOpen, setPluginPanelOpen, agentPanelVisible, setAgentPanelVisible, setConnectionDialogOpen,
     setUserManualOpen, setUserManualSection, setAboutDialogOpen, setSidebarVisible,
@@ -1630,6 +1631,8 @@ function AppContent() {
         refreshTuneModified={refreshTuneModified}
         firmwareUpdateDialogOpen={firmwareUpdateDialogOpen}
         setFirmwareUpdateDialogOpen={setFirmwareUpdateDialogOpen}
+        speeduinoBuildDialogOpen={speeduinoBuildDialogOpen}
+        setSpeeduinoBuildDialogOpen={setSpeeduinoBuildDialogOpen}
         iniCapabilities={iniCapabilities}
         newTuneDialogOpen={newTuneDialogOpen}
         setNewTuneDialogOpen={setNewTuneDialogOpen}

--- a/crates/libretune-app/src/components/DialogOverlays.tsx
+++ b/crates/libretune-app/src/components/DialogOverlays.tsx
@@ -30,6 +30,7 @@ import OnboardingDialog from "./dialogs/OnboardingDialog";
 import { PluginPanel } from "./PluginPanel";
 import { ControllerCommandDialog } from "./console/ControllerCommandDialog";
 import { FirmwareUpdateDialog } from "./dialogs/FirmwareUpdateDialog";
+import { SpeeduinoBuildDialog } from "./dialogs/SpeeduinoBuildDialog";
 import { ThemeName } from "../themes";
 import {
   type ConnectionStatus,
@@ -64,6 +65,8 @@ export interface DialogOverlaysProps {
   refreshTuneModified?: () => void | Promise<void>;
   firmwareUpdateDialogOpen: boolean;
   setFirmwareUpdateDialogOpen: (v: boolean) => void;
+  speeduinoBuildDialogOpen: boolean;
+  setSpeeduinoBuildDialogOpen: (v: boolean) => void;
   iniCapabilities: IniCapabilities | null;
   newTuneDialogOpen: boolean;
   setNewTuneDialogOpen: (v: boolean) => void;
@@ -197,6 +200,7 @@ export function DialogOverlays(props: DialogOverlaysProps) {
     loadDialogOpen, setLoadDialogOpen,
     burnDialogOpen, setBurnDialogOpen, refreshTuneModified,
     firmwareUpdateDialogOpen, setFirmwareUpdateDialogOpen, iniCapabilities,
+    speeduinoBuildDialogOpen, setSpeeduinoBuildDialogOpen,
     newTuneDialogOpen, setNewTuneDialogOpen,
     settingsDialogOpen, setSettingsDialogOpen,
     setUnitsSystem, setAutoBurnOnClose, setStatus, setStatusBarChannels, setDefaultRuntimePacketMode,
@@ -253,6 +257,10 @@ export function DialogOverlays(props: DialogOverlaysProps) {
         onClose={() => setFirmwareUpdateDialogOpen(false)}
         isConnected={status.state === "Connected"}
         iniCapabilities={iniCapabilities}
+      />
+      <SpeeduinoBuildDialog
+        isOpen={speeduinoBuildDialogOpen}
+        onClose={() => setSpeeduinoBuildDialogOpen(false)}
       />
       <NewTuneDialog isOpen={newTuneDialogOpen} onClose={() => setNewTuneDialogOpen(false)} />
       <SettingsDialog

--- a/crates/libretune-app/src/components/dialogs/SpeeduinoBuildDialog.css
+++ b/crates/libretune-app/src/components/dialogs/SpeeduinoBuildDialog.css
@@ -1,0 +1,102 @@
+.speeduino-build-dialog .speeduino-build-intro {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  margin-bottom: 16px;
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.speeduino-build-step {
+  margin-bottom: 16px;
+}
+
+.speeduino-build-step > label {
+  display: block;
+  font-size: 12px;
+  font-weight: 600;
+  margin-bottom: 6px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.speeduino-build-row {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.speeduino-build-status {
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.speeduino-build-status.ok {
+  color: #6ee7a0;
+}
+
+.speeduino-build-status.missing {
+  color: #e8c070;
+}
+
+.speeduino-build-progress {
+  width: 100%;
+  margin-top: 8px;
+  height: 6px;
+}
+
+.speeduino-build-hint {
+  margin: 4px 0 0;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.speeduino-build-port-select {
+  flex: 1;
+  padding: 8px 10px;
+  border-radius: 6px;
+  background: var(--bg-input);
+  border: 1px solid var(--border-default);
+  color: inherit;
+  font-size: 13px;
+}
+
+.speeduino-build-error {
+  padding: 10px 12px;
+  border-radius: 8px;
+  font-size: 13px;
+  margin-bottom: 12px;
+  background: rgba(255, 80, 80, 0.12);
+  border: 1px solid rgba(255, 80, 80, 0.25);
+  color: var(--error);
+}
+
+.speeduino-build-success {
+  padding: 10px 12px;
+  border-radius: 8px;
+  font-size: 13px;
+  margin-bottom: 12px;
+  background: rgba(0, 200, 100, 0.12);
+  border: 1px solid rgba(0, 200, 100, 0.25);
+  color: #6ee7a0;
+}
+
+.speeduino-build-log {
+  max-height: 220px;
+  overflow: auto;
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.35);
+  border: 1px solid var(--border-default);
+  font-family: 'Courier New', monospace;
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.speeduino-build-log-line {
+  white-space: pre-wrap;
+  word-break: break-word;
+}

--- a/crates/libretune-app/src/components/dialogs/SpeeduinoBuildDialog.tsx
+++ b/crates/libretune-app/src/components/dialogs/SpeeduinoBuildDialog.tsx
@@ -1,0 +1,359 @@
+/**
+ * Speeduino firmware build-from-source proof-of-concept dialog.
+ *
+ * Unlike FirmwareUpdateDialog (flashing an already-built STM32/rusEFI
+ * image), Speeduino ships no pre-built .hex for its AVR boards — this walks
+ * through downloading the firmware source, compiling it via an
+ * auto-fetched arduino-cli, and flashing the result. Scoped to the Arduino
+ * Mega 2560 board only; see commands/speeduino_build.rs for the backend.
+ */
+import { useCallback, useEffect, useState } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import { listen } from '@tauri-apps/api/event';
+import { Download, Cpu } from 'lucide-react';
+import { Dialog, Button } from '../common';
+import { RiskAcknowledgement } from '../common/RiskAcknowledgement';
+import './SpeeduinoBuildDialog.css';
+
+interface SpeeduinoToolchainInfo {
+  arduino_cli_path: string | null;
+  avr_core_installed: boolean;
+}
+
+interface SpeeduinoRelease {
+  version: string;
+  published_at: string;
+}
+
+interface SpeeduinoBuildResult {
+  success: boolean;
+  hex_path: string | null;
+  log: string[];
+}
+
+interface DownloadProgress {
+  received_bytes: number;
+  total_bytes: number;
+}
+
+export interface SpeeduinoBuildDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export function SpeeduinoBuildDialog({ isOpen, onClose }: SpeeduinoBuildDialogProps) {
+  const [toolchain, setToolchain] = useState<SpeeduinoToolchainInfo | null>(null);
+  const [checkingToolchain, setCheckingToolchain] = useState(false);
+  const [downloadingCli, setDownloadingCli] = useState(false);
+
+  const [release, setRelease] = useState<SpeeduinoRelease | null>(null);
+  const [checkingRelease, setCheckingRelease] = useState(false);
+
+  const [downloadProgress, setDownloadProgress] = useState<DownloadProgress | null>(null);
+  const [sourcePath, setSourcePath] = useState<string | null>(null);
+  const [downloadingSource, setDownloadingSource] = useState(false);
+
+  const [compiling, setCompiling] = useState(false);
+  const [buildResult, setBuildResult] = useState<SpeeduinoBuildResult | null>(null);
+
+  const [ports, setPorts] = useState<string[]>([]);
+  const [selectedPort, setSelectedPort] = useState('');
+  const [acknowledgeRisk, setAcknowledgeRisk] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [uploadResult, setUploadResult] = useState<SpeeduinoBuildResult | null>(null);
+
+  const [log, setLog] = useState<string[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  const busy = checkingToolchain || downloadingCli || checkingRelease || downloadingSource || compiling || uploading;
+
+  const refreshToolchain = useCallback(async () => {
+    setCheckingToolchain(true);
+    try {
+      const info = await invoke<SpeeduinoToolchainInfo>('get_speeduino_toolchain_info');
+      setToolchain(info);
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setCheckingToolchain(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setError(null);
+    setLog([]);
+    void refreshToolchain();
+    invoke<string[]>('get_serial_ports')
+      .then((p) => {
+        setPorts(p);
+        if (p.length > 0) setSelectedPort(p[0]);
+      })
+      .catch(() => setPorts([]));
+  }, [isOpen, refreshToolchain]);
+
+  useEffect(() => {
+    if (!isOpen) return undefined;
+    const unlistenLog = listen<{ line: string }>('speeduino-build:log', (event) => {
+      setLog((prev) => [...prev, event.payload.line]);
+    });
+    const unlistenProgress = listen<DownloadProgress>('speeduino-build:download-progress', (event) => {
+      setDownloadProgress(event.payload);
+    });
+    return () => {
+      void unlistenLog.then((fn) => fn());
+      void unlistenProgress.then((fn) => fn());
+    };
+  }, [isOpen]);
+
+  const handleDownloadCli = useCallback(async () => {
+    setDownloadingCli(true);
+    setError(null);
+    setDownloadProgress(null);
+    try {
+      await invoke<string>('download_arduino_cli');
+      await refreshToolchain();
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setDownloadingCli(false);
+      setDownloadProgress(null);
+    }
+  }, [refreshToolchain]);
+
+  const handleCheckRelease = useCallback(async () => {
+    setCheckingRelease(true);
+    setError(null);
+    try {
+      const r = await invoke<SpeeduinoRelease>('check_latest_speeduino_release');
+      setRelease(r);
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setCheckingRelease(false);
+    }
+  }, []);
+
+  const handleDownloadSource = useCallback(async () => {
+    if (!release) return;
+    setDownloadingSource(true);
+    setError(null);
+    setDownloadProgress(null);
+    setSourcePath(null);
+    setBuildResult(null);
+    try {
+      const path = await invoke<string>('download_speeduino_source', { version: release.version });
+      setSourcePath(path);
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setDownloadingSource(false);
+      setDownloadProgress(null);
+    }
+  }, [release]);
+
+  const handleCompile = useCallback(async () => {
+    if (!sourcePath) return;
+    setCompiling(true);
+    setError(null);
+    setBuildResult(null);
+    setLog([]);
+    try {
+      const result = await invoke<SpeeduinoBuildResult>('compile_speeduino_firmware', {
+        sketchPath: sourcePath,
+      });
+      setBuildResult(result);
+      if (!result.success) {
+        setError('Compile failed — see log below.');
+      }
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setCompiling(false);
+    }
+  }, [sourcePath]);
+
+  const handleFlash = useCallback(async () => {
+    if (!sourcePath || !selectedPort) return;
+    setUploading(true);
+    setError(null);
+    setUploadResult(null);
+    setLog([]);
+    try {
+      const result = await invoke<SpeeduinoBuildResult>('upload_speeduino_firmware', {
+        sketchPath: sourcePath,
+        port: selectedPort,
+      });
+      setUploadResult(result);
+      if (!result.success) {
+        setError('Flash failed — see log below.');
+      }
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setUploading(false);
+    }
+  }, [sourcePath, selectedPort]);
+
+  const canDownloadSource = !!release && !downloadingSource;
+  const canCompile = !!sourcePath && !!toolchain?.arduino_cli_path && !compiling;
+  const canFlash =
+    !!buildResult?.success && !!selectedPort && acknowledgeRisk && !uploading;
+
+  return (
+    <Dialog
+      open={isOpen}
+      onClose={onClose}
+      title="Build & Flash Speeduino Firmware (Proof of Concept)"
+      size="lg"
+      closeOnBackdrop={!busy}
+      className="speeduino-build-dialog"
+    >
+      <Dialog.Body>
+        <div className="speeduino-build-intro">
+          <Cpu size={18} aria-hidden />
+          <p>
+            Downloads the Speeduino firmware source, compiles it for an Arduino Mega 2560 using an
+            auto-fetched arduino-cli, and flashes the result. Proof-of-concept scope: AVR Mega 2560
+            only — ESP32/Teensy/STM32 &quot;Black&quot; variants are not supported here.
+          </p>
+        </div>
+
+        <div className="speeduino-build-step">
+          <label>1. Toolchain</label>
+          <div className="speeduino-build-row">
+            <span className={`speeduino-build-status ${toolchain?.arduino_cli_path ? 'ok' : 'missing'}`}>
+              {checkingToolchain
+                ? 'Checking…'
+                : toolchain?.arduino_cli_path
+                  ? `arduino-cli found`
+                  : 'arduino-cli not found'}
+            </span>
+            {!toolchain?.arduino_cli_path && (
+              <Button
+                variant="secondary"
+                leadingIcon={<Download size={14} />}
+                onClick={() => void handleDownloadCli()}
+                disabled={busy}
+              >
+                {downloadingCli ? 'Downloading…' : 'Download arduino-cli'}
+              </Button>
+            )}
+          </div>
+        </div>
+
+        <div className="speeduino-build-step">
+          <label>2. Firmware Release</label>
+          <div className="speeduino-build-row">
+            <span className="speeduino-build-status">
+              {release ? `Latest: ${release.version} (${release.published_at.slice(0, 10)})` : 'Not checked'}
+            </span>
+            <Button variant="secondary" onClick={() => void handleCheckRelease()} disabled={busy}>
+              {checkingRelease ? 'Checking…' : 'Check Latest Release'}
+            </Button>
+          </div>
+        </div>
+
+        <div className="speeduino-build-step">
+          <label>3. Download Source</label>
+          <div className="speeduino-build-row">
+            <span className="speeduino-build-status">
+              {sourcePath ? 'Source downloaded' : 'Not downloaded'}
+            </span>
+            <Button
+              variant="secondary"
+              onClick={() => void handleDownloadSource()}
+              disabled={!canDownloadSource || busy}
+            >
+              {downloadingSource ? 'Downloading…' : 'Download Source'}
+            </Button>
+          </div>
+          {downloadProgress && downloadProgress.total_bytes > 0 && (
+            <progress
+              className="speeduino-build-progress"
+              value={downloadProgress.received_bytes}
+              max={downloadProgress.total_bytes}
+            />
+          )}
+          {downloadProgress && (
+            <p className="speeduino-build-hint">
+              {formatBytes(downloadProgress.received_bytes)}
+              {downloadProgress.total_bytes > 0 ? ` / ${formatBytes(downloadProgress.total_bytes)}` : ''}
+            </p>
+          )}
+        </div>
+
+        <div className="speeduino-build-step">
+          <label>4. Compile</label>
+          <div className="speeduino-build-row">
+            <span className="speeduino-build-status">
+              {buildResult?.success ? `Compiled: ${buildResult.hex_path}` : 'Not compiled'}
+            </span>
+            <Button variant="secondary" onClick={() => void handleCompile()} disabled={!canCompile || busy}>
+              {compiling ? 'Compiling…' : 'Compile'}
+            </Button>
+          </div>
+        </div>
+
+        <div className="speeduino-build-step">
+          <label>5. Flash</label>
+          <div className="speeduino-build-row">
+            <select
+              className="speeduino-build-port-select"
+              value={selectedPort}
+              onChange={(e) => setSelectedPort(e.target.value)}
+              disabled={busy || ports.length === 0}
+            >
+              {ports.length === 0 && <option value="">No ports found</option>}
+              {ports.map((p) => (
+                <option key={p} value={p}>
+                  {p}
+                </option>
+              ))}
+            </select>
+            <Button variant="primary" onClick={() => void handleFlash()} disabled={!canFlash}>
+              {uploading ? 'Flashing…' : 'Flash'}
+            </Button>
+          </div>
+          <RiskAcknowledgement
+            acknowledged={acknowledgeRisk}
+            onAcknowledgedChange={setAcknowledgeRisk}
+            risk="high"
+            warning="Flashing overwrites the firmware on the connected board. Make sure the selected port is the correct Speeduino board — flashing the wrong device can leave it unable to boot."
+            acknowledgementText="I understand the risk and have selected the correct port."
+            disabled={!buildResult?.success || uploading}
+          />
+        </div>
+
+        {error && <div className="speeduino-build-error">{error}</div>}
+        {uploadResult?.success && (
+          <div className="speeduino-build-success">Flash successful.</div>
+        )}
+
+        {log.length > 0 && (
+          <div className="speeduino-build-log">
+            {log.map((line, idx) => (
+              <div key={`${idx}-${line}`} className="speeduino-build-log-line">
+                {line}
+              </div>
+            ))}
+          </div>
+        )}
+      </Dialog.Body>
+
+      <Dialog.Footer>
+        <Button variant="secondary" onClick={onClose} disabled={busy}>
+          Close
+        </Button>
+      </Dialog.Footer>
+    </Dialog>
+  );
+}
+
+export default SpeeduinoBuildDialog;

--- a/crates/libretune-app/src/menus/buildMenuItems.ts
+++ b/crates/libretune-app/src/menus/buildMenuItems.ts
@@ -41,6 +41,7 @@ export interface BuildMenuItemsDeps {
   setBurnDialogOpen: (open: boolean) => void;
   refreshTuneModified?: () => void | Promise<void>;
   setFirmwareUpdateDialogOpen: (open: boolean) => void;
+  setSpeeduinoBuildDialogOpen: (open: boolean) => void;
   setRestorePointsOpen: (open: boolean) => void;
   setTuneHistoryOpen: (open: boolean) => void;
   setSettingsDialogOpen: (open: boolean) => void;
@@ -76,7 +77,7 @@ export function buildMenuItems(deps: BuildMenuItemsDeps): TunerMenuItem[] {
     sidebarVisible, showEcuMenus, tabs, openTarget, handleStdTarget, openHelpTopic, showToast,
     closeProject, handleCreateRestorePoint,
     setNewProjectDialogOpen, setImportProjectOpen, setSaveDialogOpen, setLoadDialogOpen,
-    setBurnDialogOpen, setFirmwareUpdateDialogOpen, setRestorePointsOpen, setTuneHistoryOpen, setSettingsDialogOpen,
+    setBurnDialogOpen, setFirmwareUpdateDialogOpen, setSpeeduinoBuildDialogOpen, setRestorePointsOpen, setTuneHistoryOpen, setSettingsDialogOpen,
     setMathChannelsDialogOpen, setBaseMapDialogOpen, setTableComparisonOpen,
     setTuneFileDiffOpen, setDynoOverlayOpen, setPluginPanelOpen, agentPanelVisible, setAgentPanelVisible, setConnectionDialogOpen,
     setUserManualOpen, setUserManualSection, setAboutDialogOpen, setSidebarVisible,
@@ -263,6 +264,14 @@ export function buildMenuItems(deps: BuildMenuItemsDeps): TunerMenuItem[] {
         disabled: !currentProject || status.state !== "Connected",
       });
     }
+  }
+  if (ecuType === "Speeduino") {
+    toolItems.push({
+      id: "speeduino-build",
+      label: "Build & Flash Speeduino Firmware (PoC)",
+      onClick: () => setSpeeduinoBuildDialogOpen(true),
+      disabled: !currentProject,
+    });
   }
   if (toolItems.length > 0) toolItems.push({ id: "sep3", label: "", separator: true });
   toolItems.push({ id: "compare-tables", label: t('tools.tableCompare'), onClick: () => setTableComparisonOpen(true), disabled: !currentProject });


### PR DESCRIPTION
## Description
Adds the ability to download Speeduino firmware source, compile it, and flash it to real hardware — directly from LibreTune. Speeduino releases don't ship pre-built `.hex` files for their AVR boards, so compiling from source is the only path today. This is scoped to the Arduino Mega 2560 board only (the standard/default Speeduino target); ESP32, Teensy, and STM32 "Black" variants are not covered.

## Type of Change
- [x] New feature (non-breaking change that adds functionality)

## Related Issues
None 

## Changes Made
- New `commands/speeduino_build.rs` module (sibling to `firmware_update.rs`, not a modification of it — that file is STM32/rusEFI-specific and has no AVR/avrdude concept at all):
  - Auto-downloads `arduino-cli` on demand (no pre-installed toolchain required), matching real per-OS GitHub release asset names for Windows/Linux/macOS.
  - Installs the `arduino:avr` core on demand.
  - Checks the latest Speeduino release and downloads its source as a GitHub tag zip.
  - Compiles for `arduino:avr:mega`, with the same missing-library auto-install retry loop as the reference implementation.
  - Flashes via `arduino-cli upload`, falling back to a direct `avrdude` invocation if arduino-cli itself isn't available.
  - Releases LibreTune's own tuning connection before flashing (mirrors `update_ecu_firmware`'s existing pattern), so the serial port isn't already held open when avrdude/arduino-cli tries to use it.
  - Streams subprocess output live via `tokio::process::Command` + an async line-read `select!` loop, not just after the process exits.
- New `SpeeduinoBuildDialog.tsx`, modeled on `FirmwareUpdateDialog.tsx`'s conventions, wired into the Tools menu, gated on `ecuType === "Speeduino"`.
- New `AppState.speeduino_build_task` field (currently reserved/unused — for a future cancel-build command).
- New dependencies: `zip`, `tar`, `flate2` (archive extraction), `futures-util` (download progress streaming), `regex` (compile-error parsing). `reqwest` gains the `stream` feature.

## Testing
- [x] I have tested these changes locally
- [x] New and existing tests pass (`cargo test`)
- [x] The UI works correctly with these changes

Every function taking `AppHandle` is a thin wrapper around an `*_impl` function that takes a plain `base_dir: &Path` and `Option<&AppHandle>` (only used for event emission), so the real download/extract/compile logic is callable from a plain test without needing a running Tauri app. Added an `#[ignore]`d integration test that downloads the actual current arduino-cli, downloads the actual latest Speeduino release, compiles it, and asserts on a real `.hex` output — run explicitly, not just reviewed:

