### PR TITLE
fix(tune): reset_tune_to_defaults endianness, defaults-only, and rounding

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/csv_io.rs
+++ b/crates/libretune-app/src-tauri/src/commands/csv_io.rs
@@ -18,6 +18,7 @@ pub async fn reset_tune_to_defaults(state: tauri::State<'_, AppState>) -> Result
     let tune = tune_guard.as_mut().ok_or("No tune loaded")?;
 
     let mut reset_count = 0u32;
+    let mut skipped_no_default = 0usize;
 
     // Reset each constant to its default value
     for (name, constant) in &def.constants {
@@ -26,12 +27,14 @@ pub async fn reset_tune_to_defaults(state: tauri::State<'_, AppState>) -> Result
             continue;
         }
 
-        // Get default value from INI [Defaults] section
-        let default_value = if let Some(&default_val) = def.default_values.get(name) {
-            default_val
-        } else {
-            // No default defined - use min value as fallback
-            constant.min
+        // Only reset constants the INI actually declares a default for.
+        // Falling back to `constant.min` turned "reset to defaults" into
+        // "reset to minimum" for the ~68% of constants with no [Defaults]
+        // entry — observed live: reqFuel 12.5 -> 0, nCylinders -> "INVALID",
+        // reported as a successful reset of 730 constants.
+        let Some(&default_value) = def.default_values.get(name) else {
+            skipped_no_default += 1;
+            continue;
         };
 
         // Update PC variable locally
@@ -51,12 +54,25 @@ pub async fn reset_tune_to_defaults(state: tauri::State<'_, AppState>) -> Result
         tune.constants
             .insert(name.clone(), TuneValue::Scalar(default_value));
 
-        // Encode value to bytes and write to cache
-        let bytes = encode_constant_value(raw_value, &constant.data_type);
+        // Encode with the INI's declared endianness. encode_constant_value
+        // hardcoded big-endian, byte-swapping every multi-byte scalar on
+        // little-endian ECUs (Speeduino/rusEFI) — observed live: mapMax 260
+        // written as 1025, boostSens 2000 as 53255.
+        let mut bytes = vec![0u8; constant.data_type.size_bytes()];
+        constant
+            .data_type
+            .write_to_bytes(&mut bytes, 0, raw_value, def.endianness);
         cache.write_bytes(constant.page, constant.offset, &bytes);
         reset_count += 1;
     }
 
+    if skipped_no_default > 0 {
+        tracing::info!(
+            "reset_tune_to_defaults: {} constants reset; {} skipped (no [Defaults] entry)",
+            reset_count,
+            skipped_no_default
+        );
+    }
     Ok(reset_count)
 }
 
@@ -369,8 +385,14 @@ pub async fn import_tune_from_csv(
         tune.constants
             .insert(name.to_string(), TuneValue::Scalar(clamped_value));
 
-        // Encode value to bytes and write to cache
-        let bytes = encode_constant_value(raw_value, &constant.data_type);
+        // Encode with the INI's declared endianness. encode_constant_value
+        // hardcoded big-endian, byte-swapping every multi-byte scalar on
+        // little-endian ECUs (Speeduino/rusEFI) — observed live: mapMax 260
+        // written as 1025, boostSens 2000 as 53255.
+        let mut bytes = vec![0u8; constant.data_type.size_bytes()];
+        constant
+            .data_type
+            .write_to_bytes(&mut bytes, 0, raw_value, def.endianness);
         cache.write_bytes(constant.page, constant.offset, &bytes);
         import_count += 1;
     }
@@ -425,35 +447,6 @@ pub(crate) fn parse_csv_line(line: &str) -> Vec<&str> {
     }
 
     fields
-}
-
-/// Encode a constant value to bytes based on data type (big-endian)
-pub(crate) fn encode_constant_value(raw_value: f64, data_type: &DataType) -> Vec<u8> {
-    match data_type {
-        DataType::U08 => vec![raw_value.clamp(0.0, 255.0) as u8],
-        DataType::S08 => vec![raw_value.clamp(-128.0, 127.0) as i8 as u8],
-        DataType::U16 => {
-            let val = raw_value.clamp(0.0, 65535.0) as u16;
-            val.to_be_bytes().to_vec()
-        }
-        DataType::S16 => {
-            let val = raw_value.clamp(-32768.0, 32767.0) as i16;
-            val.to_be_bytes().to_vec()
-        }
-        DataType::U32 => {
-            let val = raw_value.clamp(0.0, 4294967295.0) as u32;
-            val.to_be_bytes().to_vec()
-        }
-        DataType::S32 => {
-            let val = raw_value.clamp(-2147483648.0, 2147483647.0) as i32;
-            val.to_be_bytes().to_vec()
-        }
-        DataType::F32 => (raw_value as f32).to_be_bytes().to_vec(),
-        DataType::F64 => raw_value.to_be_bytes().to_vec(),
-        DataType::Bits | DataType::String => {
-            vec![raw_value.clamp(0.0, 255.0) as u8]
-        }
-    }
 }
 
 /// Truncate an imported array-constant's values to `elem_count` so

--- a/crates/libretune-core/src/ini/types.rs
+++ b/crates/libretune-core/src/ini/types.rs
@@ -268,16 +268,31 @@ impl DataType {
 
         let bytes = &mut data[offset..];
         match (self, endian) {
-            (DataType::U08 | DataType::Bits, _) => bytes[0] = value as u8,
-            (DataType::S08, _) => bytes[0] = value as i8 as u8,
-            (DataType::U16, Endianness::Big) => BigEndian::write_u16(bytes, value as u16),
-            (DataType::U16, Endianness::Little) => LittleEndian::write_u16(bytes, value as u16),
-            (DataType::S16, Endianness::Big) => BigEndian::write_i16(bytes, value as i16),
-            (DataType::S16, Endianness::Little) => LittleEndian::write_i16(bytes, value as i16),
-            (DataType::U32, Endianness::Big) => BigEndian::write_u32(bytes, value as u32),
-            (DataType::U32, Endianness::Little) => LittleEndian::write_u32(bytes, value as u32),
-            (DataType::S32, Endianness::Big) => BigEndian::write_i32(bytes, value as i32),
-            (DataType::S32, Endianness::Little) => LittleEndian::write_i32(bytes, value as i32),
+            // Integer types round to the nearest raw count rather than
+            // truncating. Display-to-raw conversions land just below whole
+            // numbers whenever scale is not binary-exact (14.7 / 0.1 =
+            // 146.99999999999997), and `as` truncation then stores raw-1: a
+            // one-count quantization loss on the first write of any such
+            // value (observed live: stoich 14.7 saved as 14.6, AFR cells
+            // 12.6 reloading as 12.5).
+            (DataType::U08 | DataType::Bits, _) => bytes[0] = value.round() as u8,
+            (DataType::S08, _) => bytes[0] = value.round() as i8 as u8,
+            (DataType::U16, Endianness::Big) => BigEndian::write_u16(bytes, value.round() as u16),
+            (DataType::U16, Endianness::Little) => {
+                LittleEndian::write_u16(bytes, value.round() as u16)
+            }
+            (DataType::S16, Endianness::Big) => BigEndian::write_i16(bytes, value.round() as i16),
+            (DataType::S16, Endianness::Little) => {
+                LittleEndian::write_i16(bytes, value.round() as i16)
+            }
+            (DataType::U32, Endianness::Big) => BigEndian::write_u32(bytes, value.round() as u32),
+            (DataType::U32, Endianness::Little) => {
+                LittleEndian::write_u32(bytes, value.round() as u32)
+            }
+            (DataType::S32, Endianness::Big) => BigEndian::write_i32(bytes, value.round() as i32),
+            (DataType::S32, Endianness::Little) => {
+                LittleEndian::write_i32(bytes, value.round() as i32)
+            }
             (DataType::F32, Endianness::Big) => BigEndian::write_f32(bytes, value as f32),
             (DataType::F32, Endianness::Little) => LittleEndian::write_f32(bytes, value as f32),
             (DataType::F64, Endianness::Big) => BigEndian::write_f64(bytes, value),


### PR DESCRIPTION
Three defects, all surfacing through Reset Tune to Defaults, found by comparing
a reset+saved .msq against the INI's declared defaults on a little-endian
Speeduino.

1. Endianness. The removed `encode_constant_value` hardcoded `to_be_bytes()`,
   so on little-endian ECUs every multi-byte scalar was byte-swapped: mapMax's
   default 260 was written as 1025, boostSens 2000 as 53255. The array-write
   path in the same file already used `data_type.write_to_bytes(.., def
   .endianness)`; both scalar call sites now do too, and the divergent helper
   is deleted.

2. "Reset to defaults" was mostly "reset to minimum". Constants with no
   [Defaults] entry (~68% of them) fell back to `constant.min`: reqFuel 12.5
   became 0, nCylinders became "INVALID", all reported as a successful reset of
   730 constants. Reset now skips constants the INI declares no default for and
   logs how many were skipped.

3. Integer encoding truncated instead of rounding. `display_to_raw` lands just
   below a whole number whenever the scale is not binary-exact (14.7 / 0.1 =
   146.99999999999997), and `as u16`/`as u8` then stored raw-1 — a one-count
   quantization loss on the first write of such a value (stoich 14.7 saved as
   14.6, AFR cells 12.6 reloading as 12.5). `write_to_bytes` now rounds before
   the integer cast, which also fixes that first-write loss generally, not just
   for reset.

Verified in the reset+saved .msq against a bench ECU: mapMax 260, boostSens
2000, stoich 14.7, reqFuel unchanged, 192 constants reset rather than 730.

The rounding change is in libretune-core and affects every integer constant
write; it is included here because reset is its clearest reproduction, but it
is the broadest-reach part of this set.

---
🔎 Verified in the reset+saved .msq against a bench ECU: mapMax 260, boostSens 2000, stoich 14.7, reqFuel unchanged, 192 reset not 730.
🧩 Companion to #155. The write_to_bytes rounding change is in libretune-core and touches every integer constant write — flagged for isolated review.
🤖 Generated with [Claude Code](https://claude.com/claude-code)