### PR TITLE
feat(ini): "Search for INI Online" menu entry (on-demand)

### DIFF
--- a/crates/libretune-app/src/App.tsx
+++ b/crates/libretune-app/src/App.tsx
@@ -120,6 +120,7 @@ function AppContent() {
   const [availableProjects, setAvailableProjects] = useState<ProjectInfo[]>([]);
   const [repositoryInis, setRepositoryInis] = useState<IniEntry[]>([]);
   const [newProjectDialogOpen, setNewProjectDialogOpen] = useState(false);
+  const [onlineIniDialogOpen, setOnlineIniDialogOpen] = useState(false);
   const [baseMapDialogOpen, setBaseMapDialogOpen] = useState(false);
 
   // Connection state
@@ -1425,6 +1426,7 @@ function AppContent() {
     sidebarVisible, showEcuMenus: showEcuMenusInMenubar, tabs, openTarget, handleStdTarget, openHelpTopic, showToast,
     closeProject, handleCreateRestorePoint,
     setNewProjectDialogOpen, setImportProjectOpen, setSaveDialogOpen, setLoadDialogOpen,
+    setOnlineIniDialogOpen,
     setBurnDialogOpen, setFirmwareUpdateDialogOpen, setRestorePointsOpen, setTuneHistoryOpen, setSettingsDialogOpen,
     setMathChannelsDialogOpen, setAfrDelayTestOpen, setBaseMapDialogOpen, setTableComparisonOpen,
     setTuneFileDiffOpen, setDynoOverlayOpen, setPluginPanelOpen, agentPanelVisible, setAgentPanelVisible, setConnectionDialogOpen,
@@ -1687,6 +1689,8 @@ function AppContent() {
         setConnectionRuntimePacketMode={setConnectionRuntimePacketMode}
         newProjectDialogOpen={newProjectDialogOpen}
         setNewProjectDialogOpen={setNewProjectDialogOpen}
+        onlineIniDialogOpen={onlineIniDialogOpen}
+        setOnlineIniDialogOpen={setOnlineIniDialogOpen}
         repositoryInis={repositoryInis}
         setRepositoryInis={setRepositoryInis}
         createProject={createProject}

--- a/crates/libretune-app/src/components/DialogOverlays.tsx
+++ b/crates/libretune-app/src/components/DialogOverlays.tsx
@@ -24,6 +24,7 @@ import MigrationReportDialog from "./dialogs/MigrationReportDialog";
 import TuneFileDiffDialog from "./dialogs/TuneFileDiffDialog";
 import DynoOverlay from "./tuner-ui/DynoOverlay";
 import NewProjectDialog from "./dialogs/NewProjectDialog";
+import OnlineIniDialog from "./dialogs/OnlineIniDialog";
 import BaseMapDialog, { BaseMapResult } from "./dialogs/BaseMapDialog";
 import TuneHistoryPanel from "./TuneHistoryPanel";
 import ErrorDetailsDialog from "./dialogs/ErrorDetailsDialog";
@@ -120,6 +121,8 @@ export interface DialogOverlaysProps {
   // Project
   newProjectDialogOpen: boolean;
   setNewProjectDialogOpen: (v: boolean) => void;
+  onlineIniDialogOpen: boolean;
+  setOnlineIniDialogOpen: (v: boolean) => void;
   repositoryInis: IniEntry[];
   setRepositoryInis: React.Dispatch<React.SetStateAction<IniEntry[]>>;
   createProject: (name: string, iniId: string) => Promise<boolean>;
@@ -215,6 +218,7 @@ export function DialogOverlays(props: DialogOverlaysProps) {
     iniDefaults, applyIniDefaults,
     connectionRuntimePacketMode, setConnectionRuntimePacketMode,
     newProjectDialogOpen, setNewProjectDialogOpen,
+    onlineIniDialogOpen, setOnlineIniDialogOpen,
     repositoryInis, setRepositoryInis, createProject, handleImportTuneIntoProject,
     baseMapDialogOpen, setBaseMapDialogOpen, handleBaseMapApply,
     tuneComparisonOpen, setTuneComparisonOpen, checkStatus,
@@ -313,6 +317,11 @@ export function DialogOverlays(props: DialogOverlaysProps) {
         runtimePacketMode={connectionRuntimePacketMode}
         onRuntimePacketModeChange={setConnectionRuntimePacketMode}
       />
+      <OnlineIniDialog
+        isOpen={onlineIniDialogOpen}
+        onClose={() => setOnlineIniDialogOpen(false)}
+      />
+
       <NewProjectDialog
         isOpen={newProjectDialogOpen}
         onClose={() => setNewProjectDialogOpen(false)}

--- a/crates/libretune-app/src/components/dialogs/OnlineIniDialog.tsx
+++ b/crates/libretune-app/src/components/dialogs/OnlineIniDialog.tsx
@@ -1,0 +1,160 @@
+import { useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { Dialog, Button } from "../common";
+
+interface OnlineIniEntry {
+  source: string;
+  name: string;
+  signature: string | null;
+  download_url: string;
+  repo_path: string;
+  size: number | null;
+}
+
+interface OnlineIniDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+/**
+ * On-demand "Search for INI Online" dialog.
+ *
+ * The signature-mismatch flow already offers online INI search when connecting
+ * to an ECU, but only reactively. This exposes the same capability from the
+ * menu so a user can browse and download a definition at any time (e.g. before
+ * connecting, or in demo mode). It reuses the existing backend commands
+ * `search_online_inis` (with no signature → list everything) and
+ * `download_ini`, then switches the project to the downloaded file.
+ */
+export default function OnlineIniDialog({ isOpen, onClose }: OnlineIniDialogProps) {
+  const [results, setResults] = useState<OnlineIniEntry[]>([]);
+  const [filter, setFilter] = useState("");
+  const [searching, setSearching] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [downloading, setDownloading] = useState<string | null>(null);
+  const [done, setDone] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (isOpen && results.length === 0 && !searching) {
+      void search();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen]);
+
+  async function search() {
+    setSearching(true);
+    setError(null);
+    try {
+      // No signature → the backend returns every known online definition.
+      const found = await invoke<OnlineIniEntry[]>("search_online_inis", {
+        signature: null,
+      });
+      setResults(found);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSearching(false);
+    }
+  }
+
+  async function download(entry: OnlineIniEntry) {
+    setDownloading(entry.download_url);
+    setError(null);
+    setDone(null);
+    try {
+      const path = await invoke<string>("download_ini", {
+        downloadUrl: entry.download_url,
+        name: entry.name,
+        source: entry.source,
+      });
+      await invoke("update_project_ini", { iniPath: path, forceResync: true });
+      setDone(`Loaded ${entry.name} (${entry.source}).`);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setDownloading(null);
+    }
+  }
+
+  const shown = results.filter((r) => {
+    if (!filter.trim()) return true;
+    const q = filter.toLowerCase();
+    return (
+      r.name.toLowerCase().includes(q) ||
+      r.source.toLowerCase().includes(q) ||
+      (r.signature?.toLowerCase().includes(q) ?? false)
+    );
+  });
+
+  return (
+    <Dialog open={isOpen} onClose={onClose} title="Search for INI Online" size="lg">
+      <Dialog.Body>
+        <p style={{ marginTop: 0, opacity: 0.8 }}>
+          Browse and download ECU definitions from the online repositories
+          (Speeduino, rusEFI, …). The selected file becomes the project's INI.
+        </p>
+
+        <div style={{ display: "flex", gap: "0.5rem", marginBottom: "0.75rem" }}>
+          <input
+            type="text"
+            value={filter}
+            placeholder="Filter by name, source or signature…"
+            onChange={(e) => setFilter(e.target.value)}
+            style={{ flex: 1 }}
+          />
+          <Button variant="secondary" onClick={search} disabled={searching}>
+            {searching ? "Searching…" : "Refresh"}
+          </Button>
+        </div>
+
+        {error && (
+          <div style={{ color: "var(--color-error, #d33)", marginBottom: "0.5rem" }}>{error}</div>
+        )}
+        {done && (
+          <div style={{ color: "var(--color-success, #2a2)", marginBottom: "0.5rem" }}>{done}</div>
+        )}
+
+        <div style={{ maxHeight: "50vh", overflowY: "auto" }}>
+          {searching && shown.length === 0 ? (
+            <div style={{ opacity: 0.7, padding: "1rem" }}>Searching online repositories…</div>
+          ) : shown.length === 0 ? (
+            <div style={{ opacity: 0.7, padding: "1rem" }}>No definitions found.</div>
+          ) : (
+            <table style={{ width: "100%", borderCollapse: "collapse" }}>
+              <thead>
+                <tr style={{ textAlign: "left", opacity: 0.7 }}>
+                  <th style={{ padding: "0.25rem 0.5rem" }}>Name</th>
+                  <th style={{ padding: "0.25rem 0.5rem" }}>Source</th>
+                  <th style={{ padding: "0.25rem 0.5rem" }} />
+                </tr>
+              </thead>
+              <tbody>
+                {shown.map((entry) => (
+                  <tr key={entry.download_url} style={{ borderTop: "1px solid var(--color-border, #4443)" }}>
+                    <td style={{ padding: "0.25rem 0.5rem", wordBreak: "break-all" }}>{entry.name}</td>
+                    <td style={{ padding: "0.25rem 0.5rem" }}>{entry.source}</td>
+                    <td style={{ padding: "0.25rem 0.5rem", textAlign: "right" }}>
+                      <Button
+                        variant="primary"
+                        onClick={() => download(entry)}
+                        disabled={downloading !== null}
+                      >
+                        {downloading === entry.download_url ? "Downloading…" : "Download & Use"}
+                      </Button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </Dialog.Body>
+
+      <Dialog.Footer>
+        <Button variant="secondary" onClick={onClose}>
+          Close
+        </Button>
+      </Dialog.Footer>
+    </Dialog>
+  );
+}

--- a/crates/libretune-app/src/menus/buildMenuItems.ts
+++ b/crates/libretune-app/src/menus/buildMenuItems.ts
@@ -38,6 +38,7 @@ export interface BuildMenuItemsDeps {
   setImportProjectOpen: (open: boolean) => void;
   setSaveDialogOpen: (open: boolean) => void;
   setLoadDialogOpen: (open: boolean) => void;
+  setOnlineIniDialogOpen: (open: boolean) => void;
   setBurnDialogOpen: (open: boolean) => void;
   refreshTuneModified?: () => void | Promise<void>;
   setFirmwareUpdateDialogOpen: (open: boolean) => void;
@@ -77,6 +78,7 @@ export function buildMenuItems(deps: BuildMenuItemsDeps): TunerMenuItem[] {
     sidebarVisible, showEcuMenus, tabs, openTarget, handleStdTarget, openHelpTopic, showToast,
     closeProject, handleCreateRestorePoint,
     setNewProjectDialogOpen, setImportProjectOpen, setSaveDialogOpen, setLoadDialogOpen,
+    setOnlineIniDialogOpen,
     setBurnDialogOpen, setFirmwareUpdateDialogOpen, setRestorePointsOpen, setTuneHistoryOpen, setSettingsDialogOpen,
     setMathChannelsDialogOpen, setAfrDelayTestOpen, setBaseMapDialogOpen, setTableComparisonOpen,
     setTuneFileDiffOpen, setDynoOverlayOpen, setPluginPanelOpen, agentPanelVisible, setAgentPanelVisible, setConnectionDialogOpen,
@@ -88,6 +90,7 @@ export function buildMenuItems(deps: BuildMenuItemsDeps): TunerMenuItem[] {
     ? [
         { id: "new-project", label: t('file.newProject'), onClick: () => setNewProjectDialogOpen(true) },
         { id: "import-project", label: t('file.importProject'), onClick: () => setImportProjectOpen(true) },
+        { id: "search-ini-online", label: "Search for INI Online…", onClick: () => setOnlineIniDialogOpen(true) },
         { id: "close-project", label: t('file.closeProject'), onClick: closeProject },
         { id: "sep1", label: "", separator: true },
         { id: "save", label: t('file.saveTune'), onClick: () => setSaveDialogOpen(true) },
@@ -105,6 +108,7 @@ export function buildMenuItems(deps: BuildMenuItemsDeps): TunerMenuItem[] {
     : [
         { id: "new-project", label: t('file.newProject'), onClick: () => setNewProjectDialogOpen(true) },
         { id: "import-project", label: t('file.importProject'), onClick: () => setImportProjectOpen(true) },
+        { id: "search-ini-online", label: "Search for INI Online…", onClick: () => setOnlineIniDialogOpen(true) },
         { id: "sep1", label: "", separator: true },
         { id: "settings", label: t('file.settings'), onClick: () => setSettingsDialogOpen(true) },
         { id: "sep2", label: "", separator: true },


### PR DESCRIPTION
## Description

Online INI search already exists, but only **reactively** — it appears inside the signature-mismatch dialog when connecting to an ECU whose signature doesn't match the loaded INI. There was no way to reach it on demand (e.g. before connecting, or in demo mode). This adds a **File → "Search for INI Online…"** menu entry that opens it directly.

Addresses gap (2), discoverability, from #181.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Changes Made
- New `OnlineIniDialog` — lists every definition from the online repositories (`search_online_inis` with no signature), filters client-side, and downloads the chosen one (`download_ini` → `update_project_ini`). It reuses the exact backend commands the signature-mismatch dialog already uses; no backend changes.
- Wired through `buildMenuItems` (File menu item, both project/no-project variants), `App.tsx` (state), and `DialogOverlays` (render), following the existing dialog pattern.

## Testing
- [ ] I have tested these changes locally
- [ ] New and existing tests pass (`cargo test`)
- [ ] The UI works correctly with these changes

> **Draft / status:** frontend-only, reusing existing backend commands. `tsc --noEmit` passes locally. I could not click through the running app to visually confirm the menu item, so opening as **draft** for review + CI. Note the online search is limited by the repository's source coverage (Speeduino/rusEFI today; FOME added in #184).

## Checklist
- [ ] Code compiles without errors
- [ ] No new clippy warnings
- [ ] Code is formatted
- [x] TypeScript compiles without errors (`npx tsc --noEmit`)
- [ ] Documentation updated if needed
- [x] Commit messages follow conventional format