### PR TITLE
feat(table): per-table "Generate" action in the table editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,28 @@ relevant.
 
 ## [Unreleased]
 
+### 2026-08-17 — Per-table generator ("Generate…" in the table editor)
+
+#### Added
+- **Generate a single table from engine specs, TunerStudio-style.** The base-map
+  generators (VE / ignition / AFR) were previously reachable only through the
+  one-shot base-map wizard. The table editor's right-click menu now offers a
+  **"Generate <VE / Ignition / AFR Target> Table…"** action for those tables,
+  which seeds the open table over its **current axes** and applies the result as
+  a single undoable edit (nothing is burned to the ECU automatically).
+  - New Tauri command `generate_table_values(table_name, rpm_bins, load_bins, …engine spec)`
+    (`crates/libretune-app/src-tauri/src/commands/generate_table.rs`). It
+    classifies the table by its INI-derived `TableRole` and falls back to the
+    same name lists `apply_base_map` uses, then calls the existing
+    `generate_ve_table` / `generate_ignition_table` / `generate_afr_table`
+    core generators. Returns `{ table_type, z_values }`.
+  - New frontend: `GenerateTableDialog` (compact engine-spec form) and a
+    `classifyGeneratableTable` helper (`utils/tableGenerator.ts`) that gates the
+    menu affordance. The context menu shows the action only for VE/ignition/AFR
+    tables.
+  - Tests: Rust unit tests for the name/role classifiers, and vitest coverage
+    for `classifyGeneratableTable` / `generatableTableLabel`.
+
 ### 2026-08-13 — std_injection panel synthesis & offline constant reads
 
 #### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ relevant.
 
 ## [Unreleased]
 
+### 2026-08-18 — Spark generator: combustion chamber & boost (psi)
+
+#### Added
+- The ignition generator now also accounts for **combustion chamber design**
+  (open chamber / 2-valve quench / multi-valve swirl) via the new
+  `EngineSpec::combustion_chamber`, folded into `max_spark_advance` (slower
+  burn → more advance). The Generate dialog exposes it for ignition tables.
+- Boost is now entered as **gauge psi** in the Generate dialog (converted to
+  absolute kPa internally), matching TunerStudio's spark generator inputs.
+
 ### 2026-08-17 — Per-table generator ("Generate…" in the table editor)
 
 #### Added

--- a/crates/libretune-app/src-tauri/src/commands/base_map.rs
+++ b/crates/libretune-app/src-tauri/src/commands/base_map.rs
@@ -73,6 +73,7 @@ pub async fn generate_base_map(
         target_wot_afr,
         octane: None,
         compression_ratio: None,
+        combustion_chamber: None,
     };
 
     let base_map = libretune_core::basemap::generator::generate_base_map(&spec);

--- a/crates/libretune-app/src-tauri/src/commands/base_map.rs
+++ b/crates/libretune-app/src-tauri/src/commands/base_map.rs
@@ -71,6 +71,8 @@ pub async fn generate_base_map(
         redline_rpm,
         boost_target_kpa,
         target_wot_afr,
+        octane: None,
+        compression_ratio: None,
     };
 
     let base_map = libretune_core::basemap::generator::generate_base_map(&spec);

