### PR TITLE
fix(ini): evaluate StringContext for gauge titles and display strings

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/demo.rs
+++ b/crates/libretune-app/src-tauri/src/commands/demo.rs
@@ -225,6 +225,8 @@ mod demo_mode_tests {
             math_channels: Mutex::new(Vec::new()),
             stream_stats: Mutex::new(StreamStats::default()),
             agent_task: Mutex::new(None),
+            app_start_epoch: AppState::process_start_epoch(),
+            inc_table_cache: AppState::new_inc_table_cache(),
         };
 
         let dev_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))

--- a/crates/libretune-app/src-tauri/src/commands/ini_dialogs.rs
+++ b/crates/libretune-app/src-tauri/src/commands/ini_dialogs.rs
@@ -1,7 +1,9 @@
 //! INI dialog/indicator/port-editor/help/expression query commands.
 
+use crate::commands::string_context::build_string_context;
 use crate::port_editor::{load_port_editor_store, save_port_editor_store, PortEditorAssignment};
 use crate::state::AppState;
+use libretune_core::ini::expression::{evaluate, evaluate_display_string, Parser};
 use libretune_core::ini::{DialogDefinition, HelpTopic};
 use std::collections::HashMap;
 
@@ -17,14 +19,30 @@ use std::collections::HashMap;
 /// Returns: Boolean result of expression evaluation
 #[tauri::command]
 pub async fn evaluate_expression(
-    _state: tauri::State<'_, AppState>,
+    state: tauri::State<'_, AppState>,
     expression: String,
     context: HashMap<String, f64>,
 ) -> Result<bool, String> {
-    let mut parser = libretune_core::ini::expression::Parser::new(&expression);
+    let string_ctx = build_string_context(&state).await;
+    let mut parser = Parser::new(&expression);
     let expr = parser.parse()?;
-    let val = libretune_core::ini::expression::evaluate_simple(&expr, &context)?;
+    let val = evaluate(&expr, &context, Some(&string_ctx))?;
     Ok(val.as_bool())
+}
+
+/// Evaluate a display string that may be a braced INI expression (e.g. gauge titles).
+#[tauri::command]
+pub async fn evaluate_string_expression(
+    state: tauri::State<'_, AppState>,
+    expression: String,
+    context: HashMap<String, f64>,
+) -> Result<String, String> {
+    let string_ctx = build_string_context(&state).await;
+    Ok(evaluate_display_string(
+        &expression,
+        &context,
+        Some(&string_ctx),
+    ))
 }
 
 /// Retrieves a dialog definition from the INI file.

--- a/crates/libretune-app/src-tauri/src/commands/ini_meta.rs
+++ b/crates/libretune-app/src-tauri/src/commands/ini_meta.rs
@@ -1,6 +1,8 @@
 //! INI metadata commands (tables, curves, frontpage, gauges).
 
+use crate::commands::string_context::{build_string_context, numeric_context_from_tune};
 use crate::state::AppState;
+use libretune_core::ini::expression::evaluate_display_string;
 use serde::Serialize;
 
 #[derive(Serialize)]
