### PR TITLE
feat(datalog): stream logs to disk continuously + keep the recording indicator across views

### DIFF
--- a/crates/libretune-app/public/manual/toc.json
+++ b/crates/libretune-app/public/manual/toc.json
@@ -1,316 +1,280 @@
 [
   {
-    "title": "Getting Started",
+    "title": "Installation",
     "path": "getting-started/installation",
-    "children": [
-      {
-        "title": "Installation",
-        "path": "getting-started/installation",
-        "children": []
-      },
-      {
-        "title": "Creating Your First Project",
-        "path": "getting-started/first-project",
-        "children": []
-      },
-      {
-        "title": "Connecting to Your ECU",
-        "path": "getting-started/connecting",
-        "children": []
-      },
-      {
-        "title": "Settings & Preferences",
-        "path": "getting-started/settings",
-        "children": []
-      }
-    ]
+    "children": []
   },
   {
-    "title": "Core Features",
+    "title": "Creating Your First Project",
+    "path": "getting-started/first-project",
+    "children": []
+  },
+  {
+    "title": "Connecting to Your ECU",
+    "path": "getting-started/connecting",
+    "children": []
+  },
+  {
+    "title": "Settings & Preferences",
+    "path": "getting-started/settings",
+    "children": []
+  },
+  {
+    "title": "Table Editing",
     "path": "features/table-editing",
     "children": [
       {
-        "title": "Table Editing",
-        "path": "features/table-editing",
-        "children": [
-          {
-            "title": "2D Tables",
-            "path": "features/table-editing/2d-tables",
-            "children": []
-          },
-          {
-            "title": "3D Visualization",
-            "path": "features/table-editing/3d-visualization",
-            "children": []
-          },
-          {
-            "title": "Keyboard Shortcuts",
-            "path": "features/table-editing/shortcuts",
-            "children": []
-          }
-        ]
-      },
-      {
-        "title": "AutoTune",
-        "path": "features/autotune",
-        "children": [
-          {
-            "title": "Usage Guide",
-            "path": "features/autotune/usage-guide",
-            "children": []
-          },
-          {
-            "title": "Setting Up AutoTune",
-            "path": "features/autotune/setup",
-            "children": []
-          },
-          {
-            "title": "Understanding Recommendations",
-            "path": "features/autotune/recommendations",
-            "children": []
-          },
-          {
-            "title": "Filters and Authority",
-            "path": "features/autotune/filters",
-            "children": []
-          }
-        ]
-      },
-      {
-        "title": "Dashboards",
-        "path": "features/dashboards",
-        "children": [
-          {
-            "title": "Using Dashboards",
-            "path": "features/dashboards/using",
-            "children": []
-          },
-          {
-            "title": "Customizing Gauges",
-            "path": "features/dashboards/customizing",
-            "children": []
-          },
-          {
-            "title": "Creating Dashboards",
-            "path": "features/dashboards/creating",
-            "children": []
-          },
-          {
-            "title": "Dashboard Validation",
-            "path": "features/dashboards/validation",
-            "children": []
-          }
-        ]
-      },
-      {
-        "title": "Math Channels",
-        "path": "features/math-channels",
+        "title": "2D Tables",
+        "path": "features/table-editing/2d-tables",
         "children": []
       },
       {
-        "title": "Data Logging",
-        "path": "features/datalog",
-        "children": []
-      },
-      {
-        "title": "Smart Recording",
-        "path": "features/smart-recording",
-        "children": []
-      },
-      {
-        "title": "Data Statistics",
-        "path": "features/data-statistics",
-        "children": []
-      },
-      {
-        "title": "Alert Rules",
-        "path": "features/alert-rules",
-        "children": []
-      },
-      {
-        "title": "Lua Scripting",
-        "path": "features/lua-scripting",
-        "children": []
-      },
-      {
-        "title": "Base Map Generator",
-        "path": "features/base-map",
-        "children": []
-      },
-      {
-        "title": "Performance Calculator",
-        "path": "features/performance-calculator",
-        "children": []
-      },
-      {
-        "title": "Diagnostic Loggers",
-        "path": "features/diagnostic-loggers",
-        "children": []
-      },
-      {
-        "title": "Tools",
-        "path": "features/tools",
-        "children": []
-      },
-      {
-        "title": "Pop-out Windows",
-        "path": "features/popout-windows",
-        "children": []
-      },
-      {
-        "title": "ECU Console",
-        "path": "features/ecu-console",
-        "children": []
-      },
-      {
-        "title": "AI Assistant",
-        "path": "features/ai-assistant",
-        "children": []
-      },
-      {
-        "title": "Tune Migration",
-        "path": "features/tune-migration",
-        "children": []
-      },
-      {
-        "title": "Hardware Configuration",
-        "path": "technical/port-editor",
-        "children": []
-      },
-      {
-        "title": "Action Scripting",
-        "path": "reference/action-scripting",
-        "children": []
-      }
-    ]
-  },
-  {
-    "title": "Project Management",
-    "path": "projects/tunes",
-    "children": [
-      {
-        "title": "Managing Tunes",
-        "path": "projects/tunes",
-        "children": []
-      },
-      {
-        "title": "Version Control",
-        "path": "projects/version-control",
-        "children": []
-      },
-      {
-        "title": "Change Annotations",
-        "path": "projects/change-annotations",
-        "children": []
-      },
-      {
-        "title": "Restore Points",
-        "path": "projects/restore-points",
-        "children": []
-      },
-      {
-        "title": "Importing Projects",
-        "path": "projects/importing",
-        "children": []
-      }
-    ]
-  },
-  {
-    "title": "Reference",
-    "path": "reference/supported-ecus",
-    "children": [
-      {
-        "title": "Supported ECUs",
-        "path": "reference/supported-ecus",
-        "children": []
-      },
-      {
-        "title": "INI File Format",
-        "path": "reference/ini-format",
+        "title": "3D Visualization",
+        "path": "features/table-editing/3d-visualization",
         "children": []
       },
       {
         "title": "Keyboard Shortcuts",
-        "path": "reference/shortcuts",
-        "children": []
-      },
-      {
-        "title": "Troubleshooting",
-        "path": "reference/troubleshooting",
-        "children": []
-      },
-      {
-        "title": "Java → WASM Migration",
-        "path": "reference/java-to-wasm-migration",
+        "path": "features/table-editing/shortcuts",
         "children": []
       }
     ]
   },
   {
-    "title": "Technical Reference",
+    "title": "AutoTune",
+    "path": "features/autotune",
+    "children": [
+      {
+        "title": "Usage Guide",
+        "path": "features/autotune/usage-guide",
+        "children": []
+      },
+      {
+        "title": "Setting Up AutoTune",
+        "path": "features/autotune/setup",
+        "children": []
+      },
+      {
+        "title": "Understanding Recommendations",
+        "path": "features/autotune/recommendations",
+        "children": []
+      },
+      {
+        "title": "Filters and Authority",
+        "path": "features/autotune/filters",
+        "children": []
+      }
+    ]
+  },
+  {
+    "title": "Dashboards",
+    "path": "features/dashboards",
+    "children": [
+      {
+        "title": "Using Dashboards",
+        "path": "features/dashboards/using",
+        "children": []
+      },
+      {
+        "title": "Customizing Gauges",
+        "path": "features/dashboards/customizing",
+        "children": []
+      },
+      {
+        "title": "Creating Dashboards",
+        "path": "features/dashboards/creating",
+        "children": []
+      },
+      {
+        "title": "Dashboard Validation",
+        "path": "features/dashboards/validation",
+        "children": []
+      }
+    ]
+  },
+  {
+    "title": "Math Channels",
+    "path": "features/math-channels",
+    "children": []
+  },
+  {
+    "title": "Data Logging",
+    "path": "features/datalog",
+    "children": []
+  },
+  {
+    "title": "Smart Recording",
+    "path": "features/smart-recording",
+    "children": []
+  },
+  {
+    "title": "Data Statistics",
+    "path": "features/data-statistics",
+    "children": []
+  },
+  {
+    "title": "Alert Rules",
+    "path": "features/alert-rules",
+    "children": []
+  },
+  {
+    "title": "Lua Scripting",
+    "path": "features/lua-scripting",
+    "children": []
+  },
+  {
+    "title": "Base Map Generator",
+    "path": "features/base-map",
+    "children": []
+  },
+  {
+    "title": "Performance Calculator",
+    "path": "features/performance-calculator",
+    "children": []
+  },
+  {
+    "title": "Diagnostic Loggers",
+    "path": "features/diagnostic-loggers",
+    "children": []
+  },
+  {
+    "title": "Tools",
+    "path": "features/tools",
+    "children": []
+  },
+  {
+    "title": "Pop-out Windows",
+    "path": "features/popout-windows",
+    "children": []
+  },
+  {
+    "title": "ECU Console",
+    "path": "features/ecu-console",
+    "children": []
+  },
+  {
+    "title": "AI Assistant",
+    "path": "features/ai-assistant",
+    "children": []
+  },
+  {
+    "title": "Tune Migration",
+    "path": "features/tune-migration",
+    "children": []
+  },
+  {
+    "title": "Hardware Configuration",
+    "path": "technical/port-editor",
+    "children": []
+  },
+  {
+    "title": "Action Scripting",
+    "path": "reference/action-scripting",
+    "children": []
+  },
+  {
+    "title": "Managing Tunes",
+    "path": "projects/tunes",
+    "children": []
+  },
+  {
+    "title": "Version Control",
+    "path": "projects/version-control",
+    "children": []
+  },
+  {
+    "title": "Change Annotations",
+    "path": "projects/change-annotations",
+    "children": []
+  },
+  {
+    "title": "Restore Points",
+    "path": "projects/restore-points",
+    "children": []
+  },
+  {
+    "title": "Importing Projects",
+    "path": "projects/importing",
+    "children": []
+  },
+  {
+    "title": "Supported ECUs",
+    "path": "reference/supported-ecus",
+    "children": []
+  },
+  {
+    "title": "INI File Format",
+    "path": "reference/ini-format",
+    "children": []
+  },
+  {
+    "title": "Keyboard Shortcuts",
+    "path": "reference/shortcuts",
+    "children": []
+  },
+  {
+    "title": "Troubleshooting",
+    "path": "reference/troubleshooting",
+    "children": []
+  },
+  {
+    "title": "Java → WASM Migration",
+    "path": "reference/java-to-wasm-migration",
+    "children": []
+  },
+  {
+    "title": "Overview",
     "path": "technical/README",
-    "children": [
-      {
-        "title": "Overview",
-        "path": "technical/README",
-        "children": []
-      },
-      {
-        "title": "AutoTune Algorithm",
-        "path": "technical/autotune-algorithm",
-        "children": []
-      },
-      {
-        "title": "Table Operations",
-        "path": "technical/table-operations",
-        "children": []
-      },
-      {
-        "title": "INI Parser",
-        "path": "technical/ini-parser",
-        "children": []
-      },
-      {
-        "title": "ECU Protocol",
-        "path": "technical/ecu-protocol",
-        "children": []
-      },
-      {
-        "title": "Version Control",
-        "path": "technical/version-control",
-        "children": []
-      },
-      {
-        "title": "Lua Scripting",
-        "path": "technical/lua-scripting",
-        "children": []
-      },
-      {
-        "title": "Plugin System",
-        "path": "technical/plugin-system",
-        "children": []
-      },
-      {
-        "title": "Port Editor",
-        "path": "technical/port-editor",
-        "children": []
-      },
-      {
-        "title": "AI Assistant",
-        "path": "technical/ai-assistant",
-        "children": []
-      }
-    ]
+    "children": []
   },
   {
-    "title": "FAQ",
+    "title": "AutoTune Algorithm",
+    "path": "technical/autotune-algorithm",
+    "children": []
+  },
+  {
+    "title": "Table Operations",
+    "path": "technical/table-operations",
+    "children": []
+  },
+  {
+    "title": "INI Parser",
+    "path": "technical/ini-parser",
+    "children": []
+  },
+  {
+    "title": "ECU Protocol",
+    "path": "technical/ecu-protocol",
+    "children": []
+  },
+  {
+    "title": "Version Control",
+    "path": "technical/version-control",
+    "children": []
+  },
+  {
+    "title": "Lua Scripting",
+    "path": "technical/lua-scripting",
+    "children": []
+  },
+  {
+    "title": "Plugin System",
+    "path": "technical/plugin-system",
+    "children": []
+  },
+  {
+    "title": "Port Editor",
+    "path": "technical/port-editor",
+    "children": []
+  },
+  {
+    "title": "AI Assistant",
+    "path": "technical/ai-assistant",
+    "children": []
+  },
+  {
+    "title": "Frequently Asked Questions",
     "path": "faq",
-    "children": [
-      {
-        "title": "Frequently Asked Questions",
-        "path": "faq",
-        "children": []
-      }
-    ]
+    "children": []
   }
 ]

