### PR TITLE
fix(tune): reload the tune after restore-point load and git checkout

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/git.rs
+++ b/crates/libretune-app/src-tauri/src/commands/git.rs
@@ -6,7 +6,6 @@ use libretune_core::project::{
     format_commit_message, BranchInfo, CommitDiff, CommitInfo, VersionControl,
 };
 use serde::Serialize;
-use tauri::Emitter;
 
 use crate::state::AppState;
 
@@ -162,18 +161,37 @@ pub async fn git_checkout(
     state: tauri::State<'_, AppState>,
     sha: String,
 ) -> Result<(), String> {
-    let proj_guard = state.current_project.lock().await;
-    let project = proj_guard
-        .as_ref()
-        .ok_or_else(|| "No project open".to_string())?;
+    // Checkout writes the historical CurrentTune.msq to the working tree.
+    // Resolve the path and release the lock before reloading — the checkout
+    // alone previously left every layer above the filesystem untouched
+    // (cache, state.current_tune, UI all kept serving the pre-checkout tune,
+    // and the next save wrote it back over the restored file; ledger R9,
+    // observed live). Reloading through load_tune is what the emitted
+    // "tune:loaded" event always assumed had happened.
+    let tune_path = {
+        let proj_guard = state.current_project.lock().await;
+        let project = proj_guard
+            .as_ref()
+            .ok_or_else(|| "No project open".to_string())?;
 
-    let vc = VersionControl::open(&project.path)
-        .map_err(|e| format!("Git repository not initialized: {}", e))?;
+        let vc = VersionControl::open(&project.path)
+            .map_err(|e| format!("Git repository not initialized: {}", e))?;
 
-    vc.checkout_commit(&sha)
-        .map_err(|e| format!("Failed to checkout: {}", e))?;
+        vc.checkout_commit(&sha)
+            .map_err(|e| format!("Failed to checkout: {}", e))?;
 
-    let _ = app.emit("tune:loaded", "git_checkout");
+        project.path.join("CurrentTune.msq")
+    };
+
+    crate::commands::load_tune::load_tune(
+        state.clone(),
+        app,
+        tune_path.to_string_lossy().to_string(),
+    )
+    .await?;
+
+    // The restored tune is not what the ECU is running until written/burned.
+    *state.tune_modified.lock().await = true;
 
     Ok(())
 }
@@ -223,18 +241,32 @@ pub async fn git_switch_branch(
     state: tauri::State<'_, AppState>,
     name: String,
 ) -> Result<(), String> {
-    let proj_guard = state.current_project.lock().await;
-    let project = proj_guard
-        .as_ref()
-        .ok_or_else(|| "No project open".to_string())?;
+    // Same shape as git_checkout: the branch switch rewrites CurrentTune.msq
+    // on disk, so the in-memory tune must be reloaded or the app keeps
+    // serving (and re-saving) the previous branch's tune.
+    let tune_path = {
+        let proj_guard = state.current_project.lock().await;
+        let project = proj_guard
+            .as_ref()
+            .ok_or_else(|| "No project open".to_string())?;
 
-    let vc = VersionControl::open(&project.path)
-        .map_err(|e| format!("Git repository not initialized: {}", e))?;
+        let vc = VersionControl::open(&project.path)
+            .map_err(|e| format!("Git repository not initialized: {}", e))?;
 
-    vc.switch_branch(&name)
-        .map_err(|e| format!("Failed to switch branch: {}", e))?;
+        vc.switch_branch(&name)
+            .map_err(|e| format!("Failed to switch branch: {}", e))?;
 
-    let _ = app.emit("tune:loaded", "git_switch_branch");
+        project.path.join("CurrentTune.msq")
+    };
+
+    crate::commands::load_tune::load_tune(
+        state.clone(),
+        app,
+        tune_path.to_string_lossy().to_string(),
+    )
+    .await?;
+
+    *state.tune_modified.lock().await = true;
 
     Ok(())
 }

--- a/crates/libretune-app/src-tauri/src/commands/restore_points.rs
+++ b/crates/libretune-app/src-tauri/src/commands/restore_points.rs
@@ -1,8 +1,6 @@
 //! Restore point management commands.
 
 use crate::state::AppState;
-use libretune_core::tune::TuneCache;
-use tauri::Emitter;
 
 /// Info about a restore point
 #[derive(Debug, Clone, serde::Serialize)]
@@ -73,91 +71,59 @@ pub async fn list_restore_points(
 }
 
 /// Load a restore point as the current tune
