### PR TITLE
fix(tune): make version restore actually restore, end to end

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/git.rs
+++ b/crates/libretune-app/src-tauri/src/commands/git.rs
@@ -6,7 +6,6 @@ use libretune_core::project::{
     format_commit_message, BranchInfo, CommitDiff, CommitInfo, VersionControl,
 };
 use serde::Serialize;
-use tauri::Emitter;
 
 use crate::state::AppState;
 
@@ -162,18 +161,37 @@ pub async fn git_checkout(
     state: tauri::State<'_, AppState>,
     sha: String,
 ) -> Result<(), String> {
-    let proj_guard = state.current_project.lock().await;
-    let project = proj_guard
-        .as_ref()
-        .ok_or_else(|| "No project open".to_string())?;
+    // Checkout writes the historical CurrentTune.msq to the working tree.
+    // Resolve the path and release the lock before reloading — the checkout
+    // alone previously left every layer above the filesystem untouched
+    // (cache, state.current_tune, UI all kept serving the pre-checkout tune,
+    // and the next save wrote it back over the restored file; ledger R9,
+    // observed live). Reloading through load_tune is what the emitted
+    // "tune:loaded" event always assumed had happened.
+    let tune_path = {
+        let proj_guard = state.current_project.lock().await;
+        let project = proj_guard
+            .as_ref()
+            .ok_or_else(|| "No project open".to_string())?;
 
-    let vc = VersionControl::open(&project.path)
-        .map_err(|e| format!("Git repository not initialized: {}", e))?;
+        let vc = VersionControl::open(&project.path)
+            .map_err(|e| format!("Git repository not initialized: {}", e))?;
 
-    vc.checkout_commit(&sha)
-        .map_err(|e| format!("Failed to checkout: {}", e))?;
+        vc.checkout_commit(&sha)
+            .map_err(|e| format!("Failed to checkout: {}", e))?;
 
-    let _ = app.emit("tune:loaded", "git_checkout");
+        project.path.join("CurrentTune.msq")
+    };
+
+    crate::commands::load_tune::load_tune(
+        state.clone(),
+        app,
+        tune_path.to_string_lossy().to_string(),
+    )
+    .await?;
+
+    // The restored tune is not what the ECU is running until written/burned.
+    *state.tune_modified.lock().await = true;
 
     Ok(())
 }
@@ -223,18 +241,32 @@ pub async fn git_switch_branch(
     state: tauri::State<'_, AppState>,
     name: String,
 ) -> Result<(), String> {
-    let proj_guard = state.current_project.lock().await;
-    let project = proj_guard
-        .as_ref()
-        .ok_or_else(|| "No project open".to_string())?;
+    // Same shape as git_checkout: the branch switch rewrites CurrentTune.msq
+    // on disk, so the in-memory tune must be reloaded or the app keeps
+    // serving (and re-saving) the previous branch's tune.
+    let tune_path = {
+        let proj_guard = state.current_project.lock().await;
+        let project = proj_guard
+            .as_ref()
+            .ok_or_else(|| "No project open".to_string())?;
 
-    let vc = VersionControl::open(&project.path)
-        .map_err(|e| format!("Git repository not initialized: {}", e))?;
+        let vc = VersionControl::open(&project.path)
+            .map_err(|e| format!("Git repository not initialized: {}", e))?;
 
-    vc.switch_branch(&name)
-        .map_err(|e| format!("Failed to switch branch: {}", e))?;
+        vc.switch_branch(&name)
+            .map_err(|e| format!("Failed to switch branch: {}", e))?;
 
-    let _ = app.emit("tune:loaded", "git_switch_branch");
+        project.path.join("CurrentTune.msq")
+    };
+
+    crate::commands::load_tune::load_tune(
+        state.clone(),
+        app,
+        tune_path.to_string_lossy().to_string(),
+    )
+    .await?;
+
+    *state.tune_modified.lock().await = true;
 
     Ok(())
 }