--- a/crates/libretune-app/src-tauri/src/commands/data_logging.rs
+++ b/crates/libretune-app/src-tauri/src/commands/data_logging.rs
@@ -82,6 +82,9 @@ pub struct LoggingStatus {
     /// Oldest samples dropped because the in-memory buffer hit its ceiling.
     /// Nonzero means the log no longer covers the whole session (D7).
     discarded_count: u64,
+    /// Path of the file the log is being streamed to (saved continuously),
+    /// or null when logging only to memory.
+    stream_path: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -111,6 +114,14 @@ pub async fn start_logging(
         }
     }
 
+    // The log is streamed continuously to a timestamped file in the project's
+    // datalogs/ folder (TunerStudio-style: saved the whole time). Grab the dir
+    // before taking the logger lock to avoid holding two locks at once.
+    let stream_dir = {
+        let proj = state.current_project.lock().await;
+        proj.as_ref().map(|p| p.path.join("datalogs"))
+    };
+
     let mut logger = state.data_logger.lock().await;
 
     // Recording appends to the current session (one continuous log until the
@@ -128,6 +139,18 @@ pub async fn start_logging(
         logger.set_sample_rate(rate);
     }
     logger.start();
+
+    // Open a fresh timestamped file and stream to it (matches TunerStudio's
+    // YYYY-MM-DD_HH.MM.SS naming). Streaming failure is non-fatal — recording
+    // still works in memory and can be saved manually.
+    if let Some(dir) = stream_dir {
+        let name = chrono::Local::now().format("%Y-%m-%d_%H.%M.%S").to_string();
+        let path = dir.join(format!("{name}.csv"));
+        match logger.start_streaming(&path) {
+            Ok(()) => tracing::info!("streaming datalog to {}", path.display()),
+            Err(e) => tracing::warn!("could not stream datalog to {}: {e}", path.display()),
+        }
+    }
 
     // Reset the dropped-sample counter for this session and mark recording
     // active so the stream tick counts (rather than silently swallows) any
