### PR TITLE
perf(expr): build only the context an expression can actually reach

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/ini_dialogs.rs
+++ b/crates/libretune-app/src-tauri/src/commands/ini_dialogs.rs
@@ -1,6 +1,6 @@
 //! INI dialog/indicator/port-editor/help/expression query commands.
 
-use crate::commands::string_context::build_string_context;
+use crate::commands::string_context::{build_string_context_filtered, referenced_identifiers};
 use crate::port_editor::{load_port_editor_store, save_port_editor_store, PortEditorAssignment};
 use crate::state::AppState;
 use libretune_core::ini::expression::{evaluate, evaluate_display_string, Parser};
@@ -23,7 +23,12 @@ pub async fn evaluate_expression(
     expression: String,
     context: HashMap<String, f64>,
 ) -> Result<bool, String> {
-    let string_ctx = build_string_context(&state).await;
+    // Only the identifiers this expression mentions: the dashboard calls this
+    // every 250 ms per conditioned gauge, and the unfiltered build clones every
+    // string, array and bitfield option list in the INI (~100 ms on a real
+    // Speeduino tune) to answer a question about one or two names.
+    let names = referenced_identifiers(&expression);
+    let string_ctx = build_string_context_filtered(&state, Some(&names)).await;
     let mut parser = Parser::new(&expression);
     let expr = parser.parse()?;
     let val = evaluate(&expr, &context, Some(&string_ctx))?;
@@ -37,7 +42,8 @@ pub async fn evaluate_string_expression(
     expression: String,
     context: HashMap<String, f64>,
 ) -> Result<String, String> {
-    let string_ctx = build_string_context(&state).await;
+    let names = referenced_identifiers(&expression);
+    let string_ctx = build_string_context_filtered(&state, Some(&names)).await;
     Ok(evaluate_display_string(
         &expression,
         &context,

--- a/crates/libretune-app/src-tauri/src/commands/string_context.rs
+++ b/crates/libretune-app/src-tauri/src/commands/string_context.rs
@@ -63,15 +63,53 @@ pub fn numeric_context_from_tune(tune: Option<&TuneFile>) -> HashMap<String, f64
     context
 }
 
+/// Identifiers an expression mentions.
+///
+/// Used to build only the lookup maps an expression can actually reach. The
+/// scan is deliberately over-inclusive - it returns every bare word, including
+/// function names and keywords - because a spurious extra entry costs one map
+/// insertion while a missing one would change the result.
+pub(crate) fn referenced_identifiers(expression: &str) -> std::collections::HashSet<String> {
+    let mut out = std::collections::HashSet::new();
+    let mut word = String::new();
+    // A name cannot start with a digit, so a run beginning with one is a
+    // numeric literal and is dropped rather than inserted as junk.
+    let keep = |w: &str| w.starts_with(|c: char| c.is_alphabetic() || c == '_');
+    for ch in expression.chars() {
+        if ch.is_alphanumeric() || ch == '_' {
+            word.push(ch);
+        } else if !word.is_empty() {
+            let w = std::mem::take(&mut word);
+            if keep(&w) {
+                out.insert(w);
+            }
+        }
+    }
+    if !word.is_empty() && keep(&word) {
+        out.insert(word);
+    }
+    out
+}
+
+type NameFilter<'a> = Option<&'a std::collections::HashSet<String>>;
+
+fn wanted(filter: NameFilter, name: &str) -> bool {
+    filter.is_none_or(|f| f.contains(name))
+}
+
 fn string_map_from_tune(
     tune: Option<&TuneFile>,
     def: Option<&EcuDefinition>,
+    filter: NameFilter,
 ) -> HashMap<String, String> {
     let mut map = HashMap::new();
     let Some(tune) = tune else {
         return map;
     };
     for (name, value) in &tune.constants {
+        if !wanted(filter, name) {
+            continue;
+        }
         if let TuneValue::String(s) = value {
             let is_string_const = def
                 .and_then(|d| d.constants.get(name))
@@ -85,12 +123,18 @@ fn string_map_from_tune(
     map
 }
 
-fn bit_options_map(def: Option<&EcuDefinition>) -> HashMap<String, Vec<String>> {
+fn bit_options_map(
+    def: Option<&EcuDefinition>,
+    filter: NameFilter,
+) -> HashMap<String, Vec<String>> {
     let mut map = HashMap::new();
     let Some(def) = def else {
         return map;
     };
     for (name, constant) in &def.constants {
+        if !wanted(filter, name) {
+            continue;
+        }
         if !constant.bit_options.is_empty() {
             map.insert(name.clone(), constant.bit_options.clone());
         }
@@ -98,12 +142,15 @@ fn bit_options_map(def: Option<&EcuDefinition>) -> HashMap<String, Vec<String>> 
     map
 }
 
-fn array_map_from_tune(tune: Option<&TuneFile>) -> HashMap<String, Vec<f64>> {
+fn array_map_from_tune(tune: Option<&TuneFile>, filter: NameFilter) -> HashMap<String, Vec<f64>> {
     let mut map = HashMap::new();
     let Some(tune) = tune else {
         return map;
     };
     for (name, value) in &tune.constants {
+        if !wanted(filter, name) {
+            continue;
+        }
         if let TuneValue::Array(arr) = value {
             map.insert(name.clone(), arr.clone());
         }
@@ -130,6 +177,26 @@ fn interpolate_array(values: &[f64], index: f64) -> Option<f64> {
 
 /// Snapshot AppState into a [`StringContext`] (closures hold owned data / Arcs).
 pub async fn build_string_context(state: &AppState) -> StringContext {
+    build_string_context_filtered(state, None).await
+}
+
+/// As [`build_string_context`], but only populating entries an expression can
+/// reach.
+///
+/// The unfiltered build clones every string constant, every array, and the
+/// option list of every bitfield: on a real Speeduino INI that is 910
+/// constants, 507 of them bitfields and 144 arrays, rebuilt on every call.
+/// Measured against a live ECU it costs ~100 ms per call, and it is CPU rather
+/// than lock contention (100.6 ms with the realtime stream stopped, 115.7 ms
+/// with it running). The dashboard evaluates a visibility expression every
+/// 250 ms per conditioned gauge, so a handful of them saturates the backend -
+/// which is what made raising the realtime poll rate unusable.
+///
+/// An expression names a few identifiers, so building the rest is pure waste.
+pub async fn build_string_context_filtered(
+    state: &AppState,
+    filter: NameFilter<'_>,
+) -> StringContext {
     let def_guard = state.definition.lock().await;
     let tune_guard = state.current_tune.lock().await;
     let project_guard = state.current_project.lock().await;
@@ -137,9 +204,9 @@ pub async fn build_string_context(state: &AppState) -> StringContext {
     let demo = *state.demo_mode.lock().await;
     let streaming = state.streaming_task.lock().await.is_some();
 
-    let string_values = string_map_from_tune(tune_guard.as_ref(), def_guard.as_ref());
-    let bit_options = bit_options_map(def_guard.as_ref());
-    let arrays = array_map_from_tune(tune_guard.as_ref());
+    let string_values = string_map_from_tune(tune_guard.as_ref(), def_guard.as_ref(), filter);
+    let bit_options = bit_options_map(def_guard.as_ref(), filter);
+    let arrays = array_map_from_tune(tune_guard.as_ref(), filter);
 
     let projects_dir = Project::projects_dir()
         .map(|p| p.display().to_string())
@@ -198,9 +265,9 @@ pub fn build_string_context_from_parts(
     start_time: f64,
     cache: Arc<Mutex<IncTableCache>>,
 ) -> StringContext {
-    let string_values = string_map_from_tune(tune, def);
-    let bit_options = bit_options_map(def);
-    let arrays = array_map_from_tune(tune);
+    let string_values = string_map_from_tune(tune, def, None);
+    let bit_options = bit_options_map(def, None);
+    let arrays = array_map_from_tune(tune, None);
     let projects_dir = Project::projects_dir()
         .map(|p| p.display().to_string())
         .unwrap_or_default();
@@ -226,4 +293,37 @@ pub fn build_string_context_from_parts(
             .and_then(|table| table.lookup(lookup))
     }));
     ctx
+}
+
+#[cfg(test)]
+mod filter_tests {
+    use super::referenced_identifiers;
+
+    /// The filter decides which of the INI's ~910 constants get cloned into the
+    /// evaluation context, so it must never miss a name the expression can
+    /// reach. Being over-inclusive is free; being under-inclusive changes the
+    /// answer.
+    #[test]
+    fn finds_every_name_an_expression_can_reach() {
+        let ids = referenced_identifiers("{ nCylinders > 4 && injType == 1 }");
+        assert!(ids.contains("nCylinders"));
+        assert!(ids.contains("injType"));
+
+        // Underscores and digits are part of a name, not separators.
+        let ids = referenced_identifiers("std_injection + rtc_trim * page2Value");
+        assert!(ids.contains("std_injection"));
+        assert!(ids.contains("rtc_trim"));
+        assert!(ids.contains("page2Value"));
+
+        // Names butted against punctuation must still be seen.
+        let ids = referenced_identifiers("table(fuelLoadBins,rpm)>=veTable1Tbl");
+        for want in ["table", "fuelLoadBins", "rpm", "veTable1Tbl"] {
+            assert!(ids.contains(want), "missed {want}");
+        }
+    }
+
+    #[test]
+    fn an_expression_naming_nothing_yields_nothing() {
+        assert!(referenced_identifiers("1 + 2 * (3 - 4)").is_empty());
+    }
 }


### PR DESCRIPTION
## The problem

`evaluate_expression` rebuilt the entire INI evaluation context on every call: every string constant, every array, and the option list of every bitfield. On a real Speeduino tune that is **910 constants — 507 bitfields and 144 arrays** — cloned to answer a question naming one or two variables.

The dashboard asks one such question every 250 ms **per conditioned gauge**, so a handful of them saturates the backend.

## Measured before changing anything

Both obvious explanations were wrong:

| hypothesis | measurement | verdict |
|---|---|---|
| IPC payload | 108.1 ms empty context vs 113.7 ms with the full 233-channel one | 5.6 ms — not it |
| lock contention | 115.7 ms with realtime streaming vs 100.6 ms stopped | 15 ms — not it |

The remaining ~100 ms is CPU, in the context build.

## The fix

Build only what the expression names. No cache, so no invalidation and no staleness.

The identifier scan is deliberately over-inclusive — it returns every bare word including function names, since a spurious entry costs one map insertion while a missing one would change the result — and rejects runs starting with a digit, which are numeric literals.

```
evaluate_expression, full context, while streaming:
    before   113.7 ms median
    after      1.6 ms median  (p90 4.3, max 7.5)
```

## Effect

With that gone, a 25 ms realtime poll under a realistic dashboard load (12 conditioned gauges at 4 Hz, 960 calls) sustains 39.5 samples/sec with 1.1% of ticks skipped and no errors. The same load previously demanded roughly 4.5 seconds of backend work per second.

Bench measurement against a Speeduino 2025.01.4 target.

## Testing

`./scripts/pre-push.sh` green. Tests cover the identifier scan: underscores, digits within names, names against punctuation, and numeric literals.
