### PR TITLE
fix(ini): resolve the AFR-target table role on every Speeduino INI

### DIFF
--- a/crates/libretune-core/src/ini/parser.rs
+++ b/crates/libretune-core/src/ini/parser.rs
@@ -447,6 +447,18 @@ fn parse_ini_internal(content: &str, ctx: &mut IncludeContext) -> Result<EcuDefi
             .and_then(|n| n.to_str()),
     );
 
+    // Roles are declared by `[VeAnalyze]`/`[WueAnalyze]`, which may sit in any
+    // file of an include tree, so they can only be resolved once everything has
+    // been merged. `depth == 0` is the outermost parse; nested calls are
+    // include files still being folded into it.
+    //
+    // Doing it here rather than in each entry point means a caller cannot
+    // forget: `infer_table_roles()` already existed and was correct, but
+    // nothing ever called it, so every table kept `TableRole::Other`.
+    if ctx.depth == 0 {
+        definition.infer_table_roles();
+    }
+
     Ok(definition)
 }
 
@@ -2993,12 +3005,25 @@ fn parse_ve_analyze_entry(def: &mut EcuDefinition, key: &str, value: &str) {
     match key_lower.as_str() {
         "veanalyzemap" => {
             // veAnalyzeMap = veTableTbl, lambdaTableTbl, lambdaValue, egoCorrectionForVeAnalyze, { 1 }
-            if parts.len() >= 5 {
+            //
+            // The fifth field, activeCondition, is OPTIONAL - Speeduino writes
+            // only four:
+            //   veAnalyzeMap = veTable1Tbl, afrTable1Tbl, afr, egoCorrection
+            //
+            // Requiring five discarded the entire declaration for every
+            // Speeduino INI, silently: no VE role, no AFR-target role, and
+            // AutoTune fell back to a flat 14.7 target for every cell. On a
+            // real drive that asked to pull ~15% fuel out of the WOT region,
+            // where the target table actually calls for 12.7.
+            if parts.len() >= 4 {
                 config.ve_table_name = parts[0].trim().to_string();
                 config.target_table_name = parts[1].trim().to_string();
                 config.lambda_channel = parts[2].trim().to_string();
                 config.ego_correction_channel = parts[3].trim().to_string();
-                config.active_condition = parts[4].trim().to_string();
+                config.active_condition = parts
+                    .get(4)
+                    .map(|s| s.trim().to_string())
+                    .unwrap_or_default();
             }
         }
         "lambdatargettables" => {
@@ -3248,6 +3273,55 @@ mod tests {
             "seeding CELSIUS must select the metric branch"
         );
         set_default_symbols(Vec::<String>::new());
+    }
+
+    #[test]
+    fn ve_analyze_map_parses_speeduinos_four_field_form() {
+        let ini = "[TableEditor]
+table = veTable1Tbl, veTable1, \"VE Table\", 2
+table = afrTable1Tbl, afrTable1, \"AFR Table\", 2
+[VeAnalyze]
+veAnalyzeMap = veTable1Tbl, afrTable1Tbl, afr, egoCorrection
+";
+        let def = parse_ini(ini).expect("parses");
+        let cfg = def.ve_analyze.as_ref().expect("VeAnalyze config present");
+        assert_eq!(cfg.ve_table_name, "veTable1Tbl");
+        assert_eq!(cfg.target_table_name, "afrTable1Tbl");
+        assert_eq!(cfg.lambda_channel, "afr");
+        assert_eq!(cfg.ego_correction_channel, "egoCorrection");
+        assert_eq!(
+            cfg.active_condition, "",
+            "absent optional field stays empty"
+        );
+    }
+
+    /// Roles must be inferred by the time a caller sees the definition.
+    ///
+    /// `infer_table_roles()` was correct but called from nowhere, so every
+    /// table stayed `Other` and the AFR-target lookup could never succeed for
+    /// any INI. The fallback it dropped into guesses by name from a list
+    /// containing both `afrTable` and `lambdaTable` - which on a lambda INI
+    /// compares a ~0.88 target against a ~13 measured AFR.
+    #[test]
+    fn parsing_assigns_table_roles() {
+        let ini = "[TableEditor]
+table = veTable1Tbl, veTable1, \"VE Table\", 2
+table = afrTable1Tbl, afrTable1, \"AFR Table\", 2
+table = sparkTbl, spark, \"Spark Table\", 2
+[VeAnalyze]
+veAnalyzeMap = veTable1Tbl, afrTable1Tbl, afr, egoCorrection
+";
+        let def = parse_ini(ini).expect("parses");
+        let role = |n: &str| {
+            def.tables
+                .values()
+                .find(|t| t.name == n)
+                .map(|t| t.role)
+                .unwrap_or(crate::ini::TableRole::Other)
+        };
+        assert_eq!(role("veTable1Tbl"), crate::ini::TableRole::Ve);
+        assert_eq!(role("afrTable1Tbl"), crate::ini::TableRole::AfrTarget);
+        assert_eq!(role("sparkTbl"), crate::ini::TableRole::Ignition);
     }
 
     #[test]


### PR DESCRIPTION
## Description
Two bugs that only fail together, silently:

1. `parse_ve_analyze_entry` required five comma-separated fields, but the fifth (`activeCondition`) is optional and Speeduino writes four:
   `veAnalyzeMap = veTable1Tbl, afrTable1Tbl, afr, egoCorrection`
   The whole declaration was discarded on every Speeduino INI.
2. `infer_table_roles()` — which turns that declaration into `TableRole::AfrTarget` — was implemented, documented, and never called. Every table kept role `Other`, so the AFR-target lookup could not succeed for **any** definition.

The fix for (2) runs role inference at the end of `parse_ini_internal` when `ctx.depth == 0`, rather than adding a call to each public entry point. Roles are declared by `[VeAnalyze]`/`[WueAnalyze]`, which may appear in any file of an include tree, so they can only be resolved once everything has been merged — and `depth == 0` is exactly that moment. Putting it there also means a caller cannot forget it, which is how the function came to exist, be correct, and never run.

Consequence before the fix: AutoTune's `resolve_reference_tables()` found no declared target, fell through to name-guessing, and scored every cell against a flat 14.7 AFR. On a real 52-minute drive it recommended pulling ~12% of the fuel out of the WOT region whose target table asks for 12.7 — on an engine with no knock sensor. The name-guess fallback also contains `lambdaTable`; a near-miss there would compare a ~0.9 lambda target against a ~13 measured AFR and hit the correction authority ceiling on every pass.

## Related
First change to touch `[VeAnalyze]` parsing; no prior issue or PR covers it.

Merges cleanly with #186 in either order (verified locally — both branches merged onto main, 0 conflicts, full suite green). An earlier revision of this PR called `infer_table_roles()` from the two public entry points, which #186 also edits; the current placement removes that overlap entirely.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Testing
- [x] Two regression tests; each fails if its half of the fix is reverted (verified by re-introducing each bug)
- [x] New and existing tests pass (`cargo test`) — 386 in libretune-core, full workspace green
- [x] No new clippy warnings; `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)