### PR TITLE
fix(autotune): hit-weighting heatmap never varied, and view switches showed a live session as stopped

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/autotune_misc.rs
+++ b/crates/libretune-app/src-tauri/src/commands/autotune_misc.rs
@@ -70,6 +70,38 @@ mod tests {
 /// Recommendations remain available until explicitly cleared.
 ///
 /// Returns: Nothing on success
+/// Whether an AutoTune session is live, and against which tables.
+///
+/// The session runs in the backend and survives the AutoTune view unmounting
+/// (e.g. switching to the dashboard and back). The view calls this on mount to
+/// re-attach instead of assuming no session exists.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AutotuneStatus {
+    pub running: bool,
+    pub table_name: Option<String>,
+    pub secondary_table_name: Option<String>,
+}
+
+#[tauri::command]
+pub async fn get_autotune_status(
+    state: tauri::State<'_, AppState>,
+) -> Result<AutotuneStatus, String> {
+    let config_guard = state.autotune_config.lock().await;
+    Ok(match config_guard.as_ref() {
+        Some(config) => AutotuneStatus {
+            running: true,
+            table_name: Some(config.table_name.clone()),
+            secondary_table_name: config.secondary_table_name.clone(),
+        },
+        None => AutotuneStatus {
+            running: false,
+            table_name: None,
+            secondary_table_name: None,
+        },
+    })
+}
+
 #[tauri::command]
 pub async fn stop_autotune(state: tauri::State<'_, AppState>) -> Result<(), String> {
     let mut guard = state.autotune_state.lock().await;

--- a/crates/libretune-app/src-tauri/src/lib.rs
+++ b/crates/libretune-app/src-tauri/src/lib.rs
@@ -52,7 +52,8 @@ use commands::annotations::{
 use commands::apply_base_map::apply_base_map;
 use commands::autotune_misc::{
     burn_autotune_recommendations, get_autotune_heatmap, get_autotune_recommendations,
-    lock_autotune_cells, send_autotune_recommendations, stop_autotune, unlock_autotune_cells,
+    get_autotune_status, lock_autotune_cells, send_autotune_recommendations, stop_autotune,
+    unlock_autotune_cells,
 };
 use commands::available_inis::get_available_inis;
 use commands::base_map::generate_base_map;
@@ -288,6 +289,7 @@ pub fn run() {
             get_all_constant_values,
             start_autotune,
             stop_autotune,
+            get_autotune_status,
             get_autotune_recommendations,
             get_autotune_heatmap,
             send_autotune_recommendations,

--- a/crates/libretune-app/src-tauri/src/state.rs
+++ b/crates/libretune-app/src-tauri/src/state.rs
@@ -164,7 +164,6 @@ pub fn is_tps_channel_name(name: &str) -> bool {
 /// AutoTune configuration stored when tuning session starts
 #[derive(Clone)]
 pub struct AutoTuneConfig {
-    #[allow(dead_code)]
     pub table_name: String,
     /// Signature of the ECU definition this session's bins/tables were
     /// resolved against. If the loaded definition changes (e.g. reconnect to

--- a/crates/libretune-app/src/components/tuner-ui/AutoTune.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/AutoTune.tsx
@@ -352,6 +352,37 @@ export function AutoTune({ tableName: initialTableName = '', onClose, isConnecte
     }
   }, [secondaryTableEnabled, secondaryTable, selectedTable, secondaryOptions]);
 
+  // Re-attach to a live session. The backend session survives this view
+  // unmounting (switching to the dashboard and back), but isRunning is
+  // component state and resets to false on remount — so the view showed a
+  // running session as stopped and never resumed polling.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const status = await invoke<{
+          running: boolean;
+          tableName: string | null;
+          secondaryTableName: string | null;
+        }>('get_autotune_status');
+        if (cancelled || !status?.running) return;
+        setIsRunning(true);
+        if (status.tableName) {
+          setSelectedTable(status.tableName);
+        }
+        if (status.secondaryTableName) {
+          setSecondaryTableEnabled(true);
+          setSecondaryTable(status.secondaryTableName);
+        }
+      } catch {
+        // No session (or status unavailable) — keep the stopped default.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   // Load initial table data
   useEffect(() => {
     loadAvailableTables();
@@ -602,6 +633,12 @@ export function AutoTune({ tableName: initialTableName = '', onClose, isConnecte
     return lookup;
   }, [heatmapData]);
 
+  // Highest hit count on the board, for normalizing the weighting heatmap.
+  const maxHits = useMemo(
+    () => heatmapData.reduce((m, e) => Math.max(m, e.hit_count), 0),
+    [heatmapData]
+  );
+
   // Get cell color based on heatmap mode
   const getCellColor = useCallback(
     (x: number, y: number, value: number) => {
@@ -612,15 +649,26 @@ export function AutoTune({ tableName: initialTableName = '', onClose, isConnecte
         return 'var(--cell-locked)';
       }
 
+      if (showHeatmap === 'weighting') {
+        // hit_weighting accumulates 1.0 per accepted sample, so the previous
+        // min(1, hit_weighting) saturated after a single hit and every visited
+        // cell rendered the same colour regardless of count. Colour by hit
+        // count on a log scale against the busiest cell, interpolating the
+        // same yellow->blue ramp the legend shows (hsl(60,80%,30%) ->
+        // hsl(240,80%,50%) in RGB, matching the CSS gradient). Unhit cells go
+        // neutral — the VE-value gradient here read as hit intensity.
+        const hits = entry?.hit_count ?? 0;
+        if (hits <= 0 || maxHits <= 0) {
+          return 'var(--cell-neutral)';
+        }
+        const t = Math.log1p(hits) / Math.log1p(maxHits);
+        const lerp = (a: number, b: number) => Math.round(a + (b - a) * t);
+        return `rgb(${lerp(138, 26)}, ${lerp(138, 26)}, ${lerp(15, 230)})`;
+      }
+
       if (!entry || showHeatmap === 'none') {
         // Default value-based coloring using centralized heatmap utility
         return valueToHeatmapColor(value, 0, 100, 'tunerstudio');
-      }
-
-      if (showHeatmap === 'weighting') {
-        // Coverage/weighting heatmap using centralized utility
-        const w = Math.min(1, entry.hit_weighting);
-        return valueToHeatmapColor(w, 0, 1, 'tunerstudio');
       }
 
       if (showHeatmap === 'change') {
@@ -639,7 +687,7 @@ export function AutoTune({ tableName: initialTableName = '', onClose, isConnecte
 
       return 'var(--cell-default)';
     },
-    [heatmapLookup, showHeatmap, lockedCells, authority.max_change_per_cell]
+    [heatmapLookup, showHeatmap, lockedCells, authority.max_change_per_cell, maxHits]
   );
 
   // Stats


### PR DESCRIPTION
## Two small AutoTune view fixes

**1. The hit-weighting heatmap never varied.** Every cell rendered the same regardless of how much data backed it, so the display could not distinguish a cell with one sample from one with hundreds - which is exactly what the heatmap exists to show.

**2. Switching views showed a running session as stopped.** Navigating away and back reset the displayed state rather than reflecting the session that was still running.

## Other ECUs

UI only; no protocol or ECU interaction.

## Testing

`./scripts/pre-push.sh` green.

## Note

These are two unrelated fixes under one PR because both are small and confined to the AutoTune view. Happy to split if you would prefer them separate.
