### PR TITLE
fix(afr-delay): step fuel through wueRates[9] and actually measure the delay

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/afr_delay_test.rs
+++ b/crates/libretune-app/src-tauri/src/commands/afr_delay_test.rs
@@ -25,8 +25,10 @@
 //! - **Restore on every path.** The original value is written back after each
 //!   step, on abort, and on error. The restore is attempted even when the run
 //!   is failing, and a failure to restore is escalated loudly.
-//! - **Abortable.** The operator can stop between steps, and abort triggers an
-//!   immediate restore.
+//! - **Abortable.** Abort takes effect within one tick (~50 ms), not at the
+//!   next step boundary: an abort during the hold cuts the enrichment short
+//!   and restores immediately, and an abort during the settle skips the
+//!   remaining wait.
 
 use serde::Serialize;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -90,6 +92,25 @@ fn abort_flag() -> Arc<AtomicBool> {
 pub async fn abort_afr_delay_test() -> Result<(), String> {
     abort_flag().store(true, Ordering::SeqCst);
     Ok(())
+}
+
+/// Sleep for `total_ms`, waking every ~50 ms to check the abort flag, so an
+/// abort takes effect almost immediately instead of after the full hold or
+/// settle (up to 15 s combined — long enough that the Abort button appears
+/// dead, over an engine being held rich). Returns true if an abort was
+/// requested during (or before) the wait.
+async fn sleep_abortable(total_ms: u64) -> bool {
+    const TICK_MS: u64 = 50;
+    let mut remaining = total_ms;
+    while remaining > 0 {
+        if abort_flag().load(Ordering::SeqCst) {
+            return true;
+        }
+        let tick = remaining.min(TICK_MS);
+        tokio::time::sleep(Duration::from_millis(tick)).await;
+        remaining -= tick;
+    }
+    abort_flag().load(Ordering::SeqCst)
 }
 
 /// Run an automated series of enrichment steps.
@@ -204,13 +225,22 @@ pub async fn run_afr_delay_test(
             });
         }
 
-        tokio::time::sleep(Duration::from_millis(hold_ms)).await;
+        // Abort-aware hold: an abort mid-hold falls straight through to the
+        // restore below, so the enrichment is cut short rather than held for
+        // the remainder of `hold_ms`.
+        let aborted_mid_hold = sleep_abortable(hold_ms).await;
 
         if let Err(e) = restore(&state, baseline).await {
             return Err(format!(
                 "Applied step {step} but could not restore {FUEL_CONSTANT} to {baseline} ({e}). \
                  The engine is running RICH. CYCLE THE KEY to reload the stored tune."
             ));
+        }
+
+        if aborted_mid_hold {
+            // Restored, but the step's hold was cut short — don't count it and
+            // don't settle; the summary below reports the abort.
+            break;
         }
 
         completed = step;
@@ -227,8 +257,8 @@ pub async fn run_afr_delay_test(
             },
         );
 
-        if step < repeats {
-            tokio::time::sleep(Duration::from_millis(settle_ms)).await;
+        if step < repeats && sleep_abortable(settle_ms).await {
+            break;
         }
     }
 