@@ -108,6 +110,12 @@ pub(crate) struct FrontPageInfo {
 pub async fn get_frontpage(
     state: tauri::State<'_, AppState>,
 ) -> Result<Option<FrontPageInfo>, String> {
+    let string_ctx = build_string_context(&state).await;
+    let numeric = {
+        let tune = state.current_tune.lock().await;
+        numeric_context_from_tune(tune.as_ref())
+    };
+
     let def_guard = state.definition.lock().await;
     let def = def_guard.as_ref().ok_or("Definition not loaded")?;
 
@@ -118,8 +126,8 @@ pub async fn get_frontpage(
             .iter()
             .map(|ind| FrontPageIndicatorInfo {
                 expression: ind.expression.clone(),
-                label_off: ind.label_off.clone(),
-                label_on: ind.label_on.clone(),
+                label_off: evaluate_display_string(&ind.label_off, &numeric, Some(&string_ctx)),
+                label_on: evaluate_display_string(&ind.label_on, &numeric, Some(&string_ctx)),
                 bg_off: libretune_core::ini::FrontPageIndicator::color_to_css(&ind.bg_off),
                 fg_off: libretune_core::ini::FrontPageIndicator::color_to_css(&ind.fg_off),
                 bg_on: libretune_core::ini::FrontPageIndicator::color_to_css(&ind.bg_on),
@@ -185,12 +193,13 @@ fn gauge_expr_context(
 fn gauge_to_info(
     g: &libretune_core::ini::GaugeConfig,
     ctx: &std::collections::HashMap<String, f64>,
+    string_ctx: &libretune_core::ini::expression::StringContext,
 ) -> GaugeInfo {
     GaugeInfo {
         name: g.name.clone(),
         channel: g.channel.clone(),
-        title: g.title.clone(),
-        units: g.units.clone(),
+        title: evaluate_display_string(&g.title, ctx, Some(string_ctx)),
+        units: evaluate_display_string(&g.units, ctx, Some(string_ctx)),
         lo: resolve_gauge_field(g.lo, g.lo_expr.as_deref(), ctx),
         hi: resolve_gauge_field(g.hi, g.hi_expr.as_deref(), ctx),
         low_warning: resolve_gauge_field(g.low_warning, g.low_warning_expr.as_deref(), ctx),
@@ -205,6 +214,8 @@ fn gauge_to_info(
 pub async fn get_gauge_configs(
     state: tauri::State<'_, AppState>,
 ) -> Result<Vec<GaugeInfo>, String> {
+    let string_ctx = build_string_context(&state).await;
+
     let def_guard = state.definition.lock().await;
     let def = def_guard.as_ref().ok_or("Definition not loaded")?;
     // Same lock order as get_all_constant_values: definition → cache → tune.
@@ -215,7 +226,7 @@ pub async fn get_gauge_configs(
     let gauges: Vec<GaugeInfo> = def
         .gauges
         .values()
-        .map(|g| gauge_to_info(g, &ctx))
+        .map(|g| gauge_to_info(g, &ctx, &string_ctx))
         .collect();
     Ok(gauges)
 }
@@ -226,6 +237,8 @@ pub async fn get_gauge_config(
     state: tauri::State<'_, AppState>,
     gauge_name: String,
 ) -> Result<GaugeInfo, String> {
+    let string_ctx = build_string_context(&state).await;
+
     let def_guard = state.definition.lock().await;
     let def = def_guard.as_ref().ok_or("Definition not loaded")?;
 
@@ -239,5 +252,5 @@ pub async fn get_gauge_config(
     let tune_guard = state.current_tune.lock().await;
     let ctx = gauge_expr_context(def, tune_guard.as_ref(), cache_guard.as_ref());
 
-    Ok(gauge_to_info(gauge, &ctx))
+    Ok(gauge_to_info(gauge, &ctx, &string_ctx))
 }

--- a/crates/libretune-app/src-tauri/src/commands/load_ini.rs
+++ b/crates/libretune-app/src-tauri/src/commands/load_ini.rs
@@ -3,6 +3,7 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use crate::commands::string_context::refresh_inc_table_paths;
 use crate::paths::get_definitions_dir;
 use crate::{load_settings, save_settings, AppState};
 use libretune_core::ini::EcuDefinition;
@@ -44,6 +45,20 @@ pub async fn load_ini(
             let mut guard = state.definition.lock().await;
             *guard = Some(def);
             drop(guard);
+
+            {
+                let project_path = state
+                    .current_project
+                    .lock()
+                    .await
+                    .as_ref()
+                    .map(|p| p.path.clone());
+                refresh_inc_table_paths(
+                    &state.inc_table_cache,
+                    project_path.as_ref(),
+                    Some(get_definitions_dir(&app)),
+                );
+            }
 
             // An in-progress recording's channels were resolved against the
             // OLD definition — stop it rather than silently mixing

--- a/crates/libretune-app/src-tauri/src/commands/menu.rs
+++ b/crates/libretune-app/src-tauri/src/commands/menu.rs
@@ -1,6 +1,8 @@
 //! Menu tree and searchable index commands.
 
+use crate::commands::string_context::build_string_context;
 use crate::state::AppState;
+use libretune_core::ini::expression::StringContext;
 use libretune_core::ini::{Menu, MenuItem};
 use std::collections::HashMap;
 
@@ -9,6 +11,7 @@ pub async fn get_menu_tree(
     state: tauri::State<'_, AppState>,
     filter_context: Option<HashMap<String, f64>>,
 ) -> Result<Vec<Menu>, String> {
+    let string_ctx = build_string_context(&state).await;
     let def_guard = state.definition.lock().await;
     let def = def_guard.as_ref().ok_or("Definition not loaded")?;
 
@@ -17,7 +20,7 @@ pub async fn get_menu_tree(
     if let Some(context) = filter_context {
         let mut all_menus = Vec::new();
         for menu in &def.menus {
-            let items_with_flags = add_visibility_flags(&menu.items, &context);
+            let items_with_flags = add_visibility_flags(&menu.items, &context, &string_ctx);
             all_menus.push(Menu {
                 name: menu.name.clone(),
                 title: menu.title.clone(),
@@ -31,7 +34,11 @@ pub async fn get_menu_tree(
 }
 
 /// Recursively add visibility/enabled flags to menu items without filtering them out
-fn add_visibility_flags(items: &[MenuItem], context: &HashMap<String, f64>) -> Vec<MenuItem> {
+fn add_visibility_flags(
+    items: &[MenuItem],
+    context: &HashMap<String, f64>,
+    string_ctx: &StringContext,
+) -> Vec<MenuItem> {
     items
         .iter()
         .map(|item| {
@@ -43,8 +50,8 @@ fn add_visibility_flags(items: &[MenuItem], context: &HashMap<String, f64>) -> V
                     enabled_condition,
                     ..
                 } => {
-                    let visible = evaluate_visibility(visibility_condition, context);
-                    let enabled = evaluate_visibility(enabled_condition, context);
+                    let visible = evaluate_visibility(visibility_condition, context, string_ctx);
+                    let enabled = evaluate_visibility(enabled_condition, context, string_ctx);
                     MenuItem::Dialog {
                         label: label.clone(),
                         target: target.clone(),
@@ -61,8 +68,8 @@ fn add_visibility_flags(items: &[MenuItem], context: &HashMap<String, f64>) -> V
                     enabled_condition,
                     ..
                 } => {
-                    let visible = evaluate_visibility(visibility_condition, context);
-                    let enabled = evaluate_visibility(enabled_condition, context);
+                    let visible = evaluate_visibility(visibility_condition, context, string_ctx);
+                    let enabled = evaluate_visibility(enabled_condition, context, string_ctx);
                     MenuItem::Table {
                         label: label.clone(),
                         target: target.clone(),
@@ -79,10 +86,10 @@ fn add_visibility_flags(items: &[MenuItem], context: &HashMap<String, f64>) -> V
                     enabled_condition,
                     ..
                 } => {
-                    let visible = evaluate_visibility(visibility_condition, context);
-                    let enabled = evaluate_visibility(enabled_condition, context);
+                    let visible = evaluate_visibility(visibility_condition, context, string_ctx);
+                    let enabled = evaluate_visibility(enabled_condition, context, string_ctx);
                     // Recursively process children
-                    let children_with_flags = add_visibility_flags(sub_items, context);
+                    let children_with_flags = add_visibility_flags(sub_items, context, string_ctx);
                     MenuItem::SubMenu {
                         label: label.clone(),
                         items: children_with_flags,
@@ -99,8 +106,8 @@ fn add_visibility_flags(items: &[MenuItem], context: &HashMap<String, f64>) -> V
                     enabled_condition,
                     ..
                 } => {
-                    let visible = evaluate_visibility(visibility_condition, context);
-                    let enabled = evaluate_visibility(enabled_condition, context);
+                    let visible = evaluate_visibility(visibility_condition, context, string_ctx);
+                    let enabled = evaluate_visibility(enabled_condition, context, string_ctx);
                     MenuItem::Std {
                         label: label.clone(),
                         target: target.clone(),
@@ -117,8 +124,8 @@ fn add_visibility_flags(items: &[MenuItem], context: &HashMap<String, f64>) -> V
                     enabled_condition,
                     ..
                 } => {
-                    let visible = evaluate_visibility(visibility_condition, context);
-                    let enabled = evaluate_visibility(enabled_condition, context);
+                    let visible = evaluate_visibility(visibility_condition, context, string_ctx);
+                    let enabled = evaluate_visibility(enabled_condition, context, string_ctx);
                     MenuItem::Help {
                         label: label.clone(),
                         target: target.clone(),
@@ -135,11 +142,17 @@ fn add_visibility_flags(items: &[MenuItem], context: &HashMap<String, f64>) -> V
 }
 
 /// Evaluate visibility condition - returns true if visible (or on error/missing condition)
-fn evaluate_visibility(condition: &Option<String>, context: &HashMap<String, f64>) -> bool {
+fn evaluate_visibility(
+    condition: &Option<String>,
+    context: &HashMap<String, f64>,
+    string_ctx: &StringContext,
+) -> bool {
     if let Some(cond) = condition {
         let mut parser = libretune_core::ini::expression::Parser::new(cond);
         if let Ok(expr) = parser.parse() {
-            if let Ok(val) = libretune_core::ini::expression::evaluate_simple(&expr, context) {
+            if let Ok(val) =
+                libretune_core::ini::expression::evaluate(&expr, context, Some(string_ctx))
+            {
                 return val.as_bool();
             }
         }

--- a/crates/libretune-app/src-tauri/src/commands/mod.rs
+++ b/crates/libretune-app/src-tauri/src/commands/mod.rs
@@ -60,6 +60,7 @@ pub mod save_tune;
 pub mod settings;
 pub mod signature_helpers;
 pub mod start_autotune;
+pub mod string_context;
 pub mod sync_ecu_data;
 pub mod system;
 pub mod table_compare;

--- a/crates/libretune-app/src-tauri/src/commands/realtime_stream.rs
+++ b/crates/libretune-app/src-tauri/src/commands/realtime_stream.rs
@@ -443,6 +443,8 @@ pub async fn start_realtime_stream(
         // For demo mode, create a simulator
         let mut demo_simulator: Option<DemoSimulator> = None;
         let start_time = std::time::Instant::now();
+        let mut string_ctx =
+            crate::commands::string_context::build_string_context(&app_state).await;
 
         // Cache output channels + endianness once before the loop.
         // These don't change during a session so there's no need to re-lock every tick.
@@ -522,6 +524,10 @@ pub async fn start_realtime_stream(
             ticker.tick().await;
             tick_count += 1;
             local_ticks_total += 1;
+            if tick_count.is_multiple_of(20) {
+                string_ctx =
+                    crate::commands::string_context::build_string_context(&app_state).await;
+            }
 
             // Trace: log which phase we're in so we can find deadlocks
             if tick_count <= 25 || tick_count.is_multiple_of(20) {
@@ -557,9 +563,11 @@ pub async fn start_realtime_stream(
                         for i in order {
                             let channel = &channels_guard[i];
                             if let Some(expr) = &channel.cached_ast {
-                                if let Ok(val) =
-                                    libretune_core::ini::expression::evaluate_simple(expr, &data)
-                                {
+                                if let Ok(val) = libretune_core::ini::expression::evaluate(
+                                    expr,
+                                    &data,
+                                    Some(&string_ctx),
+                                ) {
                                     data.insert(channel.name.clone(), val.as_f64());
                                 }
                             }
@@ -709,7 +717,12 @@ pub async fn start_realtime_stream(
 
                         // Pass 2: Evaluate computed channels using parsed values as context
                         for (name, channel) in computed_channels {
-                            if let Some(val) = channel.parse_with_context(raw, *endianness, &data) {
+                            if let Some(val) = channel.parse_with_contexts(
+                                raw,
+                                *endianness,
+                                &data,
+                                Some(&string_ctx),
+                            ) {
                                 data.insert(name, val);
                             }
                         }
@@ -728,11 +741,11 @@ pub async fn start_realtime_stream(
                             for i in order {
                                 let channel = &channels_guard[i];
                                 if let Some(expr) = &channel.cached_ast {
-                                    if let Ok(val) =
-                                        libretune_core::ini::expression::evaluate_simple(
-                                            expr, &data,
-                                        )
-                                    {
+                                    if let Ok(val) = libretune_core::ini::expression::evaluate(
+                                        expr,
+                                        &data,
+                                        Some(&string_ctx),
+                                    ) {
                                         data.insert(channel.name.clone(), val.as_f64());
                                     }
                                 }
@@ -909,6 +922,8 @@ mod stale_definition_guard_tests {
             math_channels: Mutex::new(Vec::new()),
             stream_stats: Mutex::new(StreamStats::default()),
             agent_task: Mutex::new(None),
+            app_start_epoch: AppState::process_start_epoch(),
+            inc_table_cache: AppState::new_inc_table_cache(),
         }
     }
 

--- a/crates/libretune-app/src-tauri/src/commands/string_context.rs
+++ b/crates/libretune-app/src-tauri/src/commands/string_context.rs
@@ -1,0 +1,229 @@
+//! Build a snapshot-based [`StringContext`] for INI expression evaluation.
+
+use crate::state::AppState;
+use libretune_core::ini::expression::StringContext;
+use libretune_core::ini::{DataType, EcuDefinition, IncTableCache};
+use libretune_core::project::Project;
+use libretune_core::protocol::ConnectionState;
+use libretune_core::tune::{TuneFile, TuneValue};
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+/// Refresh `.inc` search paths from the current project + definitions dirs.
+pub fn refresh_inc_table_paths(
+    cache: &Mutex<IncTableCache>,
+    project_path: Option<&PathBuf>,
+    definitions_dir: Option<PathBuf>,
+) {
+    let Ok(mut cache) = cache.lock() else {
+        return;
+    };
+    cache.clear();
+    if let Some(path) = project_path {
+        cache.add_search_path(path.clone());
+    }
+    if let Some(dir) = definitions_dir {
+        cache.add_search_path(dir);
+    }
+}
+
+/// Build a numeric evaluation context from tune scalar/bool constants.
+pub fn numeric_context_from_tune(tune: Option<&TuneFile>) -> HashMap<String, f64> {
+    let mut context = HashMap::new();
+    let Some(tune) = tune else {
+        return context;
+    };
+    for (name, value) in &tune.constants {
+        match value {
+            TuneValue::Scalar(n) => {
+                context.insert(name.clone(), *n);
+            }
+            TuneValue::Bool(b) => {
+                context.insert(name.clone(), if *b { 1.0 } else { 0.0 });
+            }
+            TuneValue::Array(arr) if !arr.is_empty() => {
+                // Index expressions often reference the constant name for the first bin.
+                context.insert(name.clone(), arr[0]);
+            }
+            _ => {}
+        }
+    }
+    for (name, value) in &tune.pc_variables {
+        match value {
+            TuneValue::Scalar(n) => {
+                context.insert(name.clone(), *n);
+            }
+            TuneValue::Bool(b) => {
+                context.insert(name.clone(), if *b { 1.0 } else { 0.0 });
+            }
+            _ => {}
+        }
+    }
+    context
+}
+
+fn string_map_from_tune(
+    tune: Option<&TuneFile>,
+    def: Option<&EcuDefinition>,
+) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+    let Some(tune) = tune else {
+        return map;
+    };
+    for (name, value) in &tune.constants {
+        if let TuneValue::String(s) = value {
+            let is_string_const = def
+                .and_then(|d| d.constants.get(name))
+                .map(|c| c.data_type == DataType::String)
+                .unwrap_or(false);
+            if is_string_const {
+                map.insert(name.clone(), s.clone());
+            }
+        }
+    }
+    map
+}
+
+fn bit_options_map(def: Option<&EcuDefinition>) -> HashMap<String, Vec<String>> {
+    let mut map = HashMap::new();
+    let Some(def) = def else {
+        return map;
+    };
+    for (name, constant) in &def.constants {
+        if !constant.bit_options.is_empty() {
+            map.insert(name.clone(), constant.bit_options.clone());
+        }
+    }
+    map
+}
+
+fn array_map_from_tune(tune: Option<&TuneFile>) -> HashMap<String, Vec<f64>> {
+    let mut map = HashMap::new();
+    let Some(tune) = tune else {
+        return map;
+    };
+    for (name, value) in &tune.constants {
+        if let TuneValue::Array(arr) = value {
+            map.insert(name.clone(), arr.clone());
+        }
+    }
+    map
+}
+
+fn interpolate_array(values: &[f64], index: f64) -> Option<f64> {
+    if values.is_empty() {
+        return None;
+    }
+    if index <= 0.0 {
+        return Some(values[0]);
+    }
+    let max_idx = (values.len() - 1) as f64;
+    if index >= max_idx {
+        return Some(values[values.len() - 1]);
+    }
+    let lo = index.floor() as usize;
+    let hi = lo + 1;
+    let t = index - lo as f64;
+    Some(values[lo] + t * (values[hi] - values[lo]))
+}
+
+/// Snapshot AppState into a [`StringContext`] (closures hold owned data / Arcs).
+pub async fn build_string_context(state: &AppState) -> StringContext {
+    let def_guard = state.definition.lock().await;
+    let tune_guard = state.current_tune.lock().await;
+    let project_guard = state.current_project.lock().await;
+    let conn_guard = state.connection.lock().await;
+    let demo = *state.demo_mode.lock().await;
+    let streaming = state.streaming_task.lock().await.is_some();
+
+    let string_values = string_map_from_tune(tune_guard.as_ref(), def_guard.as_ref());
+    let bit_options = bit_options_map(def_guard.as_ref());
+    let arrays = array_map_from_tune(tune_guard.as_ref());
+
+    let projects_dir = Project::projects_dir()
+        .map(|p| p.display().to_string())
+        .unwrap_or_default();
+    let working_dir = project_guard
+        .as_ref()
+        .map(|p| p.path.display().to_string())
+        .unwrap_or_default();
+
+    let is_online = demo && streaming
+        || conn_guard
+            .as_ref()
+            .map(|c| c.state() == ConnectionState::Connected)
+            .unwrap_or(false);
+
+    let start_time = state.app_start_epoch;
+    let cache = Arc::clone(&state.inc_table_cache);
+
+    drop(conn_guard);
+    drop(project_guard);
+    drop(tune_guard);
+    drop(def_guard);
+
+    let mut ctx = StringContext {
+        start_time: Some(start_time),
+        ..Default::default()
+    };
+
+    ctx.get_string_value = Some(Box::new(move |name| string_values.get(name).cloned()));
+    ctx.get_bit_options = Some(Box::new(move |name| bit_options.get(name).cloned()));
+    ctx.get_projects_dir = Some(Box::new(move || projects_dir.clone()));
+    ctx.get_working_dir = Some(Box::new(move || working_dir.clone()));
+    ctx.is_online = Some(Box::new(move || is_online));
+    ctx.array_value = Some(Box::new(move |name, index| {
+        arrays.get(name).and_then(|v| interpolate_array(v, index))
+    }));
+    ctx.table_lookup = Some(Box::new(move |filename, lookup| {
+        let Ok(mut cache) = cache.lock() else {
+            return None;
+        };
+        cache
+            .get_or_load(filename)
+            .and_then(|table| table.lookup(lookup))
+    }));
+
+    ctx
+}
+
+/// Build context from already-held definition/tune snapshots (no AppState locks).
+#[allow(dead_code)]
+pub fn build_string_context_from_parts(
+    def: Option<&EcuDefinition>,
+    tune: Option<&TuneFile>,
+    working_dir: String,
+    is_online: bool,
+    start_time: f64,
+    cache: Arc<Mutex<IncTableCache>>,
+) -> StringContext {
+    let string_values = string_map_from_tune(tune, def);
+    let bit_options = bit_options_map(def);
+    let arrays = array_map_from_tune(tune);
+    let projects_dir = Project::projects_dir()
+        .map(|p| p.display().to_string())
+        .unwrap_or_default();
+
+    let mut ctx = StringContext {
+        start_time: Some(start_time),
+        ..Default::default()
+    };
+    ctx.get_string_value = Some(Box::new(move |name| string_values.get(name).cloned()));
+    ctx.get_bit_options = Some(Box::new(move |name| bit_options.get(name).cloned()));
+    ctx.get_projects_dir = Some(Box::new(move || projects_dir.clone()));
+    ctx.get_working_dir = Some(Box::new(move || working_dir.clone()));
+    ctx.is_online = Some(Box::new(move || is_online));
+    ctx.array_value = Some(Box::new(move |name, index| {
+        arrays.get(name).and_then(|v| interpolate_array(v, index))
+    }));
+    ctx.table_lookup = Some(Box::new(move |filename, lookup| {
+        let Ok(mut cache) = cache.lock() else {
+            return None;
+        };
+        cache
+            .get_or_load(filename)
+            .and_then(|table| table.lookup(lookup))
+    }));
+    ctx
+}

--- a/crates/libretune-app/src-tauri/src/commands/table_internals.rs
+++ b/crates/libretune-app/src-tauri/src/commands/table_internals.rs
@@ -1,7 +1,9 @@
 //! TableData struct and internal table helpers (extracted from lib.rs).
 
-use crate::{clean_axis_label, AppState};
+use crate::commands::string_context::{build_string_context, numeric_context_from_tune};
+use crate::state::AppState;
 use libretune_core::dynamic_table::{self, TableSizeInfo};
+use libretune_core::ini::expression::evaluate_display_string;
 use libretune_core::ini::Constant;
 use libretune_core::tune::{TuneFile, TuneValue};
 use serde::Serialize;
@@ -224,14 +226,20 @@ pub(crate) async fn get_table_data_internal(
         None
     };
 
+    let string_ctx = build_string_context(state).await;
+    let numeric = {
+        let tune = state.current_tune.lock().await;
+        numeric_context_from_tune(tune.as_ref())
+    };
+
     Ok(TableData {
         name: table_name_out,
         title: table_title,
         x_bins,
         y_bins,
         z_values,
-        x_axis_name: clean_axis_label(&x_label),
-        y_axis_name: clean_axis_label(&y_label),
+        x_axis_name: evaluate_display_string(&x_label, &numeric, Some(&string_ctx)),
+        y_axis_name: evaluate_display_string(&y_label, &numeric, Some(&string_ctx)),
         x_output_channel,
         y_output_channel,
         size_info,

--- a/crates/libretune-app/src-tauri/src/commands/util_helpers.rs
+++ b/crates/libretune-app/src-tauri/src/commands/util_helpers.rs
@@ -24,38 +24,6 @@ pub(crate) fn bit_mask_u8(bits: u8) -> u8 {
     }
 }
 
-/// Clean up INI expression labels for display
-/// Converts expressions like `{bitStringValue(pwmAxisLabels, gppwm1_loadAxis)}`
-/// to a readable fallback like `gppwm1_loadAxis`
-pub(crate) fn clean_axis_label(label: &str) -> String {
-    let trimmed = label.trim();
-
-    // If it's an expression (starts with {), try to extract meaningful part
-    if trimmed.starts_with('{') && trimmed.ends_with('}') {
-        // Extract content inside braces
-        let inner = &trimmed[1..trimmed.len() - 1];
-
-        // Check for bitStringValue(list, index) pattern
-        if inner.starts_with("bitStringValue(") {
-            // Extract the second parameter (the index variable name)
-            if let Some(comma_pos) = inner.find(',') {
-                let second_part = inner[comma_pos + 1..].trim();
-                // Remove trailing ) if present
-                let name = second_part.trim_end_matches(')').trim();
-                if !name.is_empty() {
-                    return name.to_string();
-                }
-            }
-        }
-
-        // Fallback: just return the inner content without braces
-        return inner.to_string();
-    }
-
-    // Not an expression, return as-is
-    trimmed.to_string()
-}
-
 /// Helper to write stream diagnostic logs to /tmp/libretune-stream.log
 pub(crate) fn stream_log(msg: &str) {
     use std::io::Write;

--- a/crates/libretune-app/src-tauri/src/lib.rs
+++ b/crates/libretune-app/src-tauri/src/lib.rs
@@ -33,8 +33,8 @@ pub(crate) use commands::types::{
     MatchingIniInfo, SignatureMatchType, SignatureMismatchInfo, SyncProgress, SyncResult,
 };
 pub(crate) use commands::util_helpers::{
-    clean_axis_label, get_conn_lock_holder, parse_runtime_packet_mode, read_raw_value,
-    set_conn_lock_holder, stream_log,
+    get_conn_lock_holder, parse_runtime_packet_mode, read_raw_value, set_conn_lock_holder,
+    stream_log,
 };
 
 // Tauri command imports — sorted alphabetically by module name.
@@ -102,8 +102,9 @@ use commands::hotkeys::{
     get_hotkey_bindings, is_onboarding_completed, mark_onboarding_completed, save_hotkey_bindings,
 };
 use commands::ini_dialogs::{
-    evaluate_expression, get_dialog_definition, get_help_topic, get_indicator_panel,
-    get_port_editor, get_port_editor_assignments, get_readout_panel, save_port_editor_assignments,
+    evaluate_expression, evaluate_string_expression, get_dialog_definition, get_help_topic,
+    get_indicator_panel, get_port_editor, get_port_editor_assignments, get_readout_panel,
+    save_port_editor_assignments,
 };
 use commands::ini_meta::{
     get_curves, get_frontpage, get_gauge_config, get_gauge_configs, get_tables,
@@ -218,6 +219,8 @@ pub fn run() {
             math_channels: Mutex::new(Vec::new()),
             stream_stats: Mutex::new(StreamStats::default()),
             agent_task: Mutex::new(None),
+            app_start_epoch: AppState::process_start_epoch(),
+            inc_table_cache: AppState::new_inc_table_cache(),
         })
         .invoke_handler(tauri::generate_handler![
             get_serial_ports,
@@ -280,6 +283,7 @@ pub fn run() {
             update_constant,
             auto_load_last_ini,
             evaluate_expression,
+            evaluate_string_expression,
             get_all_constant_values,
             start_autotune,
             stop_autotune,

--- a/crates/libretune-app/src-tauri/src/state.rs
+++ b/crates/libretune-app/src-tauri/src/state.rs
@@ -10,7 +10,9 @@ use libretune_core::autotune::{
     AutoTuneState,
 };
 use libretune_core::datalog::DataLogger;
-use libretune_core::ini::{EcuDefinition, Endianness, OutputChannel, ProtocolSettings};
+use libretune_core::ini::{
+    EcuDefinition, Endianness, IncTableCache, OutputChannel, ProtocolSettings,
+};
 use libretune_core::plugin_system::PluginManager as WasmPluginManager;
 use libretune_core::project::{IniRepository, OnlineIniRepository, Project, UserMathChannel};
 use libretune_core::protocol::{Connection, ConnectionConfig};
@@ -208,6 +210,25 @@ pub struct AppState {
     /// JoinHandle for the currently-running AI assistant turn (if any).
     /// Aborted by `agent_stop` to cancel an in-flight LLM request.
     pub agent_task: Mutex<Option<tokio::task::JoinHandle<()>>>,
+    /// Process-start epoch seconds for INI `timeNow()`.
+    pub app_start_epoch: f64,
+    /// Cached `.inc` table files for INI `table()` expressions.
+    pub inc_table_cache: Arc<std::sync::Mutex<IncTableCache>>,
+}
+
+impl AppState {
+    /// Epoch seconds at process start (for `timeNow()`).
+    pub fn process_start_epoch() -> f64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs_f64())
+            .unwrap_or(0.0)
+    }
+
+    /// Empty `.inc` table cache for AppState construction.
+    pub fn new_inc_table_cache() -> Arc<std::sync::Mutex<IncTableCache>> {
+        Arc::new(std::sync::Mutex::new(IncTableCache::default()))
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/crates/libretune-app/src-tauri/src/tests.rs
+++ b/crates/libretune-app/src-tauri/src/tests.rs
@@ -135,6 +135,8 @@ mod concurrency_tests {
             math_channels: Mutex::new(Vec::new()),
             stream_stats: Mutex::new(StreamStats::default()),
             agent_task: Mutex::new(None),
+            app_start_epoch: AppState::process_start_epoch(),
+            inc_table_cache: AppState::new_inc_table_cache(),
         });
 
         // Simulate execute_controller_command pattern: lock def -> sleep -> lock conn
@@ -214,6 +216,8 @@ mod concurrency_tests {
             math_channels: Mutex::new(Vec::new()),
             stream_stats: Mutex::new(StreamStats::default()),
             agent_task: Mutex::new(None),
+            app_start_epoch: AppState::process_start_epoch(),
+            inc_table_cache: AppState::new_inc_table_cache(),
         })
     }
 
@@ -445,6 +449,8 @@ signature = "Speeduino 2023-04"
             math_channels: Mutex::new(Vec::new()),
             stream_stats: Mutex::new(StreamStats::default()),
             agent_task: Mutex::new(None),
+            app_start_epoch: AppState::process_start_epoch(),
+            inc_table_cache: AppState::new_inc_table_cache(),
         };
 
         let matches = find_matching_inis_from_state(&state, "Speeduino 2023-05").await;
@@ -514,6 +520,8 @@ signature = "Speeduino 2023-04"
             math_channels: Mutex::new(Vec::new()),
             stream_stats: Mutex::new(StreamStats::default()),
             agent_task: Mutex::new(None),
+            app_start_epoch: AppState::process_start_epoch(),
+            inc_table_cache: AppState::new_inc_table_cache(),
         };
 
         let matches = find_matching_inis_from_state(&state, "Speeduino 2023-05").await;
@@ -586,6 +594,8 @@ signature = "Speeduino 2023-04"
             math_channels: Mutex::new(Vec::new()),
             stream_stats: Mutex::new(StreamStats::default()),
             agent_task: Mutex::new(None),
+            app_start_epoch: AppState::process_start_epoch(),
+            inc_table_cache: AppState::new_inc_table_cache(),
         };
 
         // Partial match case
@@ -670,6 +680,8 @@ signature = "Speeduino 2023-04"
             math_channels: Mutex::new(Vec::new()),
             stream_stats: Mutex::new(StreamStats::default()),
             agent_task: Mutex::new(None),
+            app_start_epoch: AppState::process_start_epoch(),
+            inc_table_cache: AppState::new_inc_table_cache(),
         };
 
         // Install factory returning a partial matching signature

--- a/crates/libretune-app/src/components/dashboards/hooks/useGaugeRangeSync.ts
+++ b/crates/libretune-app/src/components/dashboards/hooks/useGaugeRangeSync.ts
@@ -61,6 +61,7 @@ export function useGaugeRangeSync(
         return {
           Gauge: {
             ...gauge,
+            title: info.title || gauge.title,
             min: rangeOk ? info.lo : gauge.min,
             max: rangeOk ? info.hi : gauge.max,
             units: info.units,

--- a/crates/libretune-app/src/components/gauges/painters/__tests__/lineGraph.test.ts
+++ b/crates/libretune-app/src/components/gauges/painters/__tests__/lineGraph.test.ts
@@ -22,6 +22,8 @@ const mockCtx = (): CanvasRenderingContext2D =>
     createLinearGradient: () => ({ addColorStop: vi.fn() }),
     arc: vi.fn(),
     setLineDash: vi.fn(),
+    save: vi.fn(),
+    restore: vi.fn(),
     shadowColor: '',
     shadowBlur: 0,
     shadowOffsetY: 0,

--- a/crates/libretune-core/src/ini/constants.rs
+++ b/crates/libretune-core/src/ini/constants.rs
@@ -2,7 +2,7 @@
 //!
 //! Parses the [Constants] section which defines editable ECU parameters.
 
-use super::parser::split_ini_line;
+use super::split_ini_line;
 use super::types::{DataType, DynamicSizeRefs, Endianness, Shape};
 use serde::{Deserialize, Serialize};
 

--- a/crates/libretune-core/src/ini/expression.rs
+++ b/crates/libretune-core/src/ini/expression.rs
@@ -36,6 +36,21 @@ impl Value {
             Value::String(s) => !s.is_empty(),
         }
     }
+
+    /// Format for UI labels (gauge titles, axis labels, etc.).
+    pub fn to_display_string(&self) -> String {
+        match self {
+            Value::Number(n) => {
+                if n.fract() == 0.0 && n.abs() < 1e15 {
+                    format!("{}", *n as i64)
+                } else {
+                    n.to_string()
+                }
+            }
+            Value::Bool(b) => b.to_string(),
+            Value::String(s) => s.clone(),
+        }
+    }
 }
 
 /// Binary operators
@@ -1144,6 +1159,34 @@ pub fn evaluate_simple(expr: &Expr, context: &HashMap<String, f64>) -> Result<Va
     evaluate(expr, context, None)
 }
 
+/// Resolve a display string that may be a braced INI expression.
+///
+/// If `raw` trims to `{ ... }`, the inner expression is evaluated and stringified.
+/// Otherwise `raw` is returned unchanged. On parse/eval failure, returns `raw`.
+pub fn evaluate_display_string(
+    raw: &str,
+    context: &HashMap<String, f64>,
+    string_context: Option<&StringContext>,
+) -> String {
+    let trimmed = raw.trim();
+    if trimmed.starts_with('{') && trimmed.ends_with('}') && trimmed.len() >= 2 {
+        let inner = trimmed[1..trimmed.len() - 1].trim();
+        if inner.is_empty() {
+            return raw.to_string();
+        }
+        let mut parser = Parser::new(inner);
+        match parser.parse() {
+            Ok(expr) => match evaluate(&expr, context, string_context) {
+                Ok(value) => value.to_display_string(),
+                Err(_) => raw.to_string(),
+            },
+            Err(_) => raw.to_string(),
+        }
+    } else {
+        raw.to_string()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1251,6 +1294,70 @@ mod tests {
         assert_eq!(
             evaluate_simple(&expr, &context).unwrap(),
             Value::Number(0.0)
+        );
+    }
+
+    #[test]
+    fn test_string_value_with_context() {
+        let mut p = Parser::new("stringValue(gpPwmNote1)");
+        let expr = p.parse().unwrap();
+        let context = HashMap::new();
+
+        assert_eq!(
+            evaluate_simple(&expr, &context).unwrap(),
+            Value::String(String::new())
+        );
+
+        let mut string_ctx = StringContext::default();
+        string_ctx.get_string_value = Some(Box::new(|name| {
+            if name == "gpPwmNote1" {
+                Some("Radiator Fan".to_string())
+            } else {
+                None
+            }
+        }));
+        assert_eq!(
+            evaluate(&expr, &context, Some(&string_ctx)).unwrap(),
+            Value::String("Radiator Fan".to_string())
+        );
+        assert_eq!(
+            evaluate_display_string("{ stringValue(gpPwmNote1) }", &context, Some(&string_ctx)),
+            "Radiator Fan"
+        );
+    }
+
+    #[test]
+    fn test_bit_string_value_with_context() {
+        let mut p = Parser::new("bitStringValue(pwmAxisLabels, gppwm1_loadAxis)");
+        let expr = p.parse().unwrap();
+        let mut context = HashMap::new();
+        context.insert("gppwm1_loadAxis".to_string(), 1.0);
+
+        assert_eq!(
+            evaluate_simple(&expr, &context).unwrap(),
+            Value::String("INVALID[1]".to_string())
+        );
+
+        let mut string_ctx = StringContext::default();
+        string_ctx.get_bit_options = Some(Box::new(|name| {
+            if name == "pwmAxisLabels" {
+                Some(vec!["RPM".into(), "MAP".into(), "TPS".into()])
+            } else {
+                None
+            }
+        }));
+        assert_eq!(
+            evaluate(&expr, &context, Some(&string_ctx)).unwrap(),
+            Value::String("MAP".to_string())
+        );
+    }
+
+    #[test]
+    fn test_evaluate_display_string_passthrough() {
+        let context = HashMap::new();
+        assert_eq!(
+            evaluate_display_string("Engine Speed", &context, None),
+            "Engine Speed"
         );
     }
 }

--- a/crates/libretune-core/src/ini/gauges.rs
+++ b/crates/libretune-core/src/ini/gauges.rs
@@ -4,6 +4,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use super::split_ini_line;
+
 /// A gauge configuration for dashboard display
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GaugeConfig {
@@ -128,9 +130,9 @@ fn parse_num_or_expr(raw: &str, fallback: f64) -> (f64, Option<String>) {
 ///
 /// Format: name = channel, title, units, lo, hi, loD, loW, hiW, hiD, digits
 pub fn parse_gauge_line(name: &str, value: &str) -> Option<GaugeConfig> {
-    let parts: Vec<&str> = value.split(',').map(|s| s.trim()).collect();
+    let parts = split_ini_line(value);
 
-    if parts.is_empty() {
+    if parts.is_empty() || parts[0].is_empty() {
         return None;
     }
 
@@ -143,22 +145,22 @@ pub fn parse_gauge_line(name: &str, value: &str) -> Option<GaugeConfig> {
         gauge.units = parts[2].trim_matches('"').to_string();
     }
     if parts.len() > 3 {
-        (gauge.lo, gauge.lo_expr) = parse_num_or_expr(parts[3], 0.0);
+        (gauge.lo, gauge.lo_expr) = parse_num_or_expr(&parts[3], 0.0);
     }
     if parts.len() > 4 {
-        (gauge.hi, gauge.hi_expr) = parse_num_or_expr(parts[4], 100.0);
+        (gauge.hi, gauge.hi_expr) = parse_num_or_expr(&parts[4], 100.0);
     }
     if parts.len() > 5 {
-        (gauge.low_danger, gauge.low_danger_expr) = parse_num_or_expr(parts[5], 0.0);
+        (gauge.low_danger, gauge.low_danger_expr) = parse_num_or_expr(&parts[5], 0.0);
     }
     if parts.len() > 6 {
-        (gauge.low_warning, gauge.low_warning_expr) = parse_num_or_expr(parts[6], 0.0);
+        (gauge.low_warning, gauge.low_warning_expr) = parse_num_or_expr(&parts[6], 0.0);
     }
     if parts.len() > 7 {
-        (gauge.high_warning, gauge.high_warning_expr) = parse_num_or_expr(parts[7], 100.0);
+        (gauge.high_warning, gauge.high_warning_expr) = parse_num_or_expr(&parts[7], 100.0);
     }
     if parts.len() > 8 {
-        (gauge.high_danger, gauge.high_danger_expr) = parse_num_or_expr(parts[8], 100.0);
+        (gauge.high_danger, gauge.high_danger_expr) = parse_num_or_expr(&parts[8], 100.0);
     }
     if parts.len() > 9 {
         gauge.digits = parts[9].parse().unwrap_or(0);
@@ -219,5 +221,22 @@ mod tests {
         assert_eq!(gauge.channel, "rpm");
         assert_eq!(gauge.title, "Engine Speed");
         assert_eq!(gauge.hi, 8000.0);
+    }
+
+    #[test]
+    fn test_parse_gauge_line_braced_title_with_comma() {
+        let gauge = parse_gauge_line(
+            "gppwmGauge1",
+            "gppwmOutput1, { bitStringValue(pwmAxisLabels, gppwm1_loadAxis) }, \"%\", 0, 100, 0, 0, 100, 100, 1",
+        )
+        .expect("parse");
+        assert_eq!(gauge.channel, "gppwmOutput1");
+        assert_eq!(
+            gauge.title,
+            "{ bitStringValue(pwmAxisLabels, gppwm1_loadAxis) }"
+        );
+        assert_eq!(gauge.units, "%");
+        assert_eq!(gauge.hi, 100.0);
+        assert_eq!(gauge.digits, 1);
     }
 }

--- a/crates/libretune-core/src/ini/mod.rs
+++ b/crates/libretune-core/src/ini/mod.rs
@@ -22,7 +22,7 @@ mod types;
 
 pub use constants::Constant;
 pub use error::IniError;
-pub use gauges::GaugeConfig;
+pub use gauges::{parse_gauge_line, GaugeConfig};
 pub use inc_tables::{IncTable, IncTableCache};
 pub use output_channels::OutputChannel;
 pub use tables::{CurveDefinition, TableDefinition, TableRole, TableType};
@@ -30,6 +30,41 @@ pub use types::*;
 
 use std::collections::HashMap;
 use std::path::Path;
+
+/// Split an INI line value by commas, respecting quotes and braces.
+/// Handles expressions like `{ bitStringValue(algorithmUnits , algorithm) }`.
+pub fn split_ini_line(value: &str) -> Vec<String> {
+    let mut parts = Vec::new();
+    let mut current = String::new();
+    let mut in_quotes = false;
+    let mut in_braces = 0;
+
+    for ch in value.chars() {
+        match ch {
+            '"' => {
+                in_quotes = !in_quotes;
+                current.push(ch);
+            }
+            '{' if !in_quotes => {
+                in_braces += 1;
+                current.push(ch);
+            }
+            '}' if !in_quotes => {
+                in_braces -= 1;
+                current.push(ch);
+            }
+            ',' if !in_quotes && in_braces == 0 => {
+                parts.push(current.trim().to_string());
+                current = String::new();
+            }
+            _ => {
+                current.push(ch);
+            }
+        }
+    }
+    parts.push(current.trim().to_string());
+    parts
+}
 
 /// Complete ECU definition parsed from an INI file
 #[derive(Debug, Clone)]

--- a/crates/libretune-core/src/ini/output_channels.rs
+++ b/crates/libretune-core/src/ini/output_channels.rs
@@ -126,10 +126,22 @@ impl OutputChannel {
         endian: super::Endianness,
         context: &std::collections::HashMap<String, f64>,
     ) -> Option<f64> {
+        self.parse_with_contexts(data, endian, context, None)
+    }
+
+    /// Like [`parse_with_context`], but supplies a [`super::expression::StringContext`]
+    /// so functions such as `timeNow()` / `table()` can resolve.
+    pub fn parse_with_contexts(
+        &self,
+        data: &[u8],
+        endian: super::Endianness,
+        context: &std::collections::HashMap<String, f64>,
+        string_context: Option<&super::expression::StringContext>,
+    ) -> Option<f64> {
         if self.is_computed() {
             // Use cached expression if available (much faster)
             if let Some(ref expr) = self.cached_expr {
-                match super::expression::evaluate_simple(expr, context) {
+                match super::expression::evaluate(expr, context, string_context) {
                     Ok(value) => return Some(value.as_f64()),
                     Err(_) => return None,
                 }
@@ -138,7 +150,7 @@ impl OutputChannel {
             if let Some(ref expr_str) = self.expression {
                 let mut parser = super::expression::Parser::new(expr_str);
                 match parser.parse() {
-                    Ok(expr) => match super::expression::evaluate_simple(&expr, context) {
+                    Ok(expr) => match super::expression::evaluate(&expr, context, string_context) {
                         Ok(value) => return Some(value.as_f64()),
                         Err(_) => return None,
                     },

--- a/crates/libretune-core/src/ini/parser.rs
+++ b/crates/libretune-core/src/ini/parser.rs
@@ -678,40 +678,7 @@ fn parse_key_value(line: &str) -> Option<(&str, &str)> {
     }
 }
 
-/// Split an INI line value by commas, respecting quotes and braces
-/// This handles expressions like `{ bitStringValue(algorithmUnits , algorithm) }` correctly
-pub fn split_ini_line(value: &str) -> Vec<String> {
-    let mut parts = Vec::new();
-    let mut current = String::new();
-    let mut in_quotes = false;
-    let mut in_braces = 0;
-
-    for ch in value.chars() {
-        match ch {
-            '"' => {
-                in_quotes = !in_quotes;
-                current.push(ch);
-            }
-            '{' if !in_quotes => {
-                in_braces += 1;
-                current.push(ch);
-            }
-            '}' if !in_quotes => {
-                in_braces -= 1;
-                current.push(ch);
-            }
-            ',' if !in_quotes && in_braces == 0 => {
-                parts.push(current.trim().to_string());
-                current = String::new();
-            }
-            _ => {
-                current.push(ch);
-            }
-        }
-    }
-    parts.push(current.trim().to_string());
-    parts
-}
+pub use super::split_ini_line;
 
 /// Parse a #define directive
 /// Format: #define name = value1, value2, value3

--- a/crates/libretune-core/tests/string_context_display.rs
+++ b/crates/libretune-core/tests/string_context_display.rs
@@ -1,0 +1,57 @@
+//! Regression for #128: braced gauge titles via stringValue().
+
+use libretune_core::ini::expression::{evaluate_display_string, StringContext};
+use libretune_core::ini::{parse_gauge_line, EcuDefinition};
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+#[test]
+fn demo_ini_gppwm_gauge_title_resolves_with_string_context() {
+    let demo = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../libretune-app/src-tauri/resources/demo.ini");
+    if !demo.exists() {
+        // Workspace layout may differ in some CI checkouts; skip rather than fail.
+        eprintln!("demo.ini not found at {:?}, skipping", demo);
+        return;
+    }
+
+    let def = EcuDefinition::from_file(demo.to_str().unwrap()).expect("parse demo.ini");
+    let gauge = def.gauges.get("gppwmGauge1").expect("gppwmGauge1");
+    assert!(
+        gauge.title.contains("stringValue"),
+        "expected braced title, got {}",
+        gauge.title
+    );
+
+    let mut string_ctx = StringContext::default();
+    string_ctx.get_string_value = Some(Box::new(|name| {
+        if name == "gpPwmNote1" {
+            Some("gpPwmNote 1".to_string())
+        } else {
+            None
+        }
+    }));
+
+    let resolved = evaluate_display_string(&gauge.title, &HashMap::new(), Some(&string_ctx));
+    assert_eq!(resolved, "gpPwmNote 1");
+    assert_eq!(
+        evaluate_display_string(&gauge.title, &HashMap::new(), None),
+        ""
+    );
+}
+
+#[test]
+fn parse_and_resolve_string_value_title() {
+    let gauge = parse_gauge_line(
+        "gppwmGauge1",
+        "gppwmOutput1, { stringValue(gpPwmNote1) }, \"%\", 0, 100, 0, 0, 100, 100, 1",
+    )
+    .unwrap();
+
+    let mut string_ctx = StringContext::default();
+    string_ctx.get_string_value = Some(Box::new(|_| Some("Radiator Fan".into())));
+    assert_eq!(
+        evaluate_display_string(&gauge.title, &HashMap::new(), Some(&string_ctx)),
+        "Radiator Fan"
+    );
+}


### PR DESCRIPTION
Build `StringContext` from `tune/realtime` state so `{stringValue(...)}` and related `INI` display expressions resolve instead of showing raw braces (#128).