### PR TITLE
fix(tune): capture the current tune in create_restore_point

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/restore_points.rs
+++ b/crates/libretune-app/src-tauri/src/commands/restore_points.rs
@@ -18,10 +18,27 @@ pub struct RestorePointResponse {
 pub async fn create_restore_point(
     state: tauri::State<'_, AppState>,
 ) -> Result<RestorePointResponse, String> {
-    let proj_guard = state.current_project.lock().await;
+    // `Project::create_restore_point` serializes `project.current_tune`, but
+    // that field is only refreshed on load/save — every edit command
+    // (update_constant, update_table_data and the table-op helpers) writes
+    // `state.current_tune`, so the two diverge. Snapshotting the project copy
+    // captured the tune as it was when the project was opened, silently losing
+    // every edit made since. Observed on a bench ECU: a saved table edit
+    // (veTable[0][0]=42) was captured by the restore point as the original 37.
+    //
+    // Sync the project's tune from the authoritative in-memory tune before
+    // snapshotting so the restore point reflects what the user actually has —
+    // the same source `save_tune` writes to CurrentTune.msq.
+    let current = state.current_tune.lock().await.clone();
+
+    let mut proj_guard = state.current_project.lock().await;
     let project = proj_guard
-        .as_ref()
+        .as_mut()
         .ok_or_else(|| "No project open".to_string())?;
+
+    if let Some(tune) = current {
+        project.current_tune = Some(tune);
+    }
 
     let restore_path = project
         .create_restore_point()


### PR DESCRIPTION
`Project::create_restore_point` serializes `project.current_tune`, but that
field is only refreshed when a tune is loaded or saved. Every edit command —
update_constant, update_table_data, and the table-op helpers — writes
`state.current_tune`, so the two diverge as soon as the user changes anything.

Snapshotting the project copy therefore captured the tune as it was when the
project was opened, silently discarding every edit made since. A restore point
taken "to be safe" before a risky change would roll back to that change and
everything after it. Observed on a bench ECU: after a saved table edit
(veTable[0][0] = 42, confirmed persisted to CurrentTune.msq), the new restore
point captured the original value, 37.

The command now syncs the project's tune from `state.current_tune` — the same
authoritative in-memory tune save_tune writes to disk — before creating the
point.

Verified on a bench ECU: with the fix, a restore point taken after editing a
cell to 123 (and saving) contains 123 in the written .msq; before, it captured
the pre-edit value. Read back from the restore file directly to isolate this
from the separate restore-load path (#155).

Same state-divergence family as #155; that PR fixes the load side, this one
the capture side, so the restore-point feature is correct end to end.

---
🔎 Verified on a bench ECU: a restore point taken after editing a cell to 123 contains 123 in the written .msq (before: captured the stale pre-edit value).
🧩 Same state-divergence family as #155 — that PR fixes restore *load*, this one fixes restore *capture*, so the safety net is correct end to end.
🤖 Generated with [Claude Code](https://claude.com/claude-code)