### PR TITLE
fix(autotune): stop misreading accel-enrich percentage as an active flag

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/realtime_stream.rs
+++ b/crates/libretune-app/src-tauri/src/commands/realtime_stream.rs
@@ -318,11 +318,24 @@ pub(crate) async fn feed_autotune_data(
     config.last_tps = Some(tps);
     config.last_timestamp_ms = Some(current_time_ms);
 
-    // Check for accel enrichment flag
+    // Whether accel enrichment is *active*, which only a boolean channel can
+    // answer. Speeduino publishes tpsaccaen / mapaccaen for exactly this.
+    //
+    // Deliberately excludes `accelEnrich` / `tpsAE`: those carry the enrichment
+    // *amount* as a percentage multiplier where 100 means "no enrichment"
+    // (Speeduino's own gauge spans 50-150%). Treating that as a flag via
+    // "> 0.5" made the neutral value read as permanently active, so with the
+    // default exclude_accel_enrich filter AutoTune rejected 100% of samples
+    // forever on every Speeduino — silently, because this filter is not part
+    // of the rejection log line.
+    //
+    // When no boolean channel exists this stays None, and the filter below
+    // treats unknown as "do not reject": an undeterminable flag must not
+    // silently discard every sample.
     let accel_enrich_active = data
-        .get("accelEnrich")
-        .or_else(|| data.get("accelEnrichActive"))
-        .or_else(|| data.get("tpsAE"))
+        .get("accelEnrichActive")
+        .or_else(|| data.get("tpsaccaen"))
+        .or_else(|| data.get("mapaccaen"))
         .map(|v| *v > 0.5);
 
     // Create the data point

--- a/crates/libretune-core/src/autotune/mod.rs
+++ b/crates/libretune-core/src/autotune/mod.rs
@@ -395,6 +395,31 @@ impl AutoTuneState {
         self.total_samples
     }
 
+    /// Which filter rejected a sample, for the diagnostic log. Mirrors the
+    /// order of the checks in `passes_filters`.
+    fn rejection_reason(point: &VEDataPoint, filters: &AutoTuneFilters) -> &'static str {
+        if point.rpm < filters.min_rpm || point.rpm > filters.max_rpm {
+            return "rpm out of range";
+        }
+        if point.clt < filters.min_clt {
+            return "clt below min_clt";
+        }
+        let bound = |s: &Option<String>| s.as_deref().and_then(|v| v.trim().parse::<f64>().ok());
+        if bound(&filters.min_y_axis).is_some_and(|b| point.load < b) {
+            return "load below min_y_axis";
+        }
+        if bound(&filters.max_y_axis).is_some_and(|b| point.load > b) {
+            return "load above max_y_axis";
+        }
+        if point.tps_rate.abs() > filters.max_tps_rate {
+            return "tps_rate above max_tps_rate";
+        }
+        if filters.exclude_accel_enrich && point.accel_enrich_active == Some(true) {
+            return "accel enrichment active";
+        }
+        "custom_filter"
+    }
+
     pub fn add_data_point(
         &mut self,
         point: VEDataPoint,
@@ -428,14 +453,24 @@ impl AutoTuneState {
             static REJECTS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
             let n = REJECTS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             if n < 5 || n.is_multiple_of(100) {
+                // Name the specific filter. Previously the line printed only
+                // rpm/clt/tps_rate, so a rejection by load bounds or accel
+                // enrichment showed every printed value passing while samples
+                // still vanished — an hour of misdiagnosis on real hardware.
                 tracing::debug!(
+                    reason = Self::rejection_reason(&point, filters),
                     rpm = point.rpm,
                     clt = point.clt,
+                    load = point.load,
                     tps_rate = point.tps_rate,
+                    accel_enrich_active = ?point.accel_enrich_active,
                     min_rpm = filters.min_rpm,
                     max_rpm = filters.max_rpm,
                     min_clt = filters.min_clt,
+                    min_y_axis = ?filters.min_y_axis,
+                    max_y_axis = ?filters.max_y_axis,
                     max_tps_rate = filters.max_tps_rate,
+                    exclude_accel_enrich = filters.exclude_accel_enrich,
                     rejected_so_far = n + 1,
                     "AutoTune: sample rejected by filters"
                 );
@@ -831,6 +866,73 @@ pub fn compute_flow_scaled_delay_table(
 mod tests {
     #![allow(clippy::field_reassign_with_default)]
     use super::*;
+
+    /// The accel-enrich filter must only reject when the flag is known-true.
+    /// An unknown flag (None — e.g. an ECU that publishes no boolean AE
+    /// channel) must not reject: treating unknown as active silently discarded
+    /// 100% of samples on Speeduino, whose `accelEnrich` channel is a
+    /// percentage (100 = no enrichment) and was misread as a boolean.
+    #[test]
+    fn accel_filter_rejects_only_known_active() {
+        let state = AutoTuneState::default();
+        let filters = AutoTuneFilters {
+            min_rpm: 0.0,
+            min_clt: -100.0,
+            max_tps_rate: 1000.0,
+            exclude_accel_enrich: true,
+            ..Default::default()
+        };
+        let mut point = VEDataPoint::default();
+        point.rpm = 2000.0;
+        point.clt = 80.0;
+
+        point.accel_enrich_active = Some(true);
+        assert!(
+            !state.passes_filters(&point, &filters),
+            "known-active must reject"
+        );
+        assert_eq!(
+            AutoTuneState::rejection_reason(&point, &filters),
+            "accel enrichment active"
+        );
+
+        point.accel_enrich_active = Some(false);
+        assert!(
+            state.passes_filters(&point, &filters),
+            "known-inactive must pass"
+        );
+
+        point.accel_enrich_active = None;
+        assert!(state.passes_filters(&point, &filters), "unknown must pass");
+    }
+
+    /// The rejection log's reason must name the filter that actually fired —
+    /// rpm/clt looking fine while samples vanish cost an hour on real hardware.
+    #[test]
+    fn rejection_reason_names_the_failing_filter() {
+        let filters = AutoTuneFilters::default(); // min_rpm 1000, min_clt 160
+        let mut point = VEDataPoint::default();
+
+        point.rpm = 500.0;
+        assert_eq!(
+            AutoTuneState::rejection_reason(&point, &filters),
+            "rpm out of range"
+        );
+
+        point.rpm = 2000.0;
+        point.clt = 100.0;
+        assert_eq!(
+            AutoTuneState::rejection_reason(&point, &filters),
+            "clt below min_clt"
+        );
+
+        point.clt = 180.0;
+        point.tps_rate = 50.0;
+        assert_eq!(
+            AutoTuneState::rejection_reason(&point, &filters),
+            "tps_rate above max_tps_rate"
+        );
+    }
 
     /// Captures `tracing` event messages into a shared Vec so a test can assert
     /// that a specific diagnostic actually fired (the whole point of D9: these


### PR DESCRIPTION
## The bug

`exclude_accel_enrich` is meant to drop samples taken while the ECU is adding acceleration fuel. It decided that by reading a channel and testing it as a boolean.

On Speeduino, `accelEnrich` is a **percentage**, not a flag. In a 59-minute drive log it ranges 100-122 and is never 0, so `value > 0.5` was true on every sample and the filter rejected the entire session. The channels that genuinely mean "enrichment active" are `tpsaccaen` / `mapaccaen`, which are 0/1 and were true for only 0.56% of that drive.

Measured on real hardware: **0 accepted samples before, 161 in the same 15 seconds after.**

## The fix

Resolve the flag only from channels that are genuinely boolean. If no such channel exists in the INI the flag stays `None` and the filter rejects nothing - an undeterminable flag must not silently discard a whole drive.

## Other ECUs

Channel names are matched explicitly rather than by substring, so an ECU publishing none of them is unaffected: it gets `None`, and `exclude_accel_enrich` becomes a no-op rather than a data shredder.

## Testing

`./scripts/pre-push.sh` green. Verified against Speeduino 2025.01.4 on a Mazda MX-5 NA6.
