### PR TITLE
fix(ini): warn and block duplicate pin assignments before burn

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/constant_update.rs
+++ b/crates/libretune-app/src-tauri/src/commands/constant_update.rs
@@ -27,6 +27,11 @@ pub async fn update_constant(
         .unwrap_or(256) as usize;
     drop(def_guard);
 
+    // Block assigning a pin that another output already uses (rusEFI Settings Error).
+    if constant.data_type == libretune_core::ini::DataType::Bits {
+        crate::commands::pin_conflicts::deny_if_pin_conflict(&state, &name, value).await?;
+    }
+
     let mut conn_guard = state.connection.lock().await;
     let mut cache_guard = state.tune_cache.lock().await;
 

--- a/crates/libretune-app/src-tauri/src/commands/mod.rs
+++ b/crates/libretune-app/src-tauri/src/commands/mod.rs
@@ -47,6 +47,7 @@ pub mod math_channels;
 pub mod menu;
 pub mod metrics;
 pub mod online_ini;
+pub mod pin_conflicts;
 pub mod project_lifecycle;
 pub mod project_listing;
 pub mod project_mgmt;

--- a/crates/libretune-app/src-tauri/src/commands/pin_conflicts.rs
+++ b/crates/libretune-app/src-tauri/src/commands/pin_conflicts.rs
@@ -1,0 +1,76 @@
+//! Pin assignment conflict checks (pre-burn / before pin constant writes).
+
+use crate::commands::constant_values::read_constant_from_cache_or_tune;
+use crate::AppState;
+use libretune_core::pin_conflict::{
+    conflict_if_assigning, detect_pin_conflicts, PinConflictReport,
+};
+
+/// Scan the loaded tune for pins claimed by more than one constant.
+pub(crate) async fn scan_pin_conflicts(state: &AppState) -> Result<PinConflictReport, String> {
+    let def_guard = state.definition.lock().await;
+    let def = def_guard.as_ref().ok_or("Definition not loaded")?;
+    let cache_guard = state.tune_cache.lock().await;
+    let tune_guard = state.current_tune.lock().await;
+    let endianness = def.endianness;
+
+    Ok(detect_pin_conflicts(def, |name, constant| {
+        let v = read_constant_from_cache_or_tune(
+            name,
+            constant,
+            endianness,
+            tune_guard.as_ref(),
+            cache_guard.as_ref(),
+        );
+        Some(v as usize)
+    }))
+}
+
+/// Scan the loaded tune for pins claimed by more than one constant.
+#[tauri::command]
+pub async fn check_pin_conflicts(
+    state: tauri::State<'_, AppState>,
+) -> Result<PinConflictReport, String> {
+    scan_pin_conflicts(&state).await
+}
+
+/// Shared helper: reject assigning `name` to bits index `value` when that pin is taken.
+pub(crate) async fn deny_if_pin_conflict(
+    state: &AppState,
+    name: &str,
+    value: f64,
+) -> Result<(), String> {
+    let def_guard = state.definition.lock().await;
+    let def = def_guard.as_ref().ok_or("Definition not loaded")?;
+    let cache_guard = state.tune_cache.lock().await;
+    let tune_guard = state.current_tune.lock().await;
+    let endianness = def.endianness;
+    let new_index = value as usize;
+
+    if let Some(conflict) = conflict_if_assigning(def, name, new_index, |other_name, constant| {
+        if other_name == name {
+            return None;
+        }
+        let v = read_constant_from_cache_or_tune(
+            other_name,
+            constant,
+            endianness,
+            tune_guard.as_ref(),
+            cache_guard.as_ref(),
+        );
+        Some(v as usize)
+    }) {
+        return Err(format!(
+            "Pin '{}' is already used by {}. Clear that assignment first.",
+            conflict.pin_label,
+            conflict
+                .constants
+                .iter()
+                .filter(|c| c.as_str() != name)
+                .cloned()
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+    Ok(())
+}

--- a/crates/libretune-app/src-tauri/src/commands/table_ops.rs
+++ b/crates/libretune-app/src-tauri/src/commands/table_ops.rs
@@ -156,7 +156,7 @@ pub async fn resize_table_size(
 
     let connected = state.connection.lock().await.is_some();
     if connected {
-        crate::commands::tune_io::burn_to_ecu(app, state.clone())
+        crate::commands::tune_io::burn_to_ecu(app, state.clone(), None)
             .await
             .map_err(|e| format!("Resized in RAM but burn failed: {}", e))?;
     }

--- a/crates/libretune-app/src-tauri/src/commands/tune_io.rs
+++ b/crates/libretune-app/src-tauri/src/commands/tune_io.rs
@@ -51,12 +51,24 @@ pub async fn list_tune_files() -> Result<Vec<String>, String> {
 /// This is the critical "save to ECU" operation that persists changes.
 /// Saves window state first in case of issues.
 ///
+/// When `force` is not true, overlapping pin assignments abort the burn with
+/// a conflict summary (TunerStudio does not catch this; rusEFI reports it only
+/// after the fact as a Settings Error).
+///
 /// Returns: Nothing on success
 #[tauri::command]
 pub async fn burn_to_ecu(
     app: tauri::AppHandle,
     state: tauri::State<'_, AppState>,
+    force: Option<bool>,
 ) -> Result<(), String> {
+    if !force.unwrap_or(false) {
+        let report = crate::commands::pin_conflicts::scan_pin_conflicts(&state).await?;
+        if report.has_conflicts() {
+            return Err(report.summary());
+        }
+    }
+
     // Save window state before critical operation (in case of crash)
     let _ = app.save_window_state(StateFlags::all());
 

--- a/crates/libretune-app/src-tauri/src/commands/tune_misc.rs
+++ b/crates/libretune-app/src-tauri/src/commands/tune_misc.rs
@@ -198,7 +198,8 @@ pub async fn use_project_tune(
             ));
         }
 
-        let burn_result = crate::commands::tune_io::burn_to_ecu(app.clone(), state.clone()).await;
+        let burn_result =
+            crate::commands::tune_io::burn_to_ecu(app.clone(), state.clone(), None).await;
         {
             let mut conn_guard = state.connection.lock().await;
             if let Some(conn) = conn_guard.as_mut() {

--- a/crates/libretune-app/src-tauri/src/lib.rs
+++ b/crates/libretune-app/src-tauri/src/lib.rs
@@ -125,6 +125,7 @@ use commands::math_channels::{
 use commands::menu::{get_menu_tree, get_searchable_index};
 use commands::metrics::stop_metrics_task;
 use commands::online_ini::{check_internet_connectivity, download_ini, search_online_inis};
+use commands::pin_conflicts::check_pin_conflicts;
 use commands::project_lifecycle::{create_project, open_project};
 use commands::project_listing::{get_projects_path, list_projects};
 use commands::project_mgmt::{
@@ -341,6 +342,7 @@ pub fn run() {
             get_tune_constant_manifest,
             list_tune_files,
             burn_to_ecu,
+            check_pin_conflicts,
             execute_controller_command,
             get_firmware_flasher_info,
             get_firmware_update_guidance,

--- a/crates/libretune-app/src/components/tuner-ui/dialogs/BurnDialog.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/dialogs/BurnDialog.tsx
@@ -1,9 +1,18 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { AlertTriangle, Check, Flame } from 'lucide-react';
 import { invoke } from '@tauri-apps/api/core';
 import { Dialog, Button } from '../../common';
 import { DialogProps } from './types';
 import '../Dialogs.css';
+
+interface PinConflict {
+  pin_label: string;
+  constants: string[];
+}
+
+interface PinConflictReport {
+  conflicts: PinConflict[];
+}
 
 interface BurnDialogProps extends DialogProps {
   connected: boolean;
@@ -14,14 +23,49 @@ export function BurnDialog({ isOpen, onClose, connected, onBurned }: BurnDialogP
   const [isBurning, setIsBurning] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
+  const [conflicts, setConflicts] = useState<PinConflict[]>([]);
+  const [forceAck, setForceAck] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setError(null);
+      setSuccess(false);
+      setConflicts([]);
+      setForceAck(false);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const report = await invoke<PinConflictReport>('check_pin_conflicts');
+        if (!cancelled) {
+          setConflicts(report.conflicts ?? []);
+        }
+      } catch {
+        if (!cancelled) {
+          setConflicts([]);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen]);
+
+  const hasConflicts = conflicts.length > 0;
 
   const handleBurn = useCallback(async () => {
+    if (hasConflicts && !forceAck) {
+      setError('Resolve pin conflicts, or acknowledge them to burn anyway.');
+      return;
+    }
+
     setIsBurning(true);
     setError(null);
     setSuccess(false);
-    
+
     try {
-      await invoke('burn_to_ecu');
+      await invoke('burn_to_ecu', { force: hasConflicts && forceAck ? true : null });
       setSuccess(true);
       onBurned?.();
     } catch (e) {
@@ -29,7 +73,7 @@ export function BurnDialog({ isOpen, onClose, connected, onBurned }: BurnDialogP
     } finally {
       setIsBurning(false);
     }
-  }, [onClose, onBurned]);
+  }, [onBurned, hasConflicts, forceAck]);
 
   return (
     <Dialog
@@ -40,7 +84,7 @@ export function BurnDialog({ isOpen, onClose, connected, onBurned }: BurnDialogP
       closeOnBackdrop={!isBurning}
     >
       <Dialog.Body>
-        {error && <div className="dialog-error">{error}</div>}
+        {error && <div className="dialog-error" style={{ whiteSpace: 'pre-wrap' }}>{error}</div>}
         {success && <div className="dialog-success" style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}><Check size={14} /> Burn completed successfully!</div>}
 
         {!connected ? (
@@ -54,6 +98,33 @@ export function BurnDialog({ isOpen, onClose, connected, onBurned }: BurnDialogP
             <p>Make sure your tune is tested before burning.</p>
           </div>
         )}
+
+        {hasConflicts && (
+          <div className="dialog-warning" style={{ marginTop: 12, whiteSpace: 'pre-wrap' }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 8 }}>
+              <AlertTriangle size={14} />
+              <strong>Pin assignment conflict</strong>
+            </div>
+            <p style={{ margin: '0 0 8px' }}>
+              The same pin is used by multiple outputs. Burning may leave the ECU in a Settings Error state.
+            </p>
+            <ul style={{ margin: '0 0 8px', paddingLeft: 18 }}>
+              {conflicts.map((c) => (
+                <li key={c.pin_label}>
+                  Pin <strong>{c.pin_label}</strong>: {c.constants.join(', ')}
+                </li>
+              ))}
+            </ul>
+            <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}>
+              <input
+                type="checkbox"
+                checked={forceAck}
+                onChange={(e) => setForceAck(e.target.checked)}
+              />
+              I understand — burn anyway
+            </label>
+          </div>
+        )}
       </Dialog.Body>
 
       <Dialog.Footer>
@@ -61,7 +132,7 @@ export function BurnDialog({ isOpen, onClose, connected, onBurned }: BurnDialogP
         <Button
           variant="danger"
           onClick={handleBurn}
-          disabled={isBurning || !connected}
+          disabled={isBurning || !connected || (hasConflicts && !forceAck)}
         >
           {isBurning ? 'Burning...' : <><Flame size={14} /> Burn to ECU</>}
         </Button>

--- a/crates/libretune-core/src/lib.rs
+++ b/crates/libretune-core/src/lib.rs
@@ -51,6 +51,7 @@ pub mod ecu;
 pub mod ini;
 pub mod llm;
 pub mod lua;
+pub mod pin_conflict;
 pub mod plugin_api;
 pub mod plugin_system;
 pub mod port_editor;

--- a/crates/libretune-core/src/pin_conflict.rs
+++ b/crates/libretune-core/src/pin_conflict.rs
@@ -1,0 +1,300 @@
+//! Detect duplicate ECU pin assignments across INI constants.
+//!
+//! rusEFI-family firmwares reject overlapping pin uses with a Settings Error after
+//! the fact. LibreTune checks the live tune (bit option labels) so users are warned
+//! before burn and blocked from assigning a pin that is already in use.
+
+use crate::ini::{Constant, DataType, EcuDefinition};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// One physical pin claimed by multiple constants.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PinConflict {
+    /// Resolved pin label from the INI bit list (e.g. `"PD13"`, `"Low Side Output  3"`).
+    pub pin_label: String,
+    /// Constant names currently assigned to this pin.
+    pub constants: Vec<String>,
+}
+
+/// Result of scanning the tune for overlapping pin uses.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PinConflictReport {
+    /// Detected conflicts (empty when clear).
+    pub conflicts: Vec<PinConflict>,
+}
+
+impl PinConflictReport {
+    /// Whether any conflicts were found.
+    pub fn has_conflicts(&self) -> bool {
+        !self.conflicts.is_empty()
+    }
+
+    /// Human-readable summary for dialogs / burn errors.
+    pub fn summary(&self) -> String {
+        if self.conflicts.is_empty() {
+            return String::new();
+        }
+        let mut lines = vec![
+            "Pin assignment conflict(s) detected — the same pin is used by multiple outputs:"
+                .to_string(),
+        ];
+        for c in &self.conflicts {
+            lines.push(format!(
+                "• Pin '{}' used by: {}",
+                c.pin_label,
+                c.constants.join(", ")
+            ));
+        }
+        lines.push(
+            "Clear or reassign one of the functions before burning (or confirm to burn anyway)."
+                .to_string(),
+        );
+        lines.join("\n")
+    }
+}
+
+/// True when this constant looks like a pin selector (not a PinMode / boolean).
+pub fn is_pin_assignment_constant(constant: &Constant) -> bool {
+    if constant.data_type != DataType::Bits || constant.bit_options.len() < 3 {
+        return false;
+    }
+    let name = constant.name.to_ascii_lowercase();
+    if name.contains("pinmode") || name.ends_with("mode") || name.contains("invert") {
+        return false;
+    }
+    let name_looks_like_pin = name.contains("pin");
+    let has_none = constant
+        .bit_options
+        .iter()
+        .any(|o| is_unassigned_pin_label(o));
+    let has_pinish_option = constant.bit_options.iter().any(|o| looks_like_pin_label(o));
+    (name_looks_like_pin && has_none)
+        || (has_none && has_pinish_option && constant.bit_options.len() >= 8)
+}
+
+/// Labels that mean "no pin selected".
+pub fn is_unassigned_pin_label(label: &str) -> bool {
+    let t = label.trim();
+    if t.is_empty() {
+        return true;
+    }
+    matches!(
+        t.to_ascii_lowercase().as_str(),
+        "none" | "invalid" | "off" | "disabled" | "not used" | "unused" | "n/a" | "na"
+    )
+}
+
+fn looks_like_pin_label(label: &str) -> bool {
+    let t = label.trim();
+    if t.len() < 2 {
+        return false;
+    }
+    // STM32-style: PA0, PB12, PD13, PE15
+    let bytes = t.as_bytes();
+    if bytes[0].is_ascii_alphabetic()
+        && bytes.get(1).is_some_and(|b| b.is_ascii_alphabetic())
+        && t[2..].chars().all(|c| c.is_ascii_digit())
+        && !t[2..].is_empty()
+    {
+        return true;
+    }
+    let lower = t.to_ascii_lowercase();
+    lower.contains("output")
+        || lower.contains("injector")
+        || lower.contains("ignition")
+        || lower.contains("digital input")
+        || lower.contains("low side")
+        || lower.contains("high side")
+}
+
+/// Resolve the pin label for a bits constant index.
+pub fn pin_label_for_index(constant: &Constant, index: usize) -> Option<&str> {
+    constant.bit_options.get(index).map(|s| s.as_str())
+}
+
+/// Scan pin-assignment constants for duplicate non-empty pin labels.
+///
+/// `value_index` returns the current bits option index for a constant name.
+pub fn detect_pin_conflicts(
+    def: &EcuDefinition,
+    mut value_index: impl FnMut(&str, &Constant) -> Option<usize>,
+) -> PinConflictReport {
+    let mut by_pin: HashMap<String, Vec<String>> = HashMap::new();
+
+    for (name, constant) in &def.constants {
+        if !is_pin_assignment_constant(constant) {
+            continue;
+        }
+        let Some(idx) = value_index(name, constant) else {
+            continue;
+        };
+        let Some(label) = pin_label_for_index(constant, idx) else {
+            continue;
+        };
+        if is_unassigned_pin_label(label) {
+            continue;
+        }
+        by_pin
+            .entry(label.to_string())
+            .or_default()
+            .push(name.clone());
+    }
+
+    let mut conflicts: Vec<PinConflict> = by_pin
+        .into_iter()
+        .filter(|(_, names)| names.len() > 1)
+        .map(|(pin_label, mut constants)| {
+            constants.sort();
+            PinConflict {
+                pin_label,
+                constants,
+            }
+        })
+        .collect();
+    conflicts.sort_by(|a, b| a.pin_label.cmp(&b.pin_label));
+
+    PinConflictReport { conflicts }
+}
+
+/// Would assigning `new_index` on `constant_name` collide with another pin use?
+pub fn conflict_if_assigning(
+    def: &EcuDefinition,
+    constant_name: &str,
+    new_index: usize,
+    mut value_index: impl FnMut(&str, &Constant) -> Option<usize>,
+) -> Option<PinConflict> {
+    let constant = def.constants.get(constant_name)?;
+    if !is_pin_assignment_constant(constant) {
+        return None;
+    }
+    let label = pin_label_for_index(constant, new_index)?;
+    if is_unassigned_pin_label(label) {
+        return None;
+    }
+
+    let mut others = Vec::new();
+    for (name, other) in &def.constants {
+        if name == constant_name || !is_pin_assignment_constant(other) {
+            continue;
+        }
+        let Some(idx) = value_index(name, other) else {
+            continue;
+        };
+        let Some(other_label) = pin_label_for_index(other, idx) else {
+            continue;
+        };
+        if other_label == label {
+            others.push(name.clone());
+        }
+    }
+    if others.is_empty() {
+        return None;
+    }
+    others.sort();
+    let mut constants = others;
+    constants.insert(0, constant_name.to_string());
+    Some(PinConflict {
+        pin_label: label.to_string(),
+        constants,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ini::{Constant, DataType, EcuDefinition, Shape};
+
+    fn pin_const(name: &str, options: &[&str]) -> Constant {
+        let mut c = Constant::new(name, 0, 0, DataType::Bits);
+        c.shape = Shape::Scalar;
+        c.bit_position = Some(0);
+        c.bit_size = Some(8);
+        c.bit_options = options.iter().map(|s| (*s).to_string()).collect();
+        c
+    }
+
+    fn def_with(consts: Vec<Constant>) -> EcuDefinition {
+        let mut def = EcuDefinition::default();
+        for c in consts {
+            def.constants.insert(c.name.clone(), c);
+        }
+        def
+    }
+
+    #[test]
+    fn detects_duplicate_output_pins() {
+        let opts = ["NONE", "INVALID", "PA0", "PD13", "PE1"];
+        let def = def_with(vec![
+            pin_const("fuelPumpPin", &opts),
+            pin_const("gppwm1_pin", &opts),
+            pin_const("fanPin", &opts),
+        ]);
+        let values = HashMap::from([
+            ("fuelPumpPin".to_string(), 3usize), // PD13
+            ("gppwm1_pin".to_string(), 3usize),  // PD13
+            ("fanPin".to_string(), 2usize),      // PA0
+        ]);
+        let report = detect_pin_conflicts(&def, |name, _| values.get(name).copied());
+        assert!(report.has_conflicts());
+        assert_eq!(report.conflicts.len(), 1);
+        assert_eq!(report.conflicts[0].pin_label, "PD13");
+        assert_eq!(
+            report.conflicts[0].constants,
+            vec!["fuelPumpPin".to_string(), "gppwm1_pin".to_string()]
+        );
+    }
+
+    #[test]
+    fn ignores_none_and_pin_mode() {
+        let opts = ["NONE", "INVALID", "PA0", "PD13"];
+        let mut mode = pin_const("fuelPumpPinMode", &["default", "inverted", "open"]);
+        mode.bit_options = vec![
+            "default".into(),
+            "default inverted".into(),
+            "open collector".into(),
+        ];
+        let def = def_with(vec![
+            pin_const("fuelPumpPin", &opts),
+            pin_const("gppwm1_pin", &opts),
+            mode,
+        ]);
+        let values = HashMap::from([
+            ("fuelPumpPin".to_string(), 0usize),
+            ("gppwm1_pin".to_string(), 0usize),
+            ("fuelPumpPinMode".to_string(), 1usize),
+        ]);
+        let report = detect_pin_conflicts(&def, |name, _| values.get(name).copied());
+        assert!(!report.has_conflicts());
+    }
+
+    #[test]
+    fn blocks_reassign_onto_used_pin() {
+        let opts = ["NONE", "PA0", "PD13"];
+        let def = def_with(vec![
+            pin_const("waterPumpPin", &opts),
+            pin_const("gppwm1_pin", &opts),
+        ]);
+        let values = HashMap::from([("gppwm1_pin".to_string(), 2usize)]);
+        let conflict =
+            conflict_if_assigning(&def, "waterPumpPin", 2, |name, _| values.get(name).copied());
+        assert!(conflict.is_some());
+        let c = conflict.unwrap();
+        assert_eq!(c.pin_label, "PD13");
+        assert!(c.constants.contains(&"gppwm1_pin".to_string()));
+    }
+
+    #[test]
+    fn allows_clearing_to_none() {
+        let opts = ["NONE", "PA0", "PD13"];
+        let def = def_with(vec![
+            pin_const("waterPumpPin", &opts),
+            pin_const("gppwm1_pin", &opts),
+        ]);
+        let values = HashMap::from([("gppwm1_pin".to_string(), 2usize)]);
+        assert!(
+            conflict_if_assigning(&def, "waterPumpPin", 0, |name, _| values.get(name).copied())
+                .is_none()
+        );
+    }
+}


### PR DESCRIPTION
Scan `pin-selector constants` for overlapping labels so rusEFI Settings Errors like PD13 claimed by two outputs are caught before flash.
TS does not have guardrail, or at least not to my knowledge. and i really don't like that a tuning software can't warn me that pin is in use already and don't burn. 
I had a setting in **LibreTune**, burned, ECU when in crash mode just to find out in TS that this ping was in use.
(TS picture not attached to not keep paper trails of TS bits)