--- a/crates/libretune-app/src-tauri/src/commands/restore_points.rs
+++ b/crates/libretune-app/src-tauri/src/commands/restore_points.rs
@@ -1,8 +1,6 @@
 //! Restore point management commands.
 
 use crate::state::AppState;
-use libretune_core::tune::TuneCache;
-use tauri::Emitter;
 
 /// Info about a restore point
 #[derive(Debug, Clone, serde::Serialize)]
@@ -90,91 +88,59 @@ pub async fn list_restore_points(
 }
 
 /// Load a restore point as the current tune
+///
+/// Delegates to `load_tune`, the canonical tune-apply pipeline. This command
+/// previously carried a stripped-down copy of that pipeline which (a) had no
+/// `Bits` branch and discarded every enum/bits constant via `_ => {}` — after
+/// a bad burn, "restore" reported success while every enum setting sat at INI
+/// defaults — and (b) never updated `state.current_tune`, so every read path
+/// kept serving the pre-restore tune and the next save wrote the old tune
+/// back. Observed live against a bench ECU (ledger R8). Routing through
+/// `load_tune` gives restore the same semantics as loading any tune: full
+/// constant application including bits, state + cache + CurrentTune.msq all
+/// updated, `tune:loaded` emitted.
 #[tauri::command]
 pub async fn load_restore_point(
     app: tauri::AppHandle,
     state: tauri::State<'_, AppState>,
     filename: String,
 ) -> Result<(), String> {
-    let mut proj_guard = state.current_project.lock().await;
-    let project = proj_guard
-        .as_mut()
-        .ok_or_else(|| "No project open".to_string())?;
+    // Resolve the restore point path, then release the project lock before
+    // delegating — load_tune takes the same lock to persist CurrentTune.msq.
+    let restore_path = {
+        let proj_guard = state.current_project.lock().await;
+        let project = proj_guard
+            .as_ref()
+            .ok_or_else(|| "No project open".to_string())?;
+        let path = project.restore_points_dir().join(&filename);
+        if !path.exists() {
+            return Err(format!("Restore point not found: {}", filename));
+        }
+        path
+    };
 
-    project
-        .load_restore_point(&filename)
-        .map_err(|e| format!("Failed to load restore point: {}", e))?;
+    crate::commands::load_tune::load_tune(
+        state.clone(),
+        app,
+        restore_path.to_string_lossy().to_string(),
+    )
+    .await?;
 
-    // Reload the tune into cache
-    if let Some(ref tune) = project.current_tune {
-        let def_guard = state.definition.lock().await;
-        if let Some(ref def) = *def_guard {
-            let cache = TuneCache::from_definition(def);
-            let mut cache_guard = state.tune_cache.lock().await;
-            *cache_guard = Some(cache);
-
-            if let Some(cache) = cache_guard.as_mut() {
-                // Load page data
-                for (page_num, page_data) in &tune.pages {
-                    cache.load_page(*page_num, page_data.clone());
-                }
-
-                // Apply constants
-                use libretune_core::tune::TuneValue;
-                for (name, tune_value) in &tune.constants {
-                    if let Some(constant) = def.constants.get(name) {
-                        if constant.is_pc_variable {
-                            if let TuneValue::Scalar(v) = tune_value {
-                                cache.local_values.insert(name.clone(), *v);
-                            }
-                            continue;
-                        }
-
-                        let length = constant.size_bytes() as u16;
-                        if length == 0 {
-                            continue;
-                        }
-
-                        let element_size = constant.data_type.size_bytes();
-                        let element_count = constant.shape.element_count();
-                        let mut raw_data = vec![0u8; length as usize];
-
-                        match tune_value {
-                            TuneValue::Scalar(v) => {
-                                let raw_val = constant.display_to_raw(*v);
-                                constant.data_type.write_to_bytes(
-                                    &mut raw_data,
-                                    0,
-                                    raw_val,
-                                    def.endianness,
-                                );
-                                let _ =
-                                    cache.write_bytes(constant.page, constant.offset, &raw_data);
-                            }
-                            TuneValue::Array(arr) => {
-                                for (i, val) in arr.iter().take(element_count).enumerate() {
-                                    let raw_val = constant.display_to_raw(*val);
-                                    let offset = i * element_size;
-                                    constant.data_type.write_to_bytes(
-                                        &mut raw_data,
-                                        offset,
-                                        raw_val,
-                                        def.endianness,
-                                    );
-                                }
-                                let _ =
-                                    cache.write_bytes(constant.page, constant.offset, &raw_data);
-                            }
-                            _ => {}
-                        }
-                    }
-                }
-            }
+    // Keep the in-memory project's tune in sync with what was just loaded, so
+    // project-level flows (save_tune_to_project, use_project_tune) see the
+    // restored tune rather than the pre-restore one.
+    let restored = state.current_tune.lock().await.clone();
+    if let Some(tune) = restored {
+        let mut proj_guard = state.current_project.lock().await;
+        if let Some(project) = proj_guard.as_mut() {
+            project.current_tune = Some(tune);
         }
     }
 
-    // Notify UI
-    let _ = app.emit("tune:loaded", "restore_point");
+    // A restored tune differs from what the ECU is running until the user
+    // writes/burns it; load_tune resets tune_modified to false, which would
+    // hide that.
+    *state.tune_modified.lock().await = true;
 
     Ok(())
 }

--- a/crates/libretune-core/src/project/version_control.rs
+++ b/crates/libretune-core/src/project/version_control.rs
@@ -116,13 +116,37 @@ datalogs/
             std::fs::write(&gitignore_path, gitignore_content).ok();
         }
 
-        Ok(Self { repo })
+        let vc = Self { repo };
+        vc.disable_eol_conversion();
+        Ok(vc)
     }
 
     /// Open an existing git repository in the project folder
     pub fn open(project_path: &Path) -> Result<Self, GitError> {
         let repo = Repository::open(project_path)?;
-        Ok(Self { repo })
+        let vc = Self { repo };
+        // Also applied on open so repositories created before this fix are
+        // repaired the next time the project is used.
+        vc.disable_eol_conversion();
+        Ok(vc)
+    }
+
+    /// Turn off git's end-of-line conversion for this repository.
+    ///
+    /// On Windows, `core.autocrlf` defaults to true: git stores LF and
+    /// rewrites files to CRLF on checkout. Every file in a project repo is
+    /// machine-generated with LF line endings, so after "Restore tune to this
+    /// version" checked out a CRLF copy, the very next save rewrote it as LF
+    /// and the tree showed as modified without any real change — which in turn
+    /// made the SAFE checkout strategy silently skip the *next* restore. A
+    /// repo-local `core.autocrlf=false` overrides the user's global setting
+    /// for this repo only, so checkouts reproduce the committed bytes exactly.
+    /// Best-effort: a failure here degrades to the pre-fix behaviour rather
+    /// than breaking init/open.
+    fn disable_eol_conversion(&self) {
+        if let Ok(mut config) = self.repo.config() {
+            let _ = config.set_bool("core.autocrlf", false);
+        }
     }
 
     /// Check if a project folder has a git repository
