### PR TITLE
fix(math-channels): evaluate in dependency order — forward references read 0

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/realtime_stream.rs
+++ b/crates/libretune-app/src-tauri/src/commands/realtime_stream.rs
@@ -546,13 +546,16 @@ pub async fn start_realtime_stream(
                     let elapsed_ms = start_time.elapsed().as_millis() as u64;
                     let mut data = sim.update(elapsed_ms);
 
-                    // User Math Channels Evaluation (Demo)
+                    // User Math Channels Evaluation (Demo). Dependency order,
+                    // not stored order — a channel referencing another math
+                    // channel created after it would otherwise read 0 (#127).
                     {
                         let mut channels_guard = app_state.math_channels.lock().await;
-                        for channel in channels_guard.iter_mut() {
-                            if channel.cached_ast.is_none() {
-                                let _ = channel.compile();
-                            }
+                        let order = libretune_core::project::math_channel_evaluation_order(
+                            &mut channels_guard,
+                        );
+                        for i in order {
+                            let channel = &channels_guard[i];
                             if let Some(expr) = &channel.cached_ast {
                                 if let Ok(val) =
                                     libretune_core::ini::expression::evaluate_simple(expr, &data)
@@ -716,10 +719,14 @@ pub async fn start_realtime_stream(
                             stream_log(&format!("tick #{}: T4-math_ch", tick_count));
                         }
                         if let Ok(mut channels_guard) = app_state.math_channels.try_lock() {
-                            for channel in channels_guard.iter_mut() {
-                                if channel.cached_ast.is_none() {
-                                    let _ = channel.compile();
-                                }
+                            // Dependency order, not stored order — a channel
+                            // referencing another math channel created after
+                            // it would otherwise read 0 (#127).
+                            let order = libretune_core::project::math_channel_evaluation_order(
+                                &mut channels_guard,
+                            );
+                            for i in order {
+                                let channel = &channels_guard[i];
                                 if let Some(expr) = &channel.cached_ast {
                                     if let Ok(val) =
                                         libretune_core::ini::expression::evaluate_simple(

--- a/crates/libretune-core/src/project/math_channels.rs
+++ b/crates/libretune-core/src/project/math_channels.rs
@@ -35,6 +35,109 @@ impl UserMathChannel {
     }
 }
 
+/// Collect every `Expr::Variable` name referenced by an expression.
+fn collect_variables(expr: &Expr, out: &mut std::collections::HashSet<String>) {
+    match expr {
+        Expr::Literal(_) => {}
+        Expr::Variable(name) => {
+            out.insert(name.clone());
+        }
+        Expr::Binary(a, _, b) => {
+            collect_variables(a, out);
+            collect_variables(b, out);
+        }
+        Expr::Ternary(a, b, c) => {
+            collect_variables(a, out);
+            collect_variables(b, out);
+            collect_variables(c, out);
+        }
+        Expr::Unary(_, a) => collect_variables(a, out),
+        Expr::FunctionCall(_, args) => {
+            for a in args {
+                collect_variables(a, out);
+            }
+        }
+    }
+}
+
+/// Dependency-aware evaluation order for user math channels.
+///
+/// Channels are evaluated by inserting each result into the shared value map,
+/// so a channel can only see the channels evaluated before it. Iterating in
+/// stored (creation) order makes a forward reference — a channel referencing
+/// another math channel created after it — silently read 0 forever (issue
+/// #127). This returns indices in dependency order (Kahn's algorithm, stable
+/// with respect to stored order among ready channels), so creation order no
+/// longer matters. Channels involved in a reference cycle can't be ordered;
+/// they are appended in stored order, which matches the old behavior for
+/// exactly that unresolvable case.
+///
+/// Compiles any channel whose AST isn't cached yet (same as the evaluation
+/// loops did); channels that fail to compile have no dependencies.
+pub fn math_channel_evaluation_order(channels: &mut [UserMathChannel]) -> Vec<usize> {
+    use std::collections::{HashMap, HashSet};
+
+    let n = channels.len();
+    if n <= 1 {
+        return (0..n).collect();
+    }
+
+    for ch in channels.iter_mut() {
+        if ch.cached_ast.is_none() {
+            let _ = ch.compile();
+        }
+    }
+
+    let index_by_name: HashMap<&str, usize> = channels
+        .iter()
+        .enumerate()
+        .map(|(i, c)| (c.name.as_str(), i))
+        .collect();
+
+    // deps[i] = indices of math channels that channel i references.
+    let mut deps: Vec<HashSet<usize>> = vec![HashSet::new(); n];
+    for (i, ch) in channels.iter().enumerate() {
+        if let Some(expr) = &ch.cached_ast {
+            let mut vars = HashSet::new();
+            collect_variables(expr, &mut vars);
+            for v in vars {
+                if let Some(&j) = index_by_name.get(v.as_str()) {
+                    if j != i {
+                        deps[i].insert(j);
+                    }
+                }
+            }
+        }
+    }
+
+    // Kahn's algorithm, scanning in stored order each round so the result is
+    // deterministic and matches stored order whenever dependencies allow.
+    let mut ordered = Vec::with_capacity(n);
+    let mut placed = vec![false; n];
+    loop {
+        let mut progressed = false;
+        for i in 0..n {
+            if !placed[i] && deps[i].iter().all(|&j| placed[j]) {
+                placed[i] = true;
+                ordered.push(i);
+                progressed = true;
+            }
+        }
+        if !progressed {
+            break;
+        }
+    }
+
+    // Anything left is part of a reference cycle: append in stored order.
+    for (i, done) in placed.iter().enumerate() {
+        if !done {
+            ordered.push(i);
+        }
+    }
+
+    ordered
+}
+
 pub fn save_math_channels(path: &Path, channels: &[UserMathChannel]) -> Result<(), String> {
     let json = serde_json::to_string_pretty(channels).map_err(|e| e.to_string())?;
     fs::write(path, json).map_err(|e| e.to_string())
@@ -79,6 +182,78 @@ mod tests {
     fn test_invalid_expression() {
         let mut ch = UserMathChannel::new("bad".to_string(), "".to_string(), "map + ".to_string());
         assert!(ch.compile().is_err());
+    }
+
+    fn ch(name: &str, expr: &str) -> UserMathChannel {
+        UserMathChannel::new(name.to_string(), String::new(), expr.to_string())
+    }
+
+    #[test]
+    fn forward_reference_evaluates_dependency_first() {
+        // The issue #127 repro: Boost_Warn created BEFORE Boost_PSI, but it
+        // references Boost_PSI — so Boost_PSI must be evaluated first.
+        let mut channels = vec![
+            ch("Boost_Warn", "Boost_PSI > 5 ? 1 : 0"),
+            ch("Boost_PSI", "(map - 100) * 0.145"),
+        ];
+        let order = math_channel_evaluation_order(&mut channels);
+        assert_eq!(order, vec![1, 0]);
+
+        // And evaluating in that order actually produces the right values.
+        let mut data = std::collections::HashMap::from([("map".to_string(), 150.0)]);
+        for &i in &order {
+            let expr = channels[i].cached_ast.as_ref().unwrap();
+            let v = crate::ini::expression::evaluate_simple(expr, &data)
+                .unwrap()
+                .as_f64();
+            data.insert(channels[i].name.clone(), v);
+        }
+        assert!((data["Boost_PSI"] - 7.25).abs() < 1e-9);
+        assert_eq!(data["Boost_Warn"], 1.0);
+    }
+
+    #[test]
+    fn chain_orders_transitively_and_independents_keep_stored_order() {
+        // c -> b -> a defined in reverse; x is independent and stays put
+        // relative to its dependency-free peers.
+        let mut channels = vec![
+            ch("c", "b + 1"),
+            ch("x", "map * 2"),
+            ch("b", "a + 1"),
+            ch("a", "rpm / 100"),
+        ];
+        let order = math_channel_evaluation_order(&mut channels);
+        let pos = |name: &str| {
+            order
+                .iter()
+                .position(|&i| channels[i].name == name)
+                .unwrap()
+        };
+        assert!(pos("a") < pos("b"));
+        assert!(pos("b") < pos("c"));
+        // x has no deps: it must come before the channels that wait on others.
+        assert!(pos("x") < pos("b"));
+    }
+
+    #[test]
+    fn cycle_falls_back_to_stored_order_without_losing_channels() {
+        let mut channels = vec![ch("p", "q + 1"), ch("q", "p + 1"), ch("solo", "rpm")];
+        let order = math_channel_evaluation_order(&mut channels);
+        // Every channel appears exactly once.
+        let mut seen = order.clone();
+        seen.sort_unstable();
+        assert_eq!(seen, vec![0, 1, 2]);
+        // solo is orderable and comes first; the cycle keeps stored order.
+        assert_eq!(order, vec![2, 0, 1]);
+    }
+
+    #[test]
+    fn invalid_expression_still_included_in_order() {
+        let mut channels = vec![ch("bad", "map + "), ch("good", "rpm * 2")];
+        let order = math_channel_evaluation_order(&mut channels);
+        let mut seen = order.clone();
+        seen.sort_unstable();
+        assert_eq!(seen, vec![0, 1]);
     }
 
     #[test]

--- a/crates/libretune-core/src/project/mod.rs
+++ b/crates/libretune-core/src/project/mod.rs
@@ -29,7 +29,9 @@ mod properties;
 mod repository;
 mod version_control;
 
-pub use math_channels::{load_math_channels, save_math_channels, UserMathChannel};
+pub use math_channels::{
+    load_math_channels, math_channel_evaluation_order, save_math_channels, UserMathChannel,
+};
 pub use online_repository::{IniSource, OnlineIniEntry, OnlineIniRepository};
 pub use project::{
     ConnectionSettings, Project, ProjectConfig, ProjectInfo, ProjectSettings, RestorePointInfo,


### PR DESCRIPTION
## Description

Fixes #127.

User math channels were evaluated in stored (creation) order, with each result inserted into the shared value map — so a channel could only see channels positioned **before** it. Creating `Boost_Warn` (referencing `Boost_PSI`) before creating `Boost_PSI` meant `Boost_Warn` silently read `0` on every tick, forever, with no error and a green "Valid expression" in the dialog. The in-app manual promises the opposite:

> "The Evaluator determines the correct order of operations automatically. You do not need to manually order channels."

## Changes

- New `math_channel_evaluation_order` in `libretune-core`: walks each channel's compiled AST for referenced math-channel names and produces a **stable topological order** (Kahn's algorithm; stored order preserved wherever dependencies allow, so existing setups don't reshuffle).
- Reference **cycles** can't be ordered — the cyclic remainder is appended in stored order, which matches the old behavior for exactly that unresolvable case (no channel is ever dropped).
- Both evaluation loops (demo mode and live serial in `realtime_stream.rs`) now evaluate in that order.

## Type of Change

- [x] Bug fix

## Testing

- 4 new unit tests, including the exact issue repro (`Boost_Warn` before `Boost_PSI` → orders PSI first and `Boost_Warn` evaluates to 1), a transitive chain defined in reverse, a cycle (all channels kept, stored order), and an invalid expression (still included).
- `cargo test` (349 passed), `cargo clippy --workspace -- -D warnings`, `cargo fmt --check`, `tsc --noEmit`, `vitest` (147 passed), `npm run build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)