### PR TITLE
fix(tune): keep tune.constants in sync in the table-op write helpers

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/table_internals.rs
+++ b/crates/libretune-app/src-tauri/src/commands/table_internals.rs
@@ -366,6 +366,17 @@ pub(crate) async fn update_table_z_values_internal(
                 if end <= page_data.len() {
                     page_data[start..end].copy_from_slice(&raw_data);
                 }
+
+                // Offline reads prefer the parsed msq constants over page
+                // data (read_const_values checks tune.constants first), so
+                // keep them in sync or every toolbar op silently reverts on
+                // the next read while a connected ECU has already taken the
+                // write. Same invariant PR #59 established for
+                // update_table_data; these internal helpers were missed.
+                tune.constants.insert(
+                    constant.name.clone(),
+                    libretune_core::tune::TuneValue::Array(flat_values.clone()),
+                );
             }
             *state.tune_modified.lock().await = true;
         }
@@ -483,6 +494,15 @@ pub(crate) async fn update_constant_array_internal(
                 if end <= page_data.len() {
                     page_data[start..end].copy_from_slice(&raw_data);
                 }
+
+                // Same tune.constants sync as above: without it, rebin_table's
+                // axis write "succeeds", the next get_table_data serves the old
+                // bins from tune.constants, and the new axis is lost — while
+                // the ECU already received it.
+                tune.constants.insert(
+                    constant.name.clone(),
+                    libretune_core::tune::TuneValue::Array(values.clone()),
+                );
             }
 
             *state.tune_modified.lock().await = true;


### PR DESCRIPTION
PR #59 fixed offline table edits reverting on reload by writing edits into
`tune.constants` (which `read_const_values` consults before page bytes) — but
only in `update_table_data`. The two internal helpers `update_table_z_values
_internal` and `update_constant_array_internal` write cache and `tune.pages`
without touching `tune.constants`, and every table-toolbar operation (scale,
smooth, interpolate, fill, rebin, set-equal, offset — 14 call sites) plus
`rebin_table`'s axis write goes through them.

Result: the operation reported success, the grid showed the new value once, and
the next read reverted to the pre-edit value from `tune.constants`, while a
connected ECU had already received the write — so the UI and the ECU silently
disagreed, and a subsequent save could persist the stale value.

Both helpers now insert the written values into `tune.constants`, mirroring
`update_table_data`.

Verified against a bench ECU via the packaged app: `scale_cells` 88 ×2.0 now
reads back 176 (was reverting to 88); `rebin_table` with a new Y axis now keeps
that axis (was reverting to the old bins).

Companion to the restore/checkout and reset-to-defaults PRs — same class of
duplicated write path where only one copy carried the fix.

---
🔎 Verified against a bench ECU via the packaged app: scale_cells 88×2.0 reads back 176; rebin keeps its new axis.
🧩 Extends #59 to the two internal helpers it missed. Companion to #155 and the reset-defaults PR.
🤖 Generated with [Claude Code](https://claude.com/claude-code)