### PR TITLE
feat(afr-delay): continuous mode with a live trace overlay

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/afr_delay_test.rs
+++ b/crates/libretune-app/src-tauri/src/commands/afr_delay_test.rs
@@ -63,6 +63,14 @@ const MIN_STEP_PERCENT: f64 = 3.0;
 /// ran 20 while the dialog still quoted the time for 100.
 const MAX_REPEATS: u32 = 200;
 
+/// Throttle movement above which a step is not measuring transport.
+///
+/// A moving throttle changes the mixture for its own reasons and drags accel
+/// enrichment along with it. On a real 59-minute drive this and the fuel-cut
+/// test together disqualified 44 of 141 steps; the remaining 97 gave a
+/// coherent flow-scaled curve where the unfiltered set gave 52-2979 ms.
+const TPS_DOT_LIMIT: f64 = 10.0;
+
 /// Bounds on how long a step is held, in milliseconds.
 const MIN_HOLD_MS: u64 = 500;
 const MAX_HOLD_MS: u64 = 5_000;
@@ -85,6 +93,17 @@ const WUE_CONSTANT: &str = "wueRates";
 const WUE_LAST_SLOT: usize = 9;
 /// Realtime channel reporting the WUE multiplier the ECU is applying now.
 const WUE_CHANNEL: &str = "warmupEnrich";
+
+/// One sample of a step's trace, as the UI plots it. `t_ms` is relative to the
+/// step anchor, so traces from different steps overlay directly.
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TracePoint {
+    pub t_ms: i64,
+    pub afr: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pw: Option<f64>,
+}
 
 /// Progress event emitted to the frontend during a delay-test run (as
 /// `afr_delay_test:progress`). `phase` is a coarse stage label —
@@ -112,6 +131,15 @@ pub struct DelayTestProgress {
     /// Why no delay was measured for this step (operator-facing label).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rejection: Option<String>,
+    /// The step's AFR/pulse-width trace, times relative to the anchor, so the
+    /// UI can overlay it on the ones before it. Present on "settling" only.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub trace: Vec<TracePoint>,
+    /// True when the ECU was cutting fuel, or the throttle moving faster than
+    /// TPS_DOT_LIMIT, anywhere in the window - the trace is drawn but excluded
+    /// from the statistics.
+    #[serde(skip_serializing_if = "std::ops::Not::not", default)]
+    pub unusable: bool,
 }
 
 impl DelayTestProgress {
@@ -134,6 +162,8 @@ impl DelayTestProgress {
             measured_rpm: None,
             measured_load: None,
             rejection: None,
+            trace: Vec::new(),
+            unusable: false,
         }
     }
 }