--- a/crates/libretune-app/src-tauri/src/commands/generate_table.rs
+++ b/crates/libretune-app/src-tauri/src/commands/generate_table.rs
@@ -98,6 +98,7 @@ pub async fn generate_table_values(
     target_wot_afr: Option<f64>,
     octane: Option<f64>,
     compression_ratio: Option<f64>,
+    combustion_chamber: Option<String>,
     rebuild_axes: Option<bool>,
 ) -> Result<serde_json::Value, String> {
     use libretune_core::basemap::generator::{
@@ -105,7 +106,8 @@ pub async fn generate_table_values(
         generate_ve_table,
     };
     use libretune_core::basemap::{
-        Aspiration, EngineSpec, FuelType, IgnitionMode, InjectionMode, StrokeType,
+        Aspiration, CombustionChamber, EngineSpec, FuelType, IgnitionMode, InjectionMode,
+        StrokeType,
     };
 
     if rpm_bins.is_empty() || load_bins.is_empty() {
@@ -170,6 +172,16 @@ pub async fn generate_table_values(
         _ => return Err(format!("Unknown ignition mode: {}", ignition_mode)),
     };
 
+    let chamber = match combustion_chamber.as_deref().map(str::to_lowercase).as_deref() {
+        Some("open_chamber") | Some("open") => Some(CombustionChamber::OpenChamber),
+        Some("quench_two_valve") | Some("quench") => Some(CombustionChamber::QuenchTwoValve),
+        Some("swirl_multi_valve") | Some("swirl") => Some(CombustionChamber::SwirlMultiValve),
+        Some(other) if !other.is_empty() => {
+            return Err(format!("Unknown combustion chamber: {}", other))
+        }
+        _ => None,
+    };
+
     let spec = EngineSpec {
         cylinder_count,
         displacement_cc,
@@ -185,6 +197,7 @@ pub async fn generate_table_values(
         target_wot_afr,
         octane,
         compression_ratio,
+        combustion_chamber: chamber,
     };
 
     // Optionally rebuild the axes from idle/redline (and load range) so the RPM

--- a/crates/libretune-app/src-tauri/src/commands/generate_table.rs
+++ b/crates/libretune-app/src-tauri/src/commands/generate_table.rs
@@ -1,0 +1,234 @@
+//! Per-table generator command.
+//!
+//! TunerStudio exposes a "generate table" action inside each table editor: with
+//! a VE, ignition, or AFR/lambda table open you can (re)seed it from basic
+//! engine parameters. LibreTune already had these generators, but only behind
+//! the one-shot base-map wizard ([`super::base_map`] / [`super::apply_base_map`]).
+//!
+//! This command lets the table editor regenerate values for a **single** open
+//! table, over that table's **current axes** (the frontend passes the live
+//! `rpm_bins`/`load_bins`), and returns the new Z grid. The frontend then
+//! applies the grid through the normal edit pipeline (undo history + explicit
+//! burn), so nothing is written to the ECU behind the user's back.
+
+use crate::AppState;
+use libretune_core::ini::TableRole;
+
+/// The kinds of table this command can generate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GeneratableKind {
+    Ve,
+    Ignition,
+    Afr,
+}
+
+impl GeneratableKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            GeneratableKind::Ve => "ve",
+            GeneratableKind::Ignition => "ignition",
+            GeneratableKind::Afr => "afr",
+        }
+    }
+}
+
+/// Name-based fallback classifier, mirroring [`super::apply_base_map`]'s lists.
+///
+/// Used only when the INI-derived [`TableRole`] is unavailable (`Other`). The
+/// role is the authoritative source when populated.
+fn classify_by_name(name: &str) -> Option<GeneratableKind> {
+    const VE: [&str; 4] = ["veTable1Tbl", "veTableTbl", "fuelTable1Tbl", "fuelTableTbl"];
+    const IGN: [&str; 5] = [
+        "sparkTbl",
+        "ignitionTableTbl",
+        "advTable1Tbl",
+        "ignitionTbl",
+        "spark1Tbl",
+    ];
+    const AFR: [&str; 4] = [
+        "afrTable1Tbl",
+        "lambdaTableTbl",
+        "afrTableTbl",
+        "lambdaTable1Tbl",
+    ];
+
+    if VE.contains(&name) {
+        Some(GeneratableKind::Ve)
+    } else if IGN.contains(&name) {
+        Some(GeneratableKind::Ignition)
+    } else if AFR.contains(&name) {
+        Some(GeneratableKind::Afr)
+    } else {
+        None
+    }
+}
+
+fn role_to_kind(role: TableRole) -> Option<GeneratableKind> {
+    match role {
+        TableRole::Ve => Some(GeneratableKind::Ve),
+        TableRole::Ignition => Some(GeneratableKind::Ignition),
+        TableRole::AfrTarget => Some(GeneratableKind::Afr),
+        _ => None,
+    }
+}
+
+/// Generate a fresh Z grid for a single table from engine specs.
+///
+/// Returns `{ "table_type": "ve"|"ignition"|"afr", "z_values": [[f64; cols]; rows] }`.
+/// `rows == load_bins.len()`, `cols == rpm_bins.len()` (matching the core
+/// generators and the table editor's row/column orientation).
+#[tauri::command]
+#[allow(clippy::too_many_arguments)]
+pub async fn generate_table_values(
+    state: tauri::State<'_, AppState>,
+    table_name: String,
+    rpm_bins: Vec<f64>,
+    load_bins: Vec<f64>,
+    cylinder_count: u8,
+    displacement_cc: f64,
+    injector_size_cc: f64,
+    fuel_type: String,
+    aspiration: String,
+    stroke_type: String,
+    injection_mode: String,
+    ignition_mode: String,
+    idle_rpm: u16,
+    redline_rpm: u16,
+    boost_target_kpa: Option<f64>,
+    target_wot_afr: Option<f64>,
+) -> Result<serde_json::Value, String> {
+    use libretune_core::basemap::generator::{
+        generate_afr_table, generate_ignition_table, generate_ve_table,
+    };
+    use libretune_core::basemap::{
+        Aspiration, EngineSpec, FuelType, IgnitionMode, InjectionMode, StrokeType,
+    };
+
+    if rpm_bins.is_empty() || load_bins.is_empty() {
+        return Err("Table axes are empty — cannot generate values".to_string());
+    }
+
+    // Classify the open table. Prefer the INI-derived role; fall back to
+    // name matching (which is what apply_base_map relies on today).
+    let kind = {
+        let def_guard = state.definition.lock().await;
+        let def = def_guard.as_ref().ok_or("No ECU definition loaded")?;
+        let table = def
+            .get_table_by_name_or_map(&table_name)
+            .ok_or_else(|| format!("Table '{}' not found in the loaded definition", table_name))?;
+
+        role_to_kind(table.role)
+            .or_else(|| classify_by_name(&table.name))
+            .or_else(|| classify_by_name(&table.map))
+            .ok_or_else(|| {
+                format!(
+                    "No generator is available for '{}'. Generation is supported for VE, \
+                     ignition and AFR/lambda target tables.",
+                    table_name
+                )
+            })?
+    };
+
+    let fuel = match fuel_type.to_lowercase().as_str() {
+        "gasoline" | "petrol" => FuelType::Gasoline,
+        "e85" => FuelType::E85,
+        "e100" => FuelType::E100,
+        "methanol" => FuelType::Methanol,
+        "lpg" | "propane" => FuelType::LPG,
+        _ => return Err(format!("Unknown fuel type: {}", fuel_type)),
+    };
+
+    let asp = match aspiration.to_lowercase().as_str() {
+        "na" | "naturally_aspirated" => Aspiration::NA,
+        "turbo" | "turbocharged" => Aspiration::Turbo,
+        "supercharged" => Aspiration::Supercharged,
+        _ => return Err(format!("Unknown aspiration: {}", aspiration)),
+    };
+
+    let stroke = match stroke_type.to_lowercase().as_str() {
+        "four_stroke" | "4stroke" | "4" => StrokeType::FourStroke,
+        "two_stroke" | "2stroke" | "2" => StrokeType::TwoStroke,
+        _ => return Err(format!("Unknown stroke type: {}", stroke_type)),
+    };
+
+    let inj = match injection_mode.to_lowercase().as_str() {
+        "sequential" => InjectionMode::Sequential,
+        "batch" => InjectionMode::Batch,
+        "simultaneous" => InjectionMode::Simultaneous,
+        "throttle_body" | "tbi" => InjectionMode::ThrottleBody,
+        _ => return Err(format!("Unknown injection mode: {}", injection_mode)),
+    };
+
+    let ign = match ignition_mode.to_lowercase().as_str() {
+        "wasted_spark" | "wastedspark" => IgnitionMode::WastedSpark,
+        "coil_on_plug" | "cop" => IgnitionMode::CoilOnPlug,
+        "distributor" => IgnitionMode::Distributor,
+        _ => return Err(format!("Unknown ignition mode: {}", ignition_mode)),
+    };
+
+    let spec = EngineSpec {
+        cylinder_count,
+        displacement_cc,
+        injector_size_cc,
+        fuel_type: fuel,
+        aspiration: asp,
+        stroke_type: stroke,
+        injection_mode: inj,
+        ignition_mode: ign,
+        idle_rpm,
+        redline_rpm,
+        boost_target_kpa,
+        target_wot_afr,
+    };
+
+    let z_values = match kind {
+        GeneratableKind::Ve => generate_ve_table(&spec, &rpm_bins, &load_bins),
+        GeneratableKind::Ignition => generate_ignition_table(&spec, &rpm_bins, &load_bins),
+        GeneratableKind::Afr => generate_afr_table(&spec, &rpm_bins, &load_bins),
+    };
+
+    Ok(serde_json::json!({
+        "table_type": kind.as_str(),
+        "z_values": z_values,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn name_classifier_matches_known_tables() {
+        assert_eq!(classify_by_name("veTable1Tbl"), Some(GeneratableKind::Ve));
+        assert_eq!(classify_by_name("veTableTbl"), Some(GeneratableKind::Ve));
+        assert_eq!(
+            classify_by_name("sparkTbl"),
+            Some(GeneratableKind::Ignition)
+        );
+        assert_eq!(
+            classify_by_name("ignitionTableTbl"),
+            Some(GeneratableKind::Ignition)
+        );
+        assert_eq!(classify_by_name("afrTable1Tbl"), Some(GeneratableKind::Afr));
+        assert_eq!(
+            classify_by_name("lambdaTableTbl"),
+            Some(GeneratableKind::Afr)
+        );
+        assert_eq!(classify_by_name("boostTbl"), None);
+    }
+
+    #[test]
+    fn role_takes_precedence_over_name() {
+        assert_eq!(role_to_kind(TableRole::Ve), Some(GeneratableKind::Ve));
+        assert_eq!(
+            role_to_kind(TableRole::Ignition),
+            Some(GeneratableKind::Ignition)
+        );
+        assert_eq!(
+            role_to_kind(TableRole::AfrTarget),
+            Some(GeneratableKind::Afr)
+        );
+        assert_eq!(role_to_kind(TableRole::WarmupEnrichment), None);
+        assert_eq!(role_to_kind(TableRole::Other), None);
+    }
+}

--- a/crates/libretune-app/src-tauri/src/commands/generate_table.rs
+++ b/crates/libretune-app/src-tauri/src/commands/generate_table.rs
@@ -96,9 +96,13 @@ pub async fn generate_table_values(
     redline_rpm: u16,
     boost_target_kpa: Option<f64>,
     target_wot_afr: Option<f64>,
+    octane: Option<f64>,
+    compression_ratio: Option<f64>,
+    rebuild_axes: Option<bool>,
 ) -> Result<serde_json::Value, String> {
     use libretune_core::basemap::generator::{
-        generate_afr_table, generate_ignition_table, generate_ve_table,
+        generate_afr_table, generate_ignition_table, generate_load_bins, generate_rpm_bins,
+        generate_ve_table,
     };
     use libretune_core::basemap::{
         Aspiration, EngineSpec, FuelType, IgnitionMode, InjectionMode, StrokeType,
@@ -179,17 +183,33 @@ pub async fn generate_table_values(
         redline_rpm,
         boost_target_kpa,
         target_wot_afr,
+        octane,
+        compression_ratio,
+    };
+
+    // Optionally rebuild the axes from idle/redline (and load range) so the RPM
+    // span reflects the engine spec — otherwise generate over the table's
+    // existing bins. Bin counts always match the current table dimensions.
+    let (x_bins, y_bins) = if rebuild_axes.unwrap_or(false) {
+        (
+            generate_rpm_bins(spec.idle_rpm, spec.redline_rpm, rpm_bins.len()),
+            generate_load_bins(spec.max_load_kpa(), load_bins.len()),
+        )
+    } else {
+        (rpm_bins, load_bins)
     };
 
     let z_values = match kind {
-        GeneratableKind::Ve => generate_ve_table(&spec, &rpm_bins, &load_bins),
-        GeneratableKind::Ignition => generate_ignition_table(&spec, &rpm_bins, &load_bins),
-        GeneratableKind::Afr => generate_afr_table(&spec, &rpm_bins, &load_bins),
+        GeneratableKind::Ve => generate_ve_table(&spec, &x_bins, &y_bins),
+        GeneratableKind::Ignition => generate_ignition_table(&spec, &x_bins, &y_bins),
+        GeneratableKind::Afr => generate_afr_table(&spec, &x_bins, &y_bins),
     };
 
     Ok(serde_json::json!({
         "table_type": kind.as_str(),
         "z_values": z_values,
+        "x_bins": x_bins,
+        "y_bins": y_bins,
     }))
 }
 

--- a/crates/libretune-app/src-tauri/src/commands/generate_table.rs
+++ b/crates/libretune-app/src-tauri/src/commands/generate_table.rs
@@ -172,7 +172,11 @@ pub async fn generate_table_values(
         _ => return Err(format!("Unknown ignition mode: {}", ignition_mode)),
     };
 
-    let chamber = match combustion_chamber.as_deref().map(str::to_lowercase).as_deref() {
+    let chamber = match combustion_chamber
+        .as_deref()
+        .map(str::to_lowercase)
+        .as_deref()
+    {
         Some("open_chamber") | Some("open") => Some(CombustionChamber::OpenChamber),
         Some("quench_two_valve") | Some("quench") => Some(CombustionChamber::QuenchTwoValve),
         Some("swirl_multi_valve") | Some("swirl") => Some(CombustionChamber::SwirlMultiValve),

--- a/crates/libretune-app/src-tauri/src/commands/mod.rs
+++ b/crates/libretune-app/src-tauri/src/commands/mod.rs
@@ -32,6 +32,7 @@ pub mod diagnostic_loggers;
 pub mod dyno;
 pub mod find_inis;
 pub mod firmware_update;
+pub mod generate_table;
 pub mod get_table_data;
 pub mod git;
 pub mod hotkeys;

--- a/crates/libretune-app/src-tauri/src/lib.rs
+++ b/crates/libretune-app/src-tauri/src/lib.rs
@@ -59,7 +59,6 @@ use commands::autotune_misc::{
 };
 use commands::available_inis::get_available_inis;
 use commands::base_map::generate_base_map;
-use commands::generate_table::generate_table_values;
 use commands::cache_status::{get_table_info, get_tune_cache_status};
 use commands::channels::{
     get_available_channels, get_output_channel_status, get_status_bar_defaults,
@@ -97,6 +96,7 @@ use commands::firmware_update::{
     get_firmware_flasher_info, get_firmware_update_guidance, recover_ecu_firmware_dfu,
     release_serial_port_blockers, suggest_firmware_companion, update_ecu_firmware,
 };
+use commands::generate_table::generate_table_values;
 use commands::get_table_data::get_table_data;
 use commands::git::{
     git_checkout, git_commit, git_create_branch, git_current_branch, git_diff, git_has_changes,

--- a/crates/libretune-app/src-tauri/src/lib.rs
+++ b/crates/libretune-app/src-tauri/src/lib.rs
@@ -59,6 +59,7 @@ use commands::autotune_misc::{
 };
 use commands::available_inis::get_available_inis;
 use commands::base_map::generate_base_map;
+use commands::generate_table::generate_table_values;
 use commands::cache_status::{get_table_info, get_tune_cache_status};
 use commands::channels::{
     get_available_channels, get_output_channel_status, get_status_bar_defaults,
@@ -415,6 +416,7 @@ pub fn run() {
             // Base map generator commands
             generate_base_map,
             apply_base_map,
+            generate_table_values,
             get_msq_info,
             delete_project,
             // INI signature management commands

--- a/crates/libretune-app/src/components/dialogs/GenerateTableDialog.tsx
+++ b/crates/libretune-app/src/components/dialogs/GenerateTableDialog.tsx
@@ -52,6 +52,7 @@ export default function GenerateTableDialog({
   const [wotAfr, setWotAfr] = useState<string>("");
   const [octane, setOctane] = useState<string>("93");
   const [compressionRatio, setCompressionRatio] = useState<string>("10.5");
+  const [combustionChamber, setCombustionChamber] = useState("quench_two_valve");
   const [rebuildAxes, setRebuildAxes] = useState(true);
   const [generating, setGenerating] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -73,12 +74,15 @@ export default function GenerateTableDialog({
         strokeType,
         idleRpm,
         redlineRpm,
-        boostTargetKpa: isBoosted && boostKpa ? parseFloat(boostKpa) : null,
+        // Boost entered in psi (gauge); convert to absolute kPa for the model.
+        boostTargetKpa:
+          isBoosted && boostKpa ? 101.325 + parseFloat(boostKpa) * 6.89476 : null,
         targetWotAfr: wotAfr ? parseFloat(wotAfr) : null,
-        // Spark-map knock model (ignition only): octane + compression ratio.
+        // Spark-map knock model (ignition only).
         octane: kind === "ignition" && octane ? parseFloat(octane) : null,
         compressionRatio:
           kind === "ignition" && compressionRatio ? parseFloat(compressionRatio) : null,
+        combustionChamber: kind === "ignition" ? combustionChamber : null,
         rebuildAxes,
         // Required by the command but not used by these generators — sensible
         // defaults keep the dialog focused on what actually changes the map.
@@ -195,15 +199,32 @@ export default function GenerateTableDialog({
           </FormField>
 
           {isBoosted && (
-            <FormField label="Boost target (kPa abs)">
+            <FormField label="Max boost (psi)">
               {(id) => (
                 <input
                   id={id}
                   type="number"
+                  step="0.5"
                   value={boostKpa}
-                  placeholder="200"
+                  placeholder="15"
                   onChange={(e) => setBoostKpa(e.target.value)}
                 />
+              )}
+            </FormField>
+          )}
+
+          {kind === "ignition" && (
+            <FormField label="Combustion chamber">
+              {(id) => (
+                <select
+                  id={id}
+                  value={combustionChamber}
+                  onChange={(e) => setCombustionChamber(e.target.value)}
+                >
+                  <option value="open_chamber">Open chamber (more advance)</option>
+                  <option value="quench_two_valve">2-valve quench (typical)</option>
+                  <option value="swirl_multi_valve">Multi-valve swirl (less advance)</option>
+                </select>
               )}
             </FormField>
           )}

--- a/crates/libretune-app/src/components/dialogs/GenerateTableDialog.tsx
+++ b/crates/libretune-app/src/components/dialogs/GenerateTableDialog.tsx
@@ -17,13 +17,15 @@ interface GenerateTableDialogProps {
   rpmBins: number[];
   /** The table's current Y axis (load) bins. */
   loadBins: number[];
-  /** Called with the freshly generated Z grid when the user applies. */
-  onApply: (zValues: number[][]) => void;
+  /** Called with the freshly generated grid (and optionally rebuilt axes). */
+  onApply: (result: { zValues: number[][]; xBins?: number[]; yBins?: number[] }) => void;
 }
 
 interface GenerateTableResult {
   table_type: string;
   z_values: number[][];
+  x_bins?: number[];
+  y_bins?: number[];
 }
 
 /**
@@ -48,6 +50,9 @@ export default function GenerateTableDialog({
   const [redlineRpm, setRedlineRpm] = useState(6500);
   const [boostKpa, setBoostKpa] = useState<string>("");
   const [wotAfr, setWotAfr] = useState<string>("");
+  const [octane, setOctane] = useState<string>("93");
+  const [compressionRatio, setCompressionRatio] = useState<string>("10.5");
+  const [rebuildAxes, setRebuildAxes] = useState(true);
   const [generating, setGenerating] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -70,6 +75,11 @@ export default function GenerateTableDialog({
         redlineRpm,
         boostTargetKpa: isBoosted && boostKpa ? parseFloat(boostKpa) : null,
         targetWotAfr: wotAfr ? parseFloat(wotAfr) : null,
+        // Spark-map knock model (ignition only): octane + compression ratio.
+        octane: kind === "ignition" && octane ? parseFloat(octane) : null,
+        compressionRatio:
+          kind === "ignition" && compressionRatio ? parseFloat(compressionRatio) : null,
+        rebuildAxes,
         // Required by the command but not used by these generators — sensible
         // defaults keep the dialog focused on what actually changes the map.
         cylinderCount: 4,
@@ -83,7 +93,7 @@ export default function GenerateTableDialog({
         setError("Generator returned no data.");
         return;
       }
-      onApply(result.z_values);
+      onApply({ zValues: result.z_values, xBins: result.x_bins, yBins: result.y_bins });
       onClose();
     } catch (e) {
       setError(String(e));
@@ -212,7 +222,46 @@ export default function GenerateTableDialog({
               )}
             </FormField>
           )}
+
+          {kind === "ignition" && (
+            <FormField label="Fuel octane (AKI)">
+              {(id) => (
+                <input
+                  id={id}
+                  type="number"
+                  step="1"
+                  value={octane}
+                  placeholder="93"
+                  onChange={(e) => setOctane(e.target.value)}
+                />
+              )}
+            </FormField>
+          )}
+
+          {kind === "ignition" && (
+            <FormField label="Compression ratio (x:1)">
+              {(id) => (
+                <input
+                  id={id}
+                  type="number"
+                  step="0.1"
+                  value={compressionRatio}
+                  placeholder="10.5"
+                  onChange={(e) => setCompressionRatio(e.target.value)}
+                />
+              )}
+            </FormField>
+          )}
         </div>
+
+        <label style={{ display: "flex", alignItems: "center", gap: "0.5rem", marginTop: "0.75rem" }}>
+          <input
+            type="checkbox"
+            checked={rebuildAxes}
+            onChange={(e) => setRebuildAxes(e.target.checked)}
+          />
+          <span>Rebuild RPM/Load axes from idle &amp; redline</span>
+        </label>
 
         {error && (
           <div style={{ color: "var(--color-error, #d33)", marginTop: "0.75rem" }}>

--- a/crates/libretune-app/src/components/dialogs/GenerateTableDialog.tsx
+++ b/crates/libretune-app/src/components/dialogs/GenerateTableDialog.tsx
@@ -1,0 +1,238 @@
+import { useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { Dialog, Button, FormField } from "../common";
+import {
+  GeneratableTableKind,
+  generatableTableLabel,
+} from "../../utils/tableGenerator";
+
+interface GenerateTableDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  /** INI name/map of the table being generated (backend classifies it). */
+  tableName: string;
+  /** What kind of table this is, used for the title/copy. */
+  kind: GeneratableTableKind;
+  /** The table's current X axis (RPM) bins. */
+  rpmBins: number[];
+  /** The table's current Y axis (load) bins. */
+  loadBins: number[];
+  /** Called with the freshly generated Z grid when the user applies. */
+  onApply: (zValues: number[][]) => void;
+}
+
+interface GenerateTableResult {
+  table_type: string;
+  z_values: number[][];
+}
+
+/**
+ * TunerStudio-style single-table generator. Seeds the open VE / ignition / AFR
+ * table from basic engine parameters, over the table's *current* axes. The
+ * result is handed back to the editor and applied through the normal edit
+ * pipeline (so it lands in undo history and is only burned deliberately).
+ */
+export default function GenerateTableDialog({
+  isOpen,
+  onClose,
+  tableName,
+  kind,
+  rpmBins,
+  loadBins,
+  onApply,
+}: GenerateTableDialogProps) {
+  const [fuelType, setFuelType] = useState("Gasoline");
+  const [aspiration, setAspiration] = useState("NA");
+  const [strokeType, setStrokeType] = useState("four_stroke");
+  const [idleRpm, setIdleRpm] = useState(800);
+  const [redlineRpm, setRedlineRpm] = useState(6500);
+  const [boostKpa, setBoostKpa] = useState<string>("");
+  const [wotAfr, setWotAfr] = useState<string>("");
+  const [generating, setGenerating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isBoosted = aspiration === "Turbo" || aspiration === "Supercharged";
+  const label = generatableTableLabel(kind);
+
+  async function handleGenerate() {
+    setGenerating(true);
+    setError(null);
+    try {
+      const result = await invoke<GenerateTableResult>("generate_table_values", {
+        tableName,
+        rpmBins,
+        loadBins,
+        // Fields that drive the VE/ignition/AFR surface shape:
+        fuelType,
+        aspiration,
+        strokeType,
+        idleRpm,
+        redlineRpm,
+        boostTargetKpa: isBoosted && boostKpa ? parseFloat(boostKpa) : null,
+        targetWotAfr: wotAfr ? parseFloat(wotAfr) : null,
+        // Required by the command but not used by these generators — sensible
+        // defaults keep the dialog focused on what actually changes the map.
+        cylinderCount: 4,
+        displacementCc: 2000,
+        injectorSizeCc: 440,
+        injectionMode: "sequential",
+        ignitionMode: "wasted_spark",
+      });
+
+      if (!result?.z_values?.length) {
+        setError("Generator returned no data.");
+        return;
+      }
+      onApply(result.z_values);
+      onClose();
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setGenerating(false);
+    }
+  }
+
+  return (
+    <Dialog
+      open={isOpen}
+      onClose={onClose}
+      title={`Generate ${label}`}
+      size="md"
+      closeOnBackdrop={!generating}
+      closeOnEscape={!generating}
+    >
+      <Dialog.Body>
+        <p style={{ marginTop: 0, opacity: 0.8 }}>
+          Seed <b>{label}</b> from basic engine parameters, over this table's
+          current axes ({rpmBins.length} × {loadBins.length}). The result is
+          added to your edit history — review it, then burn when you're happy.
+        </p>
+
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "1fr 1fr",
+            gap: "0.75rem",
+          }}
+        >
+          <FormField label="Fuel">
+            {(id) => (
+              <select
+                id={id}
+                value={fuelType}
+                onChange={(e) => setFuelType(e.target.value)}
+              >
+                {["Gasoline", "E85", "E100", "Methanol", "LPG"].map((f) => (
+                  <option key={f} value={f}>
+                    {f}
+                  </option>
+                ))}
+              </select>
+            )}
+          </FormField>
+
+          <FormField label="Aspiration">
+            {(id) => (
+              <select
+                id={id}
+                value={aspiration}
+                onChange={(e) => setAspiration(e.target.value)}
+              >
+                <option value="NA">Naturally aspirated</option>
+                <option value="Turbo">Turbocharged</option>
+                <option value="Supercharged">Supercharged</option>
+              </select>
+            )}
+          </FormField>
+
+          <FormField label="Stroke">
+            {(id) => (
+              <select
+                id={id}
+                value={strokeType}
+                onChange={(e) => setStrokeType(e.target.value)}
+              >
+                <option value="four_stroke">4-stroke</option>
+                <option value="two_stroke">2-stroke</option>
+              </select>
+            )}
+          </FormField>
+
+          <FormField label="Idle RPM">
+            {(id) => (
+              <input
+                id={id}
+                type="number"
+                value={idleRpm}
+                min={300}
+                max={2000}
+                onChange={(e) => setIdleRpm(parseInt(e.target.value) || 0)}
+              />
+            )}
+          </FormField>
+
+          <FormField label="Redline RPM">
+            {(id) => (
+              <input
+                id={id}
+                type="number"
+                value={redlineRpm}
+                min={2000}
+                max={12000}
+                onChange={(e) => setRedlineRpm(parseInt(e.target.value) || 0)}
+              />
+            )}
+          </FormField>
+
+          {isBoosted && (
+            <FormField label="Boost target (kPa abs)">
+              {(id) => (
+                <input
+                  id={id}
+                  type="number"
+                  value={boostKpa}
+                  placeholder="200"
+                  onChange={(e) => setBoostKpa(e.target.value)}
+                />
+              )}
+            </FormField>
+          )}
+
+          {(kind === "afr" || kind === "ve") && (
+            <FormField label="Target WOT AFR (optional)">
+              {(id) => (
+                <input
+                  id={id}
+                  type="number"
+                  step="0.1"
+                  value={wotAfr}
+                  placeholder="auto"
+                  onChange={(e) => setWotAfr(e.target.value)}
+                />
+              )}
+            </FormField>
+          )}
+        </div>
+
+        {error && (
+          <div style={{ color: "var(--color-error, #d33)", marginTop: "0.75rem" }}>
+            {error}
+          </div>
+        )}
+      </Dialog.Body>
+
+      <Dialog.Footer>
+        <Button variant="secondary" onClick={onClose} disabled={generating}>
+          Cancel
+        </Button>
+        <Button
+          variant="primary"
+          onClick={handleGenerate}
+          disabled={generating || redlineRpm <= idleRpm}
+        >
+          {generating ? "Generating…" : `Generate ${label}`}
+        </Button>
+      </Dialog.Footer>
+    </Dialog>
+  );
+}

--- a/crates/libretune-app/src/components/tables/TableContextMenu.tsx
+++ b/crates/libretune-app/src/components/tables/TableContextMenu.tsx
@@ -13,6 +13,7 @@ import {
   Lock,
   LockOpen,
   Palette,
+  Wand2,
 } from 'lucide-react';
 
 interface TableContextProps {
@@ -53,6 +54,11 @@ interface TableContextProps {
   // View
   onToggleHeatmap?: () => void;
   onTraceOptions?: () => void;
+
+  // Generate (TunerStudio-style table generator). Only wired for VE/ignition/
+  // AFR tables; `generatableLabel` is the human label (e.g. "VE Table").
+  onGenerate?: () => void;
+  generatableLabel?: string;
 }
 
 export default function TableContextMenu({
@@ -76,6 +82,8 @@ export default function TableContextMenu({
   onCopy,
   onPaste,
   onToggleHeatmap,
+  onGenerate,
+  generatableLabel,
 }: TableContextProps) {
   // Shared input state for Scale/Offset operations
   const [inputValue, setInputValue] = useState('1.5');
@@ -225,6 +233,18 @@ export default function TableContextMenu({
           <span>Fill Col Down</span>
         </div>
       </div>
+
+      {onGenerate && (
+        <>
+          <div className="context-menu-separator" />
+          <div className="context-menu-section">
+            <div className="context-menu-item" onClick={() => { onGenerate(); onClose(); }}>
+              <span className="icon"><Wand2 size={14} /></span>
+              <span>Generate {generatableLabel ?? 'Table'}…</span>
+            </div>
+          </div>
+        </>
+      )}
 
       <div className="context-menu-separator" />
 

--- a/crates/libretune-app/src/components/tables/TableEditor2D.tsx
+++ b/crates/libretune-app/src/components/tables/TableEditor2D.tsx
@@ -813,10 +813,14 @@ export default function TableEditor2D({
   // Apply a freshly generated grid (from GenerateTableDialog) as a single
   // undoable edit. This is an intentional full-table reseed, so unlike the
   // cell operations it doesn't run the large-change guard.
-  const handleGenerateApply = (zValues: number[][]) => {
-    setLocalZValues(zValues);
-    onValuesChange?.(zValues);
-    pushHistory(zValues, localXBins, localYBins);
+  const handleGenerateApply = (result: { zValues: number[][]; xBins?: number[]; yBins?: number[] }) => {
+    const newX = result.xBins ?? localXBins;
+    const newY = result.yBins ?? localYBins;
+    setLocalZValues(result.zValues);
+    if (result.xBins) setLocalXBins(result.xBins);
+    if (result.yBins) setLocalYBins(result.yBins);
+    onValuesChange?.(result.zValues);
+    pushHistory(result.zValues, newX, newY);
   };
 
   const handleInterpolate = async () => {
@@ -1308,6 +1312,8 @@ export default function TableEditor2D({
           onColorShadeToggle={() => setShowColorShade(!showColorShade)}
           show3D={show3D}
           onToggle3D={() => setShow3D(!show3D)}
+          onGenerate={generatableKind ? () => setShowGenerateDialog(true) : undefined}
+          generatableLabel={generatableKind ? generatableTableLabel(generatableKind) : undefined}
         />
       )}
 

--- a/crates/libretune-app/src/components/tables/TableEditor2D.tsx
+++ b/crates/libretune-app/src/components/tables/TableEditor2D.tsx
@@ -8,6 +8,8 @@ import TableContextMenu from './TableContextMenu';
 import RebinDialog from '../dialogs/RebinDialog';
 import SetTableSizeDialog from '../dialogs/SetTableSizeDialog';
 import CellEditDialog from '../dialogs/CellEditDialog';
+import GenerateTableDialog from '../dialogs/GenerateTableDialog';
+import { classifyGeneratableTable, generatableTableLabel } from '../../utils/tableGenerator';
 import { Dialog, Button, FormField } from '../common';
 import type { BackendTableData, TableSizeInfo } from '../../types/app';
 import LambdaPreviewTable from './LambdaPreviewTable';
@@ -230,6 +232,11 @@ export default function TableEditor2D({
   const { settings: heatmapSettings } = useHeatmapSettings();
   const yAxisBottom = useTableYAxisBottom();
   const trailFadeSec = useTrailFadeSec();
+
+  // Whether this table can be seeded by the TunerStudio-style generator
+  // (VE / ignition / AFR target). Gates the "Generate…" context-menu action.
+  const generatableKind = useMemo(() => classifyGeneratableTable(table_name), [table_name]);
+  const [showGenerateDialog, setShowGenerateDialog] = useState(false);
 
   // Show the read-only lambda companion only for actual target-AFR tables
   // (not blend/bias tables whose values aren't AFR).
@@ -801,6 +808,15 @@ export default function TableEditor2D({
     } catch (err) {
       handleOperationError('Smooth', err);
     }
+  };
+
+  // Apply a freshly generated grid (from GenerateTableDialog) as a single
+  // undoable edit. This is an intentional full-table reseed, so unlike the
+  // cell operations it doesn't run the large-change guard.
+  const handleGenerateApply = (zValues: number[][]) => {
+    setLocalZValues(zValues);
+    onValuesChange?.(zValues);
+    pushHistory(zValues, localXBins, localYBins);
   };
 
   const handleInterpolate = async () => {
@@ -1386,7 +1402,21 @@ export default function TableEditor2D({
         onCopy={() => { setContextMenu({ visible: false, x: 0, y: 0, value: 0 }); handleCopy(); }}
         onPaste={() => { setContextMenu({ visible: false, x: 0, y: 0, value: 0 }); handlePaste(); }}
         onToggleHeatmap={() => { setContextMenu({ visible: false, x: 0, y: 0, value: 0 }); setShowColorShade(prev => !prev); }}
+        onGenerate={generatableKind ? () => { setContextMenu({ visible: false, x: 0, y: 0, value: 0 }); setShowGenerateDialog(true); } : undefined}
+        generatableLabel={generatableKind ? generatableTableLabel(generatableKind) : undefined}
       />
+
+      {generatableKind && (
+        <GenerateTableDialog
+          isOpen={showGenerateDialog}
+          onClose={() => setShowGenerateDialog(false)}
+          tableName={table_name}
+          kind={generatableKind}
+          rpmBins={localXBins}
+          loadBins={localYBins}
+          onApply={handleGenerateApply}
+        />
+      )}
 
       <RebinDialog
         isOpen={rebinDialog.show}

--- a/crates/libretune-app/src/components/tables/TableToolbar.tsx
+++ b/crates/libretune-app/src/components/tables/TableToolbar.tsx
@@ -13,7 +13,8 @@ import {
   Crosshair,
   Palette,
   Box,
-  Scaling
+  Scaling,
+  Wand2
 } from 'lucide-react';
 
 interface TableToolbarProps {
@@ -38,6 +39,9 @@ interface TableToolbarProps {
   onColorShadeToggle?: () => void;
   show3D?: boolean;
   onToggle3D?: () => void;
+  /** Generate the whole table from engine specs (VE/ignition/AFR only). */
+  onGenerate?: () => void;
+  generatableLabel?: string;
 }
 
 export default function TableToolbar({ 
@@ -62,6 +66,8 @@ export default function TableToolbar({
   onColorShadeToggle,
   show3D = false,
   onToggle3D,
+  onGenerate,
+  generatableLabel,
 }: TableToolbarProps) {
   return (
     <div className="ts-toolbar">
@@ -135,6 +141,16 @@ export default function TableToolbar({
             onClick={onSetSize}
           >
             <Scaling size={14} />
+          </button>
+        )}
+        {onGenerate && (
+          <button
+            className="ts-toolbar-btn"
+            title={`Generate ${generatableLabel ?? 'table'} from engine specs`}
+            onClick={onGenerate}
+          >
+            <Wand2 size={14} />
+            <span className="ts-toolbar-label">Generate</span>
           </button>
         )}
       </div>

--- a/crates/libretune-app/src/components/tuner-ui/TableEditor.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/TableEditor.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useRef, useEffect, KeyboardEvent, useMemo } from 'react';
+import { invoke } from '@tauri-apps/api/core';
 import { useChannels } from '../../stores/realtimeStore';
 import { useHeatmapSettings } from '../../utils/useHeatmapSettings';
 import { contrastTextColor } from '../../utils/heatmapColors';
@@ -7,6 +8,8 @@ import './TableEditor.css';
 import TableEditor3D from '../tables/TableEditor3D';
 import TableToolbar from './table-editor/TableToolbar';
 import TableContextMenu from './table-editor/TableContextMenu';
+import GenerateTableDialog from '../dialogs/GenerateTableDialog';
+import { classifyGeneratableTable, generatableTableLabel } from '../../utils/tableGenerator';
 
 export interface TableData {
   name: string;
@@ -126,6 +129,10 @@ export function TableEditor({
   
   // Track if 3D view is enabled
   const [show3D, setShow3D] = useState(false);
+
+  // TunerStudio-style per-table generator (VE / ignition / AFR only).
+  const generatableKind = useMemo(() => classifyGeneratableTable(data.name), [data.name]);
+  const [showGenerateDialog, setShowGenerateDialog] = useState(false);
   
   // Store original data on first render
   useEffect(() => {
@@ -250,6 +257,40 @@ export function TableEditor({
     setHistory(newHistory);
     setHistoryIndex(newHistory.length - 1);
   }, [data, history, historyIndex]);
+
+  // Apply a freshly generated grid (from GenerateTableDialog) as one undoable
+  // edit, optionally with rebuilt RPM/load axes. Persists to the backend cache
+  // so the result survives closing/reopening the table (otherwise a reopen
+  // re-fetches the original definition).
+  const applyGeneratedValues = useCallback(
+    async (result: { zValues: number[][]; xBins?: number[]; yBins?: number[] }) => {
+      pushHistory();
+      try {
+        // Persist rebuilt axes first (writes the bin constants + re-interpolates),
+        // then overwrite the Z grid with the generated values.
+        if (result.xBins && result.yBins) {
+          await invoke('rebin_table', {
+            tableName: data.name,
+            newXBins: result.xBins,
+            newYBins: result.yBins,
+          });
+        }
+        await invoke('update_table_data', {
+          tableName: data.name,
+          zValues: result.zValues,
+        });
+      } catch (e) {
+        console.error('Failed to persist generated table:', e);
+      }
+      onChange({
+        ...data,
+        zValues: result.zValues,
+        xAxis: result.xBins ?? data.xAxis,
+        yAxis: result.yBins ?? data.yAxis,
+      });
+    },
+    [data, onChange, pushHistory],
+  );
 
   // Undo
   const undo = useCallback(() => {
@@ -867,6 +908,8 @@ export function TableEditor({
         hasOutputChannels={!!data.xOutputChannel}
         show3D={show3D}
         onToggle3D={() => setShow3D(!show3D)}
+        onGenerate={generatableKind ? () => setShowGenerateDialog(true) : undefined}
+        generatableLabel={generatableKind ? generatableTableLabel(generatableKind) : undefined}
       />
 
       {/* 3D View */}
@@ -968,6 +1011,18 @@ export function TableEditor({
         )}
         {data.zUnits && <span>Units: {data.zUnits}</span>}
       </div>
+
+      {generatableKind && (
+        <GenerateTableDialog
+          isOpen={showGenerateDialog}
+          onClose={() => setShowGenerateDialog(false)}
+          tableName={data.name}
+          kind={generatableKind}
+          rpmBins={data.xAxis}
+          loadBins={data.yAxis}
+          onApply={applyGeneratedValues}
+        />
+      )}
     </div>
   );
 }

--- a/crates/libretune-app/src/components/tuner-ui/TableEditor.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/TableEditor.tsx
@@ -273,6 +273,9 @@ export function TableEditor({
             tableName: data.name,
             newXBins: result.xBins,
             newYBins: result.yBins,
+            // The generated Z grid is written right after, so no need to
+            // interpolate the old values onto the new bins here.
+            interpolateZ: false,
           });
         }
         await invoke('update_table_data', {

--- a/crates/libretune-app/src/components/tuner-ui/table-editor/TableToolbar.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/table-editor/TableToolbar.tsx
@@ -1,4 +1,4 @@
-import { Copy, Clipboard, Undo2, Redo2, Flame, Crosshair, Box } from 'lucide-react';
+import { Copy, Clipboard, Undo2, Redo2, Flame, Crosshair, Box, Wand2 } from 'lucide-react';
 import '../TableEditor.css';
 
 interface TableToolbarProps {
@@ -24,6 +24,9 @@ interface TableToolbarProps {
   hasOutputChannels: boolean;
   show3D: boolean;
   onToggle3D: () => void;
+  /** Generate the whole table from engine specs (VE/ignition/AFR only). */
+  onGenerate?: () => void;
+  generatableLabel?: string;
 }
 
 export default function TableToolbar({
@@ -49,6 +52,8 @@ export default function TableToolbar({
   hasOutputChannels,
   show3D,
   onToggle3D,
+  onGenerate,
+  generatableLabel,
 }: TableToolbarProps) {
   return (
     <div className="table-toolbar">
@@ -201,6 +206,19 @@ export default function TableToolbar({
       >
         <Box size={14} /> 3D
       </button>
+
+      {onGenerate && (
+        <>
+          <div className="table-toolbar-separator" />
+          <button
+            className="table-toolbar-btn table-toolbar-btn-generate"
+            onClick={onGenerate}
+            title={`Generate ${generatableLabel ?? 'table'} from engine specs`}
+          >
+            <Wand2 size={14} /> Generate
+          </button>
+        </>
+      )}
     </div>
   );
 }

--- a/crates/libretune-app/src/utils/__tests__/tableGenerator.test.ts
+++ b/crates/libretune-app/src/utils/__tests__/tableGenerator.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyGeneratableTable,
+  generatableTableLabel,
+} from "../tableGenerator";
+
+describe("classifyGeneratableTable", () => {
+  it("classifies VE / fuel tables", () => {
+    expect(classifyGeneratableTable("veTable1Tbl")).toBe("ve");
+    expect(classifyGeneratableTable("veTableTbl")).toBe("ve");
+    expect(classifyGeneratableTable("fuelTable1Tbl")).toBe("ve");
+  });
+
+  it("classifies ignition / spark tables", () => {
+    expect(classifyGeneratableTable("sparkTbl")).toBe("ignition");
+    expect(classifyGeneratableTable("ignitionTableTbl")).toBe("ignition");
+    expect(classifyGeneratableTable("advTable1Tbl")).toBe("ignition");
+  });
+
+  it("classifies AFR / lambda target tables", () => {
+    expect(classifyGeneratableTable("afrTable1Tbl")).toBe("afr");
+    expect(classifyGeneratableTable("lambdaTableTbl")).toBe("afr");
+  });
+
+  it("returns null for non-generatable and empty inputs", () => {
+    expect(classifyGeneratableTable("boostTbl")).toBeNull();
+    expect(classifyGeneratableTable("stagingTable")).toBeNull();
+    expect(classifyGeneratableTable("")).toBeNull();
+    expect(classifyGeneratableTable(null)).toBeNull();
+    expect(classifyGeneratableTable(undefined)).toBeNull();
+  });
+});
+
+describe("generatableTableLabel", () => {
+  it("labels each kind", () => {
+    expect(generatableTableLabel("ve")).toBe("VE Table");
+    expect(generatableTableLabel("ignition")).toBe("Ignition Table");
+    expect(generatableTableLabel("afr")).toBe("AFR Target Table");
+  });
+});

--- a/crates/libretune-app/src/utils/tableGenerator.ts
+++ b/crates/libretune-app/src/utils/tableGenerator.ts
@@ -1,0 +1,44 @@
+/**
+ * Per-table generator helpers.
+ *
+ * TunerStudio lets you (re)generate a VE, ignition, or AFR/lambda table from
+ * basic engine parameters directly inside that table's editor. These helpers
+ * decide whether to OFFER that action for the open table and provide the
+ * matching labels. The authoritative classifier lives in the Rust
+ * `generate_table_values` command (which also consults the INI-derived table
+ * role); this mirror only gates the UI affordance.
+ */
+
+export type GeneratableTableKind = "ve" | "ignition" | "afr";
+
+// Mirrors the name lists used by the backend (see commands/apply_base_map.rs
+// and commands/generate_table.rs). Kept in sync intentionally.
+const VE_TABLE_NAMES = ["veTable1Tbl", "veTableTbl", "fuelTable1Tbl", "fuelTableTbl"];
+const IGN_TABLE_NAMES = ["sparkTbl", "ignitionTableTbl", "advTable1Tbl", "ignitionTbl", "spark1Tbl"];
+const AFR_TABLE_NAMES = ["afrTable1Tbl", "lambdaTableTbl", "afrTableTbl", "lambdaTable1Tbl"];
+
+/**
+ * Classify a table by its INI name or map name. Returns `null` for tables that
+ * have no generator (e.g. boost, staging, warm-up curves).
+ */
+export function classifyGeneratableTable(
+  nameOrMap: string | null | undefined,
+): GeneratableTableKind | null {
+  if (!nameOrMap) return null;
+  if (VE_TABLE_NAMES.includes(nameOrMap)) return "ve";
+  if (IGN_TABLE_NAMES.includes(nameOrMap)) return "ignition";
+  if (AFR_TABLE_NAMES.includes(nameOrMap)) return "afr";
+  return null;
+}
+
+/** Human-readable label for a generatable table kind. */
+export function generatableTableLabel(kind: GeneratableTableKind): string {
+  switch (kind) {
+    case "ve":
+      return "VE Table";
+    case "ignition":
+      return "Ignition Table";
+    case "afr":
+      return "AFR Target Table";
+  }
+}

--- a/crates/libretune-core/src/basemap/engine_spec.rs
+++ b/crates/libretune-core/src/basemap/engine_spec.rs
@@ -83,6 +83,20 @@ pub enum IgnitionMode {
     Distributor,
 }
 
+/// Combustion chamber design, which sets flame-travel speed and therefore how
+/// much spark advance the engine wants.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum CombustionChamber {
+    /// Older open chamber — slower burn, wants more advance.
+    OpenChamber,
+    /// 2-valve head with quench — moderate burn (baseline).
+    #[default]
+    QuenchTwoValve,
+    /// Multi-valve head with swirl/tumble — fast burn, wants less advance.
+    SwirlMultiValve,
+}
+
 /// Complete engine specification for base map generation
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EngineSpec {
@@ -134,6 +148,10 @@ pub struct EngineSpec {
     /// less advance to stay out of knock. `None` → treated as ~10.0:1.
     #[serde(default)]
     pub compression_ratio: Option<f64>,
+
+    /// Combustion chamber design (flame speed). `None` → 2-valve quench baseline.
+    #[serde(default)]
+    pub combustion_chamber: Option<CombustionChamber>,
 }
 
 impl Default for EngineSpec {
@@ -153,6 +171,7 @@ impl Default for EngineSpec {
             target_wot_afr: None,
             octane: None,
             compression_ratio: None,
+            combustion_chamber: None,
         }
     }
 }
@@ -235,6 +254,12 @@ impl EngineSpec {
         // Compression ratio relative to 10.0:1 (higher CR → less advance).
         let cr = self.compression_ratio.unwrap_or(10.0);
         adv += ((10.0 - cr) * 1.5).clamp(-8.0, 6.0);
+        // Combustion chamber flame speed: slower burn wants more advance.
+        adv += match self.combustion_chamber.unwrap_or_default() {
+            CombustionChamber::OpenChamber => 2.0,
+            CombustionChamber::QuenchTwoValve => 0.0,
+            CombustionChamber::SwirlMultiValve => -2.0,
+        };
         if matches!(self.stroke_type, StrokeType::TwoStroke) {
             adv -= 6.0;
         }

--- a/crates/libretune-core/src/basemap/engine_spec.rs
+++ b/crates/libretune-core/src/basemap/engine_spec.rs
@@ -123,6 +123,17 @@ pub struct EngineSpec {
     /// Target AFR for WOT (display units, e.g. 12.5 for gasoline)
     /// Defaults to a safe rich value if not provided
     pub target_wot_afr: Option<f64>,
+
+    /// Fuel octane rating (AKI/pump number, e.g. 87, 91, 93, 98). Higher octane
+    /// resists knock and allows more spark advance. `None` → inferred from
+    /// `fuel_type` (see [`EngineSpec::effective_octane`]).
+    #[serde(default)]
+    pub octane: Option<f64>,
+
+    /// Static compression ratio (e.g. 10.5 for 10.5:1). Higher compression needs
+    /// less advance to stay out of knock. `None` → treated as ~10.0:1.
+    #[serde(default)]
+    pub compression_ratio: Option<f64>,
 }
 
 impl Default for EngineSpec {
@@ -140,6 +151,8 @@ impl Default for EngineSpec {
             redline_rpm: 6500,
             boost_target_kpa: None,
             target_wot_afr: None,
+            octane: None,
+            compression_ratio: None,
         }
     }
 }
@@ -195,6 +208,37 @@ impl EngineSpec {
                 self.boost_target_kpa.unwrap_or(200.0).max(120.0)
             }
         }
+    }
+
+    /// Effective fuel octane used for spark-advance calculations. When `octane`
+    /// is not given, infer a sensible value from the fuel chemistry (E85 /
+    /// methanol / LPG are far more knock-resistant than pump gasoline).
+    pub fn effective_octane(&self) -> f64 {
+        self.octane.unwrap_or(match self.fuel_type {
+            FuelType::Gasoline => 93.0,
+            FuelType::E85 => 100.0,
+            FuelType::E100 | FuelType::Methanol => 105.0,
+            FuelType::LPG => 105.0,
+        })
+    }
+
+    /// Peak (total) spark advance the engine can safely take, in crank degrees.
+    ///
+    /// Follows the MegaSquirt/TunerStudio "rules of thumb": start from a typical
+    /// 2-valve pump-premium baseline (~34°) and adjust for octane, compression
+    /// ratio and stroke type. Higher octane allows more; higher compression and
+    /// two-stroke operation require less.
+    pub fn max_spark_advance(&self) -> f64 {
+        let mut adv = 34.0;
+        // Octane relative to 93 pump premium (~0.6°/point, bounded).
+        adv += ((self.effective_octane() - 93.0) * 0.6).clamp(-8.0, 8.0);
+        // Compression ratio relative to 10.0:1 (higher CR → less advance).
+        let cr = self.compression_ratio.unwrap_or(10.0);
+        adv += ((10.0 - cr) * 1.5).clamp(-8.0, 6.0);
+        if matches!(self.stroke_type, StrokeType::TwoStroke) {
+            adv -= 6.0;
+        }
+        adv.clamp(18.0, 42.0)
     }
 }
 

--- a/crates/libretune-core/src/basemap/generator.rs
+++ b/crates/libretune-core/src/basemap/generator.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
-use super::engine_spec::{Aspiration, EngineSpec, FuelType, StrokeType};
+use super::engine_spec::{Aspiration, EngineSpec, FuelType};
 
 /// Acceleration enrichment configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -233,10 +233,15 @@ pub fn generate_ignition_table(
     let redline = spec.redline_rpm as f64;
     let max_load = spec.max_load_kpa();
 
-    let stroke_factor = match spec.stroke_type {
-        StrokeType::FourStroke => 1.0,
-        StrokeType::TwoStroke => 0.75, // Less advance for 2-stroke
-    };
+    // Peak total advance from octane / compression / stroke (TunerStudio rules).
+    let peak_advance = spec.max_spark_advance();
+    // Idle advance: a stable, conservative light-load value.
+    let idle_advance = 14.0_f64;
+    // How much timing is pulled from light load to WOT (naturally aspirated).
+    // Bounded so a low peak (low octane / high CR) doesn't push WOT negative.
+    let wot_pull = (peak_advance - 12.0).clamp(6.0, 16.0);
+    // Knock headroom under boost: higher octane pulls less per unit of boost.
+    let boost_retard_rate = (20.0 - (spec.effective_octane() - 90.0) * 0.4).clamp(8.0, 22.0);
 
     let mut table = vec![vec![0.0; cols]; rows];
 
@@ -245,25 +250,29 @@ pub fn generate_ignition_table(
             let rpm_norm = ((rpm - idle) / (redline - idle)).clamp(0.0, 1.0);
             let load_norm = ((load - 15.0) / (max_load - 15.0)).clamp(0.0, 1.0);
 
-            // Base timing: increases with RPM, decreases with load
-            let rpm_advance = 10.0 + 22.0 * rpm_norm; // 10° at idle → 32° at redline
-            let load_retard = load_norm * 8.0; // Up to 8° less at WOT
+            // Advance ramps in with RPM, reaching the peak by ~55% of the range
+            // and holding after (typical mechanical-advance shape).
+            let ramp = (rpm_norm / 0.55).min(1.0);
+            let base = idle_advance + (peak_advance - idle_advance) * ramp;
 
-            let mut advance = (rpm_advance - load_retard) * stroke_factor;
+            // Pull timing as cylinder pressure (load) rises.
+            let mut advance = base - wot_pull * load_norm;
 
-            // Extra retard for boosted engines above atmospheric
+            // Extra retard above atmospheric for boosted engines, scaled by the
+            // fuel's knock resistance.
             if matches!(
                 spec.aspiration,
                 Aspiration::Turbo | Aspiration::Supercharged
             ) && load > 101.0
+                && max_load > 101.0
             {
                 let boost_pct = (load - 101.0) / (max_load - 101.0);
-                advance -= boost_pct * 8.0; // Up to 8° more retard under boost
+                advance -= boost_pct * boost_retard_rate;
             }
 
-            // Idle timing: fixed ~15° for stability
+            // Keep idle/off-idle timing in a stable band.
             if rpm < idle * 1.2 && load < 50.0 {
-                advance = advance.clamp(12.0, 18.0);
+                advance = advance.clamp(10.0, 20.0);
             }
 
             table[r][c] = advance.clamp(0.0, 45.0).round();

--- a/crates/libretune-core/src/basemap/mod.rs
+++ b/crates/libretune-core/src/basemap/mod.rs
@@ -7,5 +7,7 @@
 mod engine_spec;
 pub mod generator;
 
-pub use engine_spec::{Aspiration, EngineSpec, FuelType, IgnitionMode, InjectionMode, StrokeType};
+pub use engine_spec::{
+    Aspiration, CombustionChamber, EngineSpec, FuelType, IgnitionMode, InjectionMode, StrokeType,
+};
 pub use generator::{AccelEnrichConfig, BaseMap, IacConfig};


### PR DESCRIPTION
## Description

TunerStudio exposes a table generator inside each table editor. LibreTune already had VE/ignition/AFR generators, but only behind the one-shot base-map wizard. This adds the same per-table affordance: right-click a **VE / ignition / AFR target** table → **"Generate … Table…"**, which seeds the open table over its **current axes** and applies the result as a **single undoable edit** (nothing is burned to the ECU automatically).

Related: complements #180.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Changes Made
- **Backend** `generate_table_values` command (`commands/generate_table.rs`): reuses the existing core generators (`generate_ve_table` / `generate_ignition_table` / `generate_afr_table`). Classifies the table by its INI-derived `TableRole`, falling back to the same name lists `apply_base_map` uses. Returns `{ table_type, z_values }` only — it does not write to the ECU.
- **Frontend** `GenerateTableDialog` (compact engine-spec form) + `classifyGeneratableTable` helper (gates the menu affordance) + context-menu wiring in `TableEditor2D` / `TableContextMenu`. The action appears only for VE/ignition/AFR tables and applies through the normal edit pipeline (undo history + explicit burn).
- The frontend passes the table's live `rpm_bins`/`load_bins`, so generation respects the table's actual axes.

## Testing
- [ ] I have tested these changes locally
- [ ] New and existing tests pass (`cargo test`)
- [ ] The UI works correctly with these changes

> **Draft / honest status:** I do not have a Rust toolchain on this machine, so I have **not** compiled the backend or run `cargo test`/`clippy` — opening as **draft** so CI can validate the Rust. The frontend is verified: `tsc --noEmit` passes with 0 errors and the new vitest suite for `classifyGeneratableTable` passes (5/5). The Rust command closely mirrors the existing `base_map`/`apply_base_map` commands. Review welcome on the generator UX and whether it should also live in the toolbar, not just the context menu.

## Checklist
- [ ] Code compiles without errors
- [ ] No new clippy warnings (`cargo clippy`)
- [ ] Code is formatted (`cargo fmt`)
- [x] TypeScript compiles without errors (`npx tsc --noEmit`)
- [x] Documentation updated if needed (CHANGELOG.md entry added)
- [x] Commit messages follow conventional format