### PR TITLE
fix(dash): apply seven parsed-but-ignored .dash gauge properties at render time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,52 @@ relevant.
 
 ## [Unreleased]
 
+### 2026-08-17 — Issue #129: apply seven parsed-but-ignored .dash gauge properties at render time
+
+#### Fixed
+- **`face_angle` never shaped the gauge face** — roughly a third of stock
+  TunerStudio gauges are authored with `FaceAngle=180/182/188` (half-sweep
+  faces), but every analog gauge rendered as a full circle. New shared
+  geometry helper (`painters/gaugeGeometry.ts`, `resolveGaugeArc`) resolves
+  the effective needle sweep (clamped to the face extent — the needle never
+  travels outside the face) and the face arc (centered on the sweep, which
+  reproduces the 182/188 "sweep + margin" shapes). `analogGauge.ts` now
+  draws a sector face (wedge background, arc-band bezel, text anchored
+  outside the flat side) when `face_angle < 360`; full-circle faces render
+  exactly as before. Also corrected the Rust default/parse-fallback for
+  `FaceAngle` from 270 → 360 (stock corpus values are only 360/180/182/188;
+  TunerStudio renders absent-FaceAngle gauges as full circles, and 270
+  would have shrunk them into sectors).
+- **`history_value` never seeded the peak marker** — TunerStudio persists
+  the last peak in the file; the renderer now seeds `peakValueRef` from it
+  (clamped to range) when `peak_hold` is on (`peakTracking.ts::seedPeak`).
+- **`history_delay` never decayed the peak marker** — the peak only ever
+  ratcheted upward for the life of the gauge. New pure state machine
+  (`peakTracking.ts::nextPeakState`) ratchets upward and, once
+  `history_delay` ms elapse without a new peak, lets the marker fall back to
+  the present value. `history_delay <= 0` holds forever (semantics
+  undocumented; matches previous behavior).
+- **`default_min`/`default_max` were unreachable** — the dashboard designer's
+  property editor now shows a "Reset range to default" button when the gauge
+  carries authored defaults, restoring the TunerStudio-authored range.
+  `.dash` Min/Max and the INI range auto-sync remain authoritative at render.
+
+#### Docs
+- `gauge_style` and `needle_smoothing` are now documented as intentional
+  render-time no-ops (Rust `types.rs` + `dashTypes.ts`): `gauge_style` is
+  provenance only (painter selection is `gauge_painter`; TS styles are
+  free-form names with no in-file definition), and `needle_smoothing` is
+  uniformly 1 across the stock corpus with undocumented semantics — applying
+  it would invent behaviour (per the issue reporter's recommendation).
+
+#### Tests
+- Rust: `face_angle` parse/round-trip regression tests (PR #125 pattern)
+  incl. absent → 360 and malformed → 360 fallbacks.
+- Vitest: `gaugeGeometry.test.ts` (11 tests — full-circle passthrough,
+  180/182 sector centering, sweep clamp, ccw mirroring, garbage face values)
+  and `peakTracking.test.ts` (9 tests — seed/clamp, ratchet, hold, decay,
+  hold-forever on `<= 0`, decay clock for seeded peaks).
+
 ### 2026-08-13 — std_injection panel synthesis & offline constant reads
 
 #### Fixed

--- a/crates/libretune-app/src/components/dashboards/dashTypes.ts
+++ b/crates/libretune-app/src/components/dashboards/dashTypes.ts
@@ -122,6 +122,9 @@ export interface TsGaugeConfig {
   // Identification
   id: string;
   gauge_painter: GaugePainter;
+  /** Provenance only — never applied at render (issue #129): painter
+   * selection is `gauge_painter`; TS "styles" are free-form names with no
+   * definition inside the .dash file. */
   gauge_style: string;
 
   // Data binding
@@ -201,8 +204,13 @@ export interface TsGaugeConfig {
   needle_pivot_offset_y?: number;
 
   // History/tracking
+  /** Last peak persisted by TunerStudio; seeds the peak-hold marker. */
   history_value: number;
+  /** Peak-hold hold time in ms before the marker falls back (`<= 0` holds forever). */
   history_delay: number;
+  /** Round-trip only — never applied at render (issue #129): uniformly 1
+   * across the stock corpus with undocumented semantics; the renderer
+   * already smooths the needle via a fixed lerp. */
   needle_smoothing: number;
 
   // Interaction

--- a/crates/libretune-app/src/components/dashboards/designer/PropertyEditor.tsx
+++ b/crates/libretune-app/src/components/dashboards/designer/PropertyEditor.tsx
@@ -58,6 +58,18 @@ export default function PropertyEditor({ component, onChange }: Props) {
           </div>
         </div>
 
+        {gauge.default_min != null && gauge.default_max != null && (
+          <div className="property-group">
+            <button
+              type="button"
+              title={`Restore the range this gauge was authored with in TunerStudio (${gauge.default_min} … ${gauge.default_max})`}
+              onClick={() => updateGauge({ min: gauge.default_min!, max: gauge.default_max! })}
+            >
+              Reset range to default ({gauge.default_min} … {gauge.default_max})
+            </button>
+          </div>
+        )}
+
         <div className="property-group">
           <label>Units</label>
           <input

--- a/crates/libretune-app/src/components/gauges/__tests__/peakTracking.test.ts
+++ b/crates/libretune-app/src/components/gauges/__tests__/peakTracking.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { seedPeak, nextPeakState, type PeakState } from '../peakTracking';
+import type { TsGaugeConfig } from '../../dashboards/dashTypes';
+
+type PeakFields = Pick<TsGaugeConfig, 'peak_hold' | 'history_value' | 'min' | 'max'>;
+
+const cfg = (overrides: Partial<PeakFields>): PeakFields => ({
+  peak_hold: true,
+  history_value: 0,
+  min: 0,
+  max: 100,
+  ...overrides,
+});
+
+describe('seedPeak (issue #129: history_value applied at render time)', () => {
+  it('seeds the marker from the persisted history_value', () => {
+    expect(seedPeak(cfg({ history_value: 73 }), 10)).toBe(73);
+  });
+
+  it('clamps the seeded peak into the gauge range', () => {
+    expect(seedPeak(cfg({ history_value: 500 }), 10)).toBe(100);
+    expect(seedPeak(cfg({ history_value: -40 }), 10)).toBe(0);
+  });
+
+  it('falls back to the current value when history is absent or peak-hold is off', () => {
+    expect(seedPeak(cfg({ history_value: Number.NaN }), 42)).toBe(42);
+    expect(seedPeak(cfg({ peak_hold: false, history_value: 73 }), 42)).toBe(42);
+  });
+});
+
+describe('nextPeakState (issue #129: history_delay applied at render time)', () => {
+  const held = (peak: number, at: number): PeakState => ({ peak, lastNewPeakAt: at });
+
+  it('ratchets upward and stamps the time of the new peak', () => {
+    const next = nextPeakState(held(50, 1000), 80, 2000, 15000);
+    expect(next.peak).toBe(80);
+    expect(next.lastNewPeakAt).toBe(2000);
+  });
+
+  it('holds the peak while the delay has not elapsed', () => {
+    const next = nextPeakState(held(80, 1000), 50, 1000 + 14999, 15000);
+    expect(next.peak).toBe(80);
+  });
+
+  it('lets the marker fall back to the present value once the delay elapses', () => {
+    const next = nextPeakState(held(80, 1000), 50, 1000 + 15000, 15000);
+    expect(next.peak).toBe(50);
+    expect(next.lastNewPeakAt).toBe(16000);
+  });
+
+  it('a new peak within the delay window restarts the hold', () => {
+    // Peak at t=1000, nearly decays at t=15999, new peak at t=16000 →
+    // the marker must hold from the NEW peak's timestamp.
+    let state = nextPeakState(held(80, 1000), 50, 15999, 15000);
+    state = nextPeakState(state, 90, 16000, 15000);
+    expect(state.peak).toBe(90);
+    const after = nextPeakState(state, 50, 16000 + 14999, 15000);
+    expect(after.peak).toBe(90);
+  });
+
+  it('treats history_delay <= 0 as hold-forever', () => {
+    for (const history_delay of [0, -1]) {
+      const next = nextPeakState(held(80, 1000), 50, 1_000_000, history_delay);
+      expect(next.peak, `history_delay=${history_delay}`).toBe(80);
+    }
+  });
+
+  it('starts the decay clock on the first frame without moving a seeded peak', () => {
+    const seeded: PeakState = { peak: 73, lastNewPeakAt: null };
+    const started = nextPeakState(seeded, 10, 5000, 15000);
+    expect(started.peak).toBe(73);
+    expect(started.lastNewPeakAt).toBe(5000);
+    // ...and the seeded peak then decays like a freshly observed one.
+    const decayed = nextPeakState(started, 10, 5000 + 15000, 15000);
+    expect(decayed.peak).toBe(10);
+  });
+});

--- a/crates/libretune-app/src/components/gauges/painters/__tests__/gaugeGeometry.test.ts
+++ b/crates/libretune-app/src/components/gauges/painters/__tests__/gaugeGeometry.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest';
+import { resolveGaugeArc, traceFacePath, faceOppositeDirection } from '../gaugeGeometry';
+import type { TsGaugeConfig } from '../../../dashboards/dashTypes';
+
+type GeometryFields = Pick<
+  TsGaugeConfig,
+  'sweep_begin_degree' | 'start_angle' | 'sweep_angle' | 'face_angle' | 'counter_clockwise'
+>;
+
+const geom = (overrides: Partial<GeometryFields>): GeometryFields => ({
+  sweep_begin_degree: 135,
+  start_angle: 135,
+  sweep_angle: 270,
+  face_angle: 360,
+  counter_clockwise: false,
+  ...overrides,
+});
+
+describe('resolveGaugeArc (issue #129: face_angle applied at render time)', () => {
+  it('keeps legacy geometry for a full-circle face (face_angle=360)', () => {
+    const arc = resolveGaugeArc(geom({}));
+    expect(arc.isFullCircle).toBe(true);
+    expect(arc.startDeg).toBe(135);
+    expect(arc.sweepDeg).toBe(270);
+    expect(arc.faceAngleDeg).toBe(360);
+  });
+
+  it('a FaceAngle=180 gauge resolves to a half-sweep sector centered on the needle sweep', () => {
+    // Needle sweeps 180°→360° across the top half; the face must span the
+    // same region instead of drawing a full circle.
+    const arc = resolveGaugeArc(geom({ face_angle: 180, sweep_angle: 180, sweep_begin_degree: 180 }));
+    expect(arc.isFullCircle).toBe(false);
+    expect(arc.faceAngleDeg).toBe(180);
+    expect(arc.sweepDeg).toBe(180);
+    // Face centered on the sweep mid (270° = up): 270 − 90 = 180.
+    expect(arc.faceStartDeg).toBe(180);
+  });
+
+  it('a 182° face wraps a 180° sweep with a 1° margin per side', () => {
+    const arc = resolveGaugeArc(geom({ face_angle: 182, sweep_angle: 180, sweep_begin_degree: 180 }));
+    expect(arc.faceAngleDeg).toBe(182);
+    expect(arc.faceStartDeg).toBe(270 - 91); // 179 — one degree before the sweep starts
+  });
+
+  it('clamps the needle sweep to the face extent', () => {
+    // File sets FaceAngle=180 but omits SweepAngle (parser default 270):
+    // the needle must not sweep outside the half-circle face.
+    const arc = resolveGaugeArc(geom({ face_angle: 180, sweep_angle: 270 }));
+    expect(arc.sweepDeg).toBe(180);
+  });
+
+  it('mirrors the face around the sweep for counter-clockwise gauges', () => {
+    // CCW sweep starting at 180° (left) travelling downward through 90°
+    // (bottom) to 0° (right): mid = 90° (down), so the face covers the
+    // bottom half (0°→180°).
+    const arc = resolveGaugeArc(
+      geom({ face_angle: 180, sweep_angle: 180, sweep_begin_degree: 180, counter_clockwise: true }),
+    );
+    expect(arc.counterClockwise).toBe(true);
+    expect(arc.faceStartDeg).toBe(0);
+  });
+
+  it('treats absent, NaN, or degenerate face angles as a full circle', () => {
+    for (const face_angle of [undefined, Number.NaN, 0, 10, -90]) {
+      const arc = resolveGaugeArc(geom({ face_angle: face_angle as number }));
+      expect(arc.isFullCircle, `face_angle=${face_angle}`).toBe(true);
+      expect(arc.faceAngleDeg, `face_angle=${face_angle}`).toBe(360);
+    }
+  });
+
+  it('treats over-full face angles as a full circle', () => {
+    const arc = resolveGaugeArc(geom({ face_angle: 999 }));
+    expect(arc.isFullCircle).toBe(true);
+    expect(arc.faceAngleDeg).toBe(360);
+  });
+});
+
+describe('traceFacePath', () => {
+  const calls = () => {
+    const arcs: Array<number[]> = [];
+    const ctx = {
+      beginPath: () => {},
+      moveTo: () => {},
+      closePath: () => {},
+      arc: (...a: number[]) => { arcs.push(a); },
+    } as unknown as CanvasRenderingContext2D;
+    return { ctx, arcs };
+  };
+
+  it('traces a single full-circle arc for a 360° face', () => {
+    const { ctx, arcs } = calls();
+    traceFacePath(ctx, 50, 50, 40, resolveGaugeArc(geom({})));
+    expect(arcs).toEqual([[50, 50, 40, 0, Math.PI * 2]]);
+  });
+
+  it('traces a closed wedge (pivot → arc → close) for a sector face', () => {
+    const { ctx, arcs } = calls();
+    let closed = 0;
+    const ctx2 = {
+      ...ctx,
+      closePath: () => { closed += 1; },
+      moveTo: () => {},
+    } as unknown as CanvasRenderingContext2D;
+    const arc = resolveGaugeArc(geom({ face_angle: 180, sweep_angle: 180, sweep_begin_degree: 180 }));
+    traceFacePath(ctx2, 50, 50, 40, arc);
+    expect(closed).toBe(1);
+    expect(arcs).toHaveLength(1);
+    const [cx, cy, r, start, end] = arcs[0];
+    expect(cx).toBe(50);
+    expect(cy).toBe(50);
+    expect(r).toBe(40);
+    expect(start).toBeCloseTo(Math.PI, 5); // 180°
+    expect(end).toBeCloseTo(Math.PI * 2, 5); // 360°
+  });
+});
+
+describe('faceOppositeDirection', () => {
+  it('points down for a top-half gauge (text anchors below the pivot)', () => {
+    const arc = resolveGaugeArc(geom({ face_angle: 180, sweep_angle: 180, sweep_begin_degree: 180 }));
+    const dir = faceOppositeDirection(arc);
+    expect(dir.x).toBeCloseTo(0, 5);
+    expect(dir.y).toBeCloseTo(1, 5); // canvas +y = down
+  });
+
+  it('points up for a bottom-half (CCW) gauge', () => {
+    // CCW from 180° through the bottom: the face covers the bottom half,
+    // so the text anchor must be above the pivot.
+    const arc = resolveGaugeArc(
+      geom({ face_angle: 180, sweep_angle: 180, sweep_begin_degree: 180, counter_clockwise: true }),
+    );
+    const dir = faceOppositeDirection(arc);
+    expect(dir.x).toBeCloseTo(0, 5);
+    expect(dir.y).toBeCloseTo(-1, 5);
+  });
+});

--- a/crates/libretune-app/src/components/gauges/painters/analogGauge.ts
+++ b/crates/libretune-app/src/components/gauges/painters/analogGauge.ts
@@ -2,6 +2,7 @@
 
 import { tsColorToHex, tsColorToRgba } from '../../dashboards/dashTypes';
 import { roundRect, lightenColor, darkenColor, createMetallicGradient } from '../drawUtils';
+import { resolveGaugeArc, traceFacePath, faceOppositeDirection } from './gaugeGeometry';
 import type { Painter } from './types';
 
 export const analogGaugePainter: Painter = (pctx) => {
@@ -16,42 +17,70 @@ export const analogGaugePainter: Painter = (pctx) => {
   const centerY = height / 2 + pivotOffsetY;
   const radius = size / 2 - 8;
 
+  // Geometry — resolves TunerStudio's FaceAngle/SweepAngle/SweepBeginDegree
+  // into the effective needle sweep and the face shape (issue #129): a
+  // FaceAngle < 360 renders a sector face instead of a full-circle disc.
+  const arc = resolveGaugeArc(config);
+  const ccw = arc.counterClockwise;
+  const faceStartRad = (arc.faceStartDeg * Math.PI) / 180;
+  const faceEndRad = ((arc.faceStartDeg + arc.faceAngleDeg) * Math.PI) / 180;
+
   // Background - use image if available, otherwise use color
   if (bgImage) {
-    // Center the image in the square area
-    ctx.drawImage(bgImage, centerX - size / 2, centerY - size / 2, size, size);
+    if (arc.isFullCircle) {
+      // Center the image in the square area
+      ctx.drawImage(bgImage, centerX - size / 2, centerY - size / 2, size, size);
+    } else {
+      ctx.save();
+      traceFacePath(ctx, centerX, centerY, radius, arc);
+      ctx.clip();
+      ctx.drawImage(bgImage, centerX - size / 2, centerY - size / 2, size, size);
+      ctx.restore();
+    }
   } else {
     ctx.fillStyle = tsColorToRgba(config.back_color);
-    ctx.beginPath();
-    ctx.arc(centerX, centerY, radius, 0, Math.PI * 2);
+    traceFacePath(ctx, centerX, centerY, radius, arc);
     ctx.fill();
   }
 
-  // Outer shadow
+  // Outer shadow (follows the face silhouette)
   ctx.shadowColor = 'rgba(0, 0, 0, 0.5)';
   ctx.shadowBlur = 8;
   ctx.shadowOffsetX = 3;
   ctx.shadowOffsetY = 3;
-  ctx.beginPath();
-  ctx.arc(centerX, centerY, radius, 0, Math.PI * 2);
+  traceFacePath(ctx, centerX, centerY, radius, arc);
   ctx.fillStyle = '#333';
   ctx.fill();
   ctx.shadowColor = 'transparent';
 
-  // Metallic bezel - outer ring
+  // Metallic bezel - outer ring, following the face shape
   const bezelWidth = config.border_width > 0
     ? Math.min(radius * 0.3, config.border_width)
     : Math.max(6, radius * 0.08);
   const bezelGradient = createMetallicGradient(ctx, centerX, centerY, radius + 2, radius - bezelWidth, config.trim_color);
-  ctx.beginPath();
-  ctx.arc(centerX, centerY, radius, 0, Math.PI * 2);
-  ctx.arc(centerX, centerY, radius - bezelWidth, 0, Math.PI * 2, true);
-  ctx.fillStyle = bezelGradient;
-  ctx.fill();
+  if (arc.isFullCircle) {
+    ctx.beginPath();
+    ctx.arc(centerX, centerY, radius, 0, Math.PI * 2);
+    ctx.arc(centerX, centerY, radius - bezelWidth, 0, Math.PI * 2, true);
+    ctx.fillStyle = bezelGradient;
+    ctx.fill();
+  } else {
+    // Sector face: the bezel becomes a band along the curved edge
+    ctx.beginPath();
+    ctx.arc(centerX, centerY, radius - bezelWidth / 2, faceStartRad, faceEndRad);
+    ctx.strokeStyle = bezelGradient;
+    ctx.lineWidth = bezelWidth;
+    ctx.lineCap = 'butt';
+    ctx.stroke();
+  }
 
   // Inner bezel highlight
   ctx.beginPath();
-  ctx.arc(centerX, centerY, radius - bezelWidth + 1, 0, Math.PI * 2);
+  if (arc.isFullCircle) {
+    ctx.arc(centerX, centerY, radius - bezelWidth + 1, 0, Math.PI * 2);
+  } else {
+    ctx.arc(centerX, centerY, radius - bezelWidth + 1, faceStartRad, faceEndRad);
+  }
   ctx.strokeStyle = 'rgba(255, 255, 255, 0.15)';
   ctx.lineWidth = 1;
   ctx.stroke();
@@ -66,18 +95,14 @@ export const analogGaugePainter: Painter = (pctx) => {
   faceGradient.addColorStop(0, lightenColor(backHex, 15));
   faceGradient.addColorStop(0.7, backHex);
   faceGradient.addColorStop(1, darkenColor(backHex, 10));
-  ctx.beginPath();
-  ctx.arc(centerX, centerY, faceRadius, 0, Math.PI * 2);
+  traceFacePath(ctx, centerX, centerY, faceRadius, arc);
   ctx.fillStyle = faceGradient;
   ctx.fill();
 
-  // Calculate angles (TS uses degrees, canvas uses radians)
-  const startDeg = config.sweep_begin_degree ?? config.start_angle ?? 225;
-  const sweepDeg = config.sweep_angle ?? 270;
-  const ccw = config.counter_clockwise ?? false;
-
-  const startAngle = startDeg * Math.PI / 180;
-  const sweepAngle = sweepDeg * Math.PI / 180;
+  // Needle sweep angles (TS uses degrees, canvas uses radians). The
+  // effective sweep comes from the resolved arc — clamped to the face.
+  const startAngle = (arc.startDeg * Math.PI) / 180;
+  const sweepAngle = (arc.sweepDeg * Math.PI) / 180;
   const endAngle = ccw ? startAngle - sweepAngle : startAngle + sweepAngle;
 
   // Helper to calculate angle at a given percentage (0-1) along the sweep
@@ -279,14 +304,20 @@ export const analogGaugePainter: Painter = (pctx) => {
     ctx.restore();
   }
 
-  // Title with shadow (move up to avoid overlap)
+  // Title with shadow (move up to avoid overlap). Full circles keep the
+  // legacy in-face offsets; sector faces anchor the text just outside the
+  // flat side of the gauge (a half-sweep face puts its readout below the
+  // pivot, like TunerStudio's half gauges).
+  const textDir = arc.isFullCircle ? null : faceOppositeDirection(arc);
+  const titleX = textDir ? centerX + textDir.x * faceRadius * 0.1 : centerX;
+  const titleY = textDir ? centerY + textDir.y * faceRadius * 0.1 : centerY + faceRadius * 0.25;
   ctx.shadowColor = 'rgba(0, 0, 0, 0.4)';
   ctx.shadowBlur = 2;
   ctx.fillStyle = fontHex;
   ctx.font = getFontSpec(Math.max(9, faceRadius * 0.13), { bold: true });
   ctx.textAlign = 'center';
   ctx.textBaseline = 'top';
-  ctx.fillText(config.title, centerX, centerY + faceRadius * 0.25);
+  ctx.fillText(config.title, titleX, titleY);
   ctx.shadowColor = 'transparent';
 
   // Value display with background (move down to avoid overlap)
@@ -294,7 +325,7 @@ export const analogGaugePainter: Painter = (pctx) => {
   const valueText = `${value.toFixed(config.value_digits)} ${config.units}`;
   ctx.font = getFontSpec(valueFontSize, { bold: true, monospace: true });
   const valueWidth = ctx.measureText(valueText).width;
-  const valueY = centerY + faceRadius * 0.55;
+  const valueY = textDir ? centerY + textDir.y * faceRadius * 0.32 : centerY + faceRadius * 0.55;
   ctx.fillStyle = 'rgba(0, 0, 0, 0.3)';
   roundRect(ctx, centerX - valueWidth / 2 - 4, valueY - valueFontSize / 2 - 2, valueWidth + 8, valueFontSize + 4, 3);
   ctx.fill();

--- a/crates/libretune-app/src/components/gauges/painters/gaugeGeometry.ts
+++ b/crates/libretune-app/src/components/gauges/painters/gaugeGeometry.ts
@@ -1,0 +1,113 @@
+/**
+ * gaugeGeometry — shared TunerStudio geometry resolution for circular
+ * painters (issue #129).
+ *
+ * A `.dash` gauge carries four geometry properties. TunerStudio semantics:
+ *  - `FaceAngle` — total angular extent of the gauge FACE (360 = full
+ *    circle, 180 = half-sweep face). Stock corpus values are only
+ *    360/180/182/188; the face arc is centered on the needle sweep, so a
+ *    182° face wrapping a 180° sweep leaves a 1° margin per side.
+ *  - `SweepBeginDegree` / `StartAngle` — where the needle sweep begins
+ *    (canvas degrees; 0° = right, 90° = down, clockwise positive).
+ *  - `SweepAngle` — how far the needle travels from min to max.
+ *
+ * The needle can never travel outside the face, so the effective sweep is
+ * clamped to the face extent. That also self-heals files that set
+ * `FaceAngle=180` but omit `SweepAngle` (where the parser default of 270
+ * would otherwise over-sweep a half-circle gauge).
+ */
+
+import type { TsGaugeConfig } from '../../dashboards/dashTypes';
+
+/** Smallest sector face we will render — below this, authored data is noise. */
+const MIN_FACE_ANGLE = 45;
+const MIN_SWEEP = 1;
+
+export interface GaugeArc {
+  /** Angle (canvas degrees) where the needle sweep starts. */
+  startDeg: number;
+  /** Effective needle travel in degrees (never exceeds `faceAngleDeg`). */
+  sweepDeg: number;
+  counterClockwise: boolean;
+  /** Face arc extent in degrees; 360 = full circle. */
+  faceAngleDeg: number;
+  /** Angle where the face arc starts (the face is centered on the sweep). */
+  faceStartDeg: number;
+  /** True when the face covers the full circle — painters keep their legacy path. */
+  isFullCircle: boolean;
+}
+
+/**
+ * Resolve the render-time arc geometry for a gauge. Pure — no canvas, no
+ * side effects — so it can be unit-tested against the stock-corpus shapes.
+ */
+export function resolveGaugeArc(
+  config: Pick<
+    TsGaugeConfig,
+    'sweep_begin_degree' | 'start_angle' | 'sweep_angle' | 'face_angle' | 'counter_clockwise'
+  >,
+): GaugeArc {
+  const startDeg =
+    config.sweep_begin_degree ??
+    config.start_angle ??
+    225;
+  const requestedSweep = Number.isFinite(config.sweep_angle) ? config.sweep_angle : 270;
+  // Absent/NaN/too-small faces fall back to full circle — garbage data must
+  // not shrink a gauge into a sliver; anything above 360 is still full.
+  const rawFace = config.face_angle;
+  const faceAngleDeg =
+    rawFace == null || !Number.isFinite(rawFace) || rawFace < MIN_FACE_ANGLE
+      ? 360
+      : Math.min(rawFace, 360);
+  // The needle travels inside the face, never beyond it.
+  const sweepDeg = Math.max(MIN_SWEEP, Math.min(requestedSweep, faceAngleDeg));
+  const ccw = config.counter_clockwise ?? false;
+
+  // Face arc is centered on the sweep arc (mirrored for counter-clockwise).
+  const sweepMidDeg = ccw ? startDeg - sweepDeg / 2 : startDeg + sweepDeg / 2;
+  const faceStartDeg = sweepMidDeg - faceAngleDeg / 2;
+
+  return {
+    startDeg,
+    sweepDeg,
+    counterClockwise: ccw,
+    faceAngleDeg,
+    faceStartDeg,
+    isFullCircle: faceAngleDeg >= 360,
+  };
+}
+
+/**
+ * Trace the gauge face onto the canvas: a full circle, or a closed pie
+ * wedge covering `[faceStartDeg, faceStartDeg + faceAngleDeg]`. Only
+ * traces the path — the caller fills/strokes it.
+ */
+export function traceFacePath(
+  ctx: CanvasRenderingContext2D,
+  centerX: number,
+  centerY: number,
+  radius: number,
+  arc: GaugeArc,
+): void {
+  ctx.beginPath();
+  if (arc.isFullCircle) {
+    ctx.arc(centerX, centerY, radius, 0, Math.PI * 2);
+    return;
+  }
+  const startRad = (arc.faceStartDeg * Math.PI) / 180;
+  const endRad = ((arc.faceStartDeg + arc.faceAngleDeg) * Math.PI) / 180;
+  ctx.moveTo(centerX, centerY);
+  ctx.arc(centerX, centerY, radius, startRad, endRad);
+  ctx.closePath();
+}
+
+/**
+ * Unit vector pointing AWAY from the face — where a sector-face gauge
+ * should anchor its title/value text (e.g. a top-half gauge puts its
+ * readout below the pivot, like TunerStudio's half gauges). Only meaningful
+ * when `!arc.isFullCircle`.
+ */
+export function faceOppositeDirection(arc: GaugeArc): { x: number; y: number } {
+  const midRad = ((arc.faceStartDeg + arc.faceAngleDeg / 2) * Math.PI) / 180;
+  return { x: -Math.cos(midRad), y: -Math.sin(midRad) };
+}

--- a/crates/libretune-app/src/components/gauges/peakTracking.ts
+++ b/crates/libretune-app/src/components/gauges/peakTracking.ts
@@ -1,0 +1,70 @@
+/**
+ * peakTracking — peak-hold state machine for gauges with `peak_hold`
+ * (TunerStudio's `ShowHistory`) — issue #129.
+ *
+ * TunerStudio persists the last peak as `HistoryValue` and holds the
+ * on-gauge peak marker for `HistoryDelay` milliseconds before letting it
+ * fall back to the present value. A `HistoryDelay <= 0` is treated as
+ * "hold forever": the value is undocumented in the `.dash` format, and
+ * holding matches the previous renderer behaviour, so it can never make
+ * the marker worse than before.
+ *
+ * Pure functions only — no canvas, no timers — so the rAF loop in
+ * `useGaugeRenderer` stays thin and this stays unit-testable.
+ */
+
+import type { TsGaugeConfig } from '../dashboards/dashTypes';
+
+export interface PeakState {
+  peak: number;
+  /**
+   * Timestamp (ms, rAF clock) of the last upward ratchet or decay reset.
+   * `null` before the first frame; the first `nextPeakState` call starts
+   * the decay clock, which is what makes a peak seeded from the file's
+   * `history_value` decay like a freshly observed one.
+   */
+  lastNewPeakAt: number | null;
+}
+
+/**
+ * Seed the peak from the file's persisted `history_value`, clamped into
+ * the gauge range. Falls back to the caller's value (the current display
+ * value) when history is absent or peak-hold is off.
+ */
+export function seedPeak(
+  config: Pick<TsGaugeConfig, 'peak_hold' | 'history_value' | 'min' | 'max'>,
+  fallback: number,
+): number {
+  if (!config.peak_hold) return fallback;
+  const history = config.history_value;
+  if (!Number.isFinite(history)) return fallback;
+  return Math.max(config.min, Math.min(config.max, history));
+}
+
+/**
+ * Advance the peak state by one frame.
+ *
+ * @param state   Current state.
+ * @param target  The gauge's current animation target (fresh store value).
+ * @param nowMs   Frame timestamp (rAF clock).
+ * @param delayMs `history_delay` in ms; `<= 0` holds the peak forever.
+ */
+export function nextPeakState(
+  state: PeakState,
+  target: number,
+  nowMs: number,
+  delayMs: number,
+): PeakState {
+  // First frame: start the decay clock without moving the (possibly
+  // seeded) peak.
+  const lastNewPeakAt = state.lastNewPeakAt ?? nowMs;
+  if (target > state.peak) {
+    return { peak: target, lastNewPeakAt: nowMs };
+  }
+  if (delayMs > 0 && nowMs - lastNewPeakAt >= delayMs) {
+    // Hold expired — the marker falls back to the present value and the
+    // timer restarts (a visual no-op while the value stays put).
+    return { peak: target, lastNewPeakAt: nowMs };
+  }
+  return state.lastNewPeakAt === lastNewPeakAt ? state : { ...state, lastNewPeakAt };
+}

--- a/crates/libretune-app/src/components/gauges/useGaugeRenderer.ts
+++ b/crates/libretune-app/src/components/gauges/useGaugeRenderer.ts
@@ -20,6 +20,7 @@
 import { useEffect, useRef } from 'react';
 import type { TsGaugeConfig } from '../dashboards/dashTypes';
 import { useRealtimeStore } from '../../stores/realtimeStore';
+import { seedPeak, nextPeakState, type PeakState } from './peakTracking';
 
 /** Lerp factor per animation frame (~280ms to converge at 60fps). */
 const ANIMATION_LERP = 0.25;
@@ -75,9 +76,11 @@ export interface UseGaugeRendererResult {
    */
   displayValueRef: React.MutableRefObject<number>;
   /**
-   * Persistent peak (maximum) of the display value since this gauge
-   * mounted. Painters consult this when `config.peak_hold === true` to
-   * draw a TS-style peak marker. Resets when the gauge is reseated
+   * Persistent peak (maximum) of the display value. Painters consult this
+   * when `config.peak_hold === true` to draw a TS-style peak marker.
+   * Seeded from the gauge's persisted `history_value` (issue #129) and,
+   * when `history_delay > 0`, decayed back to the present value once the
+   * hold expires (`peakTracking.ts`). Resets when the gauge is reseated
    * (component remount).
    */
   peakValueRef: React.MutableRefObject<number>;
@@ -95,9 +98,11 @@ export function useGaugeRenderer(opts: UseGaugeRendererOptions): UseGaugeRendere
 
   // displayValueRef holds the CURRENTLY DISPLAYED (smoothly animated) value.
   const displayValueRef = useRef(initialClamped);
-  // peakValueRef holds the maximum value ever observed by the gauge —
-  // used for the optional `peak_hold` marker.
-  const peakValueRef = useRef(initialClamped);
+  // peakValueRef holds the peak-hold marker value — seeded from the .dash
+  // file's persisted HistoryValue, ratcheted upward by the animation loop,
+  // and decayed per HistoryDelay (see peakTracking.ts).
+  const peakValueRef = useRef(seedPeak(config, initialClamped));
+  const peakStateRef = useRef<PeakState>({ peak: peakValueRef.current, lastNewPeakAt: null });
   // targetRef holds the ANIMATION TARGET — updated by store reads or the
   // sweep/demo prop-sync effect below.
   const targetRef = useRef(initialClamped);
@@ -254,9 +259,15 @@ export function useGaugeRenderer(opts: UseGaugeRendererOptions): UseGaugeRendere
       }
 
       const target = targetRef.current;
-      if (target > peakValueRef.current) {
-        peakValueRef.current = target;
-      }
+      // Peak-hold: ratchet upward, and once `history_delay` has elapsed
+      // without a new peak, let the marker fall back to the present value.
+      peakStateRef.current = nextPeakState(
+        peakStateRef.current,
+        target,
+        timestamp,
+        config.history_delay,
+      );
+      peakValueRef.current = peakStateRef.current.peak;
       const diff = target - displayValueRef.current;
       const keepAlive = continuousRender && !overrideStoreRef.current && channel;
       if (Math.abs(diff) > epsilon) {
@@ -302,7 +313,22 @@ export function useGaugeRenderer(opts: UseGaugeRendererOptions): UseGaugeRendere
     // every 100ms. Costs ~one hash lookup per gauge per tick.
     const watchdog = setInterval(() => {
       if (!loopActive || overrideStoreRef.current || !channel) return;
-      if (rafIdRef.current !== null) return; // Already animating.
+      if (rafIdRef.current === null) {
+        // Peak-hold decay must advance even while the loop is idle
+        // (steady value) — otherwise the marker would hold forever.
+        // performance.now() shares the rAF clock.
+        const next = nextPeakState(
+          peakStateRef.current,
+          targetRef.current,
+          performance.now(),
+          config.history_delay,
+        );
+        if (next !== peakStateRef.current) {
+          peakStateRef.current = next;
+          peakValueRef.current = next.peak;
+          drawFrame();
+        }
+      }
       const raw = readStoreValue();
       if (raw !== undefined) {
         const peg = config.peg_limits;
@@ -333,6 +359,7 @@ export function useGaugeRenderer(opts: UseGaugeRendererOptions): UseGaugeRendere
     config.max,
     config.peg_limits,
     config.antialiasing_on,
+    config.history_delay,
     continuousRender,
   ]);
 

--- a/crates/libretune-core/src/dash/parser.rs
+++ b/crates/libretune-core/src/dash/parser.rs
@@ -586,7 +586,9 @@ fn set_gauge_property(gauge: &mut GaugeConfig, prop: &str, value: &str) {
         "ItalicFont" => gauge.italic_font = value.parse().unwrap_or(false),
         "SweepAngle" => gauge.sweep_angle = value.parse().unwrap_or(270),
         "StartAngle" => gauge.start_angle = value.parse().unwrap_or(135),
-        "FaceAngle" => gauge.face_angle = value.parse().unwrap_or(270),
+        // Fallback 360 = full-circle face: a malformed value must not turn
+        // the gauge into a partial-sector face it was never authored with.
+        "FaceAngle" => gauge.face_angle = value.parse().unwrap_or(360),
         "SweepBeginDegree" => gauge.sweep_begin_degree = value.parse().unwrap_or(135),
         "CounterClockwise" => gauge.counter_clockwise = value.parse().unwrap_or(false),
         "MajorTicks" => gauge.major_ticks = value.parse().unwrap_or(-1.0),
@@ -845,6 +847,92 @@ mod tests {
             DashComponent::Gauge(g) => assert!(
                 g.peak_hold,
                 "peak_hold must survive a write/parse round-trip"
+            ),
+            _ => panic!("Expected Gauge component"),
+        }
+    }
+
+    /// `FaceAngle` drives the face shape (full circle vs. sector) at render
+    /// time (issue #129) — roughly a third of stock TunerStudio gauges use
+    /// 180°, which must survive parsing rather than silently becoming the
+    /// default. Gauges without the property stay full-circle (360).
+    #[test]
+    fn test_face_angle_parses_and_defaults() {
+        let dash_with = |face_angle: &str| {
+            format!(
+                r#"<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<dsh xmlns="http://www.EFIAnalytics.com/:dsh">
+    <bibliography author="Test" company="TestCo" writeDate="2025-01-01"/>
+    <versionInfo fileFormat="3.0" firmwareSignature="speeduino"/>
+    <gaugeCluster antiAliasing="true" clusterBackgroundColor="-16777216">
+        <dashComp type="Gauge">
+            <Title type="String">RPM</Title>
+            <OutputChannel type="String">rpm</OutputChannel>
+            <GaugePainter type="GaugePainter">Analog Gauge</GaugePainter>
+            {face_angle}
+        </dashComp>
+    </gaugeCluster>
+</dsh>"#
+            )
+        };
+
+        let gauge_from = |xml: &str| {
+            let mut dash = parse_dash_file(xml).expect("parse");
+            match dash.gauge_cluster.components.remove(0) {
+                DashComponent::Gauge(g) => *g,
+                _ => panic!("Expected Gauge component"),
+            }
+        };
+
+        let half = gauge_from(&dash_with("<FaceAngle type=\"int\">180</FaceAngle>"));
+        assert_eq!(
+            half.face_angle, 180,
+            "FaceAngle=180 must parse through, otherwise half-sweep faces render as full circles"
+        );
+
+        let absent = gauge_from(&dash_with(""));
+        assert_eq!(
+            absent.face_angle, 360,
+            "a gauge without FaceAngle must default to a full-circle face"
+        );
+
+        let malformed = gauge_from(&dash_with("<FaceAngle type=\"int\">abc</FaceAngle>"));
+        assert_eq!(
+            malformed.face_angle, 360,
+            "an unparseable FaceAngle must fall back to full-circle, not a partial sector"
+        );
+    }
+
+    /// A gauge authored with a sector face must keep it through a
+    /// write/parse round-trip.
+    #[test]
+    fn test_face_angle_round_trips() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<dsh xmlns="http://www.EFIAnalytics.com/:dsh">
+    <bibliography author="Test" company="TestCo" writeDate="2025-01-01"/>
+    <versionInfo fileFormat="3.0" firmwareSignature="speeduino"/>
+    <gaugeCluster antiAliasing="true" clusterBackgroundColor="-16777216">
+        <dashComp type="Gauge">
+            <Title type="String">RPM</Title>
+            <OutputChannel type="String">rpm</OutputChannel>
+            <GaugePainter type="GaugePainter">Analog Gauge</GaugePainter>
+            <FaceAngle type="int">180</FaceAngle>
+        </dashComp>
+    </gaugeCluster>
+</dsh>"#;
+
+        let dash = parse_dash_file(xml).expect("parse");
+        let written = crate::dash::writer::write_dash_file(&dash).expect("write");
+        assert!(
+            written.contains("<FaceAngle type=\"int\">180</FaceAngle>"),
+            "face_angle must survive a write, got:\n{written}"
+        );
+
+        let mut reparsed = parse_dash_file(&written).expect("reparse");
+        match reparsed.gauge_cluster.components.remove(0) {
+            DashComponent::Gauge(g) => assert_eq!(
+                g.face_angle, 180,
+                "face_angle must survive a write/parse round-trip"
             ),
             _ => panic!("Expected Gauge component"),
         }

--- a/crates/libretune-core/src/dash/types.rs
+++ b/crates/libretune-core/src/dash/types.rs
@@ -356,6 +356,9 @@ pub struct GaugeConfig {
 
     // Gauge type
     pub gauge_painter: GaugePainter,
+    // Provenance only — intentionally never applied at render time (issue
+    // #129): painter selection is `gauge_painter`; TunerStudio "styles" are
+    // free-form names with no definition inside the .dash file.
     pub gauge_style: String, // Original style name from file
 
     // Data binding
@@ -437,6 +440,10 @@ pub struct GaugeConfig {
     // History/tracking
     pub history_value: f64,
     pub history_delay: i32,
+    // Round-trip only — intentionally never applied at render time (issue
+    // #129): the value is uniformly 1 across the stock corpus and
+    // TunerStudio's semantics for it are undocumented, so applying it would
+    // invent behaviour. The renderer already smooths via a fixed lerp.
     pub needle_smoothing: i32,
 
     // Interaction
@@ -524,7 +531,10 @@ impl Default for GaugeConfig {
             italic_font: false,
             sweep_angle: 270,
             start_angle: 135,
-            face_angle: 270,
+            // TunerStudio renders a gauge without `FaceAngle` as a full
+            // circle; the stock corpus only ever carries 360/180/182/188
+            // (issue #129), so 360 is the faithful absent-value default.
+            face_angle: 360,
             sweep_begin_degree: 135,
             counter_clockwise: false,
             major_ticks: -1.0,


### PR DESCRIPTION
Fixes #129

Follow-up to the ShowHistory fix (PR #125) for the same bug class: gauge properties that parse, round-trip, and serialize to the frontend — but were never read by any painter or renderer hook.

## Root cause

All seven properties complete the data pipeline (XML → `parser.rs` → `GaugeConfig` → serde JSON → `TsGaugeConfig`) and die at the last step: painter dispatch uses only `gauge_painter`, geometry came from `sweep_angle`/`sweep_begin_degree` alone, and the peak tracker only ratcheted upward with no seed or decay.

## Changes per property

- **`face_angle`** (the headline symptom — ~⅓ of stock gauges use 180/182/188° half-sweep faces but rendered as full circles):
  - New shared helper `painters/gaugeGeometry.ts` (`resolveGaugeArc`) resolves the effective needle sweep — clamped to the face extent, so the needle never travels outside the face (this also self-heals files that set `FaceAngle=180` but omit `SweepAngle`) — and the face arc centered on the sweep, which reproduces the observed 182/188 "sweep + margin" shapes.
  - `analogGauge.ts` (incl. its `BasicAnalogGauge`/`CircleAnalogGauge` aliases) draws a sector face when `face_angle < 360`: wedge background, arc-band bezel along the curved edge, and title/value text anchored outside the flat side of the gauge, like TunerStudio half gauges. **Full-circle faces render exactly as before.**
  - Rust default/parse-fallback for `FaceAngle` corrected 270 → 360: the stock corpus only carries 360/180/182/188 and TS renders absent-`FaceAngle` gauges as full circles, so the old 270 default would have shrunk them into sectors. Absent and malformed values now fall back to 360.
- **`history_value`** — seeds the peak-hold marker from the persisted peak (clamped to the gauge range) instead of the current value, restoring TS's cross-session peak.
- **`history_delay`** — the peak marker now decays back to the present value once the hold expires; `history_delay <= 0` holds forever (semantics undocumented; conservative choice that can't render worse than before). New pure state machine `peakTracking.ts`; it advances in the rAF loop **and** from the idle watchdog, because the loop goes idle on steady values and the marker would otherwise never decay.
- **`default_min` / `default_max`** — the dashboard designer's property editor gains a "Reset range to default (min … max)" button when the gauge carries authored defaults. Render-time precedence is unchanged: `.dash` Min/Max and the INI range auto-sync stay authoritative (TS semantics — defaults are what the gauge resets to).
- **`gauge_style` / `needle_smoothing`** — documented as intentional render-time no-ops in Rust `types.rs` and `dashTypes.ts`, referencing the issue: `gauge_style` is provenance only (painter selection is `gauge_painter`; TS styles are free-form names with no in-file definition), and `needle_smoothing` is uniformly 1 across the stock corpus with undocumented semantics — applying it would invent behaviour, per the issue reporter's recommendation.

## Tests

- **Rust** (PR #125 pattern, inline-XML): `test_face_angle_parses_and_defaults` (180 parses through; absent → 360; malformed → 360) and `test_face_angle_round_trips` (write/parse keeps 180).
- **Vitest**: `gaugeGeometry.test.ts` (11 tests — full-circle passthrough, 180/182° sector centering, sweep clamped to face, ccw mirroring, garbage face values, face path tracing, text-anchor direction) and `peakTracking.test.ts` (9 tests — seed/clamp, ratchet, hold, decay, new-peak restarts the hold, hold-forever on `<= 0`, decay clock for seeded peaks).

Full suites: 649 Rust tests, 169 frontend tests, clippy and `tsc` clean.

## Deliberately out of scope

`roundGauge`, `tachometer`, `fuelMeter`, `roundDashedGauge`, and `sweepGauge` still don't consume `face_angle` — none of them consume any TunerStudio geometry today (hardcoded arcs or already sweep-shaped bands), so wiring `face_angle` into only them would be inconsistent. The round gauge family could be migrated onto `resolveGaugeArc` wholesale in a follow-up if desired.