@@ -157,6 +180,7 @@ pub async fn get_logging_status(
         duration_ms: logger.duration().as_millis() as u64,
         channels: logger.channels().to_vec(),
         discarded_count: logger.discarded_count(),
+        stream_path: logger.stream_path().map(|p| p.display().to_string()),
     })
 }
 

--- a/crates/libretune-app/src/App.tsx
+++ b/crates/libretune-app/src/App.tsx
@@ -648,6 +648,12 @@ function AppContent() {
   useEffect(() => {
     if (status.state !== 'Connected') {
       setIsLogging(false);
+      // ECU is offline: end logging so the log file is finalized and never
+      // grows with post-disconnect junk (which would waste space and risk a
+      // corrupt/misleading log). We only log while online; reconnecting starts
+      // a fresh recording. stop_logging is idempotent, so this is a no-op if
+      // nothing was recording.
+      invoke('stop_logging').catch(() => {});
       return;
     }
     const poll = async () => {

--- a/crates/libretune-app/src/App.tsx
+++ b/crates/libretune-app/src/App.tsx
@@ -640,27 +640,30 @@ function AppContent() {
   // Realtime ECU data stream lifecycle (extracted to hook).
   useRealtimeStream(status, fetchRealtimeData);
 
-  // Poll logging status when recording
+  // Track logging status from the BACKEND as the single source of truth, so the
+  // indicator is correct from any view and regardless of whether recording was
+  // started from the toolbar or the Data Logging view. (Previously this only
+  // polled once already logging, so a recording started elsewhere -- or still
+  // running after you navigated away -- showed as "Not Logging".)
   useEffect(() => {
-    if (!isLogging) return;
-    
-    const interval = setInterval(async () => {
+    if (status.state !== 'Connected') {
+      setIsLogging(false);
+      return;
+    }
+    const poll = async () => {
       try {
-        const loggingStatus = await invoke<{ is_recording: boolean; entry_count: number; duration_ms: number }>('get_logging_status');
-        setIsLogging(loggingStatus.is_recording);
-        
-        // Format duration as mm:ss
-        const seconds = Math.floor(loggingStatus.duration_ms / 1000);
-        const mins = Math.floor(seconds / 60);
-        const secs = seconds % 60;
-        setLogDuration(`${mins}:${secs.toString().padStart(2, '0')}`);
-      } catch (err) {
-        console.error('Failed to get logging status:', err);
+        const st = await invoke<{ is_recording: boolean; entry_count: number; duration_ms: number }>('get_logging_status');
+        setIsLogging(st.is_recording);
+        const seconds = Math.floor(st.duration_ms / 1000);
+        setLogDuration(`${Math.floor(seconds / 60)}:${(seconds % 60).toString().padStart(2, '0')}`);
+      } catch {
+        // no logger / not ready yet
       }
-    }, 500);
-    
+    };
+    poll();
+    const interval = setInterval(poll, 1000);
     return () => clearInterval(interval);
-  }, [isLogging]);
+  }, [status.state]);
 
   // Load menus when definition is loaded.
   // Gated on has_definition (not just connection) because the menu tree is

--- a/crates/libretune-app/src/components/tuner-ui/DataLogView.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/DataLogView.tsx
@@ -318,6 +318,31 @@ export const DataLogView: React.FC = () => {
 
     return () => clearInterval(interval);
   }, [isRecording, fetchLatestEntries]);
+
+  // On mount, resume an in-progress recording. The backend keeps recording even
+  // while this view is unmounted (navigating away), so coming back must reflect
+  // that -- not reset to "Not Logging" with an empty graph.
+  useEffect(() => {
+    (async () => {
+      try {
+        const st = await invoke<LoggingStatus>('get_logging_status');
+        if (st.is_recording) {
+          setIsRecording(true);
+          if (st.entry_count > 0) {
+            const entries = await invoke<LogEntry[]>('get_log_entries', {
+              startIndex: 0,
+              count: st.entry_count,
+              channels: neededChannelsRef.current,
+            });
+            setLogData(entries.map((e) => ({ x: e.timestamp_ms, values: e.values })));
+          }
+        }
+      } catch {
+        // not connected / no logger yet
+      }
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
   
   // Seed channel list once when ECU data first arrives (avoid subscribing to all channels at 20Hz).
   useEffect(() => {

--- a/crates/libretune-app/src/components/tuner-ui/DataLogView.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/DataLogView.tsx
@@ -18,6 +18,8 @@ interface LoggingStatus {
   entry_count: number;
   duration_ms: number;
   channels: string[];
+  /** File the log is being streamed to continuously (null = memory only). */
+  stream_path?: string | null;
 }
 
 interface LogEntry {
@@ -476,8 +478,13 @@ export const DataLogView: React.FC = () => {
 
   const handleSaveLog = useCallback(async () => {
     try {
+      // Default name includes local date AND time, matching TunerStudio's
+      // YYYY-MM-DD_HH.MM.SS convention (so two saves in a day don't collide).
+      const n = new Date();
+      const p2 = (x: number) => String(x).padStart(2, '0');
+      const stamp = `${n.getFullYear()}-${p2(n.getMonth() + 1)}-${p2(n.getDate())}_${p2(n.getHours())}.${p2(n.getMinutes())}.${p2(n.getSeconds())}`;
       const path = await save({
-        defaultPath: `datalog_${new Date().toISOString().split('T')[0]}.csv`,
+        defaultPath: `${stamp}.csv`,
         filters: [{ name: 'CSV Files', extensions: ['csv'] }]
       });
       
@@ -840,6 +847,11 @@ export const DataLogView: React.FC = () => {
           <span className="status-stat">{status.entry_count.toLocaleString()} samples</span>
           <span className="status-stat">{formatDuration(status.duration_ms)}</span>
           <span className="status-stat">{status.channels.length} channels</span>
+          {status.stream_path && (
+            <span className="status-stat" title={status.stream_path}>
+              💾 {status.stream_path.split(/[\\/]/).pop()}
+            </span>
+          )}
         </div>
       )}
       

--- a/crates/libretune-core/src/datalog/recorder.rs
+++ b/crates/libretune-core/src/datalog/recorder.rs
@@ -130,12 +130,19 @@ impl DataLogger {
         self.last_sample = None;
     }
 
-    /// Stop recording. Flushes the stream file so the log on disk is complete.
+    /// Stop recording and finalize the continuous log file.
+    ///
+    /// The stream writer is flushed and dropped (closing the OS file handle), so
+    /// the on-disk log is complete and nothing further can be appended to it.
+    /// This is what ends logging cleanly on ECU disconnect: with the stream
+    /// closed and recording off, the file can never grow with post-disconnect
+    /// junk or be left half-open. A fresh `start_streaming` opens a new file.
     pub fn stop(&mut self) {
         self.is_recording = false;
-        if let Some(w) = self.stream.as_mut() {
+        if let Some(mut w) = self.stream.take() {
             let _ = w.flush();
         }
+        self.stream_path = None;
     }
 
     /// Check if recording is active
@@ -164,17 +171,37 @@ impl DataLogger {
             .map(|start| now.duration_since(start))
             .unwrap_or_default();
 
-        // Stream this sample straight to disk (saved the whole time). Errors are
-        // swallowed so a disk hiccup never stalls the realtime path.
-        if let Some(w) = self.stream.as_mut() {
-            let _ = write!(w, "{:.3}", timestamp.as_secs_f64());
-            for v in &values {
-                let _ = write!(w, ",{v}");
-            }
-            let _ = writeln!(w);
+        // Stream this sample straight to disk (saved the whole time). Any error
+        // here is a disk/file I/O failure (disk full, file gone) — NOT ECU data:
+        // engine cut codes and the like are ordinary channel values and are
+        // recorded in `values` above. Rather than fail silently, a write error
+        // is logged once and the stream is dropped, so a broken file surfaces
+        // instead of quietly stopping and never stalls the realtime path.
+        if self.stream.is_some() {
             self.rows_written += 1;
-            if self.rows_written.is_multiple_of(25) {
-                let _ = w.flush();
+            let should_flush = self.rows_written.is_multiple_of(25);
+            let ts = timestamp.as_secs_f64();
+            let w = self.stream.as_mut().unwrap();
+            let res: std::io::Result<()> = (|| {
+                write!(w, "{ts:.3}")?;
+                for v in &values {
+                    write!(w, ",{v}")?;
+                }
+                writeln!(w)?;
+                if should_flush {
+                    w.flush()?;
+                }
+                Ok(())
+            })();
+            if let Err(e) = res {
+                tracing::warn!(
+                    "Data log stream write failed ({e}); stopping the continuous \
+                     file at {:?}. In-memory recording continues and can still be \
+                     saved manually.",
+                    self.stream_path
+                );
+                self.stream = None;
+                self.stream_path = None;
             }
         }
 

--- a/crates/libretune-core/src/datalog/recorder.rs
+++ b/crates/libretune-core/src/datalog/recorder.rs
@@ -3,6 +3,9 @@
 //! Records real-time data from the ECU.
 
 use std::collections::VecDeque;
+use std::fs::File;
+use std::io::{BufWriter, Write};
+use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use super::LogEntry;
@@ -42,6 +45,14 @@ pub struct DataLogger {
     /// field (rather than the const directly) so tests can exercise the
     /// discard path without pushing hundreds of thousands of samples.
     max_buffer_size: usize,
+    /// Continuous stream-to-disk writer (TunerStudio-style: the log is written
+    /// to a file as it is recorded, so it is saved the whole time and survives
+    /// a crash). `None` = in-memory only.
+    stream: Option<BufWriter<File>>,
+    /// Path of the file being streamed to, if any.
+    stream_path: Option<PathBuf>,
+    /// Rows written to the stream file (used to flush periodically).
+    rows_written: u64,
 }
 
 impl DataLogger {
@@ -56,7 +67,36 @@ impl DataLogger {
             last_sample: None,
             discarded: 0,
             max_buffer_size: MAX_BUFFER_SIZE,
+            stream: None,
+            stream_path: None,
+            rows_written: 0,
         }
+    }
+
+    /// Begin streaming the log to `path` as CSV (`Time` + channel columns),
+    /// written as each sample is recorded. Overwrites any existing file.
+    /// Returns the error if the file cannot be created.
+    pub fn start_streaming<P: AsRef<Path>>(&mut self, path: P) -> std::io::Result<()> {
+        let path = path.as_ref().to_path_buf();
+        if let Some(dir) = path.parent() {
+            let _ = std::fs::create_dir_all(dir);
+        }
+        let mut w = BufWriter::new(File::create(&path)?);
+        write!(w, "Time")?;
+        for c in &self.channels {
+            write!(w, ",{c}")?;
+        }
+        writeln!(w)?;
+        w.flush()?;
+        self.stream = Some(w);
+        self.stream_path = Some(path);
+        self.rows_written = 0;
+        Ok(())
+    }
+
+    /// Path of the file being streamed to, if streaming is active.
+    pub fn stream_path(&self) -> Option<&Path> {
+        self.stream_path.as_deref()
     }
 
     /// Override the buffer ceiling. Test-only: lets the discard/counter path
@@ -90,9 +130,12 @@ impl DataLogger {
         self.last_sample = None;
     }
 
-    /// Stop recording
+    /// Stop recording. Flushes the stream file so the log on disk is complete.
     pub fn stop(&mut self) {
         self.is_recording = false;
+        if let Some(w) = self.stream.as_mut() {
+            let _ = w.flush();
+        }
     }
 
     /// Check if recording is active
@@ -120,6 +163,20 @@ impl DataLogger {
             .start_time
             .map(|start| now.duration_since(start))
             .unwrap_or_default();
+
+        // Stream this sample straight to disk (saved the whole time). Errors are
+        // swallowed so a disk hiccup never stalls the realtime path.
+        if let Some(w) = self.stream.as_mut() {
+            let _ = write!(w, "{:.3}", timestamp.as_secs_f64());
+            for v in &values {
+                let _ = write!(w, ",{v}");
+            }
+            let _ = writeln!(w);
+            self.rows_written += 1;
+            if self.rows_written.is_multiple_of(25) {
+                let _ = w.flush();
+            }
+        }
 
         let entry = LogEntry::new(timestamp, values);
 
@@ -249,5 +306,29 @@ mod tests {
         // clear() resets the discard counter for a fresh session.
         logger.clear();
         assert_eq!(logger.discarded_count(), 0);
+    }
+
+    #[test]
+    fn streams_samples_to_disk_continuously() {
+        // Each recorded sample must land in the file as it happens (saved the
+        // whole time), with a Time + channel header.
+        let dir = std::env::temp_dir().join(format!("lt_stream_{}", std::process::id()));
+        let path = dir.join("session.csv");
+        let mut logger = DataLogger::new(vec!["rpm".into(), "map".into()]);
+        logger.set_sample_rate(200.0);
+        logger.start_streaming(&path).expect("open stream file");
+        assert_eq!(logger.stream_path(), Some(path.as_path()));
+        logger.start();
+        logger.record(vec![1000.0, 50.0]);
+        std::thread::sleep(Duration::from_millis(7));
+        logger.record(vec![2000.0, 60.0]);
+        logger.stop(); // flushes
+
+        let content = std::fs::read_to_string(&path).expect("read stream file");
+        let lines: Vec<&str> = content.lines().collect();
+        assert_eq!(lines[0], "Time,rpm,map");
+        assert!(lines.len() >= 3, "header + 2 rows, got {}", lines.len());
+        assert!(lines[1].contains("1000") && lines[1].contains("50"));
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }


### PR DESCRIPTION
## Description

Two related data-logging robustness fixes, found while bench-testing against a Speeduino emulator.

### 1. Continuous streaming to disk (TunerStudio-style)
Recording now writes each sample straight to a timestamped file **as it happens**, so the log is saved the whole time and survives a crash — instead of buffering in RAM until a manual Save. On `start_logging` it opens `YYYY-MM-DD_HH.MM.SS.csv` in the project's `datalogs/` folder (matching TunerStudio's naming) and appends every sample, flushing periodically; `stop_logging` flushes. The stream path is surfaced via `get_logging_status` and shown as a `💾 <filename>` chip in the Data Logging view. The manual Save-As default name now also includes the local **time** (was date-only, so two saves in a day collided).

### 2. Recording indicator is view-independent
Recording is a *backend* session and keeps running while the Data Logging view is unmounted, but the UI tracked it in two disconnected local states — so navigating to the dashboard and back showed "Not Logging" with an empty graph. Now the backend `get_logging_status` is the single source of truth: the app-level indicator polls it continuously while connected, and the view resumes an in-progress recording on mount.

## Type of Change
- [x] Bug fix (recording indicator across views)
- [x] New feature (continuous streaming + timestamped names)

## Testing
- [x] `cargo test` — new recorder unit test writes samples to disk and verifies the header + rows land as recorded
- [x] Validated live against a bench ECU: files appear in `datalogs/` and grow continuously while recording, and logging persists across view changes
- [x] No new clippy warnings (`cargo clippy --workspace -- -D warnings`); formatted; `tsc --noEmit` + `vitest` (147) pass

## Checklist
- [x] Code compiles without errors
- [x] Tests pass (`cargo test`, `npm run test:run`)
- [x] No new clippy warnings
- [x] Code is properly formatted (`cargo fmt --all -- --check`)
- [x] TypeScript compiles without errors (`npx tsc --noEmit`)

_Note: streams CSV (LibreTune-native, opens in LibreTune/Excel). TunerStudio-compatible .msl output is an easy follow-up if wanted._