### PR TITLE
fix(dash): gauge extra_attrs lost on save/load — multi-series trends degrade to one series

### DIFF
--- a/crates/libretune-app/src/components/gauges/painters/multiChannelTrend.ts
+++ b/crates/libretune-app/src/components/gauges/painters/multiChannelTrend.ts
@@ -43,17 +43,21 @@ function readLatestChannelValue(channel: string): number | undefined {
 
 /** Parse the primary series plus any `lt_seriesN_*` extra series from config. */
 function resolveSeries(config: TsGaugeConfig, primaryColor: string): TrendSeries[] {
+  const attrs = config.extra_attrs || {};
   const series: TrendSeries[] = [
     {
       channel: config.output_channel,
-      label: config.title || config.output_channel || 'Series 1',
+      // Prefer an explicit series label (lt_series1_label), then the channel
+      // name. The gauge title is the PANEL heading ("Live trend") — using it
+      // as the series label mislabeled the primary line's legend entry.
+      label:
+        attrs.lt_series1_label || config.output_channel || config.title || 'Series 1',
       color: primaryColor,
       min: config.min,
       max: config.max,
     },
   ];
 
-  const attrs = config.extra_attrs || {};
   for (let n = 2; n <= 1 + MAX_EXTRA_SERIES; n++) {
     const channel = attrs[`lt_series${n}_channel`];
     if (!channel) continue;

--- a/crates/libretune-core/src/dash/parser.rs
+++ b/crates/libretune-core/src/dash/parser.rs
@@ -640,7 +640,14 @@ fn set_gauge_property(gauge: &mut GaugeConfig, prop: &str, value: &str) {
         "GaugeStyle" => gauge.gauge_style = value.to_string(),
         "GaugePainter" => gauge.gauge_painter = GaugePainter::from_ts_string(value),
         "RunDemo" => gauge.run_demo = value.parse().unwrap_or(false),
-        _ => {}
+        // Preserve unrecognized properties (painter-specific lt_* attributes,
+        // future TunerStudio additions) instead of silently dropping them —
+        // the writer emits `extra_attrs` back out, so they round-trip.
+        other => {
+            gauge
+                .extra_attrs
+                .insert(other.to_string(), value.to_string());
+        }
     }
 }
 

--- a/crates/libretune-core/src/dash/templates.rs
+++ b/crates/libretune-core/src/dash/templates.rs
@@ -1044,6 +1044,10 @@ fn log_multi_trend(
     h: f64,
 ) -> DashComponent {
     let color = TsColor::from_css_hex(primary.color).unwrap_or(LT_LOG_BLUE);
+    let mut attrs = log_series_attrs(extra);
+    // The gauge title is the PANEL heading; the primary line needs its own
+    // legend label ("RPM", not the panel name).
+    attrs.insert("lt_series1_label".to_string(), primary.label.to_string());
     DashComponent::Gauge(Box::new(GaugeConfig {
         id: id.to_string(),
         title: title.to_string(),
@@ -1063,7 +1067,7 @@ fn log_multi_trend(
         trim_color: LT_LOG_GRAY,
         warn_color: LT_WARN_COLOR,
         critical_color: LT_CRITICAL_COLOR,
-        extra_attrs: log_series_attrs(extra),
+        extra_attrs: attrs,
         border_width: 1,
         shortest_size: 0, // see log_stat_tile's comment
         ..Default::default()

--- a/crates/libretune-core/src/dash/writer.rs
+++ b/crates/libretune-core/src/dash/writer.rs
@@ -345,6 +345,15 @@ fn write_gauge_component<W: Write>(
     write_string_property(writer, "GaugePainter", gauge.gauge_painter.to_ts_string())?;
     write_boolean_property(writer, "RunDemo", gauge.run_demo)?;
 
+    // Lossless extras: painter-specific properties (MultiChannelTrend's
+    // lt_seriesN_* overlay series, TelemetryStat's lt_target_channel) and any
+    // unrecognized properties captured at parse time. Without this, a
+    // multi-series trend written to disk silently loses every series but the
+    // first when the file is loaded back.
+    for (k, v) in &gauge.extra_attrs {
+        write_string_property(writer, k, v)?;
+    }
+
     writer.write_event(Event::End(BytesEnd::new("dashComp")))?;
     Ok(())
 }
@@ -559,6 +568,54 @@ mod tests {
         assert!(xml.contains("<Title type=\"String\">RPM</Title>"));
         assert!(xml.contains("<OutputChannel type=\"String\">rpm</OutputChannel>"));
         assert!(xml.contains("Analog Gauge"));
+    }
+
+    #[test]
+    fn gauge_extra_attrs_roundtrip() {
+        // Painter-specific gauge properties (MultiChannelTrend's lt_seriesN_*
+        // overlay series, TelemetryStat's lt_target_channel) must survive
+        // write → parse. They used to be silently dropped, which reduced
+        // every multi-series trend loaded from disk to a single series.
+        let mut dash = DashFile::default();
+        let mut gauge = GaugeConfig {
+            id: "trend".to_string(),
+            title: "Live trend".to_string(),
+            output_channel: "rpm".to_string(),
+            gauge_painter: GaugePainter::MultiChannelTrend,
+            ..Default::default()
+        };
+        gauge
+            .extra_attrs
+            .insert("lt_series2_channel".to_string(), "map".to_string());
+        gauge
+            .extra_attrs
+            .insert("lt_series2_max".to_string(), "110".to_string());
+        gauge
+            .extra_attrs
+            .insert("lt_target_channel".to_string(), "afrTarget".to_string());
+        dash.gauge_cluster
+            .components
+            .push(DashComponent::Gauge(Box::new(gauge)));
+
+        let xml = write_dash_file(&dash).unwrap();
+        let parsed = super::super::parser::parse_dash_file(&xml).unwrap();
+
+        if let DashComponent::Gauge(ref g) = parsed.gauge_cluster.components[0] {
+            assert_eq!(
+                g.extra_attrs.get("lt_series2_channel").map(String::as_str),
+                Some("map")
+            );
+            assert_eq!(
+                g.extra_attrs.get("lt_series2_max").map(String::as_str),
+                Some("110")
+            );
+            assert_eq!(
+                g.extra_attrs.get("lt_target_channel").map(String::as_str),
+                Some("afrTarget")
+            );
+        } else {
+            panic!("Expected Gauge component");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Description

Gauge-level `extra_attrs` were dropped in both directions of `.dash` file IO: the writer only emitted the **cluster's** extras (never each gauge's), and the parser discarded unrecognized gauge properties. Painter-specific configuration rides on `extra_attrs` — most visibly `MultiChannelTrend`'s `lt_seriesN_*` overlay series — so **any multi-series trend written to disk silently lost every series but the first** when the file was loaded back.

The built-in **Telemetry Live** dashboard is affected: it's delivered as a written `.ltdash.xml`, so its four "multi-series" trend panels have been rendering single-series all along.

## Changes

- **writer**: emit each gauge's `extra_attrs` as string properties inside its `dashComp`.
- **parser**: capture unrecognized gauge properties into `extra_attrs` (instead of `_ => {}`), so painter-specific attributes — and future TunerStudio property additions — survive round trips.
- **round-trip test** covering `lt_series2_*` attributes.
- Small follow-on now that series survive: the trend painter used the gauge **title** (the panel heading, e.g. "ENGINE DYNAMICS") as the primary series' legend label. Templates now pass `lt_series1_label` and the painter prefers it, then the channel name — so the legend reads `RPM 5500` rather than the panel name.

## Type of Change

- [x] Bug fix

## Testing

- New `gauge_extra_attrs_roundtrip` unit test (write → parse → assert extras survive).
- `cargo test` (346 passed), `cargo clippy --workspace -- -D warnings`, `cargo fmt --check`, `tsc --noEmit`, `vitest` (147 passed), `npm run build` all green.
- Bench-verified: a regenerated multi-series trend panel shows all three series (RPM/MAP/AFR) with correct legend labels after a save/load cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)