### PR TITLE
fix(ini): resolve gauge range {expressions} instead of silently defaulting to 100

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/constant_values.rs
+++ b/crates/libretune-app/src-tauri/src/commands/constant_values.rs
@@ -23,6 +23,21 @@ pub async fn get_all_constant_values(
     let cache_guard = state.tune_cache.lock().await;
     let tune_guard = state.current_tune.lock().await;
 
+    Ok(collect_scalar_constant_values(
+        def,
+        tune_guard.as_ref(),
+        cache_guard.as_ref(),
+    ))
+}
+
+/// Current value of every scalar constant, read from tune/cache (no ECU
+/// round-trip). Shared by visibility-condition evaluation and INI gauge-range
+/// expression resolution (`{rpmhigh}` etc.).
+pub(crate) fn collect_scalar_constant_values(
+    def: &libretune_core::ini::EcuDefinition,
+    tune: Option<&libretune_core::tune::TuneFile>,
+    cache: Option<&libretune_core::tune::TuneCache>,
+) -> HashMap<String, f64> {
     let mut values = HashMap::new();
     for (name, constant) in &def.constants {
         // Skip array constants (only need scalars for visibility conditions)
@@ -30,18 +45,11 @@ pub async fn get_all_constant_values(
             continue;
         }
 
-        let value = read_constant_from_cache_or_tune(
-            name,
-            constant,
-            def.endianness,
-            tune_guard.as_ref(),
-            cache_guard.as_ref(),
-        );
+        let value = read_constant_from_cache_or_tune(name, constant, def.endianness, tune, cache);
 
         values.insert(name.clone(), value);
     }
-
-    Ok(values)
+    values
 }
 
 /// Read a single constant value from tune file or cache (no ECU connection needed).