@@ -293,6 +323,29 @@ mod tests {
     fn hold_and_settle_are_bounded() {
         assert_eq!(0u64.clamp(MIN_HOLD_MS, MAX_HOLD_MS), MIN_HOLD_MS);
         assert_eq!(u64::MAX.clamp(MIN_HOLD_MS, MAX_HOLD_MS), MAX_HOLD_MS);
+    }
+
+    /// Abort must interrupt a wait within a tick or two, not after the full
+    /// duration — this is the "Abort button appears dead for 15 s over a rich
+    /// engine" regression. Single test (not two) because the abort flag is a
+    /// process-wide static shared with any parallel test.
+    #[tokio::test]
+    async fn abort_interrupts_a_long_wait_quickly() {
+        // Phase 1: no abort — the full (short) wait elapses, returns false.
+        abort_flag().store(false, Ordering::SeqCst);
+        assert!(!sleep_abortable(120).await);
+
+        // Phase 2: abort pre-set — a 5 s wait must return true immediately.
+        abort_flag().store(true, Ordering::SeqCst);
+        let started = std::time::Instant::now();
+        assert!(sleep_abortable(5_000).await);
+        assert!(
+            started.elapsed() < Duration::from_millis(1_000),
+            "abort took {:?} to interrupt the wait",
+            started.elapsed()
+        );
+
+        abort_flag().store(false, Ordering::SeqCst);
     }
 
     /// The enriched value must round to the constant's 0.1 resolution and be

--- a/crates/libretune-app/src-tauri/src/commands/afr_delay_test.rs
+++ b/crates/libretune-app/src-tauri/src/commands/afr_delay_test.rs
@@ -22,6 +22,9 @@
 //! - **RAM only, never burned.** The step is written to the ECU's live memory,
 //!   so it is not persisted. Cycling the key restores the stored tune even if
 //!   this process dies mid-step.
+//! - **One byte.** The lever is the warmup curve's warm-plateau slot
+//!   (`wueRates[9]`, normally 100%): a single-byte write steps fuelling
+//!   engine-wide, and a single byte restores it. See [`WUE_CONSTANT`].
 //! - **Restore on every path.** The original value is written back after each
 //!   step, on abort, and on error. The restore is attempted even when the run
 //!   is failing, and a failure to restore is escalated loudly.
@@ -33,8 +36,11 @@
 use serde::Serialize;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use std::time::Duration;
+use std::sync::Mutex as StdMutex;
+use std::time::{Duration, Instant};
 use tauri::{AppHandle, Emitter};
+
+use libretune_core::autotune::delay_measure::{detect_delay, AfrSample, DelayTable};
 
 use crate::state::AppState;
 
@@ -47,21 +53,45 @@ const MAX_STEP_PERCENT: f64 = 20.0;
 /// into normal cycle-to-cycle scatter and no delay can be extracted.
 const MIN_STEP_PERCENT: f64 = 3.0;
 
+/// Most steps a single run will perform.
+///
+/// Each step writes and restores one byte, so the cost of more steps is time,
+/// not risk — and the statistics need them: individual measurements scatter by
+/// hundreds of milliseconds, so a trustworthy delay figure comes from many
+/// repeats rather than a few. The cap only stops a mistyped value running for
+/// hours. The previous ceiling of 20 was both low and silent: asking for 100
+/// ran 20 while the dialog still quoted the time for 100.
+const MAX_REPEATS: u32 = 200;
+
 /// Bounds on how long a step is held, in milliseconds.
 const MIN_HOLD_MS: u64 = 500;
 const MAX_HOLD_MS: u64 = 5_000;
 
-/// Constant used as the fuel multiplier. `reqFuel` scales every injector pulse
-/// equally, so the step is independent of position in the VE table — unlike
-/// editing a table cell, where interpolation between cells would blur it.
-const FUEL_CONSTANT: &str = "reqFuel";
+/// The fuel lever: the LAST slot of the warmup-enrichment curve.
+///
+/// On a warm engine the firmware's `correctionWUE()` returns this slot's raw
+/// value every fuel calculation — cache-free, multiplied straight into pulse
+/// width engine-wide (corrections.cpp @ 202501). The INI mandates the slot be
+/// 100 (= 100%, no enrichment) on a healthy tune, so stepping it to 108 is an
+/// instant +8% everywhere with a ONE-BYTE write, and restoring is one byte
+/// back. Earlier levers failed: `reqFuel` is in requiresPowerCycle (live
+/// writes ignored by a running engine — measured), and whole-VE-table
+/// stepping needs 256 writes each way with the edge smeared across ~2.5 s of
+/// serial. As a bonus the ECU broadcasts the multiplier it is actually
+/// applying (`warmupEnrich` output channel), giving a ground-truth anchor for
+/// the moment the step took effect.
+const WUE_CONSTANT: &str = "wueRates";
+/// Index of the warm-plateau slot within the WUE curve.
+const WUE_LAST_SLOT: usize = 9;
+/// Realtime channel reporting the WUE multiplier the ECU is applying now.
+const WUE_CHANNEL: &str = "warmupEnrich";
 
 /// Progress event emitted to the frontend during a delay-test run (as
 /// `afr_delay_test:progress`). `phase` is a coarse stage label —
 /// "starting", "enriching", "settling", then "complete" or "aborted".
-/// `applied_value` and `baseline_value` are the current and restore
-/// fuel-constant values so the UI can show exactly what is written and
-/// confirm the restore.
+/// `applied_value` and `baseline_value` are the applied and restore
+/// WUE-slot values (percent) so the UI can show exactly what is written
+/// and confirm the restore.
 #[derive(Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DelayTestProgress {
@@ -71,6 +101,41 @@ pub struct DelayTestProgress {
     pub applied_value: f64,
     pub baseline_value: f64,
     pub message: String,
+    /// Measured transport delay for the step just completed, when the AFR
+    /// trace supported one. Absent on phases other than "settling".
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub measured_delay_ms: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub measured_rpm: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub measured_load: Option<f64>,
+    /// Why no delay was measured for this step (operator-facing label).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rejection: Option<String>,
+}
+
+impl DelayTestProgress {
+    fn plain(
+        phase: &str,
+        step: u32,
+        total_steps: u32,
+        applied_value: f64,
+        baseline_value: f64,
+        message: String,
+    ) -> Self {
+        Self {
+            phase: phase.into(),
+            step,
+            total_steps,
+            applied_value,
+            baseline_value,
+            message,
+            measured_delay_ms: None,
+            measured_rpm: None,
+            measured_load: None,
+            rejection: None,
+        }
+    }
 }
 
 fn emit(app: &AppHandle, p: DelayTestProgress) {
@@ -113,12 +178,198 @@ async fn sleep_abortable(total_ms: u64) -> bool {
     abort_flag().load(Ordering::SeqCst)
 }
 
+/// Delay measurements accumulated across runs: (rpm, load, delay_ms).
+/// Session-scoped by design — a delay map belongs to one engine/exhaust
+/// combination; clearing is explicit via [`clear_afr_delay_samples`].
+static DELAY_SAMPLES: std::sync::OnceLock<StdMutex<Vec<(f64, f64, f64)>>> =
+    std::sync::OnceLock::new();
+
+fn delay_samples() -> &'static StdMutex<Vec<(f64, f64, f64)>> {
+    DELAY_SAMPLES.get_or_init(|| StdMutex::new(Vec::new()))
+}
+
+/// Realtime channels the sampler needs, resolved once per run from a live
+/// snapshot's keys (INI channel naming varies across dialects).
+struct SampleChannels {
+    afr: String,
+    rpm: Option<String>,
+    load: Option<String>,
+    /// The ECU-reported WUE multiplier — used to gate on the warm plateau and
+    /// to anchor t0 at the moment the ECU actually applied the step.
+    wue: Option<String>,
+}
+
+fn resolve_sample_channels(
+    snapshot: &std::collections::HashMap<String, f64>,
+) -> Option<SampleChannels> {
+    let find_exact = |want: &str| {
+        snapshot
+            .keys()
+            .find(|k| k.eq_ignore_ascii_case(want))
+            .cloned()
+    };
+    let afr = find_exact("afr")
+        .or_else(|| {
+            snapshot
+                .keys()
+                .find(|k| {
+                    let l = k.to_ascii_lowercase();
+                    l.contains("afr") && !l.contains("target") && !l.contains("protect")
+                })
+                .cloned()
+        })
+        .or_else(|| find_exact("lambda"))
+        .or_else(|| find_exact("o2"))?;
+    Some(SampleChannels {
+        afr,
+        rpm: find_exact("rpm"),
+        // MAP in kPa preferred as the load axis; TPS is the fallback.
+        load: find_exact("map").or_else(|| find_exact("tps")),
+        wue: find_exact(WUE_CHANNEL),
+    })
+}
+
+/// Read or write the single byte of `wueRates[WUE_LAST_SLOT]`, with the same
+/// cache/tune bookkeeping as the table-cell writer. One count=1 frame on the
+/// wire — the write form proven to reach a running engine.
+async fn wue_slot(state: &AppState, write: Option<u8>) -> Result<u8, String> {
+    let (page, offset) = {
+        let def_guard = state.definition.lock().await;
+        let def = def_guard.as_ref().ok_or("Definition not loaded")?;
+        let c = def
+            .constants
+            .get(WUE_CONSTANT)
+            .ok_or_else(|| format!("{WUE_CONSTANT} not found in this INI"))?;
+        // Never compute an offset past the curve the INI actually declares.
+        // Speeduino ships `wueRates = array, U08, 4, [10]`, so slot 9 is the
+        // last valid one — but a fork or an older firmware with a shorter
+        // curve would otherwise have this write a live byte into whichever
+        // constant follows it in the page, on a running engine.
+        let count = c.shape.element_count();
+        if count <= WUE_LAST_SLOT {
+            return Err(format!(
+                "{WUE_CONSTANT} declares {count} element(s); the delay test needs at least {}. \
+                 This firmware's warm-up curve is too short for the test to drive it safely.",
+                WUE_LAST_SLOT + 1
+            ));
+        }
+        let elem = c.data_type.size_bytes().max(1);
+        (c.page, c.offset + (WUE_LAST_SLOT * elem) as u16)
+    };
+
+    let mut conn_guard = state.connection.lock().await;
+    let mut cache_guard = state.tune_cache.lock().await;
+
+    let current = cache_guard
+        .as_ref()
+        .and_then(|c| c.read_bytes(page, offset, 1).map(|b| b[0]))
+        .ok_or("WUE curve not in the tune cache — sync the ECU first")?;
+
+    let Some(value) = write else {
+        return Ok(current);
+    };
+
+    if let Some(cache) = cache_guard.as_mut() {
+        cache.write_bytes(page, offset, &[value]);
+    }
+    let mut tune_guard = state.current_tune.lock().await;
+    if let Some(tune) = tune_guard.as_mut() {
+        if let Some(page_data) = tune.pages.get_mut(&page) {
+            if (offset as usize) < page_data.len() {
+                page_data[offset as usize] = value;
+            }
+        }
+    }
+    if let Some(conn) = conn_guard.as_mut() {
+        let params = libretune_core::protocol::commands::WriteMemoryParams {
+            can_id: 0,
+            page,
+            offset,
+            data: vec![value],
+        };
+        conn.write_memory(params)
+            .map_err(|e| format!("ECU write failed: {e}"))?;
+    } else {
+        return Err("Not connected to the ECU".to_string());
+    }
+    Ok(current)
+}
+
+/// Sample AFR (and remember the latest rpm/load) for `total_ms`, checking the
+/// abort flag between samples exactly like [`sleep_abortable`]. Each sample is
+/// a live single-shot read that serializes with the realtime stream on the
+/// connection lock, giving ~15-20 Hz effective — adequate for transport delays
+/// of 100-500 ms. Read failures skip the sample rather than aborting the run
+/// (a short trace downgrades to a rejection, not an error).
+///
+/// Returns true if an abort was requested during the window.
+async fn sample_window(
+    state: &tauri::State<'_, AppState>,
+    epoch: Instant,
+    channels: Option<&SampleChannels>,
+    total_ms: u64,
+    out: &mut Vec<AfrSample>,
+    last_point: &mut (Option<f64>, Option<f64>),
+    // When set: (threshold, slot for first crossing time). The ECU's reported
+    // WUE multiplier crossing the threshold marks the instant the step was
+    // actually applied — a ground-truth t0 immune to serial/write latency.
+    mut wue_edge: Option<(f64, &mut Option<u64>)>,
+) -> bool {
+    const TICK_MS: u64 = 30;
+    let end = epoch.elapsed().as_millis() as u64 + total_ms;
+    loop {
+        if abort_flag().load(Ordering::SeqCst) {
+            return true;
+        }
+        let now = epoch.elapsed().as_millis() as u64;
+        if now >= end {
+            return abort_flag().load(Ordering::SeqCst);
+        }
+        if let Some(ch) = channels {
+            if let Ok(snap) = crate::commands::realtime_get::get_realtime_data(state.clone()).await
+            {
+                let t_ms = epoch.elapsed().as_millis() as u64;
+                if let Some(afr) = snap.get(&ch.afr) {
+                    out.push(AfrSample { t_ms, afr: *afr });
+                }
+                if let Some(rpm_key) = &ch.rpm {
+                    if let Some(v) = snap.get(rpm_key) {
+                        last_point.0 = Some(*v);
+                    }
+                }
+                if let Some(load_key) = &ch.load {
+                    if let Some(v) = snap.get(load_key) {
+                        last_point.1 = Some(*v);
+                    }
+                }
+                if let Some((threshold, slot)) = wue_edge.as_mut() {
+                    if slot.is_none() {
+                        if let Some(wue_key) = &ch.wue {
+                            if let Some(v) = snap.get(wue_key) {
+                                if *v >= *threshold {
+                                    **slot = Some(t_ms);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(TICK_MS)).await;
+    }
+}
+
 /// Run an automated series of enrichment steps.
 ///
 /// `step_percent` is clamped to [`MIN_STEP_PERCENT`]..=[`MAX_STEP_PERCENT`] and
 /// forced positive. `hold_ms` is how long the enrichment is applied;
 /// `settle_ms` is the pause afterwards for the mixture to return to baseline
 /// before the next step.
+///
+/// Each step now also measures the AFR transport delay: a short pre-roll
+/// establishes the baseline, the hold window is sampled live, and the edge is
+/// extracted by [`detect_delay`]. Successful measurements accumulate into the
+/// session's rpm×load delay table ([`get_afr_delay_table`]).
 #[tauri::command]
 pub async fn run_afr_delay_test(
     app: AppHandle,
@@ -133,60 +384,106 @@ pub async fn run_afr_delay_test(
     let step_percent = step_percent.abs().clamp(MIN_STEP_PERCENT, MAX_STEP_PERCENT);
     let hold_ms = hold_ms.clamp(MIN_HOLD_MS, MAX_HOLD_MS);
     let settle_ms = settle_ms.clamp(MIN_HOLD_MS, MAX_HOLD_MS * 2);
-    let repeats = repeats.clamp(1, 20);
+    let requested_repeats = repeats;
+    let repeats = repeats.clamp(1, MAX_REPEATS);
 
-    // Read the baseline through the same path the UI uses, so the restore
-    // target is what the engine is actually running rather than an assumption.
+    // Baseline = the tune's warm-plateau WUE value (the INI mandates 100).
     // Reading it up front also fails the run early if the ECU is unreachable,
     // instead of discovering that after a step has already been applied.
-    let baseline = crate::commands::constants_read::get_constant_value(
-        state.clone(),
-        FUEL_CONSTANT.to_string(),
-    )
-    .await
-    .map_err(|e| format!("Could not read {FUEL_CONSTANT} ({e}). Connect and load a tune first."))?;
+    let baseline = wue_slot(&state, None)
+        .await
+        .map_err(|e| format!("Could not read {WUE_CONSTANT}[{WUE_LAST_SLOT}] ({e})."))?;
 
-    if baseline <= 0.0 {
+    if baseline == 0 {
         return Err(format!(
-            "{FUEL_CONSTANT} reads {baseline}, which is not a usable baseline"
+            "{WUE_CONSTANT}[{WUE_LAST_SLOT}] reads 0, which is not a usable baseline"
         ));
     }
 
-    let enriched = (baseline * (1.0 + step_percent / 100.0) * 10.0).round() / 10.0;
-    if enriched <= baseline {
+    let enriched_u8 = ((baseline as f64) * (1.0 + step_percent / 100.0)).round() as u16;
+    let enriched_u8 = enriched_u8.min(255) as u8;
+    if enriched_u8 <= baseline {
         return Err(format!(
             "A {step_percent:.1}% step on {baseline} does not change the value at this \
              resolution. Use a larger step."
         ));
     }
+    let baseline = baseline as f64;
+    let enriched = enriched_u8 as f64;
 
     abort_flag().store(false, Ordering::SeqCst);
 
+    // One clock for the whole run: sample timestamps and step anchors must be
+    // comparable for the delay extraction.
+    let epoch = Instant::now();
+
+    // Resolve the AFR/rpm/load channel names once from a live snapshot. When
+    // unavailable (offline, or no AFR channel in this INI) the run proceeds as
+    // a plain step test and every step reports a rejection instead of a delay.
+    let channels = crate::commands::realtime_get::get_realtime_data(state.clone())
+        .await
+        .ok()
+        .as_ref()
+        .and_then(resolve_sample_channels);
+
+    // Warm-plateau gate: the lever maps 1:1 onto fuelling only when the ECU
+    // is already applying the last WUE slot. The ECU reports what it applies
+    // via the warmupEnrich channel — a higher reading means the engine is
+    // still on the warmup ramp and any measurement would be scaled and mushy.
+    if let Some(ch) = channels.as_ref() {
+        if let Some(wue_key) = &ch.wue {
+            if let Ok(snap) = crate::commands::realtime_get::get_realtime_data(state.clone()).await
+            {
+                if let Some(applied) = snap.get(wue_key) {
+                    if (applied - baseline).abs() > 2.0 {
+                        return Err(format!(
+                            "Engine is still in warmup: the ECU is applying {applied:.0}% \
+                             warmup enrichment vs the warm-plateau value {baseline:.0}. \
+                             Warm it up, then run the test."
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    // If the request was trimmed, say so here rather than quietly running
+    // fewer steps than the operator asked for and than the UI estimated.
+    let clamp_note = if requested_repeats > repeats {
+        format!(" (asked for {requested_repeats}, capped at {repeats})")
+    } else {
+        String::new()
+    };
+
     emit(
         &app,
-        DelayTestProgress {
-            phase: "starting".into(),
-            step: 0,
-            total_steps: repeats,
-            applied_value: enriched,
-            baseline_value: baseline,
-            message: format!(
-                "{FUEL_CONSTANT} {baseline:.1} -> {enriched:.1} ({step_percent:.1}% richer), \
-                 {repeats} steps, {hold_ms} ms hold. RAM only, never burned."
+        DelayTestProgress::plain(
+            "starting",
+            0,
+            repeats,
+            enriched,
+            baseline,
+            format!(
+                "WUE step {baseline:.0}% -> {enriched:.0}% ({step_percent:.1}% richer), \
+                 {repeats} steps{clamp_note}, {hold_ms} ms hold. \
+                 One byte, RAM only, never burned."
             ),
-        },
+        ),
     );
 
     // Anything that leaves this function must first put `baseline` back. The
     // helper is used on the happy path, on abort, and on error.
     async fn restore(state: &tauri::State<'_, AppState>, baseline: f64) -> Result<(), String> {
-        crate::commands::constant_update::update_constant(
-            state.clone(),
-            FUEL_CONSTANT.to_string(),
-            baseline,
-        )
-        .await
+        wue_slot(state, Some(baseline as u8)).await.map(|_| ())
     }
+
+    /// Baseline window sampled immediately before each enrichment write.
+    /// Sized for real-world sampling: live single-shot reads contend with the
+    /// realtime stream for the serial link and land at ~5-9 Hz on hardware
+    /// (not the ~20 Hz seen on the bench), so 600 ms could gather fewer than
+    /// MIN_BASELINE_SAMPLES and reject every step. 1.5 s gives 7+ samples at
+    /// the worst observed rate.
+    const PRE_ROLL_MS: u64 = 1_500;
 
     let mut completed = 0u32;
     for step in 1..=repeats {
@@ -196,43 +493,75 @@ pub async fn run_afr_delay_test(
 
         emit(
             &app,
-            DelayTestProgress {
-                phase: "enriching".into(),
+            DelayTestProgress::plain(
+                "enriching",
                 step,
-                total_steps: repeats,
-                applied_value: enriched,
-                baseline_value: baseline,
-                message: format!("step {step}/{repeats}: hold steady"),
-            },
+                repeats,
+                enriched,
+                baseline,
+                format!("step {step}/{repeats}: hold steady"),
+            ),
         );
 
-        if let Err(e) = crate::commands::constant_update::update_constant(
-            state.clone(),
-            FUEL_CONSTANT.to_string(),
-            enriched,
+        // Baseline trace for this step's delay extraction (abort-aware, like
+        // every other wait in the run).
+        let mut pre = Vec::new();
+        let mut point = (None, None);
+        if sample_window(
+            &state,
+            epoch,
+            channels.as_ref(),
+            PRE_ROLL_MS,
+            &mut pre,
+            &mut point,
+            None,
         )
         .await
         {
+            break;
+        }
+
+        if let Err(e) = wue_slot(&state, Some(enriched as u8)).await {
             // The write failed, so the ECU may or may not have taken it.
             // Restore regardless and stop.
             let restore_err = restore(&state, baseline).await.err();
             return Err(match restore_err {
                 None => format!("Step {step} failed to apply ({e}). Baseline restored."),
                 Some(r) => format!(
-                    "Step {step} failed to apply ({e}) AND restoring {FUEL_CONSTANT} to \
+                    "Step {step} failed to apply ({e}) AND restoring the WUE slot to \
                      {baseline} also failed ({r}). CYCLE THE KEY to reload the stored tune."
                 ),
             });
         }
 
-        // Abort-aware hold: an abort mid-hold falls straight through to the
-        // restore below, so the enrichment is cut short rather than held for
-        // the remainder of `hold_ms`.
-        let aborted_mid_hold = sleep_abortable(hold_ms).await;
+        // Fallback anchor: the instant the write finished. Preferred anchor:
+        // the ECU's own warmupEnrich channel crossing toward the stepped
+        // value, captured during the hold sampling — the moment the ECU
+        // actually started applying the step, immune to serial and
+        // scheduling latency.
+        let write_anchor_ms = epoch.elapsed().as_millis() as u64;
+        let mut ecu_anchor_ms: Option<u64> = None;
+        let wue_threshold = (baseline + enriched) / 2.0;
+
+        // Abort-aware hold, sampling AFR throughout: an abort mid-hold falls
+        // straight through to the restore below, so the enrichment is cut
+        // short rather than held for the remainder of `hold_ms`.
+        let mut post = Vec::new();
+        let aborted_mid_hold = sample_window(
+            &state,
+            epoch,
+            channels.as_ref(),
+            hold_ms,
+            &mut post,
+            &mut point,
+            Some((wue_threshold, &mut ecu_anchor_ms)),
+        )
+        .await;
+        let anchor_ms = ecu_anchor_ms.unwrap_or(write_anchor_ms);
 
         if let Err(e) = restore(&state, baseline).await {
             return Err(format!(
-                "Applied step {step} but could not restore {FUEL_CONSTANT} to {baseline} ({e}). \
+                "Applied step {step} but could not restore the WUE slot to {baseline} ({e}). \
                  The engine is running RICH. CYCLE THE KEY to reload the stored tune."
             ));
         }
@@ -245,17 +574,50 @@ pub async fn run_afr_delay_test(
 
         completed = step;
 
-        emit(
-            &app,
-            DelayTestProgress {
-                phase: "settling".into(),
-                step,
-                total_steps: repeats,
-                applied_value: baseline,
-                baseline_value: baseline,
-                message: format!("step {step}/{repeats} done, settling"),
-            },
+        // Extract this step's transport delay from the sampled traces.
+        let measurement = if channels.is_some() {
+            Some(detect_delay(anchor_ms, &pre, &post))
+        } else {
+            None
+        };
+
+        let mut settling = DelayTestProgress::plain(
+            "settling",
+            step,
+            repeats,
+            baseline,
+            baseline,
+            format!("step {step}/{repeats} done, settling"),
         );
+        match measurement {
+            Some(Ok(m)) => {
+                let (rpm, load) = point;
+                if let (Some(rpm), Some(load)) = (rpm, load) {
+                    delay_samples()
+                        .lock()
+                        .map(|mut v| v.push((rpm, load, m.delay_ms)))
+                        .ok();
+                }
+                settling.measured_delay_ms = Some(m.delay_ms);
+                settling.measured_rpm = rpm;
+                settling.measured_load = load;
+                settling.message = format!(
+                    "step {step}/{repeats}: delay {:.0} ms (AFR moved {:.2}), settling",
+                    m.delay_ms, m.excursion
+                );
+            }
+            Some(Err(rej)) => {
+                settling.rejection = Some(rej.label().to_string());
+                settling.message = format!(
+                    "step {step}/{repeats}: no measurement ({}), settling",
+                    rej.label()
+                );
+            }
+            None => {
+                settling.rejection = Some("no AFR channel / offline".to_string());
+            }
+        }
+        emit(&app, settling);
 
         if step < repeats && sleep_abortable(settle_ms).await {
             break;
@@ -266,31 +628,56 @@ pub async fn run_afr_delay_test(
     // broken by an abort between the enrich and the restore.
     restore(&state, baseline).await.map_err(|e| {
         format!(
-            "Test finished but the final restore of {FUEL_CONSTANT} to {baseline} failed ({e}). \
+            "Test finished but the final restore of the WUE slot to {baseline} failed ({e}). \
              CYCLE THE KEY to reload the stored tune."
         )
     })?;
 
     let aborted = abort_flag().load(Ordering::SeqCst);
     let summary = format!(
-        "{} after {completed}/{repeats} steps. {FUEL_CONSTANT} restored to {baseline:.1}. \
+        "{} after {completed}/{repeats} steps. WUE slot restored to {baseline:.0}%. \
          Nothing was burned.",
         if aborted { "Aborted" } else { "Completed" }
     );
 
     emit(
         &app,
-        DelayTestProgress {
-            phase: if aborted { "aborted" } else { "complete" }.into(),
-            step: completed,
-            total_steps: repeats,
-            applied_value: baseline,
-            baseline_value: baseline,
-            message: summary.clone(),
-        },
+        DelayTestProgress::plain(
+            if aborted { "aborted" } else { "complete" },
+            completed,
+            repeats,
+            baseline,
+            baseline,
+            summary.clone(),
+        ),
     );
 
     Ok(summary)
+}
+
+/// The session's accumulated rpm×load delay table, aggregated from every
+/// successful step measurement since the last clear.
+#[tauri::command]
+pub async fn get_afr_delay_table() -> Result<DelayTable, String> {
+    let samples = delay_samples()
+        .lock()
+        .map_err(|_| "delay sample store poisoned".to_string())?;
+    let mut table = DelayTable::new();
+    for (rpm, load, delay_ms) in samples.iter() {
+        table.add(*rpm, *load, *delay_ms);
+    }
+    Ok(table)
+}
+
+/// Discard all accumulated delay measurements (e.g. after exhaust or sensor
+/// changes that invalidate the map).
+#[tauri::command]
+pub async fn clear_afr_delay_samples() -> Result<(), String> {
+    delay_samples()
+        .lock()
+        .map_err(|_| "delay sample store poisoned".to_string())?
+        .clear();
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/libretune-app/src-tauri/src/lib.rs
+++ b/crates/libretune-app/src-tauri/src/lib.rs
@@ -41,7 +41,9 @@ pub(crate) use commands::util_helpers::{
 use commands::adaptive_timing::{
     disable_adaptive_timing, enable_adaptive_timing, get_adaptive_timing_stats,
 };
-use commands::afr_delay_test::{abort_afr_delay_test, run_afr_delay_test};
+use commands::afr_delay_test::{
+    abort_afr_delay_test, clear_afr_delay_samples, get_afr_delay_table, run_afr_delay_test,
+};
 use commands::agent::{
     agent_apply_proposals, agent_delete_chat, agent_list_chats, agent_load_chat, agent_save_chat,
     agent_send_message, agent_status, agent_stop,
@@ -267,6 +269,8 @@ pub fn run() {
             // AFR transport-delay step test
             run_afr_delay_test,
             abort_afr_delay_test,
+            get_afr_delay_table,
+            clear_afr_delay_samples,
             // Math Channels
             get_math_channels,
             set_math_channel,

--- a/crates/libretune-app/src/components/dialogs/AfrDelayTestDialog.css
+++ b/crates/libretune-app/src/components/dialogs/AfrDelayTestDialog.css
@@ -166,3 +166,49 @@
   font-size: 0.95rem;
   font-weight: 600;
 }
+
+.afr-delay-measured {
+  margin-top: 4px;
+  font-size: 12px;
+  color: var(--accent-color, #4caf50);
+}
+
+.afr-delay-rejection {
+  margin-top: 4px;
+  font-size: 12px;
+  opacity: 0.7;
+}
+
+.afr-delay-table {
+  margin-top: 12px;
+}
+
+.afr-delay-table-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 12px;
+  opacity: 0.85;
+  margin-bottom: 4px;
+}
+
+.afr-delay-table table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 11px;
+}
+
+.afr-delay-table th,
+.afr-delay-table td {
+  border: 1px solid var(--border-color, #333);
+  padding: 2px 6px;
+  text-align: center;
+}
+
+.afr-delay-table td.no-data {
+  opacity: 0.35;
+}
+
+.afr-delay-table td.has-data {
+  font-weight: 600;
+}

--- a/crates/libretune-app/src/components/dialogs/AfrDelayTestDialog.tsx
+++ b/crates/libretune-app/src/components/dialogs/AfrDelayTestDialog.tsx
@@ -23,6 +23,30 @@ interface Progress {
   appliedValue: number;
   baselineValue: number;
   message: string;
+  measuredDelayMs?: number;
+  measuredRpm?: number;
+  measuredLoad?: number;
+  rejection?: string;
+}
+
+interface DelayCell {
+  n: number;
+  mean_ms: number;
+  range_ms: number;
+}
+
+interface DelayTable {
+  rpm_edges: number[];
+  load_edges: number[];
+  /** cells[load_bin][rpm_bin] */
+  cells: DelayCell[][];
+}
+
+/** Human label for a bin: "<edge", "a-b", or "edge+" for the open top bin. */
+function binLabel(edges: number[], i: number, unit: string): string {
+  if (i === 0) return `<${edges[0]}${unit}`;
+  if (i >= edges.length) return `${edges[edges.length - 1]}${unit}+`;
+  return `${edges[i - 1]}-${edges[i]}${unit}`;
 }
 
 interface Props {
@@ -40,11 +64,36 @@ export const AfrDelayTestDialog: React.FC<Props> = ({ isOpen, onClose }) => {
   const [progress, setProgress] = useState<Progress | null>(null);
   const [result, setResult] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [delayTable, setDelayTable] = useState<DelayTable | null>(null);
+
+  const refreshTable = useCallback(async () => {
+    try {
+      setDelayTable(await invoke<DelayTable>('get_afr_delay_table'));
+    } catch { /* command unavailable — leave the table hidden */ }
+  }, []);
 
   useEffect(() => {
-    const un = listen<Progress>('afr_delay_test:progress', (e) => setProgress(e.payload));
+    const un = listen<Progress>('afr_delay_test:progress', (e) => {
+      setProgress(e.payload);
+      // A settling event carries this step's measurement (or rejection) —
+      // refresh the aggregate table so the grid fills in live.
+      if (e.payload.phase === 'settling' || e.payload.phase === 'complete') {
+        refreshTable();
+      }
+    });
     return () => { un.then((f) => f()); };
-  }, []);
+  }, [refreshTable]);
+
+  useEffect(() => {
+    if (isOpen) refreshTable();
+  }, [isOpen, refreshTable]);
+
+  const clearSamples = useCallback(async () => {
+    try {
+      await invoke('clear_afr_delay_samples');
+      await refreshTable();
+    } catch { /* best effort */ }
+  }, [refreshTable]);
 
   const start = useCallback(async () => {
     setError(null);
@@ -79,9 +128,9 @@ export const AfrDelayTestDialog: React.FC<Props> = ({ isOpen, onClose }) => {
         <h2>AFR Delay Test</h2>
 
         <p className="afr-delay-intro">
-          Applies a timed enrichment step so the delay between a fuelling change and
-          the wideband seeing it can be measured from the log. Repeat at several
-          rpm and load points to build a delay map.
+          Applies a timed enrichment step and measures, live, how long the wideband
+          takes to see it. Each successful step adds to the rpm × load delay map
+          below. Run it warm, at several steady rpm and load points.
         </p>
 
         <div className="afr-delay-safety">
@@ -91,7 +140,7 @@ export const AfrDelayTestDialog: React.FC<Props> = ({ isOpen, onClose }) => {
             <ul>
               <li>The step can only make the mixture richer, never leaner.</li>
               <li>Written to live memory — cycling the key restores the stored tune.</li>
-              <li><code>reqFuel</code> is restored after every step and on abort.</li>
+              <li>One byte (the warm-plateau WUE slot) is stepped and restored after every step and on abort.</li>
               <li>Hold the engine steady yourself; this does not touch throttle.</li>
             </ul>
           </div>
@@ -121,7 +170,7 @@ export const AfrDelayTestDialog: React.FC<Props> = ({ isOpen, onClose }) => {
           </label>
           <label>
             Repeats
-            <input type="number" min={1} max={20} step={1} value={repeats}
+            <input type="number" min={1} max={200} step={1} value={repeats}
               disabled={running}
               onChange={(e) => setRepeats(Number(e.target.value))} />
             <span className="unit">steps</span>
@@ -144,10 +193,59 @@ export const AfrDelayTestDialog: React.FC<Props> = ({ isOpen, onClose }) => {
             </div>
             {progress.baselineValue > 0 && (
               <div className="afr-delay-values">
-                reqFuel baseline {progress.baselineValue.toFixed(1)} ms
-                {progress.phase === 'enriching' && ` -> applying ${progress.appliedValue.toFixed(1)} ms`}
+                WUE baseline {progress.baselineValue.toFixed(0)}%
+                {progress.phase === 'enriching' && ` -> applying ${progress.appliedValue.toFixed(0)}%`}
               </div>
             )}
+            {progress.measuredDelayMs !== undefined && (
+              <div className="afr-delay-measured">
+                Measured: <strong>{Math.round(progress.measuredDelayMs)} ms</strong>
+                {progress.measuredRpm !== undefined && progress.measuredLoad !== undefined &&
+                  ` @ ${Math.round(progress.measuredRpm)} rpm / ${Math.round(progress.measuredLoad)} load`}
+              </div>
+            )}
+            {progress.rejection && (
+              <div className="afr-delay-rejection">No measurement: {progress.rejection}</div>
+            )}
+          </div>
+        )}
+
+        {delayTable && delayTable.cells.some((row) => row.some((c) => c.n > 0)) && (
+          <div className="afr-delay-table">
+            <div className="afr-delay-table-head">
+              <span>Measured delay by operating point (ms, mean · n)</span>
+              <button type="button" disabled={running} onClick={clearSamples}>Clear</button>
+            </div>
+            <table>
+              <thead>
+                <tr>
+                  <th>load \ rpm</th>
+                  {delayTable.cells[0].map((_, r) => (
+                    <th key={r}>{binLabel(delayTable.rpm_edges, r, '')}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {/* High load on top, like a VE table. */}
+                {[...delayTable.cells].reverse().map((row, revI) => {
+                  const l = delayTable.cells.length - 1 - revI;
+                  return (
+                    <tr key={l}>
+                      <th>{binLabel(delayTable.load_edges, l, '')}</th>
+                      {row.map((c, r) => (
+                        <td
+                          key={r}
+                          className={c.n > 0 ? 'has-data' : 'no-data'}
+                          title={c.n > 0 ? `range ${Math.round(c.range_ms)} ms over ${c.n} steps` : 'no samples'}
+                        >
+                          {c.n > 0 ? `${Math.round(c.mean_ms)} · ${c.n}` : '—'}
+                        </td>
+                      ))}
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
           </div>
         )}
 

--- a/crates/libretune-core/src/autotune/delay_measure.rs
+++ b/crates/libretune-core/src/autotune/delay_measure.rs
@@ -1,0 +1,417 @@
+//! AFR transport-delay extraction from an enrichment step.
+//!
+//! The delay test applies a fuel step at a known instant; the wideband sees it
+//! only after the exhaust transport delay plus the sensor's own lag. This
+//! module turns the sampled AFR trace around one step into a single measured
+//! delay, or declines when the trace can't support one.
+//!
+//! Pure functions, no I/O — the command layer feeds it samples and an anchor
+//! timestamp. Everything here is unit-tested against synthetic traces because
+//! the bench simulator's AFR does not respond to fuelling; first live
+//! validation happens on a real engine.
+
+use serde::Serialize;
+
+/// One realtime sample: milliseconds (monotonic, same clock as the step
+/// anchor) and the AFR reading.
+#[derive(Debug, Clone, Copy)]
+pub struct AfrSample {
+    pub t_ms: u64,
+    pub afr: f64,
+}
+
+/// A successful delay extraction for one enrichment step.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct DelayMeasurement {
+    /// Milliseconds from the step anchor to the detected AFR response edge.
+    pub delay_ms: f64,
+    /// AFR drop actually observed at detection relative to baseline.
+    pub excursion: f64,
+    /// Pre-step baseline the edge was measured against.
+    pub baseline_afr: f64,
+}
+
+/// Why a step produced no measurement — surfaced to the UI so a silent
+/// no-result is distinguishable from a broken run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DelayRejection {
+    /// Fewer pre-step samples than needed to establish a baseline.
+    InsufficientBaseline,
+    /// Pre-step AFR was moving too much to anchor a baseline (operator not
+    /// steady, or sensor noise beyond usable).
+    UnstableBaseline,
+    /// No sustained excursion past the threshold inside the window (step too
+    /// small for the noise, sensor dead, or — on the bench — a simulator
+    /// whose AFR ignores fuelling).
+    NoResponse,
+}
+
+impl DelayRejection {
+    /// Short operator-facing label.
+    pub fn label(&self) -> &'static str {
+        match self {
+            DelayRejection::InsufficientBaseline => "too few baseline samples",
+            DelayRejection::UnstableBaseline => "baseline unstable — hold steadier",
+            DelayRejection::NoResponse => "no AFR response detected",
+        }
+    }
+}
+
+/// Minimum samples required in the pre-step window.
+const MIN_BASELINE_SAMPLES: usize = 4;
+/// Baseline scatter (median absolute deviation) above which no edge can be
+/// trusted, in AFR points.
+const MAX_BASELINE_MAD: f64 = 0.35;
+/// The excursion must exceed max(K_MAD * MAD, MIN_EXCURSION_AFR).
+const K_MAD: f64 = 3.0;
+const MIN_EXCURSION_AFR: f64 = 0.15;
+/// An edge only counts when the crossing is sustained for this many samples,
+/// so a single noise spike cannot fake a response.
+const SUSTAIN_SAMPLES: usize = 2;
+
+fn median(values: &mut [f64]) -> f64 {
+    values.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let n = values.len();
+    if n % 2 == 1 {
+        values[n / 2]
+    } else {
+        (values[n / 2 - 1] + values[n / 2]) / 2.0
+    }
+}
+
+/// Median absolute deviation — robust scatter estimate for a noisy trace.
+fn mad(values: &[f64], med: f64) -> f64 {
+    let mut devs: Vec<f64> = values.iter().map(|v| (v - med).abs()).collect();
+    median(&mut devs)
+}
+
+/// Extract the transport delay for one enrichment step.
+///
+/// `anchor_ms` is the instant the enriched value finished writing to the ECU.
+/// `pre` are samples strictly before the anchor (baseline window); `post` are
+/// samples at or after it, in time order. Enrichment drives AFR *down*, so the
+/// edge is the first sustained crossing below `baseline - threshold`.
+pub fn detect_delay(
+    anchor_ms: u64,
+    pre: &[AfrSample],
+    post: &[AfrSample],
+) -> Result<DelayMeasurement, DelayRejection> {
+    if pre.len() < MIN_BASELINE_SAMPLES {
+        return Err(DelayRejection::InsufficientBaseline);
+    }
+
+    let mut base_vals: Vec<f64> = pre.iter().map(|s| s.afr).collect();
+    let baseline = median(&mut base_vals);
+    let scatter = mad(&base_vals, baseline);
+    if scatter > MAX_BASELINE_MAD {
+        return Err(DelayRejection::UnstableBaseline);
+    }
+
+    let threshold = (K_MAD * scatter).max(MIN_EXCURSION_AFR);
+    let trigger = baseline - threshold;
+
+    let mut run = 0usize;
+    let mut edge: Option<&AfrSample> = None;
+    // Sample immediately before the crossing, for sub-sample interpolation.
+    let mut before_edge: Option<&AfrSample> = None;
+    let mut prev: Option<&AfrSample> = None;
+    for s in post {
+        if s.afr < trigger {
+            run += 1;
+            if run == 1 {
+                edge = Some(s);
+                before_edge = prev;
+            }
+            if run >= SUSTAIN_SAMPLES {
+                let e = edge.expect("run >= 1 implies edge set");
+
+                // The crossing happened somewhere between the last sample above
+                // the trigger and this first one below it, not exactly when the
+                // sample landed. Reporting the sample time alone biases every
+                // measurement late by half a sample interval on average — 31 ms
+                // at the ~16 Hz these logs actually run at, which is a large
+                // share of a high-flow delay. Interpolate linearly across the
+                // crossing instead.
+                let crossing_ms = match before_edge {
+                    Some(b) if b.afr > e.afr && b.t_ms < e.t_ms => {
+                        let span = (e.t_ms - b.t_ms) as f64;
+                        let frac = ((b.afr - trigger) / (b.afr - e.afr)).clamp(0.0, 1.0);
+                        b.t_ms as f64 + span * frac
+                    }
+                    // No usable prior sample (the crossing is the first sample
+                    // after the anchor): fall back to the sample's own time.
+                    _ => e.t_ms as f64,
+                };
+                let delay_ms = (crossing_ms - anchor_ms as f64).max(0.0);
+
+                return Ok(DelayMeasurement {
+                    delay_ms,
+                    excursion: baseline - e.afr,
+                    baseline_afr: baseline,
+                });
+            }
+        } else {
+            run = 0;
+            edge = None;
+            before_edge = None;
+        }
+        prev = Some(s);
+    }
+
+    Err(DelayRejection::NoResponse)
+}
+
+/// Fixed coarse grid for aggregating measurements by operating point.
+/// Bin edges chosen for a small NA engine; a cell is (load_bin, rpm_bin).
+pub const RPM_EDGES: [f64; 5] = [1200.0, 2000.0, 3000.0, 4500.0, 6500.0];
+pub const LOAD_EDGES: [f64; 4] = [40.0, 60.0, 80.0, 100.0];
+
+/// One aggregated cell of the delay table.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Serialize)]
+pub struct DelayCell {
+    pub n: u32,
+    pub mean_ms: f64,
+    /// Simple spread indicator: max - min of contributing delays.
+    pub range_ms: f64,
+    #[serde(skip)]
+    min_ms: f64,
+    #[serde(skip)]
+    max_ms: f64,
+}
+
+/// rpm × load grid of aggregated delay measurements.
+#[derive(Debug, Clone, Serialize)]
+pub struct DelayTable {
+    /// Upper edges of the rpm bins; the last bin is open-ended.
+    pub rpm_edges: Vec<f64>,
+    /// Upper edges of the load bins; the last bin is open-ended.
+    pub load_edges: Vec<f64>,
+    /// `cells[load_bin][rpm_bin]`
+    pub cells: Vec<Vec<DelayCell>>,
+}
+
+impl DelayTable {
+    pub fn new() -> Self {
+        let rows = LOAD_EDGES.len() + 1;
+        let cols = RPM_EDGES.len() + 1;
+        Self {
+            rpm_edges: RPM_EDGES.to_vec(),
+            load_edges: LOAD_EDGES.to_vec(),
+            cells: vec![vec![DelayCell::default(); cols]; rows],
+        }
+    }
+
+    fn bin(edges: &[f64], v: f64) -> usize {
+        edges.iter().position(|e| v < *e).unwrap_or(edges.len())
+    }
+
+    /// Bin indices for an operating point — exposed for tests and callers
+    /// that need to address a cell directly.
+    pub fn cell_index(&self, rpm: f64, load: f64) -> (usize, usize) {
+        (
+            Self::bin(&self.load_edges, load),
+            Self::bin(&self.rpm_edges, rpm),
+        )
+    }
+
+    /// Fold one measurement taken at (rpm, load) into its cell.
+    pub fn add(&mut self, rpm: f64, load: f64, delay_ms: f64) {
+        let (l, r) = self.cell_index(rpm, load);
+        let c = &mut self.cells[l][r];
+        if c.n == 0 {
+            c.min_ms = delay_ms;
+            c.max_ms = delay_ms;
+        } else {
+            c.min_ms = c.min_ms.min(delay_ms);
+            c.max_ms = c.max_ms.max(delay_ms);
+        }
+        c.mean_ms = (c.mean_ms * c.n as f64 + delay_ms) / (c.n as f64 + 1.0);
+        c.n += 1;
+        c.range_ms = c.max_ms - c.min_ms;
+    }
+}
+
+impl Default for DelayTable {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn trace(points: &[(u64, f64)]) -> Vec<AfrSample> {
+        points
+            .iter()
+            .map(|&(t_ms, afr)| AfrSample { t_ms, afr })
+            .collect()
+    }
+
+    /// The crossing rarely lands exactly on a sample. Reporting the sample's own
+    /// time biases every measurement late by up to a full interval — 63 ms at
+    /// the ~16 Hz these logs run at, which is a big share of a high-flow delay.
+    /// Interpolating across the crossing must land between the two samples and
+    /// close to where the AFR genuinely passed the trigger.
+    #[test]
+    fn crossing_is_interpolated_between_samples() {
+        // Baseline 14.70, MAD ~0 so the trigger is baseline - MIN_EXCURSION_AFR.
+        let pre = trace(&[(0, 14.70), (60, 14.70), (120, 14.70), (180, 14.70)]);
+        // AFR is still at baseline at 240, then well past the trigger at 300:
+        // the true crossing lies between, nearer 300 the deeper the last sample.
+        let post = trace(&[(240, 14.70), (300, 14.30), (360, 14.10), (420, 14.05)]);
+
+        let m = detect_delay(240, &pre, &post).expect("should measure");
+        assert!(
+            m.delay_ms > 0.0 && m.delay_ms < 60.0,
+            "interpolated crossing {:.0} ms must fall inside the 240-300 ms sample gap",
+            m.delay_ms
+        );
+        // Reporting the raw sample time would have given exactly 60 ms.
+        assert!(
+            m.delay_ms < 59.0,
+            "expected sub-sample resolution, got the sample time itself ({:.0} ms)",
+            m.delay_ms
+        );
+    }
+
+    /// When the very first post-anchor sample is already past the trigger there
+    /// is nothing to interpolate from; the sample time is the honest answer and
+    /// must not be mangled into a negative or absurd delay.
+    #[test]
+    fn crossing_on_the_first_sample_falls_back_cleanly() {
+        let pre = trace(&[(0, 14.70), (60, 14.70), (120, 14.70), (180, 14.70)]);
+        let post = trace(&[(240, 14.20), (300, 14.10), (360, 14.05)]);
+        let m = detect_delay(240, &pre, &post).expect("should measure");
+        assert_eq!(
+            m.delay_ms, 0.0,
+            "first sample at the anchor means zero delay"
+        );
+    }
+
+    /// Clean step: steady 14.7 baseline. AFR is still 14.68 at 320 ms and 14.2
+    /// at 380 ms, so it passes the 14.55 trigger at ~336 ms — 136 ms after the
+    /// anchor. Reporting the sample time would say 180 ms, 44 ms late.
+    #[test]
+    fn clean_step_yields_the_transport_delay() {
+        let pre = trace(&[
+            (0, 14.7),
+            (40, 14.68),
+            (80, 14.72),
+            (120, 14.7),
+            (160, 14.69),
+        ]);
+        let post = trace(&[
+            (200, 14.7),
+            (240, 14.71),
+            (280, 14.69),
+            (320, 14.68),
+            (380, 14.2), // edge
+            (420, 13.9),
+            (460, 13.7),
+        ]);
+        let m = detect_delay(200, &pre, &post).expect("clean step must measure");
+        assert!(
+            (m.delay_ms - 136.25).abs() < 0.5,
+            "interpolated crossing, got {}",
+            m.delay_ms
+        );
+        assert!(m.excursion > 0.4);
+        assert!((m.baseline_afr - 14.7).abs() < 0.05);
+    }
+
+    /// A single noise spike below threshold must not register as the edge.
+    #[test]
+    fn single_spike_is_not_an_edge() {
+        let pre = trace(&[(0, 14.7), (40, 14.7), (80, 14.7), (120, 14.7)]);
+        let post = trace(&[
+            (200, 14.7),
+            (240, 13.9), // lone spike
+            (280, 14.7),
+            (320, 14.71),
+            (360, 14.69),
+        ]);
+        assert_eq!(
+            detect_delay(200, &pre, &post),
+            Err(DelayRejection::NoResponse)
+        );
+    }
+
+    /// A sustained crossing right after a lone spike anchors on the real run,
+    /// not the spike: the crossing is interpolated between 280 ms (14.7) and
+    /// 320 ms (14.0), giving ~89 ms — comfortably after the 40 ms spike.
+    #[test]
+    fn edge_anchors_at_the_sustained_run() {
+        let pre = trace(&[(0, 14.7), (40, 14.7), (80, 14.7), (120, 14.7)]);
+        let post = trace(&[
+            (200, 14.7),
+            (240, 13.9), // spike, run resets after
+            (280, 14.7),
+            (320, 14.0), // real edge starts
+            (360, 13.8),
+        ]);
+        let m = detect_delay(200, &pre, &post).expect("must measure");
+        assert!(
+            (m.delay_ms - 88.6).abs() < 0.5,
+            "must anchor on the sustained run, got {}",
+            m.delay_ms
+        );
+    }
+
+    #[test]
+    fn wandering_baseline_is_rejected() {
+        let pre = trace(&[(0, 13.2), (40, 15.4), (80, 12.9), (120, 15.8), (160, 13.5)]);
+        let post = trace(&[(200, 12.0), (240, 12.0), (280, 12.0)]);
+        assert_eq!(
+            detect_delay(200, &pre, &post),
+            Err(DelayRejection::UnstableBaseline)
+        );
+    }
+
+    #[test]
+    fn too_few_baseline_samples_rejected() {
+        let pre = trace(&[(0, 14.7), (40, 14.7)]);
+        let post = trace(&[(200, 13.0), (240, 13.0)]);
+        assert_eq!(
+            detect_delay(200, &pre, &post),
+            Err(DelayRejection::InsufficientBaseline)
+        );
+    }
+
+    /// The dead simulator case: AFR never reacts. Must decline, not invent.
+    #[test]
+    fn flat_trace_declines() {
+        let pre = trace(&[(0, 14.7), (40, 14.7), (80, 14.7), (120, 14.7)]);
+        let post: Vec<AfrSample> = (0..40)
+            .map(|i| AfrSample {
+                t_ms: 200 + i * 40,
+                afr: 14.7 + if i % 2 == 0 { 0.02 } else { -0.02 },
+            })
+            .collect();
+        assert_eq!(
+            detect_delay(200, &pre, &post),
+            Err(DelayRejection::NoResponse)
+        );
+    }
+
+    #[test]
+    fn table_bins_and_aggregates() {
+        let mut t = DelayTable::new();
+        t.add(900.0, 35.0, 400.0); // idle cell
+        t.add(950.0, 38.0, 360.0); // same cell
+        t.add(3200.0, 85.0, 140.0); // mid-rpm, high-load
+        t.add(7000.0, 105.0, 90.0); // open-ended top bins
+
+        let idle = &t.cells[0][0];
+        assert_eq!(idle.n, 2);
+        assert!((idle.mean_ms - 380.0).abs() < 1e-9);
+        assert!((idle.range_ms - 40.0).abs() < 1e-9);
+
+        let (l, r) = t.cell_index(3200.0, 85.0);
+        assert_eq!(t.cells[l][r].n, 1);
+
+        let top = &t.cells[LOAD_EDGES.len()][RPM_EDGES.len()];
+        assert_eq!(top.n, 1);
+        assert!((top.mean_ms - 90.0).abs() < 1e-9);
+    }
+}

--- a/crates/libretune-core/src/autotune/mod.rs
+++ b/crates/libretune-core/src/autotune/mod.rs
@@ -15,6 +15,7 @@
 
 pub mod accel_enrich;
 pub mod anomaly;
+pub mod delay_measure;
 pub mod health;
 pub mod predictor;
 


### PR DESCRIPTION
## The AFR delay test cannot work on a running engine

It steps **`reqFuel`**, which this INI lists under `requiresPowerCycle` — alongside `nCylinders` and `injLayout`:

```
requiresPowerCycle = reqFuel
```

The firmware reads it at boot, so a live write changes nothing. The test writes the value, restores it, and the mixture never moves. Measured on a Speeduino 2025.01.4 target: the AFR trace is flat across the entire step. Nothing in the UI indicates this.

## And nothing extracted a delay

The test stepped and restored, but computed no number — there was no measurement, only the actuation.

## The fix

**A lever the running engine actually reads.** On a warm engine `correctionWUE()` returns the warm-plateau slot's raw value on every fuel calculation, cache-free, multiplied straight into pulse width engine-wide (`corrections.cpp` @ 202501). So a **one-byte** write steps fuelling everywhere and one byte restores it. The INI mandates that slot be 100% on a healthy tune, and the ECU broadcasts what it is applying via `warmupEnrich` — which gives a ground-truth anchor for when the step actually took effect, rather than when we sent it.

**An actual measurement**: baseline median and MAD from a pre-roll, a sustained-crossing detector, and an rpm × load table aggregating repeats.

Three further fixes, each found only on hardware:

- **The crossing is interpolated between samples.** Reporting the sample's own time biases every measurement late by up to a full interval — 63 ms at the ~16 Hz these logs really run at, a large share of a high-flow delay.
- **The baseline pre-roll is 1.5 s, not 600 ms.** 600 ms assumed ~20 Hz sampling; at the rate real hardware delivers it produced fewer than the required baseline samples, so every step was rejected as "unstable baseline".
- **`wueRates[9]` is bounds-checked** against the length the INI declares. The slot index was hardcoded, so a firmware with a shorter warm-up curve would have written a live byte into whichever constant follows it.

## Safety

Unchanged and deliberately narrow: enrichment only (the step is clamped positive — a rich excursion is harmless, a lean one at load is not), bounded magnitude, RAM only so a key cycle restores the stored tune, and the original value written back on every exit path including abort and error.

## Testing

`./scripts/pre-push.sh` green. Exercised against a Speeduino 2025.01.4 bench target and on a Mazda MX-5 NA6, where it produced 141 usable steps across a 59-minute drive.

## Note

Builds on #176 (immediate abort) — both touch the same file, and an abort that waits up to 15 s with the engine held rich is worth having under this.
