### PR TITLE
feat(ini): add FOME as an online INI source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,22 @@ relevant.
   and `peakTracking.test.ts` (9 tests — seed/clamp, ratchet, hold, decay,
   hold-forever on `<= 0`, decay clock for seeded peaks).
 
+### 2026-08-17 — Online INI discovery covers FOME
+
+#### Added
+- **FOME added as an online INI source.** The online INI repository
+  (`search_online_inis` → `OnlineIniRepository`) previously fetched definitions
+  only from Speeduino and rusEFI. It now also fetches FOME's TunerStudio INIs
+  (`FOME-Tech/fome-fw/firmware/tunerstudio`), so signature-based discovery works
+  for FOME ECUs too. The `"fome"` source string is accepted by `download_ini`.
+
+#### Changed
+- The set of upstream sources the search iterates over is now centralized in
+  `IniSource::online_sources()` (previously a hard-coded array inside
+  `refresh_cache`), so adding future platforms is a one-line change plus URLs.
+  Added tests asserting every online source has both a GitHub API URL and a
+  raw-content prefix, and is never the `Custom` (no-upstream) tag.
+
 ### 2026-08-13 — std_injection panel synthesis & offline constant reads
 
 #### Fixed

--- a/crates/libretune-app/src-tauri/src/commands/online_ini.rs
+++ b/crates/libretune-app/src-tauri/src/commands/online_ini.rs
@@ -70,6 +70,7 @@ pub async fn download_ini(
     let source_enum = match source.to_lowercase().as_str() {
         "speeduino" => IniSource::Speeduino,
         "rusefi" => IniSource::RusEFI,
+        "fome" => IniSource::Fome,
         _ => IniSource::Custom,
     };
 

--- a/crates/libretune-core/src/project/online_repository.rs
+++ b/crates/libretune-core/src/project/online_repository.rs
@@ -46,10 +46,22 @@ pub struct OnlineIniEntry {
 pub enum IniSource {
     Speeduino,
     RusEFI,
+    /// FOME — a rusEFI fork; its TunerStudio INIs live under
+    /// `FOME-Tech/fome-fw/firmware/tunerstudio`.
+    Fome,
     Custom,
 }
 
 impl IniSource {
+    /// Every source the online search fetches from, in priority order.
+    ///
+    /// `Custom` is intentionally excluded — it has no upstream URL and is only
+    /// used to tag user-imported files. Add new upstream platforms here (and
+    /// give them URLs below) to widen auto-discovery coverage.
+    pub fn online_sources() -> &'static [IniSource] {
+        &[IniSource::Speeduino, IniSource::RusEFI, IniSource::Fome]
+    }
+
     /// Get the GitHub API URL for searching this source
     pub fn github_api_url(&self) -> Option<&'static str> {
         match self {
@@ -58,6 +70,9 @@ impl IniSource {
             ),
             IniSource::RusEFI => {
                 Some("https://api.github.com/repos/rusefi/rusefi/contents/firmware/tunerstudio")
+            }
+            IniSource::Fome => {
+                Some("https://api.github.com/repos/FOME-Tech/fome-fw/contents/firmware/tunerstudio")
             }
             IniSource::Custom => None,
         }
@@ -68,6 +83,7 @@ impl IniSource {
         match self {
             IniSource::Speeduino => Some("https://raw.githubusercontent.com/noisymime/speeduino/master/reference/tunerstudio"),
             IniSource::RusEFI => Some("https://raw.githubusercontent.com/rusefi/rusefi/master/firmware/tunerstudio"),
+            IniSource::Fome => Some("https://raw.githubusercontent.com/FOME-Tech/fome-fw/master/firmware/tunerstudio"),
             IniSource::Custom => None,
         }
     }
@@ -76,6 +92,7 @@ impl IniSource {
         match self {
             IniSource::Speeduino => "Speeduino",
             IniSource::RusEFI => "rusEFI",
+            IniSource::Fome => "FOME",
             IniSource::Custom => "Custom",
         }
     }
@@ -152,8 +169,8 @@ impl OnlineIniRepository {
     async fn refresh_cache(&mut self) -> Result<(), io::Error> {
         self.cache.clear();
 
-        // Fetch from each source
-        for source in [IniSource::Speeduino, IniSource::RusEFI] {
+        // Fetch from each upstream source
+        for &source in IniSource::online_sources() {
             match self.fetch_source_inis(source).await {
                 Ok(entries) => self.cache.extend(entries),
                 Err(e) => {
@@ -285,6 +302,32 @@ mod tests {
     fn test_ini_source_urls() {
         assert!(IniSource::Speeduino.github_api_url().is_some());
         assert!(IniSource::RusEFI.github_api_url().is_some());
+        assert!(IniSource::Fome.github_api_url().is_some());
         assert!(IniSource::Custom.github_api_url().is_none());
+    }
+
+    #[test]
+    fn test_online_sources_all_have_urls() {
+        // Every source the search iterates over must have both a GitHub API URL
+        // and a raw-content prefix, and must not be the Custom (no-upstream) tag.
+        for &source in IniSource::online_sources() {
+            assert_ne!(source, IniSource::Custom);
+            assert!(
+                source.github_api_url().is_some(),
+                "{:?} has no github_api_url",
+                source
+            );
+            assert!(
+                source.raw_url_prefix().is_some(),
+                "{:?} has no raw_url_prefix",
+                source
+            );
+        }
+    }
+
+    #[test]
+    fn test_fome_is_an_online_source() {
+        assert!(IniSource::online_sources().contains(&IniSource::Fome));
+        assert_eq!(IniSource::Fome.display_name(), "FOME");
     }
 }


### PR DESCRIPTION
## Description

Widens online INI auto-discovery to **FOME**. The online INI repository (`search_online_inis` → `OnlineIniRepository`) previously fetched definitions only from Speeduino and rusEFI; FOME ECUs had no online match. FOME (a rusEFI fork) ships its TunerStudio INIs at `FOME-Tech/fome-fw/firmware/tunerstudio`, so this wires that source in.

Addresses gap (1) from #181 (coverage). epicEFI and MegaSquirt MS2/MS3 still need a confirmed upstream and are left for follow-up.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Changes Made
- Add `IniSource::Fome` with its GitHub API URL, raw-content prefix, and display name (`crates/libretune-core/src/project/online_repository.rs`).
- Centralize the searched upstreams in `IniSource::online_sources()` and use it in `refresh_cache`, so future platforms are a one-line addition.
- Accept the `"fome"` source string in the `download_ini` command.
- Tests: `Fome` has URLs and is an online source; every online source has both a GitHub API URL and a raw prefix and is never `Custom`.

## Testing
- [ ] I have tested these changes locally
- [ ] New and existing tests pass (`cargo test`)
- [ ] The UI works correctly with these changes

> **Draft / honest status:** I don't have a Rust toolchain on this machine, so I have **not** compiled or run `cargo test`/`clippy` — opening as **draft** so CI can validate. The change is small and additive (no exhaustive `match` on `IniSource` outside the enum's own methods; the one string→enum map uses a `_ => Custom` catch-all). I verified the upstream path resolves: `FOME-Tech/fome-fw/firmware/tunerstudio` contains a `.ini` and the repo's default branch is `master`.

## Checklist
- [ ] Code compiles without errors
- [ ] No new clippy warnings (`cargo clippy`)
- [ ] Code is formatted (`cargo fmt`)
- [x] TypeScript compiles without errors (`npx tsc --noEmit`) — N/A, Rust-only change
- [x] Documentation updated if needed (CHANGELOG.md entry added)
- [x] Commit messages follow conventional format