### PR TITLE
docs: std_injection panel synthesis & offline constant reads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -302,6 +302,19 @@ Based on analysis of common ECU tuning software patterns:
 Detailed session-by-session history has moved to [CHANGELOG.md](CHANGELOG.md).
 What follows is a high-level pointer to the most recent cleanup pass.
 
+### std_* panel synthesis & offline constant reads (Aug 2026)
+
+- **`std_injection` panel now synthesized (Issue #152)** — built-in
+  `std_*` panels referenced via `panel = std_*` are no longer stubbed with a
+  placeholder; `EcuDefinition::std_panel_definition` rebuilds them from the
+  constants present in the loaded INI (`std_injection` → injection constants
+  incl. `reqFuel`; `std_ms3Rtc` → `rtc_trim`). Validated against a 687-file
+  ECU corpus.
+- **Offline constant reads now fall back to the cache** — `get_constant_value`
+  returned `0` for `<pageData>`-format MSQs; now falls back to the
+  `TuneCache` (decoded page bytes) like the canonical helper does.
+- See the `2026-08-13` CHANGELOG block for details.
+
 ### UI / menu pass (Jul 2026)
 
 - **Menu i18n (Issue #72)** — all File/Edit/View/Tools menu items and toolbar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,50 @@ relevant.
 
 ## [Unreleased]
 
+### 2026-08-13 — std_injection panel synthesis & offline constant reads
+
+#### Fixed
+- **`reqFuel` (and all injection constants) missing from the Engine Constants
+  dialog** (Issue #152) — the Speeduino/MS2/MS3 `engine_constants` dialog nests
+  a built-in TunerStudio panel via `panel = std_injection`. `std_injection` is
+  not a `dialog =` defined in any INI; it renders `reqFuel`, `divider`,
+  `alternate`, `injType`, `nCylinders`, `nInjectors`, `injOpen` from
+  `[Constants]`. LibreTune's `buildStdPlaceholderDefinition` was pre-empting
+  resolution of `std_injection` with a single placeholder `Label`, so the
+  entire panel collapsed to one line of text and every constant in it
+  (including `reqFuel`) was invisible. This was not a tune-import bug — the
+  MSQ constants parsed and applied fine; only the UI was stubbed out.
+  - Added `EcuDefinition::std_panel_definition(name)` (core), which synthesizes
+    a real `DialogDefinition` from the candidate constants actually present in
+    the loaded INI (missing candidates are skipped, so the same panel adapts
+    across Speeduino/MS2/MS3 despite naming differences). `get_dialog_definition`
+    consults it after the real-dialog lookup.
+  - Extended to `std_ms3Rtc` (Speeduino RTC panel) → surfaces `rtc_trim`.
+  - Frontend: removed the pre-emptive `std_injection` placeholder;
+    `buildStdPlaceholderDefinition` is now the *final* fallback for genuinely
+    unknown `std_*` panels (e.g. `std_ms2gentherm`).
+  - Drive-by: `std_panel_definition` previously hardcoded
+    `title: "Injection Setup"` for all panels; refactored to a per-panel
+    `(title, candidates)` tuple so `std_ms3Rtc` is correctly titled.
+  - Validated against a 687-file ECU corpus (rusEFI/epicEFI/FOME/Speeduino/
+    MS2/MS3/MShift): 100% parse success; `reqFuel` present in every affected
+    platform.
+
+- **Every constant displayed `0` offline for `<pageData>`-format MSQs** —
+  `get_constant_value`'s offline branch read *only* from `tune.constants`
+  (named `<constant>` XML tags) and returned `0` when not found by name. But
+  most MSQs (and every "Use LibreTune Settings" save) store data as raw
+  `<pageData>` blobs, for which `tune.constants` is empty. The decoded data
+  was sitting in the `TuneCache` the whole time, but the offline branch
+  refused to fall back to it. A second instance of the same bug existed for
+  bits constants (no cache fallback at all when offline).
+  - Scalar path: fall through to the cache instead of returning `0.0`.
+  - Bits path: added a cache fallback that extracts the packed bit field from
+    the decoded page bytes.
+  - This makes `get_constant_value` consistent with the canonical helper
+    `read_constant_from_cache_or_tune` (CSV export / pin conflicts already did
+    it correctly).
+
 ### 2026-08-01 — Table editing operations restored
 
 #### Fixed

--- a/crates/libretune-app/public/manual/technical/ini-parser.md
+++ b/crates/libretune-app/public/manual/technical/ini-parser.md
@@ -176,8 +176,22 @@ pub enum MenuItem {
 **Special Targets**:
 - `std_separator` - Horizontal line
 - `std_realtime` - Opens dashboard
+- `std_port_edit` - Opens I/O port editor
 - Table names - Opens table editor
 - Dialog names - Opens settings dialog
+
+**Built-in `std_*` panels** referenced via `panel = std_*` inside a `dialog`
+are not defined as a `dialog =` anywhere in the INI — they are TunerStudio
+standard panels. LibreTune synthesizes them on the fly from the constants
+actually present in `[Constants]` (`EcuDefinition::std_panel_definition`):
+- `std_injection` - Required Fuel / injection constants (`reqFuel`,
+  `nCylinders`, `injType`, `divider`, `alternate`, `nInjectors`, `injOpen`).
+  Missing candidates are skipped, so the same panel adapts across
+  Speeduino/MS2/MS3 despite small naming differences.
+- `std_ms3Rtc` - Real Time Clock (`rtc_trim`); gated by `{rtc_mode}` in the
+  enclosing dialog.
+Other `std_*` panels the synthesizer does not handle (e.g. `std_ms2gentherm`,
+`std_ms3SdConsole`) fall back to a friendly placeholder Label.
 
 **Keyboard Shortcuts**: `&` prefix marks the hotkey character
 

--- a/docs/src/technical/ini-parser.md
+++ b/docs/src/technical/ini-parser.md
@@ -176,8 +176,22 @@ pub enum MenuItem {
 **Special Targets**:
 - `std_separator` - Horizontal line
 - `std_realtime` - Opens dashboard
+- `std_port_edit` - Opens I/O port editor
 - Table names - Opens table editor
 - Dialog names - Opens settings dialog
+
+**Built-in `std_*` panels** referenced via `panel = std_*` inside a `dialog`
+are not defined as a `dialog =` anywhere in the INI — they are TunerStudio
+standard panels. LibreTune synthesizes them on the fly from the constants
+actually present in `[Constants]` (`EcuDefinition::std_panel_definition`):
+- `std_injection` - Required Fuel / injection constants (`reqFuel`,
+  `nCylinders`, `injType`, `divider`, `alternate`, `nInjectors`, `injOpen`).
+  Missing candidates are skipped, so the same panel adapts across
+  Speeduino/MS2/MS3 despite small naming differences.
+- `std_ms3Rtc` - Real Time Clock (`rtc_trim`); gated by `{rtc_mode}` in the
+  enclosing dialog.
+Other `std_*` panels the synthesizer does not handle (e.g. `std_ms2gentherm`,
+`std_ms3SdConsole`) fall back to a friendly placeholder Label.
 
 **Keyboard Shortcuts**: `&` prefix marks the hotkey character
 


### PR DESCRIPTION
# docs: std_injection panel synthesis & offline constant reads

Documentation updates for the two fixes landed today (PRs #163 and #164).

## Changes

- **`CHANGELOG.md`** — new `2026-08-13` dated block under `## [Unreleased]` documenting both fixes:
  - `std_injection`/`std_ms3Rtc` panel synthesis (Issue #152)
  - Offline constant read cache fallback for `<pageData>`-format MSQs
- **`docs/src/technical/ini-parser.md`** — expanded the "Special Targets" list to document:
  - The built-in `std_*` panels referenced via `panel = std_*`
  - Which panels are synthesized (`std_injection`, `std_ms3Rtc`) and which fall back to a placeholder
  - Added the previously-missing `std_port_edit` to the menu-target list
- **`public/manual/technical/ini-parser.md`** — synced from `docs/src/` via `sync-manual.mjs` (kept identical).
- **`AGENTS.md`** — new "Aug 2026" pointer block in "Recent Changes" pointing to the CHANGELOG entry, matching the existing high-level-pointer pattern.

## Notes

- The `ini-parser.md` edit was made in `docs/src/` (the source of truth) and propagated to `public/manual/` with the sync script; the two copies are byte-identical.
- No code changes — docs only. Safe to merge independent of #163/#164.

## Test plan

- [x] Verified `docs/src/` and `public/manual/` ini-parser copies are identical after sync
- [x] CHANGELOG follows the existing Keep a Changelog dated-block format
- [x] AGENTS.md pointer matches the existing Jul 2026 / Apr 2026 block pattern
