### PR TITLE
test(app): stop the toolbar integration test failing on a 1 s deadline

### DIFF
--- a/crates/libretune-app/src/__tests__/App.integration.test.tsx
+++ b/crates/libretune-app/src/__tests__/App.integration.test.tsx
@@ -105,14 +105,28 @@ describe('App integration (toolbar connection-info)', () => {
       </LoadingProvider>
     );
 
-    // Packet mode label should show 'Auto' for connected state (wait for mount to stabilize)
-    await waitFor(() => expect(screen.getByText('Auto')).toBeInTheDocument());
+    // Packet mode label should show 'Auto' for connected state.
+    //
+    // Generous timeout on purpose: mounting App fires a chain of async invokes
+    // (repository init, project list, settings, connection status, menu tree)
+    // before the toolbar can render the packet mode. testing-library's default
+    // is 1000 ms, which this clears comfortably when the file runs alone but
+    // not when the full suite saturates the machine - the failure was
+    // "Unable to find an element with the text: Auto", i.e. the deadline, not
+    // a wrong render. It made pre-push.sh fail at random on Windows while
+    // passing in CI.
+    await waitFor(() => expect(screen.getByText('Auto')).toBeInTheDocument(), {
+      timeout: 10_000,
+    });
 
     // After our synthetic metrics event arrives (via the spy), the metrics element should show a unit like kB/s or MB/s
-    await waitFor(() => {
-      const text = container.querySelector('.conn-metrics')?.textContent || '';
-      expect(/B\/s|kB\/s|MB\/s/.test(text)).toBe(true);
-    });
+    await waitFor(
+      () => {
+        const text = container.querySelector('.conn-metrics')?.textContent || '';
+        expect(/B\/s|kB\/s|MB\/s/.test(text)).toBe(true);
+      },
+      { timeout: 10_000 },
+    );
 
     listenMock.mockRestore();
 
@@ -121,10 +135,13 @@ describe('App integration (toolbar connection-info)', () => {
     expect(metricsEl).toBeTruthy();
 
     // After our synthetic metrics event arrives, the metrics element should show a unit like kB/s or MB/s
-    await waitFor(() => {
-      const text = container.querySelector('.conn-metrics')?.textContent || '';
-      expect(/B\/s|kB\/s|MB\/s/.test(text)).toBe(true);
-    });
+    await waitFor(
+      () => {
+        const text = container.querySelector('.conn-metrics')?.textContent || '';
+        expect(/B\/s|kB\/s|MB\/s/.test(text)).toBe(true);
+      },
+      { timeout: 10_000 },
+    );
   });
 
   it('shows placeholder packet mode when disconnected', async () => {


### PR DESCRIPTION
## The problem

`App integration > shows packet mode and receives metrics when connected` fails intermittently, and when it does it takes `./scripts/pre-push.sh` with it — so the documented pre-push gate blocks at random.

It passes in CI, so this is invisible there and only affects contributors running the script locally.

## It's a deadline, not a wrong render

The test mounts the whole App, which fires a chain of async invokes — repository init, project list, settings, connection status, menu tree — before the toolbar can render the packet mode. It then waits for that label with testing-library's default **1000 ms**.

Run alone the file clears that comfortably (3/3 here). In the full 26-file suite, with workers saturating the machine, it does not, and the assertion reports `Unable to find an element with the text: Auto`.

## Diagnosis, not assumption

Two things confirm it:

- The same failure appears on a branch whose only change is a **backend Rust cherry-pick**, which cannot affect a frontend render.
- Widening the deadline makes the full suite pass **147/147 twice consecutively**, where it had been failing consistently.

## The fix

Widened to 10 s. This adds no real delay — the assertion still resolves the moment the label appears — it only stops a slow machine being read as a failure.

## Testing

`./scripts/pre-push.sh` green; full suite 147/147 on repeated runs.