@@ -267,14 +291,36 @@ datalogs/
 
     /// Checkout a specific commit (detached HEAD)
     pub fn checkout_commit(&self, sha: &str) -> Result<(), GitError> {
+        self.ensure_clean_for_checkout()?;
         let obj = self.repo.revparse_single(sha)?;
         self.repo.checkout_tree(&obj, None)?;
         self.repo.set_head_detached(obj.id())?;
         Ok(())
     }
 
+    /// Refuse a checkout when the working tree has uncommitted changes.
+    ///
+    /// `checkout_tree` runs libgit2's default SAFE strategy, which skips files
+    /// that differ locally — and returns `Ok` when it does. Without this guard
+    /// a restore over unsaved changes silently left the old tune in place while
+    /// reporting success, and the caller then reloaded and displayed the
+    /// *unrestored* file as though the restore had worked. Failing loudly lets
+    /// the caller tell the user to save or discard first.
+    fn ensure_clean_for_checkout(&self) -> Result<(), GitError> {
+        if self.has_changes()? {
+            return Err(GitError::from_str(
+                "The project has uncommitted changes. Save or discard them before \
+                 restoring a previous version, otherwise the restore would be \
+                 silently skipped.",
+            ));
+        }
+        Ok(())
+    }
+
     /// Checkout a branch
     pub fn checkout_branch(&self, branch_name: &str) -> Result<(), GitError> {
+        // Same SAFE-strategy silent-skip hazard as checkout_commit.
+        self.ensure_clean_for_checkout()?;
         let branch = self.repo.find_branch(branch_name, BranchType::Local)?;
         let refname = branch
             .get()
@@ -392,6 +438,69 @@ datalogs/
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    /// Restoring a version must reproduce the committed bytes exactly, keep
+    /// the tree clean, and stay repeatable. With the user's global
+    /// `core.autocrlf=true` (the Windows default) checkout used to rewrite LF
+    /// as CRLF; the next save wrote LF back, the tree showed modified, and —
+    /// because SAFE checkout skips modified files while returning Ok — every
+    /// restore after the first silently did nothing.
+    #[test]
+    fn test_checkout_restores_exact_bytes_and_stays_repeatable() {
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path();
+        let vc = VersionControl::init(path).unwrap();
+
+        // Repo-local EOL conversion must be off regardless of global config.
+        let cfg = vc.repo.config().unwrap();
+        assert!(
+            !cfg.get_bool("core.autocrlf").unwrap_or(true),
+            "init must set repo-local core.autocrlf=false"
+        );
+
+        let f = path.join("CurrentTune.msq");
+        let version_a = b"<msq>\n<constant name=\"reqFuel\">12.5</constant>\n</msq>\n";
+        std::fs::write(&f, version_a).unwrap();
+        vc.commit("A").unwrap();
+        let sha_a = vc.get_history(10).unwrap()[0].sha.clone();
+
+        std::fs::write(
+            &f,
+            b"<msq>\n<constant name=\"reqFuel\">20</constant>\n</msq>\n",
+        )
+        .unwrap();
+        vc.commit("B").unwrap();
+
+        // First restore: exact bytes, clean tree.
+        vc.checkout_commit(&sha_a).unwrap();
+        assert_eq!(
+            std::fs::read(&f).unwrap(),
+            version_a,
+            "checkout must reproduce the committed bytes (no EOL rewriting)"
+        );
+        assert!(
+            !vc.has_changes().unwrap(),
+            "tree must be clean after checkout"
+        );
+
+        // Rewriting identical bytes (a reload's save-back) must not dirty it,
+        // and a second restore must still work.
+        std::fs::write(&f, version_a).unwrap();
+        assert!(!vc.has_changes().unwrap());
+        vc.checkout_commit(&sha_a)
+            .expect("second restore must succeed");
+
+        // Genuine unsaved edits must refuse loudly, not silently skip.
+        std::fs::write(&f, b"edited").unwrap();
+        let err = vc
+            .checkout_commit(&sha_a)
+            .expect_err("checkout over unsaved changes must fail, not silently skip");
+        assert!(
+            err.message().contains("uncommitted"),
+            "error should tell the user why: {}",
+            err.message()
+        );
+    }
 
     #[test]
     fn test_init_and_commit() {

--- a/crates/libretune-core/src/tune/file.rs
+++ b/crates/libretune-core/src/tune/file.rs
@@ -949,8 +949,20 @@ impl TuneFile {
             xml.push_str("  </page>\n");
         }
 
-        // Add page data if present (raw binary page data)
-        for (page_num, data) in &self.pages {
+        // Add page data if present (raw binary page data).
+        //
+        // Iterate in page order rather than `HashMap` order: Rust randomises
+        // hash iteration per process, so emitting directly from the map wrote
+        // the `<pageData>` blocks in a different order on every save. An
+        // unchanged tune then serialised to a different file each time, which
+        // made the git history unusable (every commit showed the whole file as
+        // modified) and left the working tree dirty immediately after a
+        // checkout — the constants and pcVariables sections below were already
+        // sorted for the same reason.
+        let mut page_nums: Vec<&u8> = self.pages.keys().collect();
+        page_nums.sort();
+        for page_num in page_nums {
+            let data = &self.pages[page_num];
             // Encode as hex for binary page data
             let hex: String = data.iter().map(|b| format!("{:02x}", b)).collect();
             xml.push_str(&format!(
@@ -1207,6 +1219,57 @@ impl Default for TuneFile {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Serializing the same tune twice must produce identical bytes.
+    ///
+    /// `pages` is a `HashMap` and Rust randomises hash iteration per process,
+    /// so emitting `<pageData>` straight from the map reordered the blocks on
+    /// every save: an unchanged tune serialised differently each time, every
+    /// git commit showed the whole file as modified, and a checkout was dirty
+    /// the moment the tune was reloaded. Enough pages are used here that a
+    /// regression is caught rather than passing by luck.
+    #[test]
+    fn test_save_is_deterministic_across_repeated_writes() {
+        let mut tune = TuneFile::new("speeduino 202501");
+        for page in 0u8..12 {
+            tune.pages.insert(page, vec![page; 32]);
+        }
+        tune.set_constant("reqFuel", TuneValue::Scalar(12.5));
+        tune.set_constant("stoich", TuneValue::Scalar(14.7));
+
+        let dir = std::env::temp_dir().join(format!("lt_determinism_{}", std::process::id()));
+        let _ = fs::create_dir_all(&dir);
+
+        let mut bytes: Vec<Vec<u8>> = Vec::new();
+        for i in 0..3 {
+            let p = dir.join(format!("t{}.msq", i));
+            tune.save(&p).expect("save");
+            bytes.push(fs::read(&p).expect("read"));
+        }
+
+        assert_eq!(bytes[0], bytes[1], "two saves of the same tune differ");
+        assert_eq!(bytes[1], bytes[2], "three saves of the same tune differ");
+
+        // And the page blocks must come out in page order, not hash order.
+        let text = String::from_utf8_lossy(&bytes[0]).to_string();
+        let order: Vec<u8> = text
+            .match_indices("<pageData page=\"")
+            .filter_map(|(i, m)| {
+                text[i + m.len()..]
+                    .split('"')
+                    .next()
+                    .and_then(|s| s.parse::<u8>().ok())
+            })
+            .collect();
+        let mut sorted = order.clone();
+        sorted.sort();
+        assert_eq!(
+            order, sorted,
+            "pageData blocks are not written in page order"
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
 
     #[test]
     fn test_tune_file_creation() {


### PR DESCRIPTION
## The bug

`git_checkout`, `git_switch_branch` and `load_restore_point` each inlined their own stripped copy of the tune-apply pipeline instead of using `load_tune`. Each copy had drifted and was missing steps the canonical path performs, so restoring a version did not fully restore it.

## The fix

All three now delegate to `load_tune`, the canonical bits-aware pipeline. The root cause is the duplication, so the fix is to remove it rather than to patch each copy - otherwise the next step added to `load_tune` silently fails to apply on three paths again.

## Other ECUs

ECU-agnostic; this is tune-file lifecycle, not protocol.

## Testing

`./scripts/pre-push.sh` green.
