### PR TITLE
fix(autotune): keep tuning settings across restarts

### DIFF
--- a/crates/libretune-app/src/components/tuner-ui/AutoTune.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/AutoTune.tsx
@@ -183,6 +183,41 @@ interface VeAnalyzeConfig {
 // AutoTune Component
 // =============================================================================
 
+/// AutoTune's tuning parameters, kept across restarts.
+///
+/// These are per-engine facts the operator measures once - a transport delay of
+/// ~470 ms at idle, a coolant threshold in the INI's own units - not view state
+/// worth re-deriving each launch. They used to reset on every start, and the
+/// default `lambda_delay_ms: 0` does not mean "no delay": it means "fall back
+/// to the built-in RPM curve", which tops out at 200 ms. On a car whose real
+/// idle delay is more than twice that, samples land in the wrong cell and the
+/// low-load corrections come back inflated - which is what happened on a
+/// 59-minute drive where the delay had simply never been set.
+///
+/// Versioned so a future field change discards old state rather than merging a
+/// stale shape into a new one.
+const SETTINGS_KEY = 'libretune.autotune.settings.v1';
+
+function loadPersisted<T>(key: string, fallback: T): T {
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return fallback;
+    // Merge over the fallback so a field added since the value was written
+    // takes its default instead of arriving undefined.
+    return { ...fallback, ...(JSON.parse(raw) as object) } as T;
+  } catch {
+    return fallback;
+  }
+}
+
+function persist(key: string, value: unknown) {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    // localStorage unavailable - settings just won't survive the restart
+  }
+}
+
 export function AutoTune({ tableName: initialTableName = '', onClose, isConnected }: AutoTuneProps) {
   const { showToast } = useToast();
 
@@ -206,16 +241,18 @@ export function AutoTune({ tableName: initialTableName = '', onClose, isConnecte
   const [loadSourceHint, setLoadSourceHint] = useState<string | null>(null);
 
   // Settings state
-  const [settings, setSettings] = useState<AutoTuneSettings>({
+  const [settings, setSettings] = useState<AutoTuneSettings>(() =>
+    loadPersisted<AutoTuneSettings>(`${SETTINGS_KEY}.settings`, {
     target_afr: 14.7,
     algorithm: 'simple',
     update_rate_ms: 100,
     lambda_delay_ms: 0,
     lambda_delay_flow_scaled: false,
     lambda_delay_floor_ms: 120,
-  });
+  }));
 
-  const [filters, setFilters] = useState<AutoTuneFilters>({
+  const [filters, setFilters] = useState<AutoTuneFilters>(() =>
+    loadPersisted<AutoTuneFilters>(`${SETTINGS_KEY}.filters`, {
     min_rpm: 800,
     max_rpm: 7000,
     min_tps: 0,
@@ -227,14 +264,21 @@ export function AutoTune({ tableName: initialTableName = '', onClose, isConnecte
     require_steady_state: true,
     steady_state_rpm_delta: 50,
     steady_state_time_ms: 500,
-  });
+  }));
 
-  const [authority, setAuthority] = useState<AutoTuneAuthorityLimits>({
+  const [authority, setAuthority] = useState<AutoTuneAuthorityLimits>(() =>
+    loadPersisted<AutoTuneAuthorityLimits>(`${SETTINGS_KEY}.authority`, {
     max_change_per_cell: 15,
     max_total_change: 30,
     min_value: 0,
     max_value: 200,
-  });
+  }));
+
+  // Write back on change, so the next launch starts where the operator left
+  // off rather than at a default that silently disables the measured delay.
+  useEffect(() => persist(`${SETTINGS_KEY}.settings`, settings), [settings]);
+  useEffect(() => persist(`${SETTINGS_KEY}.filters`, filters), [filters]);
+  useEffect(() => persist(`${SETTINGS_KEY}.authority`, authority), [authority]);
 
   // Reference-table / lambda-match configuration (bug #2, #14).
   // Leaving the AFR table blank uses auto-discovery from the INI, falling back

--- a/crates/libretune-app/src/components/tuner-ui/__tests__/AutoTune.test.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/__tests__/AutoTune.test.tsx
@@ -78,3 +78,50 @@ describe('AutoTune connection awareness', () => {
     );
   });
 });
+
+// The lambda delay is a measured per-engine fact (about 470 ms at idle on the
+// reference NA6), not view state. It used to reset on every launch, and the
+// default of 0 does not mean "no delay" - it means "fall back to the built-in
+// RPM curve", which caps at 200 ms. A whole 59-minute drive was tuned against
+// that fallback because the setting had silently reverted, inflating every
+// low-load correction.
+//
+// Queried by row rather than by label: the settings rows render <label> and
+// <input> as siblings with no htmlFor, so getByLabelText cannot resolve them.
+describe('AutoTune settings persistence', () => {
+  const delayInput = async () => {
+    const label = await screen.findByText(/(Lambda|Idle) Delay \(ms\):/);
+    const input = label.parentElement?.querySelector('input[type="number"]');
+    if (!input) throw new Error('delay input not found next to its label');
+    return input as HTMLInputElement;
+  };
+
+  beforeEach(() => {
+    localStorage.clear();
+    mockInvoke();
+  });
+
+  it('restores a measured lambda delay across a remount', async () => {
+    const { unmount } = render(
+      <ToastProvider><AutoTune isConnected onClose={() => {}} /></ToastProvider>,
+    );
+
+    const delay = await delayInput();
+    await userEvent.clear(delay);
+    await userEvent.type(delay, '470');
+    await waitFor(() =>
+      expect(localStorage.getItem('libretune.autotune.settings.v1.settings'))
+        .toContain('470'),
+    );
+
+    unmount();
+    render(<ToastProvider><AutoTune isConnected onClose={() => {}} /></ToastProvider>);
+    expect((await delayInput()).value).toBe('470');
+  });
+
+  it('falls back to defaults when stored state is corrupt', async () => {
+    localStorage.setItem('libretune.autotune.settings.v1.settings', '{not json');
+    render(<ToastProvider><AutoTune isConnected onClose={() => {}} /></ToastProvider>);
+    expect((await delayInput()).value).toBe('0');
+  });
+});


### PR DESCRIPTION
## The problem

AutoTune's settings, filters and authority limits live in `useState` with no persistence, so every launch resets them.

That is wrong for what they are: a transport delay measured at ~470 ms at idle, or a coolant threshold in the INI's own units, are per-engine facts the operator measures once — not view state.

## Why it fails quietly

The default `lambda_delay_ms` is `0`, and 0 does not mean "no delay". It means **fall back to the built-in RPM curve**, which tops out at 200 ms. On an engine whose real idle delay is more than twice that, every sample is attributed to the wrong cell.

That is not hypothetical. Across a 59-minute drive on a Mazda NA6 the delay had never been set, `start_autotune` logged its fallback, and the low-load recommendations came back inflated while the mid-load ones were fine. The operator had not forgotten — the app forgot, every launch.

## The fix

Stored in localStorage, matching the 16 other components here that already persist UI state that way.

- Keys are versioned so a future field change discards stale state rather than merging a stale shape into a new one.
- A stored value is merged over the defaults, so a field added later takes its default instead of arriving `undefined`.
- Corrupt JSON falls back to defaults rather than throwing.

## Note

The tests query by settings row rather than by label, because these rows render `<label>` and `<input>` as siblings with no `htmlFor` — `getByLabelText` cannot resolve them. Worth fixing separately: it also means clicking a label doesn't focus its field.

## Testing

`./scripts/pre-push.sh` green. Tests cover a value surviving a remount, and recovery from corrupt stored state.