@@ -197,6 +227,33 @@ struct SampleChannels {
     /// The ECU-reported WUE multiplier — used to gate on the warm plateau and
     /// to anchor t0 at the moment the ECU actually applied the step.
     wue: Option<String>,
+    /// Injector pulse width: the fuel the engine actually received, as opposed
+    /// to the multiplier we asked for. Overlaying it against AFR is how the
+    /// delay is read by eye, and it is the honest t0 - the commanded step and
+    /// the delivered step are not the same instant.
+    pw: Option<String>,
+    /// Deceleration fuel cut and throttle rate. A step measured while the ECU
+    /// is cutting fuel, or while the throttle is moving, is not measuring
+    /// transport; both are recorded so the trace can be marked unusable.
+    dfco: Option<String>,
+    tps_dot: Option<String>,
+}
+
+/// What was true at each sampled instant besides AFR: the fuel actually
+/// delivered, and whether the moment was valid to measure at all.
+struct SampleContext {
+    pw: Option<f64>,
+    dfco: bool,
+    tps_dot: f64,
+}
+
+/// One window's samples: AFR for the delay extraction, and the matching
+/// context for the plot and the validity test. Kept together so the two can
+/// never drift out of step - they are pushed as a pair.
+#[derive(Default)]
+struct StepSamples {
+    afr: Vec<AfrSample>,
+    ctx: Vec<SampleContext>,
 }
 
 fn resolve_sample_channels(
@@ -221,6 +278,9 @@ fn resolve_sample_channels(
         .or_else(|| find_exact("lambda"))
         .or_else(|| find_exact("o2"))?;
     Some(SampleChannels {
+        pw: find_exact("pulseWidth").or_else(|| find_exact("pw")),
+        dfco: find_exact("DFCOOn").or_else(|| find_exact("dfco")),
+        tps_dot: find_exact("TPSdot").or_else(|| find_exact("tpsDot")),
         afr,
         rpm: find_exact("rpm"),
         // MAP in kPa preferred as the load axis; TPS is the fallback.
@@ -308,7 +368,7 @@ async fn sample_window(
     epoch: Instant,
     channels: Option<&SampleChannels>,
     total_ms: u64,
-    out: &mut Vec<AfrSample>,
+    out: &mut StepSamples,
     last_point: &mut (Option<f64>, Option<f64>),
     // When set: (threshold, slot for first crossing time). The ECU's reported
     // WUE multiplier crossing the threshold marks the instant the step was
@@ -330,7 +390,21 @@ async fn sample_window(
             {
                 let t_ms = epoch.elapsed().as_millis() as u64;
                 if let Some(afr) = snap.get(&ch.afr) {
-                    out.push(AfrSample { t_ms, afr: *afr });
+                    out.afr.push(AfrSample { t_ms, afr: *afr });
+                    out.ctx.push(SampleContext {
+                        pw: ch.pw.as_ref().and_then(|k| snap.get(k)).copied(),
+                        dfco: ch
+                            .dfco
+                            .as_ref()
+                            .and_then(|k| snap.get(k))
+                            .is_some_and(|v| *v > 0.5),
+                        tps_dot: ch
+                            .tps_dot
+                            .as_ref()
+                            .and_then(|k| snap.get(k))
+                            .copied()
+                            .unwrap_or(0.0),
+                    });
                 }
                 if let Some(rpm_key) = &ch.rpm {
                     if let Some(v) = snap.get(rpm_key) {
@@ -522,7 +596,7 @@ pub async fn run_afr_delay_test(
 
         // Baseline trace for this step's delay extraction (abort-aware, like
         // every other wait in the run).
-        let mut pre = Vec::new();
+        let mut pre = StepSamples::default();
         let mut point = (None, None);
         if sample_window(
             &state,
@@ -563,7 +637,7 @@ pub async fn run_afr_delay_test(
         // Abort-aware hold, sampling AFR throughout: an abort mid-hold falls
         // straight through to the restore below, so the enrichment is cut
         // short rather than held for the remainder of `hold_ms`.
-        let mut post = Vec::new();
+        let mut post = StepSamples::default();
         let aborted_mid_hold = sample_window(
             &state,
             epoch,
@@ -593,10 +667,35 @@ pub async fn run_afr_delay_test(
 
         // Extract this step's transport delay from the sampled traces.
         let measurement = if channels.is_some() {
-            Some(detect_delay(anchor_ms, &pre, &post))
+            Some(detect_delay(anchor_ms, &pre.afr, &post.afr))
         } else {
             None
         };
+
+        // The step's trace, for the UI to overlay on the ones before it.
+        // Times are relative to the anchor so steps taken at different moments
+        // line up, and pulse width rides along because the delay is read from
+        // where AFR moves relative to where the FUEL moved - the commanded step
+        // and the delivered step are not the same instant.
+        let trace: Vec<TracePoint> = pre
+            .afr
+            .iter()
+            .chain(post.afr.iter())
+            .zip(pre.ctx.iter().chain(post.ctx.iter()))
+            .map(|(s, c)| TracePoint {
+                t_ms: s.t_ms as i64 - anchor_ms as i64,
+                afr: s.afr,
+                pw: c.pw,
+            })
+            .collect();
+        // A step taken while fuel was cut, or while the throttle was moving,
+        // is not measuring transport. Mark it so the UI can draw it greyed and
+        // leave it out of the statistics rather than silently discarding it.
+        let unusable = pre
+            .ctx
+            .iter()
+            .chain(post.ctx.iter())
+            .any(|c| c.dfco || c.tps_dot.abs() > TPS_DOT_LIMIT);
 
         let mut settling = DelayTestProgress::plain(
             "settling",
@@ -606,6 +705,8 @@ pub async fn run_afr_delay_test(
             baseline,
             format!("step {step}/{repeats} done, settling"),
         );
+        settling.trace = trace;
+        settling.unusable = unusable;
         match measurement {
             Some(Ok(m)) => {
                 let (rpm, load) = point;

--- a/crates/libretune-app/src-tauri/src/commands/afr_delay_test.rs
+++ b/crates/libretune-app/src-tauri/src/commands/afr_delay_test.rs
@@ -384,8 +384,20 @@ pub async fn run_afr_delay_test(
     let step_percent = step_percent.abs().clamp(MIN_STEP_PERCENT, MAX_STEP_PERCENT);
     let hold_ms = hold_ms.clamp(MIN_HOLD_MS, MAX_HOLD_MS);
     let settle_ms = settle_ms.clamp(MIN_HOLD_MS, MAX_HOLD_MS * 2);
+    // `repeats == 0` means run until the operator stops it. Delay resolution
+    // comes from the number of events in each rpm/load bin, not from the sample
+    // rate - bootstrapping a real drive put a 34-event bin at +/-20 ms and a
+    // 10-event bin at +/-80 ms - so a long run that keeps stepping while the
+    // car is driven normally fills the map far better than a fixed batch.
+    let continuous = repeats == 0;
     let requested_repeats = repeats;
-    let repeats = repeats.clamp(1, MAX_REPEATS);
+    let repeats = if continuous {
+        u32::MAX
+    } else {
+        repeats.clamp(1, MAX_REPEATS)
+    };
+    // What the UI is told the total is; 0 reads as "unbounded" there.
+    let reported_total = if continuous { 0 } else { repeats };
 
     // Baseline = the tune's warm-plateau WUE value (the INI mandates 100).
     // Reading it up front also fails the run early if the ECU is unreachable,
@@ -449,10 +461,15 @@ pub async fn run_afr_delay_test(
 
     // If the request was trimmed, say so here rather than quietly running
     // fewer steps than the operator asked for and than the UI estimated.
-    let clamp_note = if requested_repeats > repeats {
+    let clamp_note = if !continuous && requested_repeats > repeats {
         format!(" (asked for {requested_repeats}, capped at {repeats})")
     } else {
         String::new()
+    };
+    let run_len = if continuous {
+        "running until stopped".to_string()
+    } else {
+        format!("{repeats} steps{clamp_note}")
     };
 
     emit(
@@ -465,7 +482,7 @@ pub async fn run_afr_delay_test(
             baseline,
             format!(
                 "WUE step {baseline:.0}% -> {enriched:.0}% ({step_percent:.1}% richer), \
-                 {repeats} steps{clamp_note}, {hold_ms} ms hold. \
+                 {run_len}, {hold_ms} ms hold. \
                  One byte, RAM only, never burned."
             ),
         ),
@@ -496,7 +513,7 @@ pub async fn run_afr_delay_test(
             DelayTestProgress::plain(
                 "enriching",
                 step,
-                repeats,
+                reported_total,
                 enriched,
                 baseline,
                 format!("step {step}/{repeats}: hold steady"),
@@ -584,7 +601,7 @@ pub async fn run_afr_delay_test(
         let mut settling = DelayTestProgress::plain(
             "settling",
             step,
-            repeats,
+            reported_total,
             baseline,
             baseline,
             format!("step {step}/{repeats} done, settling"),

--- a/crates/libretune-app/src/components/dialogs/AfrDelayTestDialog.tsx
+++ b/crates/libretune-app/src/components/dialogs/AfrDelayTestDialog.tsx
@@ -15,6 +15,7 @@ import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
 import { AlertTriangle, Play, Square } from 'lucide-react';
 import './AfrDelayTestDialog.css';
+import DelayTraceOverlay, { DelayTrace, TracePoint } from './DelayTraceOverlay';
 
 interface Progress {
   phase: string;
@@ -27,6 +28,8 @@ interface Progress {
   measuredRpm?: number;
   measuredLoad?: number;
   rejection?: string;
+  trace?: TracePoint[];
+  unusable?: boolean;
 }
 
 interface DelayCell {
@@ -64,6 +67,10 @@ export const AfrDelayTestDialog: React.FC<Props> = ({ isOpen, onClose }) => {
   // so a run left going for a whole drive fills the map far better than any
   // fixed count taken at one operating point.
   const [continuous, setContinuous] = useState(false);
+  // Every step's trace, kept so they can be overlaid. A single step cannot be
+  // timed - the scatter is larger than the response - so the reading only
+  // means anything once they are stacked.
+  const [traces, setTraces] = useState<DelayTrace[]>([]);
 
   const [running, setRunning] = useState(false);
   const [progress, setProgress] = useState<Progress | null>(null);
@@ -80,6 +87,13 @@ export const AfrDelayTestDialog: React.FC<Props> = ({ isOpen, onClose }) => {
   useEffect(() => {
     const un = listen<Progress>('afr_delay_test:progress', (e) => {
       setProgress(e.payload);
+      if (e.payload.trace?.length) {
+        setTraces((prev) => [
+          ...prev,
+          { step: e.payload.step, points: e.payload.trace as TracePoint[],
+            unusable: Boolean(e.payload.unusable) },
+        ]);
+      }
       // A settling event carries this step's measurement (or rejection) —
       // refresh the aggregate table so the grid fills in live.
       if (e.payload.phase === 'settling' || e.payload.phase === 'complete') {
@@ -103,6 +117,7 @@ export const AfrDelayTestDialog: React.FC<Props> = ({ isOpen, onClose }) => {
   const start = useCallback(async () => {
     setError(null);
     setResult(null);
+    setTraces([]);
     setRunning(true);
     try {
       const summary = await invoke<string>('run_afr_delay_test', {
@@ -264,6 +279,11 @@ export const AfrDelayTestDialog: React.FC<Props> = ({ isOpen, onClose }) => {
             </table>
           </div>
         )}
+
+        <div className="afr-delay-overlay-section">
+          <h3>AFR response</h3>
+          <DelayTraceOverlay traces={traces} />
+        </div>
 
         {result && <div className="afr-delay-result">{result}</div>}
         {error && (

--- a/crates/libretune-app/src/components/dialogs/AfrDelayTestDialog.tsx
+++ b/crates/libretune-app/src/components/dialogs/AfrDelayTestDialog.tsx
@@ -59,6 +59,11 @@ export const AfrDelayTestDialog: React.FC<Props> = ({ isOpen, onClose }) => {
   const [holdMs, setHoldMs] = useState(2000);
   const [settleMs, setSettleMs] = useState(3000);
   const [repeats, setRepeats] = useState(5);
+  // Run until stopped rather than for a fixed batch. Delay resolution comes
+  // from how many events land in each rpm/load bin, not from the sample rate,
+  // so a run left going for a whole drive fills the map far better than any
+  // fixed count taken at one operating point.
+  const [continuous, setContinuous] = useState(false);
 
   const [running, setRunning] = useState(false);
   const [progress, setProgress] = useState<Progress | null>(null);
@@ -101,7 +106,8 @@ export const AfrDelayTestDialog: React.FC<Props> = ({ isOpen, onClose }) => {
     setRunning(true);
     try {
       const summary = await invoke<string>('run_afr_delay_test', {
-        stepPercent, holdMs, settleMs, repeats,
+        stepPercent, holdMs, settleMs,
+        repeats: continuous ? 0 : repeats,
       });
       setResult(summary);
     } catch (e) {
@@ -112,7 +118,7 @@ export const AfrDelayTestDialog: React.FC<Props> = ({ isOpen, onClose }) => {
     } finally {
       setRunning(false);
     }
-  }, [stepPercent, holdMs, settleMs, repeats]);
+  }, [stepPercent, holdMs, settleMs, repeats, continuous]);
 
   const abort = useCallback(async () => {
     try { await invoke('abort_afr_delay_test'); } catch { /* best effort */ }
@@ -121,6 +127,7 @@ export const AfrDelayTestDialog: React.FC<Props> = ({ isOpen, onClose }) => {
   if (!isOpen) return null;
 
   const estSeconds = Math.round((repeats * (holdMs + settleMs)) / 1000);
+  const stepsPerMinute = Math.round(60000 / (holdMs + settleMs));
 
   return (
     <div className="dialog-overlay" onClick={running ? undefined : onClose}>
@@ -171,15 +178,24 @@ export const AfrDelayTestDialog: React.FC<Props> = ({ isOpen, onClose }) => {
           <label>
             Repeats
             <input type="number" min={1} max={200} step={1} value={repeats}
-              disabled={running}
+              disabled={running || continuous}
               onChange={(e) => setRepeats(Number(e.target.value))} />
             <span className="unit">steps</span>
+          </label>
+          <label className="afr-delay-continuous">
+            <input type="checkbox" checked={continuous} disabled={running}
+              onChange={(e) => setContinuous(e.target.checked)} />
+            Run until stopped
           </label>
         </div>
 
         <p className="afr-delay-estimate">
-          Approximately {estSeconds}s. Start recording first, and keep rpm and load
-          steady throughout.
+          {continuous
+            ? `Runs until you press Stop, about ${stepsPerMinute} steps per minute. `
+              + 'Start recording first. Drive normally - every steady moment adds a '
+              + 'measurement, and the map fills where you actually drive.'
+            : `Approximately ${estSeconds}s. Start recording first, and keep rpm and `
+              + 'load steady throughout.'}
         </p>
 
         {progress && (

--- a/crates/libretune-app/src/components/dialogs/AfrDelayTestDialog.tsx
+++ b/crates/libretune-app/src/components/dialogs/AfrDelayTestDialog.tsx
@@ -296,7 +296,12 @@ export const AfrDelayTestDialog: React.FC<Props> = ({ isOpen, onClose }) => {
         <div className="afr-delay-actions">
           {running ? (
             <button type="button" className="danger" onClick={abort}>
-              <Square size={14} /> Abort and restore
+              {/* "Stop", not "Abort": the copy above promises a Stop button,
+                  and this ends the run cleanly - the WUE slot is restored and
+                  every measurement collected so far is kept. "Abort" reads as
+                  "discard what you have", which is the opposite of what it
+                  does, and on a continuous run that is the ONLY way to finish. */}
+              <Square size={14} /> Stop and restore
             </button>
           ) : (
             <>

--- a/crates/libretune-app/src/components/dialogs/DelayTraceOverlay.tsx
+++ b/crates/libretune-app/src/components/dialogs/DelayTraceOverlay.tsx
@@ -1,5 +1,12 @@
 import React, { useMemo } from 'react';
 
+// Imported HERE, by the component that needs it, rather than from a shared
+// barrel: nothing imported that barrel, so every rule in this stylesheet was
+// dead and the traces fell back to the SVG defaults - fill black, stroke none.
+// A plot of 107 correctly-computed paths rendered as one black blob. Keeping
+// the import next to the markup it styles is what stops that recurring.
+import '../../styles/dialogs.css';
+
 /**
  * Overlaid pulse-width / AFR traces from the AFR delay test.
  *

--- a/crates/libretune-app/src/components/dialogs/DelayTraceOverlay.tsx
+++ b/crates/libretune-app/src/components/dialogs/DelayTraceOverlay.tsx
@@ -1,0 +1,206 @@
+import React, { useMemo } from 'react';
+
+/**
+ * Overlaid pulse-width / AFR traces from the AFR delay test.
+ *
+ * Why an overlay rather than a number per step: an 8% enrichment moves pulse
+ * width about 4% and AFR about 1 AFR, while per-trace scatter is +/-2-3 AFR.
+ * Single steps genuinely cannot be timed - on a 59-minute drive, per-step
+ * threshold detection returned anywhere from 52 ms to 2979 ms for what is one
+ * transport delay. Stacked, the same events give a clean curve.
+ *
+ * The delay is read where the median AFR reaches HALF its excursion. That is
+ * the steepest, most repeatable part of the rise, and it is the physically
+ * meaningful figure: the step response is the cumulative distribution of
+ * transit times, so its half-height is the median transit. The leading edge is
+ * only the fastest path, and it sits down in the noise - reading at 15%
+ * instead spread the same data over 25-300 ms including a physically
+ * impossible 25 ms.
+ */
+export interface TracePoint {
+  tMs: number;
+  afr: number;
+  pw?: number;
+}
+
+export interface DelayTrace {
+  step: number;
+  points: TracePoint[];
+  unusable: boolean;
+}
+
+interface Props {
+  traces: DelayTrace[];
+}
+
+const W = 560;
+const H = 300;
+const PAD = { l: 44, r: 46, t: 14, b: 28 };
+const T_MIN = -400;
+const T_MAX = 2000;
+/// Where on the rise the delay is read. See the note above.
+const ONSET_FRACTION = 0.5;
+/// Below this the AFR never really moved, so there is nothing to time.
+const MIN_EXCURSION = 0.25;
+/// Resample step for the median, in ms.
+const BIN = 25;
+
+/** Baseline-subtracted AFR, so traces from different mixtures overlay. */
+function normalise(points: TracePoint[]): TracePoint[] {
+  const pre = points.filter((p) => p.tMs < 0).map((p) => p.afr);
+  if (!pre.length) return [];
+  const sorted = [...pre].sort((a, b) => a - b);
+  const base = sorted[Math.floor(sorted.length / 2)];
+  const pwPre = points.filter((p) => p.tMs < 0 && p.pw != null).map((p) => p.pw as number);
+  const pwBase = pwPre.length
+    ? [...pwPre].sort((a, b) => a - b)[Math.floor(pwPre.length / 2)]
+    : 0;
+  return points.map((p) => ({
+    tMs: p.tMs,
+    afr: p.afr - base,
+    pw: p.pw == null ? undefined : p.pw - pwBase,
+  }));
+}
+
+function median(xs: number[]): number {
+  const s = [...xs].sort((a, b) => a - b);
+  return s.length % 2 ? s[(s.length - 1) / 2] : (s[s.length / 2 - 1] + s[s.length / 2]) / 2;
+}
+
+/** Median across traces on a fixed time grid, plus the 50% crossing. */
+function stack(traces: DelayTrace[]) {
+  const usable = traces.filter((t) => !t.unusable).map((t) => normalise(t.points));
+  const grid: number[] = [];
+  for (let t = T_MIN; t <= T_MAX; t += BIN) grid.push(t);
+
+  const med = grid.map((t) => {
+    const vals: number[] = [];
+    for (const tr of usable) {
+      // Linear interpolation between the samples either side of t. This is
+      // what recovers sub-sample timing: each step lands at a random phase
+      // relative to the sample clock, so averaging dithers. Bootstrapping a
+      // real drive gave +/-20 ms from 34 events at a 49 ms sample period.
+      for (let i = 1; i < tr.length; i++) {
+        const a = tr[i - 1];
+        const b = tr[i];
+        if (a.tMs <= t && t <= b.tMs) {
+          const f = b.tMs === a.tMs ? 0 : (t - a.tMs) / (b.tMs - a.tMs);
+          vals.push(a.afr + f * (b.afr - a.afr));
+          break;
+        }
+      }
+    }
+    return vals.length ? median(vals) : NaN;
+  });
+
+  const after = grid.map((t, i) => (t > 0 ? med[i] : NaN)).filter((v) => !Number.isNaN(v));
+  const peak = after.length ? Math.min(...after) : NaN;
+
+  let delayMs: number | null = null;
+  if (Number.isFinite(peak) && peak <= -MIN_EXCURSION) {
+    const thr = peak * ONSET_FRACTION;
+    for (let i = 1; i < grid.length; i++) {
+      if (grid[i] <= 0 || Number.isNaN(med[i]) || Number.isNaN(med[i - 1])) continue;
+      if (med[i] <= thr) {
+        const span = med[i - 1] - med[i];
+        const f = span === 0 ? 0 : (med[i - 1] - thr) / span;
+        delayMs = grid[i - 1] + f * BIN;
+        break;
+      }
+    }
+  }
+  return { grid, med, usableCount: usable.length, delayMs, peak };
+}
+
+export const DelayTraceOverlay: React.FC<Props> = ({ traces }) => {
+  const { grid, med, usableCount, delayMs, peak } = useMemo(() => stack(traces), [traces]);
+
+  const afrLo = -2.5;
+  const afrHi = 0.8;
+  const x = (t: number) => PAD.l + ((t - T_MIN) / (T_MAX - T_MIN)) * (W - PAD.l - PAD.r);
+  const y = (a: number) => PAD.t + ((afrHi - a) / (afrHi - afrLo)) * (H - PAD.t - PAD.b);
+
+  const path = (pts: TracePoint[]) =>
+    pts
+      .filter((p) => p.tMs >= T_MIN && p.tMs <= T_MAX)
+      .map((p, i) => `${i ? 'L' : 'M'}${x(p.tMs).toFixed(1)},${y(p.afr).toFixed(1)}`)
+      .join(' ');
+
+  const medPath = grid
+    .map((t, i) => (Number.isNaN(med[i]) ? null : `${x(t).toFixed(1)},${y(med[i]).toFixed(1)}`))
+    .filter(Boolean)
+    .map((c, i) => `${i ? 'L' : 'M'}${c}`)
+    .join(' ');
+
+  if (!traces.length) {
+    return (
+      <p className="delay-overlay-empty">
+        Traces appear here as steps complete. Each one is drawn faint; the bold line is
+        their median, and the delay is read where it reaches half its excursion.
+      </p>
+    );
+  }
+
+  return (
+    <div className="delay-overlay">
+      <svg viewBox={`0 0 ${W} ${H}`} role="img" aria-label="AFR response traces">
+        {/* zero lines */}
+        <line x1={x(0)} y1={PAD.t} x2={x(0)} y2={H - PAD.b} className="delay-overlay-step" />
+        <line x1={PAD.l} y1={y(0)} x2={W - PAD.r} y2={y(0)} className="delay-overlay-zero" />
+
+        {traces.map((t) => (
+          <path
+            key={t.step}
+            d={path(normalise(t.points))}
+            className={t.unusable ? 'delay-overlay-trace unusable' : 'delay-overlay-trace'}
+          />
+        ))}
+
+        {medPath && <path d={medPath} className="delay-overlay-median" />}
+
+        {delayMs != null && (
+          <>
+            <line
+              x1={x(delayMs)}
+              y1={PAD.t}
+              x2={x(delayMs)}
+              y2={H - PAD.b}
+              className="delay-overlay-marker"
+            />
+            <text x={x(delayMs) + 6} y={PAD.t + 14} className="delay-overlay-label">
+              {delayMs.toFixed(0)} ms
+            </text>
+          </>
+        )}
+
+        {[0, 500, 1000, 1500, 2000].map((t) => (
+          <text key={t} x={x(t)} y={H - 8} className="delay-overlay-tick">
+            {t / 1000}s
+          </text>
+        ))}
+        {[0, -1, -2].map((a) => (
+          <text key={a} x={8} y={y(a) + 4} className="delay-overlay-tick">
+            {a}
+          </text>
+        ))}
+      </svg>
+
+      <p className="delay-overlay-summary">
+        {usableCount} usable of {traces.length}
+        {traces.length - usableCount > 0 &&
+          ` (${traces.length - usableCount} during fuel cut or throttle movement)`}
+        {delayMs != null ? (
+          <>
+            {' — '}
+            <strong>{delayMs.toFixed(0)} ms</strong> at half of a {Math.abs(peak).toFixed(2)} AFR
+            excursion
+          </>
+        ) : (
+          ' — not enough movement to read a delay yet'
+        )}
+      </p>
+    </div>
+  );
+};
+
+export default DelayTraceOverlay;

--- a/crates/libretune-app/src/components/dialogs/__tests__/DelayTraceOverlay.test.tsx
+++ b/crates/libretune-app/src/components/dialogs/__tests__/DelayTraceOverlay.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import DelayTraceOverlay, { DelayTrace } from '../DelayTraceOverlay';
+
+/**
+ * A trace that sits at 14.7 until `startMs`, ramps linearly to `startMs + rampMs`
+ * ending `depth` AFR richer, then holds. Sampled every 49 ms to match the real
+ * logging rate, offset by `phase` so successive traces land at different points
+ * relative to the sample clock - that dither is what recovers sub-sample timing.
+ */
+function ramp(step: number, startMs: number, rampMs: number, depth: number, phase = 0): DelayTrace {
+  const points = [];
+  for (let t = -400 + phase; t <= 1200; t += 49) {
+    let afr = 14.7;
+    if (t > startMs) afr = 14.7 - depth * Math.min(1, (t - startMs) / rampMs);
+    points.push({ tMs: t, afr, pw: t > startMs ? 1.75 : 1.65 });
+  }
+  return { step, points, unusable: false };
+}
+
+describe('DelayTraceOverlay', () => {
+  it('reads the delay at half the excursion, not at the leading edge', () => {
+    // Ramp starts at 100 ms and completes at 300 ms, so the half-height is
+    // 200 ms. The leading edge would report ~100 ms, which is the fastest gas
+    // rather than the median transit time.
+    const traces = [0, 7, 13, 21, 33].map((phase, i) => ramp(i + 1, 100, 200, 1.0, phase));
+    render(<DelayTraceOverlay traces={traces} />);
+
+    const summary = screen.getByText(/usable of/);
+    const ms = Number(summary.textContent?.match(/(\d+)\s*ms/)?.[1]);
+    expect(ms).toBeGreaterThan(170);
+    expect(ms).toBeLessThan(230);
+  });
+
+  it('resolves finer than the 49 ms sample period', () => {
+    // Two populations 100 ms apart must be distinguishable even though that is
+    // only two samples: dithered phase plus interpolation gets well inside one
+    // sample interval.
+    const read = (start: number) => {
+      const { unmount } = render(
+        <DelayTraceOverlay
+          traces={[0, 11, 23, 37, 41].map((p, i) => ramp(i + 1, start, 200, 1.0, p))}
+        />,
+      );
+      const ms = Number(
+        screen.getByText(/usable of/).textContent?.match(/(\d+)\s*ms/)?.[1],
+      );
+      unmount();
+      return ms;
+    };
+    expect(read(300) - read(200)).toBeGreaterThan(60);
+  });
+
+  it('excludes steps taken during fuel cut or throttle movement', () => {
+    const good = [0, 9, 17].map((p, i) => ramp(i + 1, 100, 200, 1.0, p));
+    const junk = ramp(99, 900, 100, 3.0);
+    junk.unusable = true;
+
+    render(<DelayTraceOverlay traces={[...good, junk]} />);
+    const summary = screen.getByText(/usable of/);
+    expect(summary.textContent).toContain('3 usable of 4');
+    // The junk trace is late and deep; had it counted, the reading would move.
+    const ms = Number(summary.textContent?.match(/(\d+)\s*ms/)?.[1]);
+    expect(ms).toBeLessThan(300);
+  });
+
+  it('says so rather than inventing a number when nothing moved', () => {
+    const flat: DelayTrace = {
+      step: 1,
+      points: Array.from({ length: 30 }, (_, i) => ({ tMs: -400 + i * 49, afr: 14.7 })),
+      unusable: false,
+    };
+    render(<DelayTraceOverlay traces={[flat]} />);
+    expect(screen.getByText(/not enough movement/)).toBeInTheDocument();
+  });
+});

--- a/crates/libretune-app/src/styles/dialogs.css
+++ b/crates/libretune-app/src/styles/dialogs.css
@@ -1,0 +1,18 @@
+
+/* AFR delay-test trace overlay.
+   Individual steps are faint because none of them is readable on its own; the
+   median is what carries the measurement. Unusable steps (fuel cut, or the
+   throttle moving) are drawn dashed rather than hidden, so a run that produces
+   nothing shows why. */
+.delay-overlay svg { width: 100%; height: auto; background: var(--panel-bg, #1b1b1b); border-radius: 4px; }
+.delay-overlay-trace { fill: none; stroke: #4a90d9; stroke-width: 1; opacity: 0.18; }
+.delay-overlay-trace.unusable { stroke: #888; opacity: 0.12; stroke-dasharray: 2 3; }
+.delay-overlay-median { fill: none; stroke: #4a90d9; stroke-width: 2.5; }
+.delay-overlay-marker { stroke: #3fb950; stroke-width: 1.5; }
+.delay-overlay-label { fill: #3fb950; font-size: 12px; font-weight: 600; }
+.delay-overlay-step { stroke: #999; stroke-width: 1; stroke-dasharray: 3 3; }
+.delay-overlay-zero { stroke: #666; stroke-width: 0.75; }
+.delay-overlay-tick { fill: #999; font-size: 10px; }
+.delay-overlay-summary { margin: 4px 0 0; font-size: 12px; color: var(--text-secondary, #bbb); }
+.delay-overlay-empty { font-size: 12px; color: var(--text-secondary, #999); margin: 4px 0; }
+.afr-delay-overlay-section h3 { font-size: 13px; margin: 12px 0 4px; }


### PR DESCRIPTION
## Description
The AFR delay test previously ran a fixed batch of steps. Delay resolution comes from events per rpm/load bin, not sample rate (bootstrapping a real drive put a 34-event bin at ±20 ms and a 10-event bin at ±80 ms), so a fixed batch under-fills the map. `repeats = 0` now runs until stopped: the test keeps stepping while the car is driven normally and the map fills where the car actually goes. The stop button ends the run cleanly — the WUE byte is restored and every measurement is kept — and is labelled "Stop and restore" to match (on a continuous run it is the only way to finish; "Abort" read as "discard").

The dialog now overlays the pulse-width and AFR traces of every step, baseline-normalised and stacked, with the median and its 50% crossing marked. Single steps genuinely cannot be timed (per-step thresholding returned 52–2979 ms for what is one transport delay); stacked, the same events give a clean curve.

Also fixes `dialogs.css` being imported by nothing — every rule in it was dead, and the overlay's correctly-computed SVG paths rendered as a single black shape (SVG default fill, no stroke). The stylesheet is imported by the component that needs it, which is also what prevents it being orphaned again.

## Related
Builds on #176/#177 (the wueRates step test and responsive abort).

## Type of Change
- [x] New feature (non-breaking change that adds functionality)
- [x] Bug fix (the stylesheet import and button label)

## Testing
- [x] Used on a real 52-minute drive: 244 step edges collected, 115 usable measurements, ON/OFF edge medians 438/453 ms
- [x] `cargo test` green; `npx tsc --noEmit` clean; `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)