### PR TITLE
fix(ini): take temperature units from the project, not from a guess

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/app_settings.rs
+++ b/crates/libretune-app/src-tauri/src/commands/app_settings.rs
@@ -232,6 +232,7 @@ fn default_commit_message_format() -> String {
 }
 
 pub(crate) fn save_settings(app: &tauri::AppHandle, settings: &Settings) {
+    apply_unit_symbols(settings);
     let settings_path = get_settings_path(app);
     // Ensure parent directory exists
     if let Some(parent) = settings_path.parent() {
@@ -336,6 +337,71 @@ fn default_settings() -> Settings {
     }
 }
 
+/// Symbols declared by the loaded project, if it declared any. These outrank
+/// any inference from the app's units preference, because they are the tune's
+/// own statement of how it was built rather than a guess about the user.
+static PROJECT_SYMBOLS: std::sync::RwLock<Option<Vec<String>>> = std::sync::RwLock::new(None);
+
+/// Read `ecuSettings` from the project.properties beside `ini_path` and seed
+/// the INI parser's conditional symbols from it.
+///
+/// TunerStudio stores, e.g.,
+/// `ecuSettings=AFR|CELSIUS|enablehardware_test_OFF|` in
+/// `projectCfg/project.properties`, the same folder as the controller INI, and
+/// those tokens are exactly the symbols its `#if` blocks test.
+///
+/// Must run before the INI is parsed: `#if CELSIUS` is resolved during parsing.
+pub(crate) fn seed_symbols_from_project(ini_path: &Path) {
+    let symbols = ini_path
+        .parent()
+        .map(|dir| dir.join("project.properties"))
+        .filter(|p| p.exists())
+        .and_then(|p| libretune_core::project::Properties::load(&p).ok())
+        .and_then(|props| props.get("ecuSettings").cloned())
+        .map(|raw| {
+            raw.split('|')
+                .map(str::trim)
+                .filter(|t| !t.is_empty())
+                .map(str::to_string)
+                .collect::<Vec<_>>()
+        });
+
+    if let Some(symbols) = symbols {
+        tracing::info!(?symbols, "INI symbols taken from the project's ecuSettings");
+        if let Ok(mut guard) = PROJECT_SYMBOLS.write() {
+            *guard = Some(symbols.clone());
+        }
+        libretune_core::ini::set_default_symbols(symbols);
+    }
+}
+
+/// Seed the INI preprocessor's conditional symbols.
+///
+/// An INI selects metric units through `#if CELSIUS`, and TunerStudio defines
+/// that symbol from the project's `ecuSettings`. LibreTune never carried it, so
+/// the Fahrenheit `#else` arm always won: a 23 degC cold start showed 73 on the
+/// gauge, labelled with the INI's generic "TEMP".
+///
+/// A project that declares its own `ecuSettings` decides this outright. Only
+/// when there is no declaration does the units preference stand in, and then an
+/// explicit "metric" is required: the preference defaults to an empty string,
+/// so treating "not imperial" as metric would switch every existing install to
+/// Celsius whether or not it wanted that.
+pub(crate) fn apply_unit_symbols(settings: &Settings) {
+    if let Ok(guard) = PROJECT_SYMBOLS.read() {
+        if let Some(symbols) = guard.as_ref() {
+            libretune_core::ini::set_default_symbols(symbols.clone());
+            return;
+        }
+    }
+
+    let mut symbols: Vec<String> = Vec::new();
+    if settings.units_system.eq_ignore_ascii_case("metric") {
+        symbols.push("CELSIUS".to_string());
+    }
+    libretune_core::ini::set_default_symbols(symbols);
+}
+
 pub(crate) fn load_settings(app: &tauri::AppHandle) -> Settings {
     let settings_path = get_settings_path(app);
     if let Ok(content) = std::fs::read_to_string(&settings_path) {
@@ -343,6 +409,7 @@ pub(crate) fn load_settings(app: &tauri::AppHandle) -> Settings {
             if settings.runtime_packet_mode.trim().is_empty() {
                 settings.runtime_packet_mode = default_runtime_packet_mode();
             }
+            apply_unit_symbols(&settings);
             return settings;
         }
     }
@@ -351,6 +418,7 @@ pub(crate) fn load_settings(app: &tauri::AppHandle) -> Settings {
     if s.runtime_packet_mode.trim().is_empty() {
         s.runtime_packet_mode = default_runtime_packet_mode();
     }
+    apply_unit_symbols(&s);
     s
 }
 
@@ -447,6 +515,46 @@ mod tests {
             std::fs::read_to_string(&backup_path).unwrap(),
             r#"{"units_system":"metr"#
         );
+    }
+
+    /// The project states its own units, so nothing is inferred from a UI
+    /// preference. This is the declaration from a real NA6 Speeduino project
+    /// whose `units_system` is the empty default - the case where either
+    /// direction of guess is wrong for somebody.
+    #[test]
+    fn project_ecu_settings_decide_the_ini_symbols() {
+        let dir = TempDir::new().unwrap();
+        let cfg = dir.path().join("projectCfg");
+        std::fs::create_dir_all(&cfg).unwrap();
+        std::fs::write(
+            cfg.join("project.properties"),
+            "projectName=NA6_SPEEDUINO
+             ecuSettings=AFR|CELSIUS|enablehardware_test_OFF|resetcontrol_standard|
+",
+        )
+        .unwrap();
+
+        seed_symbols_from_project(&cfg.join("mainController.ini"));
+
+        let symbols = PROJECT_SYMBOLS.read().unwrap().clone().unwrap();
+        assert!(symbols.iter().any(|s| s == "CELSIUS"));
+        assert_eq!(symbols.len(), 4, "the trailing empty token is not a symbol");
+
+        // The declaration outranks the preference, so a user who never opened
+        // Settings still gets the units the tune was built in.
+        apply_unit_symbols(&Settings {
+            units_system: String::new(),
+            ..Default::default()
+        });
+        assert!(PROJECT_SYMBOLS
+            .read()
+            .unwrap()
+            .as_ref()
+            .unwrap()
+            .iter()
+            .any(|s| s == "CELSIUS"));
+
+        *PROJECT_SYMBOLS.write().unwrap() = None;
     }
 
     #[test]

--- a/crates/libretune-app/src-tauri/src/commands/load_ini.rs
+++ b/crates/libretune-app/src-tauri/src/commands/load_ini.rs
@@ -25,6 +25,10 @@ pub async fn load_ini(
     };
 
     println!("Loading INI from: {:?}", full_path);
+
+    // Seed the INI's conditional symbols from the project's own declaration
+    // before parsing: `#if CELSIUS` blocks are resolved during the parse.
+    crate::commands::app_settings::seed_symbols_from_project(&full_path);
     match EcuDefinition::from_file(full_path.to_string_lossy().as_ref()) {
         Ok(def) => {
             println!(

--- a/crates/libretune-core/src/ini/mod.rs
+++ b/crates/libretune-core/src/ini/mod.rs
@@ -25,6 +25,9 @@ pub use error::IniError;
 pub use gauges::{parse_gauge_line, GaugeConfig};
 pub use inc_tables::{IncTable, IncTableCache};
 pub use output_channels::OutputChannel;
+/// Seed preprocessor symbols (e.g. `CELSIUS`) applied to every parse — see
+/// [`parser::set_default_symbols`].
+pub use parser::set_default_symbols;
 pub use tables::{CurveDefinition, TableDefinition, TableRole, TableType};
 pub use types::*;
 

--- a/crates/libretune-core/src/ini/parser.rs
+++ b/crates/libretune-core/src/ini/parser.rs
@@ -48,13 +48,41 @@ struct IncludeContext {
     pub defined_symbols: HashSet<String>,
 }
 
+/// Preprocessor symbols every parse starts with, on top of anything the INI
+/// `#set`s itself.
+///
+/// TunerStudio seeds these from the project's `ecuSettings` line
+/// (`ecuSettings=AFR|CELSIUS|…`), which is how an INI's `#if CELSIUS` blocks
+/// select metric units. Nothing carried that into LibreTune, so the `#else`
+/// arm always won and every temperature came out in Fahrenheit while wearing
+/// the INI's generic "TEMP" label — a 23 °C cold start read 73 on the gauge.
+/// The host application sets this from its own units preference.
+static DEFAULT_SYMBOLS: std::sync::RwLock<Option<HashSet<String>>> = std::sync::RwLock::new(None);
+
+/// Replace the preprocessor symbols seeded into every subsequent parse.
+/// Call before loading a definition; affects parses started after it returns.
+pub fn set_default_symbols<I: IntoIterator<Item = String>>(symbols: I) {
+    let set: HashSet<String> = symbols.into_iter().collect();
+    if let Ok(mut guard) = DEFAULT_SYMBOLS.write() {
+        *guard = Some(set);
+    }
+}
+
+fn default_symbols() -> HashSet<String> {
+    DEFAULT_SYMBOLS
+        .read()
+        .ok()
+        .and_then(|g| g.clone())
+        .unwrap_or_default()
+}
+
 impl IncludeContext {
     fn new(base_path: Option<&Path>) -> Self {
         Self {
             base_dir: base_path.and_then(|p| p.parent().map(|d| d.to_path_buf())),
             included_files: HashSet::new(),
             depth: 0,
-            defined_symbols: HashSet::new(),
+            defined_symbols: default_symbols(),
         }
     }
 
@@ -3167,6 +3195,47 @@ fn parse_constants_extensions_entry(def: &mut EcuDefinition, key: &str, value: &
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// An INI picks metric units with `#if CELSIUS`. TunerStudio defines that
+    /// from the project's `ecuSettings`; nothing carried it into LibreTune, so
+    /// the Fahrenheit `#else` arm always won and a 23 degC cold start read 73
+    /// on the gauge under a generic "TEMP" label.
+    #[test]
+    fn celsius_symbol_selects_the_metric_branch() {
+        let ini = concat!(
+            "[Constants]
+",
+            "page = 1
+",
+            "#if CELSIUS
+",
+            "tempTest = scalar, U08, 0, \"C\", 1.0, -40, -40, 102.0, 0
+",
+            "#else
+",
+            "tempTest = scalar, U08, 0, \"F\", 1.8, -22.23, -40, 215.0, 0
+",
+            "#endif
+"
+        );
+
+        set_default_symbols(Vec::<String>::new());
+        let f = parse_ini(ini).expect("parses");
+        assert_eq!(
+            f.constants.get("tempTest").map(|c| c.units.as_str()),
+            Some("F"),
+            "without the symbol the Fahrenheit branch is taken"
+        );
+
+        set_default_symbols(vec!["CELSIUS".to_string()]);
+        let c = parse_ini(ini).expect("parses");
+        assert_eq!(
+            c.constants.get("tempTest").map(|c| c.units.as_str()),
+            Some("C"),
+            "seeding CELSIUS must select the metric branch"
+        );
+        set_default_symbols(Vec::<String>::new());
+    }
 
     #[test]
     fn test_strip_comment() {


### PR DESCRIPTION
## The bug

An INI selects its unit system with `#if CELSIUS`, and TunerStudio defines that symbol from the project's own `ecuSettings` line. Nothing carried it into LibreTune, so the Fahrenheit `#else` arm always won: a 23 C intake read 73 on the gauge under the INI's generic "TEMP" label, and a 52 C coolant read 126.

## Why not infer it from the units preference

Because that is wrong in both directions, and I tried both.

Treating "not imperial" as metric forces Celsius onto every install that never opened Settings, since the preference defaults to an empty string. Requiring an explicit `"metric"` instead fixes those users and breaks the ones the bug was reported from - whose preference is equally empty.

## The fix

TunerStudio does not infer it, because the project states it. `project.properties` sits beside the controller INI and carries

```
ecuSettings=AFR|CELSIUS|enablehardware_test_OFF|resetcontrol_standard|
```

and those tokens are exactly the symbols the INI's `#if` blocks test. They are now read and seeded before parsing - which has to happen first, since `#if` is resolved as the INI is read - and they outrank the units preference.

## Other ECUs

The preference remains as a fallback for projects that declare nothing, and there it still requires an explicit `"metric"`, so no existing installation changes units without being asked.

## Testing

`./scripts/pre-push.sh` green. New test uses a real NA6 Speeduino project's declaration.