+///
+/// Delegates to `load_tune`, the canonical tune-apply pipeline. This command
+/// previously carried a stripped-down copy of that pipeline which (a) had no
+/// `Bits` branch and discarded every enum/bits constant via `_ => {}` — after
+/// a bad burn, "restore" reported success while every enum setting sat at INI
+/// defaults — and (b) never updated `state.current_tune`, so every read path
+/// kept serving the pre-restore tune and the next save wrote the old tune
+/// back. Observed live against a bench ECU (ledger R8). Routing through
+/// `load_tune` gives restore the same semantics as loading any tune: full
+/// constant application including bits, state + cache + CurrentTune.msq all
+/// updated, `tune:loaded` emitted.
 #[tauri::command]
 pub async fn load_restore_point(
     app: tauri::AppHandle,
     state: tauri::State<'_, AppState>,
     filename: String,
 ) -> Result<(), String> {
-    let mut proj_guard = state.current_project.lock().await;
-    let project = proj_guard
-        .as_mut()
-        .ok_or_else(|| "No project open".to_string())?;
+    // Resolve the restore point path, then release the project lock before
+    // delegating — load_tune takes the same lock to persist CurrentTune.msq.
+    let restore_path = {
+        let proj_guard = state.current_project.lock().await;
+        let project = proj_guard
+            .as_ref()
+            .ok_or_else(|| "No project open".to_string())?;
+        let path = project.restore_points_dir().join(&filename);
+        if !path.exists() {
+            return Err(format!("Restore point not found: {}", filename));
+        }
+        path
+    };
 
-    project
-        .load_restore_point(&filename)
-        .map_err(|e| format!("Failed to load restore point: {}", e))?;
+    crate::commands::load_tune::load_tune(
+        state.clone(),
+        app,
+        restore_path.to_string_lossy().to_string(),
+    )
+    .await?;
 
-    // Reload the tune into cache
-    if let Some(ref tune) = project.current_tune {
-        let def_guard = state.definition.lock().await;
-        if let Some(ref def) = *def_guard {
-            let cache = TuneCache::from_definition(def);
-            let mut cache_guard = state.tune_cache.lock().await;
-            *cache_guard = Some(cache);
-
-            if let Some(cache) = cache_guard.as_mut() {
-                // Load page data
-                for (page_num, page_data) in &tune.pages {
-                    cache.load_page(*page_num, page_data.clone());
-                }
-
-                // Apply constants
-                use libretune_core::tune::TuneValue;
-                for (name, tune_value) in &tune.constants {
-                    if let Some(constant) = def.constants.get(name) {
-                        if constant.is_pc_variable {
-                            if let TuneValue::Scalar(v) = tune_value {
-                                cache.local_values.insert(name.clone(), *v);
-                            }
-                            continue;
-                        }
-
-                        let length = constant.size_bytes() as u16;
-                        if length == 0 {
-                            continue;
-                        }
-
-                        let element_size = constant.data_type.size_bytes();
-                        let element_count = constant.shape.element_count();
-                        let mut raw_data = vec![0u8; length as usize];
-
-                        match tune_value {
-                            TuneValue::Scalar(v) => {
-                                let raw_val = constant.display_to_raw(*v);
-                                constant.data_type.write_to_bytes(
-                                    &mut raw_data,
-                                    0,
-                                    raw_val,
-                                    def.endianness,
-                                );
-                                let _ =
-                                    cache.write_bytes(constant.page, constant.offset, &raw_data);
-                            }
-                            TuneValue::Array(arr) => {
-                                for (i, val) in arr.iter().take(element_count).enumerate() {
-                                    let raw_val = constant.display_to_raw(*val);
-                                    let offset = i * element_size;
-                                    constant.data_type.write_to_bytes(
-                                        &mut raw_data,
-                                        offset,
-                                        raw_val,
-                                        def.endianness,
-                                    );
-                                }
-                                let _ =
-                                    cache.write_bytes(constant.page, constant.offset, &raw_data);
-                            }
-                            _ => {}
-                        }
-                    }
-                }
-            }
+    // Keep the in-memory project's tune in sync with what was just loaded, so
+    // project-level flows (save_tune_to_project, use_project_tune) see the
+    // restored tune rather than the pre-restore one.
+    let restored = state.current_tune.lock().await.clone();
+    if let Some(tune) = restored {
+        let mut proj_guard = state.current_project.lock().await;
+        if let Some(project) = proj_guard.as_mut() {
+            project.current_tune = Some(tune);
         }
     }
 
-    // Notify UI
-    let _ = app.emit("tune:loaded", "restore_point");
+    // A restored tune differs from what the ECU is running until the user
+    // writes/burns it; load_tune resets tune_modified to false, which would
+    // hide that.
+    *state.tune_modified.lock().await = true;
 
     Ok(())
 }


### PR DESCRIPTION
Restore points and git version control are the safety net when a burn goes
wrong, and neither actually restored the tune.

`load_restore_point`, `git_checkout` and `git_switch_branch` each rewrote the
project's CurrentTune.msq on disk (git checkout / branch switch), or ran a
stripped-down copy of the tune-apply loop (restore point), and then only emitted
`tune:loaded`. Nothing reloaded the tune into `state.current_tune` or the cache.
Every UI listener responds to that event by re-reading from the backend, which
still held the pre-restore tune — so "Restore tune to this version" reported
success, showed the user the same values, and the next save wrote the stale tune
straight back over the freshly-restored file.

The restore-point copy was additionally missing the `DataType::Bits` branch and
discarded every `String`/`Bool` value via `_ => {}` — post the quoted-MSQ fix
that is how every enum/bits constant (nCylinders, algorithm, ...) is stored, so
after a bad burn "restore" silently reset all of them to INI defaults.

All three commands now delegate to `load_tune`, the canonical apply pipeline:
full constant application including bits, `state.current_tune`/cache/CurrentTune
.msq all updated, and `tune_modified` set true since a restored tune differs
from what the ECU is running until written.

Verified by driving the packaged app against a bench ECU over a debug bridge:
`git_checkout(A)` now flips the in-app read from the B-commit value (77) to the
A-commit value (55); `load_restore_point` flips a changed cell (99) back to the
restore point's content (37). Before, both stayed stale and the next save
clobbered the restore.

This is one of several duplicated write/apply paths in the codebase where a
fix landed on one copy and not the others; the table-edit and
reset-to-defaults counterparts are separate PRs.

---
🔎 Verified by driving the packaged app against a bench ECU simulator, not just unit tests.
🧩 One of three PRs addressing duplicated write/apply paths where a fix landed on one copy and not the others (see #table-edit-persistence, #reset-defaults-correctness).
🤖 Generated with [Claude Code](https://claude.com/claude-code)