--- a/crates/libretune-app/src-tauri/src/commands/ini_meta.rs
+++ b/crates/libretune-app/src-tauri/src/commands/ini_meta.rs
@@ -136,29 +136,86 @@ pub async fn get_frontpage(
 /// Used to configure dashboard gauges.
 ///
 /// Returns: Vector of GaugeInfo for all defined gauges
+/// Resolve one gauge numeric field: literal value, or its `{expression}`
+/// evaluated against the current tune/default values. An expression that
+/// cannot be resolved yields NaN (serialized as `null`), NOT the parser's
+/// placeholder fallback — a bogus 100 here is what pegged RPM gauges at 100
+/// after a range sync. The frontend treats non-finite as "keep the
+/// dashboard's own value".
+fn resolve_gauge_field(
+    literal: f64,
+    expr: Option<&str>,
+    ctx: &std::collections::HashMap<String, f64>,
+) -> f64 {
+    let Some(expr) = expr else {
+        return literal;
+    };
+    let parsed = match libretune_core::ini::expression::Parser::new(expr).parse() {
+        Ok(p) => p,
+        Err(_) => return f64::NAN,
+    };
+    match libretune_core::ini::expression::evaluate(&parsed, ctx, None) {
+        Ok(v) => {
+            let f = v.as_f64();
+            if f.is_finite() {
+                f
+            } else {
+                f64::NAN
+            }
+        }
+        Err(_) => f64::NAN,
+    }
+}
+
+/// Build the expression context for gauge ranges: scalar constant values from
+/// the tune/cache, plus INI `defaultValue` entries (PcVariables like
+/// `rpmhigh` live there) filling any gaps.
+fn gauge_expr_context(
+    def: &libretune_core::ini::EcuDefinition,
+    tune: Option<&libretune_core::tune::TuneFile>,
+    cache: Option<&libretune_core::tune::TuneCache>,
+) -> std::collections::HashMap<String, f64> {
+    let mut ctx = super::constant_values::collect_scalar_constant_values(def, tune, cache);
+    for (name, value) in &def.default_values {
+        ctx.entry(name.clone()).or_insert(*value);
+    }
+    ctx
+}
+
+fn gauge_to_info(
+    g: &libretune_core::ini::GaugeConfig,
+    ctx: &std::collections::HashMap<String, f64>,
+) -> GaugeInfo {
+    GaugeInfo {
+        name: g.name.clone(),
+        channel: g.channel.clone(),
+        title: g.title.clone(),
+        units: g.units.clone(),
+        lo: resolve_gauge_field(g.lo, g.lo_expr.as_deref(), ctx),
+        hi: resolve_gauge_field(g.hi, g.hi_expr.as_deref(), ctx),
+        low_warning: resolve_gauge_field(g.low_warning, g.low_warning_expr.as_deref(), ctx),
+        high_warning: resolve_gauge_field(g.high_warning, g.high_warning_expr.as_deref(), ctx),
+        low_danger: resolve_gauge_field(g.low_danger, g.low_danger_expr.as_deref(), ctx),
+        high_danger: resolve_gauge_field(g.high_danger, g.high_danger_expr.as_deref(), ctx),
+        digits: g.digits,
+    }
+}
+
 #[tauri::command]
 pub async fn get_gauge_configs(
     state: tauri::State<'_, AppState>,
 ) -> Result<Vec<GaugeInfo>, String> {
     let def_guard = state.definition.lock().await;
     let def = def_guard.as_ref().ok_or("Definition not loaded")?;
+    // Same lock order as get_all_constant_values: definition → cache → tune.
+    let cache_guard = state.tune_cache.lock().await;
+    let tune_guard = state.current_tune.lock().await;
+    let ctx = gauge_expr_context(def, tune_guard.as_ref(), cache_guard.as_ref());
 
     let gauges: Vec<GaugeInfo> = def
         .gauges
         .values()
-        .map(|g| GaugeInfo {
-            name: g.name.clone(),
-            channel: g.channel.clone(),
-            title: g.title.clone(),
-            units: g.units.clone(),
-            lo: g.lo,
-            hi: g.hi,
-            low_warning: g.low_warning,
-            high_warning: g.high_warning,
-            low_danger: g.low_danger,
-            high_danger: g.high_danger,
-            digits: g.digits,
-        })
+        .map(|g| gauge_to_info(g, &ctx))
         .collect();
     Ok(gauges)
 }
@@ -177,17 +234,10 @@ pub async fn get_gauge_config(
         .get(&gauge_name)
         .ok_or_else(|| format!("Gauge {} not found", gauge_name))?;
 
-    Ok(GaugeInfo {
-        name: gauge.name.clone(),
-        channel: gauge.channel.clone(),
-        title: gauge.title.clone(),
-        units: gauge.units.clone(),
-        lo: gauge.lo,
-        hi: gauge.hi,
-        low_warning: gauge.low_warning,
-        high_warning: gauge.high_warning,
-        low_danger: gauge.low_danger,
-        high_danger: gauge.high_danger,
-        digits: gauge.digits,
-    })
+    // Same lock order as get_all_constant_values: definition → cache → tune.
+    let cache_guard = state.tune_cache.lock().await;
+    let tune_guard = state.current_tune.lock().await;
+    let ctx = gauge_expr_context(def, tune_guard.as_ref(), cache_guard.as_ref());
+
+    Ok(gauge_to_info(gauge, &ctx))
 }

--- a/crates/libretune-app/src/components/dashboards/hooks/useGaugeRangeSync.ts
+++ b/crates/libretune-app/src/components/dashboards/hooks/useGaugeRangeSync.ts
@@ -51,11 +51,18 @@ export function useGaugeRangeSync(
         const info = byChannel.get(channelKey) || byName.get(nameKey);
         if (!info) return comp;
 
+        // Only adopt the INI range when it's actually usable. Unresolvable
+        // INI range expressions arrive as null/NaN (e.g. `hi = {rpmhigh}`
+        // with no tune loaded), and a degenerate hi <= lo would peg the
+        // gauge; in both cases keep the dashboard's own range.
+        const rangeOk =
+          Number.isFinite(info.lo) && Number.isFinite(info.hi) && info.hi > info.lo;
+
         return {
           Gauge: {
             ...gauge,
-            min: info.lo,
-            max: info.hi,
+            min: rangeOk ? info.lo : gauge.min,
+            max: rangeOk ? info.hi : gauge.max,
             units: info.units,
             low_warning: Number.isFinite(info.low_warning) ? info.low_warning : gauge.low_warning,
             high_warning: Number.isFinite(info.high_warning) ? info.high_warning : gauge.high_warning,

--- a/crates/libretune-core/src/ini/gauges.rs
+++ b/crates/libretune-core/src/ini/gauges.rs
@@ -39,6 +39,25 @@ pub struct GaugeConfig {
 
     /// Decimal digits for display
     pub digits: u8,
+
+    /// Raw `{expression}` text for each numeric field that was not a literal
+    /// number in the INI (e.g. the Speeduino tachometer's `hi = {rpmhigh}`).
+    /// The numeric fields above then hold only a placeholder fallback, and
+    /// callers with access to tune/default values must resolve the expression
+    /// to get the real value — parse time has no tune loaded to resolve
+    /// against. Silently using the fallback is what pegged RPM gauges at 100.
+    #[serde(default)]
+    pub lo_expr: Option<String>,
+    #[serde(default)]
+    pub hi_expr: Option<String>,
+    #[serde(default)]
+    pub low_danger_expr: Option<String>,
+    #[serde(default)]
+    pub low_warning_expr: Option<String>,
+    #[serde(default)]
+    pub high_warning_expr: Option<String>,
+    #[serde(default)]
+    pub high_danger_expr: Option<String>,
 }
 
 impl GaugeConfig {
@@ -56,6 +75,12 @@ impl GaugeConfig {
             lo: 0.0,
             hi: 100.0,
             digits: 0,
+            lo_expr: None,
+            hi_expr: None,
+            low_danger_expr: None,
+            low_warning_expr: None,
+            high_warning_expr: None,
+            high_danger_expr: None,
         }
     }
 
@@ -82,6 +107,23 @@ impl Default for GaugeConfig {
     }
 }
 
+/// Parse a numeric gauge field that the INI allows to be either a literal
+/// number or an `{expression}`. Returns the literal (or `fallback`) plus the
+/// captured expression text (braces stripped) when it isn't a plain number.
+fn parse_num_or_expr(raw: &str, fallback: f64) -> (f64, Option<String>) {
+    match raw.parse::<f64>() {
+        Ok(v) => (v, None),
+        Err(_) => {
+            let t = raw.trim();
+            if let Some(inner) = t.strip_prefix('{').and_then(|s| s.strip_suffix('}')) {
+                (fallback, Some(inner.trim().to_string()))
+            } else {
+                (fallback, None)
+            }
+        }
+    }
+}
+
 /// Parse a gauge configuration line
 ///
 /// Format: name = channel, title, units, lo, hi, loD, loW, hiW, hiD, digits
@@ -101,22 +143,22 @@ pub fn parse_gauge_line(name: &str, value: &str) -> Option<GaugeConfig> {
         gauge.units = parts[2].trim_matches('"').to_string();
     }
     if parts.len() > 3 {
-        gauge.lo = parts[3].parse().unwrap_or(0.0);
+        (gauge.lo, gauge.lo_expr) = parse_num_or_expr(parts[3], 0.0);
     }
     if parts.len() > 4 {
-        gauge.hi = parts[4].parse().unwrap_or(100.0);
+        (gauge.hi, gauge.hi_expr) = parse_num_or_expr(parts[4], 100.0);
     }
     if parts.len() > 5 {
-        gauge.low_danger = parts[5].parse().unwrap_or(0.0);
+        (gauge.low_danger, gauge.low_danger_expr) = parse_num_or_expr(parts[5], 0.0);
     }
     if parts.len() > 6 {
-        gauge.low_warning = parts[6].parse().unwrap_or(0.0);
+        (gauge.low_warning, gauge.low_warning_expr) = parse_num_or_expr(parts[6], 0.0);
     }
     if parts.len() > 7 {
-        gauge.high_warning = parts[7].parse().unwrap_or(100.0);
+        (gauge.high_warning, gauge.high_warning_expr) = parse_num_or_expr(parts[7], 100.0);
     }
     if parts.len() > 8 {
-        gauge.high_danger = parts[8].parse().unwrap_or(100.0);
+        (gauge.high_danger, gauge.high_danger_expr) = parse_num_or_expr(parts[8], 100.0);
     }
     if parts.len() > 9 {
         gauge.digits = parts[9].parse().unwrap_or(0);
@@ -142,6 +184,28 @@ mod tests {
         assert!(gauge.is_warning(600.0));
         assert!(gauge.is_warning(6800.0));
         assert!(gauge.is_normal(3000.0));
+    }
+
+    #[test]
+    fn expression_fields_are_captured_not_silently_defaulted() {
+        // Real Speeduino 202501 tachometer line: hi/hiW/hiD are {expressions}
+        // referencing PcVariables (rpmhigh etc.), not literals. The old parser
+        // silently fell back to 100, which pegged RPM gauges at 100 after a
+        // range sync. The expression text must be captured so callers can
+        // resolve the real value against tune/default values.
+        let gauge = parse_gauge_line(
+            "tachometer",
+            "rpm, \"Engine Speed\", \"RPM\", 0, {rpmhigh}, 300, 600, {rpmwarn}, {rpmdang}, 0, 0",
+        )
+        .unwrap();
+        assert_eq!(gauge.hi_expr.as_deref(), Some("rpmhigh"));
+        assert_eq!(gauge.high_warning_expr.as_deref(), Some("rpmwarn"));
+        assert_eq!(gauge.high_danger_expr.as_deref(), Some("rpmdang"));
+        // Literal fields have no expression captured.
+        assert_eq!(gauge.lo_expr, None);
+        assert_eq!(gauge.low_danger_expr, None);
+        assert_eq!(gauge.lo, 0.0);
+        assert_eq!(gauge.low_danger, 300.0);
     }
 
     #[test]


### PR DESCRIPTION
## Description

The Speeduino 202501 INI defines the tachometer gauge as:

```
tachometer = rpm, "Engine Speed", "RPM", 0, {rpmhigh}, 300, 600, {rpmwarn}, {rpmdang}, 0, 0
```

`hi`, `hiW` and `hiD` are INI **expressions** referencing PcVariables — not literals. The gauge parser did `parse().unwrap_or(100.0)`, so every expression-valued field silently became a placeholder (100/0). Any dashboard that synced gauge ranges from the INI then **pegged its RPM gauge at 100** (peg-limits clamps the value to the gauge max), with spurious warning/danger coloring to match. Found on the bench with a Speeduino 202501: the ECU reported 5500+ rpm while every RPM display sat at exactly 100.

## Changes

- **`ini/gauges.rs`** — capture the expression text (`hi_expr` etc.) instead of discarding it; literal fields parse exactly as before. Unit test covers the real tachometer line.
- **`get_gauge_configs` / `get_gauge_config`** — evaluate captured expressions with the existing INI expression evaluator against the current scalar constant values from the tune/cache, plus INI `defaultValue` entries (PcVariables like `rpmhigh` live there). Unresolvable expressions serialize as `null` rather than a fabricated number.
- **`useGaugeRangeSync`** — only adopt an INI range when it's finite and `hi > lo`; otherwise keep the dashboard's own range, so a bad range can never brick a gauge again.

## Type of Change

- [x] Bug fix

## Testing

- New unit test parses the real Speeduino tachometer line and asserts the expressions are captured and literals unaffected.
- `cargo test` (346 passed), `cargo clippy --workspace -- -D warnings`, `cargo fmt --check`, `tsc --noEmit`, `vitest` (147 passed), `npm run build` all green.
- Bench-verified against a Speeduino 202501: RPM gauge range resolves to the tune's `rpmhigh` after sync instead of pegging at 100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)