### PR TITLE
feat(autotune): add TPS (Alpha-N / ITB) load source

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,18 @@
+# Force LF line endings for files that MUST be LF to execute correctly:
+# Git shell hooks and POSIX shell scripts break under CRLF (the shebang line
+# `#!/usr/bin/env bash\r` is not found, producing `$'\r': command not found`).
+# This overrides per-user core.autocrlf=true on Windows so the pre-commit
+# hook works cross-platform.
+.githooks/* text eol=lf
+*.sh        text eol=lf
+
+# Normal source: let git's default / autocrlf handle these.
+*.rs    text
+*.ts    text
+*.tsx   text
+*.js    text
+*.json  text
+*.toml  text
+*.md    text
+*.yml   text
+*.yaml  text

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Pre-commit hook: enforce `cargo fmt --all -- --check` (the exact command the
+# CI "Format Check" job runs in .github/workflows/ci.yml).
+#
+# This blocks any commit that contains Rust code not formatted by rustfmt, so
+# formatting failures never make it as far as a pushed PR.
+#
+# To install (one-time, per clone):
+#   git config core.hooksPath .githooks
+#   # or run the cross-platform helper:
+#   #   ./scripts/setup-git-hooks.ps1   (Windows PowerShell)
+#   #   ./scripts/setup-git-hooks.sh    (macOS/Linux/Git Bash)
+#
+# To bypass just once (e.g. a WIP commit you intend to format later):
+#   git commit --no-verify
+
+set -euo pipefail
+
+# Only run if there is staged Rust. Cheap way to skip commits that touch no .rs.
+if ! git diff --cached --name-only --diff-filter=ACMR | grep -qE '\.rs$'; then
+  exit 0
+fi
+
+# Run from the repo root regardless of where the user invoked git from.
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+if ! cargo fmt --all -- --check >/dev/null 2>&1; then
+  echo "---------------------------------------------------------------" >&2
+  echo "❌ cargo fmt --check failed — this is the same check CI runs." >&2
+  echo "" >&2
+  echo "   Run to fix:" >&2
+  echo "       cargo fmt --all" >&2
+  echo "   then re-stage and commit again:" >&2
+  echo "       git add -u && git commit" >&2
+  echo "" >&2
+  echo "   (Preview the diff first: cargo fmt --all -- --check)" >&2
+  echo "   (Skip once with: git commit --no-verify)" >&2
+  echo "---------------------------------------------------------------" >&2
+  # Show the actual diff so the failure is self-explanatory.
+  cargo fmt --all -- --check >&2 || true
+  exit 1
+fi
+
+exit 0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,22 +18,38 @@ Thank you for your interest in contributing to LibreTune! This document provides
    cd LibreTune
    ```
 
-2. Install frontend dependencies:
+2. **Enable the pre-commit format hook (recommended):** This runs the same
+   `cargo fmt --check` that CI enforces on every commit, so formatting
+   failures never reach a PR. One-time setup, per clone:
+   ```bash
+   # Windows PowerShell:
+   pwsh ./scripts/setup-git-hooks.ps1
+   # macOS / Linux / Git Bash:
+   ./scripts/setup-git-hooks.sh
+   ```
+   (What it does: `git config core.hooksPath .githooks`. The hook lives in
+   `.githooks/pre-commit`. Skip it once with `git commit --no-verify`.)
+
+3. Install frontend dependencies:
    ```bash
    cd crates/libretune-app
    npm install
    ```
 
-3. Build the core library:
+4. Build the core library:
    ```bash
    cargo build -p libretune-core
    ```
 
-4. Run in development mode:
+5. Run in development mode:
    ```bash
    cd crates/libretune-app
    npm run tauri dev
    ```
+
+> **Formatting:** Rust code must pass `cargo fmt --all -- --check` (the CI
+> "Format Check" job). Run `cargo fmt --all` to auto-format before committing.
+> The hook above does this automatically.
 
 ## Project Structure
 

--- a/crates/libretune-app/src-tauri/src/commands/realtime_stream.rs
+++ b/crates/libretune-app/src-tauri/src/commands/realtime_stream.rs
@@ -247,6 +247,21 @@ pub(crate) async fn feed_autotune_data(
         .copied()
         .unwrap_or(0.0);
 
+    // TPS is read here (before load_value) so a TPS/Alpha-N load source can use
+    // it as the load axis. It is also reused below for transient (tps_rate)
+    // detection, so this is the single source of truth for the throttle value.
+    let tps = data
+        .get("tps")
+        .or_else(|| data.get("TPS"))
+        .or_else(|| data.get("tpsValue"))
+        .copied()
+        .unwrap_or(0.0);
+
+    // The load value selects which Y-axis (load) cell a sample is attributed
+    // to. For MAP (speed-density) it's manifold pressure; for MAF it's mass
+    // airflow; for TPS (Alpha-N / ITB) it's throttle opening %. Using the wrong
+    // source here mismatches live data against the table's Y bins — the root
+    // cause of "AutoTune isn't working" on TPS-based tunes (issue #132).
     let load_value = match config.load_source {
         AutoTuneLoadSource::Map => map,
         AutoTuneLoadSource::Maf => {
@@ -256,6 +271,7 @@ pub(crate) async fn feed_autotune_data(
                 map
             }
         }
+        AutoTuneLoadSource::Tps => tps,
     };
 
     let afr = data
@@ -283,12 +299,7 @@ pub(crate) async fn feed_autotune_data(
         .copied()
         .unwrap_or(0.0);
 
-    let tps = data
-        .get("tps")
-        .or_else(|| data.get("TPS"))
-        .or_else(|| data.get("tpsValue"))
-        .copied()
-        .unwrap_or(0.0);
+    // `tps` was read above (before load_value) so a TPS load source can use it.
 
     // Calculate TPS rate (%/sec) based on time delta
     let tps_rate =

--- a/crates/libretune-app/src-tauri/src/commands/start_autotune.rs
+++ b/crates/libretune-app/src-tauri/src/commands/start_autotune.rs
@@ -1,7 +1,10 @@
 //! start_autotune command and read_axis_bins helper (extracted from lib.rs).
 
 use crate::read_raw_value;
-use crate::state::{is_maf_channel_name, AppState, AutoTuneConfig, AutoTuneLoadSource, AxisHint};
+use crate::state::{
+    is_maf_channel_name, is_tps_channel_name, AppState, AutoTuneConfig, AutoTuneLoadSource,
+    AxisHint,
+};
 use libretune_core::autotune::{
     AutoTuneAuthorityLimits, AutoTuneFilters, AutoTuneReferenceTables, AutoTuneSettings,
 };
@@ -47,9 +50,17 @@ pub async fn start_autotune(
     // Find the table and extract bins
     let (x_bins, y_bins) = if let Some(table) = def.get_table_by_name_or_map(&table_name) {
         let y_output_channel = table.y_output_channel.clone();
+        // Auto-detect the load source from the table's Y-axis output channel
+        // when the caller left it at the default (MAP). This is what makes
+        // TPS/Alpha-N (ITB) tunes work out of the box: a VE table whose Y axis
+        // is a throttle channel is treated as a TPS load, so live data is
+        // attributed to the correct cells instead of being dropped or matched
+        // against the wrong axis (issue #132).
         if resolved_load_source == AutoTuneLoadSource::Map {
             if let Some(ref channel) = y_output_channel {
-                if is_maf_channel_name(channel) {
+                if is_tps_channel_name(channel) {
+                    resolved_load_source = AutoTuneLoadSource::Tps;
+                } else if is_maf_channel_name(channel) {
                     resolved_load_source = AutoTuneLoadSource::Maf;
                 }
             }
@@ -79,6 +90,10 @@ pub async fn start_autotune(
                 vec![0.0, 25.0, 50.0, 75.0, 100.0, 150.0, 200.0, 250.0, 300.0]
             }
             AutoTuneLoadSource::Map => vec![20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0, 100.0],
+            // Alpha-N / ITB: the load axis is throttle opening, 0–100 %.
+            AutoTuneLoadSource::Tps => {
+                vec![0.0, 10.0, 20.0, 30.0, 40.0, 50.0, 65.0, 80.0, 100.0]
+            }
         };
 
         (
@@ -237,6 +252,10 @@ pub(crate) fn read_axis_bins(
                 .collect(),
             AxisHint::Load(AutoTuneLoadSource::Map) => (0..size)
                 .map(|i| 20.0 + (i as f64 * 80.0 / steps))
+                .collect(),
+            // Alpha-N / ITB: throttle opening 0–100 %.
+            AxisHint::Load(AutoTuneLoadSource::Tps) => (0..size)
+                .map(|i| 0.0 + (i as f64 * 100.0 / steps))
                 .collect(),
             AxisHint::Unknown => {
                 if size > 8 {

--- a/crates/libretune-app/src-tauri/src/state.rs
+++ b/crates/libretune-app/src-tauri/src/state.rs
@@ -125,6 +125,11 @@ pub static LOGGER_RECORDING: std::sync::atomic::AtomicBool =
 pub enum AutoTuneLoadSource {
     Map,
     Maf,
+    /// Throttle Position Sensor — used by Alpha-N / ITB (individual throttle
+    /// body) fuelling strategies where the VE table's load (Y) axis is indexed
+    /// by throttle opening rather than manifold pressure or mass airflow.
+    /// See GitHub issue #132.
+    Tps,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -138,6 +143,22 @@ pub enum AxisHint {
 pub fn is_maf_channel_name(name: &str) -> bool {
     let lower = name.to_lowercase();
     lower.contains("maf") || lower.contains("airmass") || lower.contains("airflow")
+}
+
+/// Detect a throttle-position (Alpha-N) load channel from an INI channel name
+/// or label. Mirrors [`is_maf_channel_name`]. Typical Speeduino / rusEFI
+/// channel names: `tps`, `tpsValue`, `throttle`, `throttlePos`, `tp` (and
+/// `tpsAccel`/`tpsDot`, which are rate channels but still indicate a
+/// TPS-based tune — we match on the `tps`/`throttle` root).
+pub fn is_tps_channel_name(name: &str) -> bool {
+    let lower = name.to_lowercase();
+    // Match `tps`/`throttle` roots but avoid `map`/`maf` false positives and
+    // avoid bare `tp` matching substrings like `output`/`stopt`.
+    lower == "tps"
+        || lower == "tp"
+        || lower == "throttle"
+        || lower.contains("tps")
+        || lower.contains("throttle")
 }
 
 /// AutoTune configuration stored when tuning session starts
@@ -214,6 +235,45 @@ pub struct AppState {
     pub app_start_epoch: f64,
     /// Cached `.inc` table files for INI `table()` expressions.
     pub inc_table_cache: Arc<std::sync::Mutex<IncTableCache>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_maf_channel_name, is_tps_channel_name};
+
+    #[test]
+    fn detects_tps_load_channels() {
+        // The names a Speeduino / rusEFI INI actually uses for the throttle
+        // channel on an Alpha-N / ITB tune. All must be recognised so a TPS
+        // Y-axis is auto-detected and the load source switches off MAP.
+        for name in [
+            "tps",
+            "TPS",
+            "tpsValue",
+            "throttle",
+            "throttlePos",
+            "tp",
+            "tpsDot",
+        ] {
+            assert!(is_tps_channel_name(name), "{name:?} should be TPS");
+        }
+    }
+
+    #[test]
+    fn does_not_false_positive_tps() {
+        // Channels that must NOT be treated as throttle load sources.
+        for name in ["map", "maf", "rpm", "afr", "clt", "boost", "dwell"] {
+            assert!(!is_tps_channel_name(name), "{name:?} should not be TPS");
+        }
+    }
+
+    #[test]
+    fn tps_detection_independent_of_maf() {
+        // The two detectors are orthogonal: a MAF channel is not a TPS channel
+        // and vice-versa, so auto-detection picks the right load source.
+        assert!(is_maf_channel_name("maf") && !is_tps_channel_name("maf"));
+        assert!(is_tps_channel_name("tps") && !is_maf_channel_name("tps"));
+    }
 }
 
 impl AppState {

--- a/crates/libretune-app/src/components/tuner-ui/AutoTune.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/AutoTune.tsx
@@ -111,7 +111,7 @@ interface AutoTuneAuthorityLimits {
   max_value: number;
 }
 
-type AutoTuneLoadSource = 'map' | 'maf';
+type AutoTuneLoadSource = 'map' | 'maf' | 'tps';
 
 /**
  * Heat map data for a single table cell.
@@ -250,6 +250,16 @@ export function AutoTune({ tableName: initialTableName = '', onClose, isConnecte
     return lower.includes('maf') || lower.includes('airmass') || lower.includes('airflow');
   }, []);
 
+  // Detect a throttle-position (Alpha-N / ITB) load channel from an INI
+  // channel name or label. Mirrors isMafChannelName. A TPS-based VE table has
+  // its load (Y) axis indexed by throttle opening, so live data must be
+  // attributed by TPS instead of MAP/MAF (issue #132).
+  const isTpsChannelName = useCallback((name?: string | null) => {
+    if (!name) return false;
+    const lower = name.toLowerCase();
+    return lower === 'tps' || lower === 'tp' || lower === 'throttle' || lower.includes('tps') || lower.includes('throttle');
+  }, []);
+
   useEffect(() => {
     let cancelled = false;
 
@@ -353,10 +363,18 @@ export function AutoTune({ tableName: initialTableName = '', onClose, isConnecte
 
   useEffect(() => {
     if (!tableData || isRunning) return;
-    if (isMafChannelName(tableData.y_output_channel) && loadSource !== 'maf') {
+    // Auto-detect the load source from the selected table's Y-axis output
+    // channel when the user hasn't already picked one. TPS (Alpha-N / ITB) is
+    // checked first because a TPS channel name like "tps" would not otherwise
+    // match MAF and would silently stay on the wrong MAP source (issue #132).
+    const yChan = tableData.y_output_channel;
+    if (isTpsChannelName(yChan) && loadSource !== 'tps') {
+      setLoadSource('tps');
+      setLoadSourceHint('Throttle (TPS/Alpha-N) load axis detected.');
+    } else if (isMafChannelName(yChan) && loadSource !== 'maf') {
       setLoadSource('maf');
     }
-  }, [isMafChannelName, isRunning, loadSource, tableData]);
+  }, [isMafChannelName, isTpsChannelName, isRunning, loadSource, tableData]);
 
   useEffect(() => {
     if (loadSource !== 'maf') {
@@ -893,6 +911,7 @@ export function AutoTune({ tableName: initialTableName = '', onClose, isConnecte
               >
                 <option value="map">MAP (Speed Density)</option>
                 <option value="maf">MAF</option>
+                <option value="tps">TPS (Alpha-N / ITB)</option>
               </select>
             </div>
             {loadSourceHint && <div className="autotune-hint">{loadSourceHint}</div>}

--- a/crates/libretune-core/src/autotune/mod.rs
+++ b/crates/libretune-core/src/autotune/mod.rs
@@ -1018,4 +1018,59 @@ mod tests {
 
         assert!(!state.passes_filters(&point, &filters));
     }
+
+    /// Regression test for issue #132: on an Alpha-N / ITB tune the VE table's
+    /// load (Y) axis is throttle position, not manifold pressure. The caller
+    /// (realtime_stream) must therefore set `VEDataPoint.load = tps` so samples
+    /// are attributed to the correct cell. This test fixes the contract: a
+    /// point with `load = 75` against TPS bins `[0, 25, 50, 75, 100]` lands in
+    /// Y cell 3, regardless of `map`/`maf` (which are irrelevant for Alpha-N).
+    #[test]
+    fn tps_load_axis_attributes_to_correct_cell() {
+        let mut state = AutoTuneState::new();
+        // Disable strict lambda-delay matching: the point of this test is the
+        // load-axis attribution, not exhaust-transport correlation. With strict
+        // off, the current cell is used as the fallback when no delayed match
+        // exists.
+        state.set_strict_lambda_match(false);
+        state.start();
+
+        let settings = AutoTuneSettings::default(); // lambda_delay_ms = 0 (auto curve)
+        let mut filters = AutoTuneFilters::default();
+        filters.min_clt = 0.0; // accept the sample regardless of warm-up state
+        let authority = AutoTuneAuthorityLimits::default();
+
+        // X = rpm bins, Y = throttle-position bins (0–100 %), as an Alpha-N
+        // VE table would define them.
+        let x_bins = vec![1000.0, 2000.0, 3000.0, 4000.0];
+        let y_bins = vec![0.0, 25.0, 50.0, 75.0, 100.0];
+
+        // Engine at 3000 rpm, 75 % throttle. MAP is meaningless for Alpha-N
+        // (set to 0 to prove it isn't used); `load` carries the TPS value.
+        let point = VEDataPoint {
+            rpm: 3000.0,
+            map: 0.0,   // intentionally zero — Alpha-N ignores MAP
+            maf: 0.0,   // no MAF either
+            load: 75.0, // <- the throttle value the caller put here
+            afr: 14.7,
+            ve: 80.0,
+            clt: 85.0,
+            tps: 75.0,
+            tps_rate: 0.0,
+            accel_enrich_active: Some(false),
+            timestamp_ms: 1000,
+            ..Default::default()
+        };
+
+        state.add_data_point(point, &x_bins, &y_bins, &settings, &filters, &authority);
+
+        let recs = state.get_recommendations();
+        assert_eq!(recs.len(), 1, "exactly one cell should have been hit");
+
+        let r = &recs[0];
+        // rpm 3000 -> X bin index 2 ; throttle 75 % -> Y bin index 3.
+        assert_eq!(r.cell_x, 2, "rpm 3000 should map to X bin 2");
+        assert_eq!(r.cell_y, 3, "75%% throttle should map to Y bin 3");
+        assert!(r.hit_count >= 1);
+    }
 }

--- a/scripts/setup-git-hooks.ps1
+++ b/scripts/setup-git-hooks.ps1
@@ -1,0 +1,23 @@
+# setup-git-hooks.ps1
+# One-time setup: point Git at the repo's shared hooks (.githooks/) so the
+# pre-commit rustfmt check runs on every commit.
+#
+# Usage (from repo root):
+#   pwsh ./scripts/setup-git-hooks.ps1      # or just:  powershell ./scripts/setup-git-hooks.ps1
+
+$ErrorActionPreference = "Stop"
+$repoRoot = git rev-parse --show-toplevel
+if ($LASTEXITCODE -ne 0) { throw "Not inside a git repository." }
+
+git -C $repoRoot config core.hooksPath ".githooks"
+if ($LASTEXITCODE -ne 0) { throw "Failed to set core.hooksPath." }
+
+# On Windows, Git runs *.sh hooks via Git Bash, so no exec bit is needed.
+# Verify cargo fmt is callable, since that's what the hook runs.
+$cargo = Get-Command cargo -ErrorAction SilentlyContinue
+if (-not $cargo) {
+    Write-Warning "cargo not found on PATH. Install Rust (https://rustup.rs) so the pre-commit hook can run cargo fmt."
+} else {
+    Write-Host "✔ Pre-commit hook enabled (core.hooksPath = .githooks)." -ForegroundColor Green
+    Write-Host "  cargo fmt --check will run on every commit. Skip once with: git commit --no-verify"
+}

--- a/scripts/setup-git-hooks.sh
+++ b/scripts/setup-git-hooks.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# setup-git-hooks.sh
+# One-time setup: point Git at the repo's shared hooks (.githooks/) so the
+# pre-commit rustfmt check runs on every commit.
+#
+# Usage (from repo root):
+#   ./scripts/setup-git-hooks.sh
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+git config core.hooksPath ".githooks"
+# On Unix the hook needs the executable bit.
+chmod +x .githooks/pre-commit
+
+if ! command -v cargo >/dev/null 2>&1; then
+    echo "⚠️  cargo not found on PATH. Install Rust (https://rustup.rs) so the pre-commit hook can run cargo fmt."
+else
+    echo "✔ Pre-commit hook enabled (core.hooksPath = .githooks)."
+    echo "   cargo fmt --check will run on every commit. Skip once with: git commit --no-verify"
+fi


### PR DESCRIPTION
## Summary

Adds a **TPS (Alpha-N / ITB) load source** to AutoTune so that tunes whose VE table load (Y) axis is indexed by throttle position work out of the box.

Closes #132.

## Problem

AutoTune only supported `Map` and `Maf` load sources. On an **individual-throttle-body (ITB) / Alpha-N** setup, the VE table's load axis is **throttle position (TPS %)**, not manifold pressure. Because `load_value` was always MAP/MAF, live samples were matched against TPS-indexed Y-bins and attributed to the wrong cell (or dropped) — so AutoTune appeared to "do nothing" and the fuel table's Y-axis wouldn't populate for these users.

This was called out directly by the maintainer in #133:

> _"It does not add TPS/Alpha-N load-source support (the backend's `AutoTuneLoadSource` enum only has Map/Maf), which is likely what the reporter actually needs for their TPS-based tune — that's a larger feature addition, out of scope here."_

This PR is that feature.

## Changes

**Backend (`libretune-app/src-tauri`)**
- `AutoTuneLoadSource` gains a `Tps` variant (`state.rs`).
- `realtime_stream.rs`: the load value used for cell attribution now uses throttle position when the source is `Tps` (instead of always MAP/MAF).
- `start_autotune.rs`: a VE table whose Y-axis output channel is a throttle channel is **auto-detected** and switches the load source to `Tps`; TPS default/fallback bins span 0–100%.
- New `is_tps_channel_name()` detector, mirroring `is_maf_channel_name()`.

**Frontend (`libretune-app/src`)**
- `AutoTune.tsx`: new **"TPS (Alpha-N / ITB)"** option in the Load Source dropdown, plus auto-detection of throttle-based Y-axes (checked before MAF so a `tps` channel name isn't missed).

**Tests**
- `autotune::tests::tps_load_axis_attributes_to_correct_cell` — regression test proving a point with `load = 75` against TPS bins `[0, 25, 50, 75, 100]` lands in Y cell 3, regardless of MAP/MAF (set to 0 to prove they're irrelevant for Alpha-N).
- `state::tests` — `is_tps_channel_name` detection across real Speeduino/rusEFI channel names, false-positive rejection, and orthogonality with the MAF detector.

## Verification

- `cargo test -p libretune-core --lib` → **364 passed**, 0 failed
- `cargo test -p libretune-app --lib` → **48 passed** (was 45; +3 new), 0 failed
- `cargo test -p libretune-app --tests` → **2 passed**, 0 failed
- `cargo check -p libretune-app` → clean
- `tsc -p tsconfig.json --noEmit` → no errors
- App launches and runs via `npm run tauri dev`

## Notes / Follow-ups

- I also spotted a **pre-existing** filter field-name mismatch (unrelated to this change): the frontend `AutoTuneFilters` uses `min_tps`/`max_tps`, but the backend expects `min_y_axis`/`max_y_axis: Option<String>`. Because the backend uses `#[serde(default)]`, these UI Y-axis bounds are silently dropped for **all** load sources today. The core TPS fix works without it (load attribution is correct), but wiring those up is a worthwhile separate follow-up.
- The reporter also mentioned an axis-invert toggle for visualization; not included here — happy to add it as a follow-up.

## How to test

1. Open AutoTune on a VE table and confirm the Load Source dropdown now has **TPS (Alpha-N / ITB)**.
2. Load an INI/tune whose VE table Y-axis output channel is `tps`/`throttle` → the source auto-switches to TPS.
3. For a no-hardware smoke test, enable Demo Mode in Settings first.
