### PR TITLE
feat(wizard): Connect-ECU wizard skeleton (Phase 1)

### DIFF
--- a/crates/libretune-app/src/App.tsx
+++ b/crates/libretune-app/src/App.tsx
@@ -120,6 +120,7 @@ function AppContent() {
   const [availableProjects, setAvailableProjects] = useState<ProjectInfo[]>([]);
   const [repositoryInis, setRepositoryInis] = useState<IniEntry[]>([]);
   const [newProjectDialogOpen, setNewProjectDialogOpen] = useState(false);
+  const [connectEcuWizardOpen, setConnectEcuWizardOpen] = useState(false);
   const [baseMapDialogOpen, setBaseMapDialogOpen] = useState(false);
 
   // Connection state
@@ -1424,7 +1425,7 @@ function AppContent() {
     t, currentProject, tuneModified, status, ecuType, iniCapabilities, backendMenus, theme,
     sidebarVisible, showEcuMenus: showEcuMenusInMenubar, tabs, openTarget, handleStdTarget, openHelpTopic, showToast,
     closeProject, handleCreateRestorePoint,
-    setNewProjectDialogOpen, setImportProjectOpen, setSaveDialogOpen, setLoadDialogOpen,
+    setNewProjectDialogOpen, setConnectEcuWizardOpen, setImportProjectOpen, setSaveDialogOpen, setLoadDialogOpen,
     setBurnDialogOpen, setFirmwareUpdateDialogOpen, setRestorePointsOpen, setTuneHistoryOpen, setSettingsDialogOpen,
     setMathChannelsDialogOpen, setAfrDelayTestOpen, setBaseMapDialogOpen, setTableComparisonOpen,
     setTuneFileDiffOpen, setDynoOverlayOpen, setPluginPanelOpen, agentPanelVisible, setAgentPanelVisible, setConnectionDialogOpen,
@@ -1687,6 +1688,8 @@ function AppContent() {
         setConnectionRuntimePacketMode={setConnectionRuntimePacketMode}
         newProjectDialogOpen={newProjectDialogOpen}
         setNewProjectDialogOpen={setNewProjectDialogOpen}
+        connectEcuWizardOpen={connectEcuWizardOpen}
+        setConnectEcuWizardOpen={setConnectEcuWizardOpen}
         repositoryInis={repositoryInis}
         setRepositoryInis={setRepositoryInis}
         createProject={createProject}

--- a/crates/libretune-app/src/components/DialogOverlays.tsx
+++ b/crates/libretune-app/src/components/DialogOverlays.tsx
@@ -24,6 +24,7 @@ import MigrationReportDialog from "./dialogs/MigrationReportDialog";
 import TuneFileDiffDialog from "./dialogs/TuneFileDiffDialog";
 import DynoOverlay from "./tuner-ui/DynoOverlay";
 import NewProjectDialog from "./dialogs/NewProjectDialog";
+import ConnectEcuWizard from "./dialogs/ConnectEcuWizard";
 import BaseMapDialog, { BaseMapResult } from "./dialogs/BaseMapDialog";
 import TuneHistoryPanel from "./TuneHistoryPanel";
 import ErrorDetailsDialog from "./dialogs/ErrorDetailsDialog";
@@ -120,6 +121,8 @@ export interface DialogOverlaysProps {
   // Project
   newProjectDialogOpen: boolean;
   setNewProjectDialogOpen: (v: boolean) => void;
+  connectEcuWizardOpen: boolean;
+  setConnectEcuWizardOpen: (v: boolean) => void;
   repositoryInis: IniEntry[];
   setRepositoryInis: React.Dispatch<React.SetStateAction<IniEntry[]>>;
   createProject: (name: string, iniId: string) => Promise<boolean>;
@@ -215,6 +218,7 @@ export function DialogOverlays(props: DialogOverlaysProps) {
     iniDefaults, applyIniDefaults,
     connectionRuntimePacketMode, setConnectionRuntimePacketMode,
     newProjectDialogOpen, setNewProjectDialogOpen,
+    connectEcuWizardOpen, setConnectEcuWizardOpen,
     repositoryInis, setRepositoryInis, createProject, handleImportTuneIntoProject,
     baseMapDialogOpen, setBaseMapDialogOpen, handleBaseMapApply,
     tuneComparisonOpen, setTuneComparisonOpen, checkStatus,
@@ -313,6 +317,11 @@ export function DialogOverlays(props: DialogOverlaysProps) {
         runtimePacketMode={connectionRuntimePacketMode}
         onRuntimePacketModeChange={setConnectionRuntimePacketMode}
       />
+      <ConnectEcuWizard
+        isOpen={connectEcuWizardOpen}
+        onClose={() => setConnectEcuWizardOpen(false)}
+      />
+
       <NewProjectDialog
         isOpen={newProjectDialogOpen}
         onClose={() => setNewProjectDialogOpen(false)}

--- a/crates/libretune-app/src/components/dialogs/ConnectEcuWizard.tsx
+++ b/crates/libretune-app/src/components/dialogs/ConnectEcuWizard.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { open as openFileDialog } from "@tauri-apps/plugin-dialog";
 import { Dialog, Button } from "../common";
 import {
   WizardTransport,
@@ -12,8 +13,28 @@ import {
   stepTitle,
   isSerialTransport,
   paramsComplete,
+  bestLocalMatch,
   WIZARD_BAUD_RATES,
+  type WizardIniMatch,
 } from "../../utils/connectEcuWizard";
+
+interface ConnectResult {
+  signature: string;
+}
+interface OnlineIniEntry {
+  source: string;
+  name: string;
+  signature: string | null;
+  download_url: string;
+  repo_path: string;
+  size: number | null;
+}
+/** The INI the wizard has resolved for the ECU (from a local, online or manual source). */
+interface ResolvedIni {
+  path: string;
+  name: string;
+  source: string;
+}
 
 interface ConnectEcuWizardProps {
   isOpen: boolean;
@@ -21,15 +42,14 @@ interface ConnectEcuWizardProps {
 }
 
 /**
- * Connect-ECU wizard — Phase 1 skeleton.
+ * Connect-ECU wizard.
  *
- * Provides the guided multi-step shell (transport → params → connect → detect →
- * resolve INI → name). Navigation and the offline branch are fully wired and
- * unit-tested (`utils/connectEcuWizard.ts`); the per-step content is filled in
- * by later phases, which will reuse the existing `ConnectionDialog`,
- * `connect_to_ecu`, `search_online_inis` / `download_ini`, `import_ini` and
- * project-creation flows. Steps that aren't implemented yet show a clear
- * placeholder so the flow is navigable end-to-end.
+ * Guided flow: transport → connection params → connect & read signature →
+ * resolve the INI definition (auto local match → online search/download →
+ * manual upload) → name the project. Reuses existing backend commands
+ * (`get_serial_ports`, `connect_to_ecu`, `find_matching_inis`,
+ * `search_online_inis` / `download_ini`, `import_ini`). Project creation is the
+ * remaining step (Phase 4); the offline branch skips straight to naming.
  */
 export default function ConnectEcuWizard({ isOpen, onClose }: ConnectEcuWizardProps) {
   const [transport, setTransport] = useState<WizardTransport | null>(null);
@@ -59,11 +79,112 @@ export default function ConnectEcuWizard({ isOpen, onClose }: ConnectEcuWizardPr
     }
   }
 
+  // Connect + detect (Phase 3).
+  const [connecting, setConnecting] = useState(false);
+  const [signature, setSignature] = useState<string | null>(null);
+  const [connectError, setConnectError] = useState<string | null>(null);
+
+  // Resolve INI (Phase 3).
+  const [resolving, setResolving] = useState(false);
+  const [localMatches, setLocalMatches] = useState<WizardIniMatch[]>([]);
+  const [onlineResults, setOnlineResults] = useState<OnlineIniEntry[]>([]);
+  const [resolvedIni, setResolvedIni] = useState<ResolvedIni | null>(null);
+  const [resolveBusy, setResolveBusy] = useState<string | null>(null);
+
   // Scan serial ports when entering the params step for a serial transport.
   useEffect(() => {
     if (step === "params" && isSerialTransport(transport)) void scanPorts();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [step, transport]);
+
+  async function connectAndDetect() {
+    setConnecting(true);
+    setConnectError(null);
+    setSignature(null);
+    try {
+      const result = await invoke<ConnectResult>("connect_to_ecu", {
+        connectionType: transport === "wifi" ? "Tcp" : "Serial",
+        portName: isSerialTransport(transport) ? port : "",
+        baudRate: baud,
+        tcpHost: transport === "wifi" ? host : null,
+        tcpPort: transport === "wifi" ? tcpPort : null,
+      });
+      setSignature(result.signature);
+    } catch (e) {
+      setConnectError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setConnecting(false);
+    }
+  }
+
+  // Auto-connect when entering the connect step.
+  useEffect(() => {
+    if (step === "connect" && !connecting && signature === null && connectError === null) {
+      void connectAndDetect();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [step]);
+
+  async function resolveIni(sig: string) {
+    setResolving(true);
+    setLocalMatches([]);
+    setOnlineResults([]);
+    try {
+      const [local, online] = await Promise.all([
+        invoke<WizardIniMatch[]>("find_matching_inis", { ecuSignature: sig }).catch(() => []),
+        invoke<OnlineIniEntry[]>("search_online_inis", { signature: sig }).catch(() => []),
+      ]);
+      setLocalMatches(local);
+      setOnlineResults(online);
+      // Auto-select the best local match, if any.
+      const best = bestLocalMatch(local);
+      if (best) setResolvedIni({ path: best.path, name: best.name, source: "local" });
+    } finally {
+      setResolving(false);
+    }
+  }
+
+  // Kick off INI resolution when entering the resolve step (needs a signature).
+  useEffect(() => {
+    if (step === "resolveIni" && signature && !resolving && localMatches.length === 0 && onlineResults.length === 0) {
+      void resolveIni(signature);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [step, signature]);
+
+  async function downloadOnline(entry: OnlineIniEntry) {
+    setResolveBusy(entry.download_url);
+    try {
+      const path = await invoke<string>("download_ini", {
+        downloadUrl: entry.download_url,
+        name: entry.name,
+        source: entry.source,
+      });
+      setResolvedIni({ path, name: entry.name, source: entry.source });
+    } catch {
+      /* surfaced via lack of selection */
+    } finally {
+      setResolveBusy(null);
+    }
+  }
+
+  async function pickManualIni() {
+    const selected = await openFileDialog({
+      filters: [{ name: "INI definition", extensions: ["ini"] }],
+    });
+    if (!selected || Array.isArray(selected)) return;
+    setResolveBusy("manual");
+    try {
+      const entry = await invoke<{ path: string; name: string }>("import_ini", {
+        sourcePath: selected,
+      });
+      setResolvedIni({ path: entry.path, name: entry.name, source: "manual" });
+    } catch {
+      /* ignore */
+    } finally {
+      setResolveBusy(null);
+    }
+  }
 
   const steps = wizardSteps(transport);
   const stepIndex = steps.indexOf(step);
@@ -73,7 +194,11 @@ export default function ConnectEcuWizard({ isOpen, onClose }: ConnectEcuWizardPr
       ? transport !== null
       : step === "params"
         ? paramsComplete(transport, params)
-        : true;
+        : step === "connect"
+          ? signature !== null
+          : step === "resolveIni"
+            ? resolvedIni !== null
+            : true;
 
   function reset() {
     setTransport(null);
@@ -82,6 +207,12 @@ export default function ConnectEcuWizard({ isOpen, onClose }: ConnectEcuWizardPr
     setPorts([]);
     setPort("");
     setHost("");
+    setConnecting(false);
+    setSignature(null);
+    setConnectError(null);
+    setLocalMatches([]);
+    setOnlineResults([]);
+    setResolvedIni(null);
   }
   function handleClose() {
     reset();
@@ -187,17 +318,79 @@ export default function ConnectEcuWizard({ isOpen, onClose }: ConnectEcuWizardPr
         )}
 
         {step === "connect" && (
-          <PlaceholderStep
-            phase="Phase 3"
-            text="Connects (connect_to_ecu) and reads the ECU firmware signature."
-          />
+          <div>
+            {connecting && <div style={{ opacity: 0.8 }}>Connecting and reading the ECU signature…</div>}
+            {signature && !connecting && (
+              <div style={{ color: "var(--color-success, #2a2)" }}>
+                ✓ ECU detected. Signature:
+                <div style={{ fontFamily: "monospace", marginTop: 4, wordBreak: "break-all" }}>{signature}</div>
+              </div>
+            )}
+            {connectError && !connecting && (
+              <div>
+                <div style={{ color: "var(--color-error, #d33)" }}>Could not connect: {connectError}</div>
+                <Button variant="secondary" onClick={connectAndDetect} style={{ marginTop: "0.5rem" }}>
+                  Retry
+                </Button>
+              </div>
+            )}
+          </div>
         )}
 
         {step === "resolveIni" && (
-          <PlaceholderStep
-            phase="Phase 3"
-            text="Resolves the INI definition automatically: local match by signature → online search/download → manual upload fallback."
-          />
+          <div style={{ display: "flex", flexDirection: "column", gap: "0.75rem" }}>
+            {resolving && <div style={{ opacity: 0.8 }}>Looking for a matching definition…</div>}
+
+            {resolvedIni && (
+              <div style={{ color: "var(--color-success, #2a2)" }}>
+                ✓ Using <b>{resolvedIni.name}</b> ({resolvedIni.source}).
+              </div>
+            )}
+
+            {localMatches.length > 0 && (
+              <div>
+                <div style={{ fontWeight: 600, marginBottom: 4 }}>Local matches</div>
+                {localMatches.map((m) => (
+                  <div key={m.path} style={{ display: "flex", alignItems: "center", gap: 8, padding: "2px 0" }}>
+                    <span style={{ flex: 1 }}>
+                      {m.name} <span style={{ opacity: 0.6, fontSize: 12 }}>({m.match_type})</span>
+                    </span>
+                    <Button variant="secondary" onClick={() => setResolvedIni({ path: m.path, name: m.name, source: "local" })}>
+                      Use
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {onlineResults.length > 0 && (
+              <div>
+                <div style={{ fontWeight: 600, marginBottom: 4 }}>Online</div>
+                {onlineResults.slice(0, 8).map((e) => (
+                  <div key={e.download_url} style={{ display: "flex", alignItems: "center", gap: 8, padding: "2px 0" }}>
+                    <span style={{ flex: 1, wordBreak: "break-all" }}>
+                      {e.name} <span style={{ opacity: 0.6, fontSize: 12 }}>({e.source})</span>
+                    </span>
+                    <Button variant="secondary" onClick={() => downloadOnline(e)} disabled={resolveBusy !== null}>
+                      {resolveBusy === e.download_url ? "Downloading…" : "Download & use"}
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {!resolving && localMatches.length === 0 && onlineResults.length === 0 && (
+              <div style={{ opacity: 0.8 }}>
+                No matching definition found locally or online. Upload the <code>.ini</code> from your ECU bundle.
+              </div>
+            )}
+
+            <div>
+              <Button variant="secondary" onClick={pickManualIni} disabled={resolveBusy === "manual"}>
+                {resolveBusy === "manual" ? "Importing…" : "Choose .ini file manually…"}
+              </Button>
+            </div>
+          </div>
         )}
 
         {step === "name" && (
@@ -246,21 +439,5 @@ export default function ConnectEcuWizard({ isOpen, onClose }: ConnectEcuWizardPr
         )}
       </Dialog.Footer>
     </Dialog>
-  );
-}
-
-function PlaceholderStep({ phase, text }: { phase: string; text: string }) {
-  return (
-    <div
-      style={{
-        border: "1px dashed var(--color-border, #8884)",
-        borderRadius: 6,
-        padding: "1rem",
-        opacity: 0.85,
-      }}
-    >
-      <div style={{ fontWeight: 600, marginBottom: "0.25rem" }}>Coming in {phase}</div>
-      <div style={{ fontSize: 13 }}>{text}</div>
-    </div>
   );
 }

--- a/crates/libretune-app/src/components/dialogs/ConnectEcuWizard.tsx
+++ b/crates/libretune-app/src/components/dialogs/ConnectEcuWizard.tsx
@@ -1,0 +1,162 @@
+import { useState } from "react";
+import { Dialog, Button } from "../common";
+import {
+  WizardTransport,
+  WizardStep,
+  wizardSteps,
+  nextStep,
+  prevStep,
+  isLastStep,
+  transportLabel,
+  stepTitle,
+} from "../../utils/connectEcuWizard";
+
+interface ConnectEcuWizardProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Connect-ECU wizard — Phase 1 skeleton.
+ *
+ * Provides the guided multi-step shell (transport → params → connect → detect →
+ * resolve INI → name). Navigation and the offline branch are fully wired and
+ * unit-tested (`utils/connectEcuWizard.ts`); the per-step content is filled in
+ * by later phases, which will reuse the existing `ConnectionDialog`,
+ * `connect_to_ecu`, `search_online_inis` / `download_ini`, `import_ini` and
+ * project-creation flows. Steps that aren't implemented yet show a clear
+ * placeholder so the flow is navigable end-to-end.
+ */
+export default function ConnectEcuWizard({ isOpen, onClose }: ConnectEcuWizardProps) {
+  const [transport, setTransport] = useState<WizardTransport | null>(null);
+  const [step, setStep] = useState<WizardStep>("transport");
+  const [projectName, setProjectName] = useState("");
+
+  const steps = wizardSteps(transport);
+  const stepIndex = steps.indexOf(step);
+  const last = isLastStep(step, transport);
+  const canAdvance = step !== "transport" || transport !== null;
+
+  function reset() {
+    setTransport(null);
+    setStep("transport");
+    setProjectName("");
+  }
+  function handleClose() {
+    reset();
+    onClose();
+  }
+
+  const transports: WizardTransport[] = ["usb", "bluetooth", "wifi", "offline"];
+
+  return (
+    <Dialog open={isOpen} onClose={handleClose} title="Connect ECU / New Project" size="md">
+      <Dialog.Body>
+        <div style={{ opacity: 0.7, fontSize: 12, marginBottom: "0.75rem" }}>
+          Step {stepIndex + 1} of {steps.length} — {stepTitle(step)}
+        </div>
+
+        {step === "transport" && (
+          <div style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+            {transports.map((t) => (
+              <label
+                key={t}
+                style={{ display: "flex", alignItems: "center", gap: "0.5rem", cursor: "pointer" }}
+              >
+                <input
+                  type="radio"
+                  name="wizard-transport"
+                  checked={transport === t}
+                  onChange={() => setTransport(t)}
+                />
+                <span>{transportLabel(t)}</span>
+              </label>
+            ))}
+          </div>
+        )}
+
+        {step === "params" && (
+          <PlaceholderStep
+            phase="Phase 2"
+            text={`Connection settings for ${transport ? transportLabel(transport) : ""} (port / baud, or host / TCP port) go here — reusing the existing ConnectionDialog fields and port scan.`}
+          />
+        )}
+
+        {step === "connect" && (
+          <PlaceholderStep
+            phase="Phase 3"
+            text="Connects (connect_to_ecu) and reads the ECU firmware signature."
+          />
+        )}
+
+        {step === "resolveIni" && (
+          <PlaceholderStep
+            phase="Phase 3"
+            text="Resolves the INI definition automatically: local match by signature → online search/download → manual upload fallback."
+          />
+        )}
+
+        {step === "name" && (
+          <div>
+            <label style={{ display: "block", marginBottom: "0.5rem" }}>Project name</label>
+            <input
+              type="text"
+              value={projectName}
+              placeholder="My ECU project"
+              onChange={(e) => setProjectName(e.target.value)}
+              style={{ width: "100%" }}
+            />
+            {transport === "offline" && (
+              <p style={{ opacity: 0.7, fontSize: 12, marginTop: "0.5rem" }}>
+                Offline: you'll pick an INI definition by hand (today's New Project behaviour).
+              </p>
+            )}
+            <p style={{ opacity: 0.6, fontSize: 12, marginTop: "0.75rem" }}>
+              Project creation is wired in a later phase.
+            </p>
+          </div>
+        )}
+      </Dialog.Body>
+
+      <Dialog.Footer>
+        <Button variant="secondary" onClick={handleClose}>
+          Cancel
+        </Button>
+        {stepIndex > 0 && (
+          <Button variant="secondary" onClick={() => setStep(prevStep(step, transport))}>
+            Back
+          </Button>
+        )}
+        {last ? (
+          <Button variant="primary" onClick={handleClose} disabled={!projectName.trim()}>
+            Finish
+          </Button>
+        ) : (
+          <Button
+            variant="primary"
+            onClick={() => setStep(nextStep(step, transport))}
+            disabled={!canAdvance}
+          >
+            Next
+          </Button>
+        )}
+      </Dialog.Footer>
+    </Dialog>
+  );
+}
+
+function PlaceholderStep({ phase, text }: { phase: string; text: string }) {
+  return (
+    <div
+      style={{
+        border: "1px dashed var(--color-border, #8884)",
+        borderRadius: 6,
+        padding: "1rem",
+        opacity: 0.85,
+      }}
+    >
+      <div style={{ fontWeight: 600, marginBottom: "0.25rem" }}>Coming in {phase}</div>
+      <div style={{ fontSize: 13 }}>{text}</div>
+    </div>
+  );
+}

--- a/crates/libretune-app/src/components/dialogs/ConnectEcuWizard.tsx
+++ b/crates/libretune-app/src/components/dialogs/ConnectEcuWizard.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import { invoke } from "@tauri-apps/api/core";
 import { Dialog, Button } from "../common";
 import {
   WizardTransport,
@@ -9,6 +10,9 @@ import {
   isLastStep,
   transportLabel,
   stepTitle,
+  isSerialTransport,
+  paramsComplete,
+  WIZARD_BAUD_RATES,
 } from "../../utils/connectEcuWizard";
 
 interface ConnectEcuWizardProps {
@@ -32,15 +36,52 @@ export default function ConnectEcuWizard({ isOpen, onClose }: ConnectEcuWizardPr
   const [step, setStep] = useState<WizardStep>("transport");
   const [projectName, setProjectName] = useState("");
 
+  // Connection parameters (Phase 2).
+  const [ports, setPorts] = useState<string[]>([]);
+  const [scanningPorts, setScanningPorts] = useState(false);
+  const [port, setPort] = useState("");
+  const [baud, setBaud] = useState(115200);
+  const [host, setHost] = useState("");
+  const [tcpPort, setTcpPort] = useState(29000);
+
+  const params = { port, baud, host, tcpPort };
+
+  async function scanPorts() {
+    setScanningPorts(true);
+    try {
+      const found = await invoke<string[]>("get_serial_ports");
+      setPorts(found);
+      if (found.length > 0 && !found.includes(port)) setPort(found[0]);
+    } catch {
+      setPorts([]);
+    } finally {
+      setScanningPorts(false);
+    }
+  }
+
+  // Scan serial ports when entering the params step for a serial transport.
+  useEffect(() => {
+    if (step === "params" && isSerialTransport(transport)) void scanPorts();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [step, transport]);
+
   const steps = wizardSteps(transport);
   const stepIndex = steps.indexOf(step);
   const last = isLastStep(step, transport);
-  const canAdvance = step !== "transport" || transport !== null;
+  const canAdvance =
+    step === "transport"
+      ? transport !== null
+      : step === "params"
+        ? paramsComplete(transport, params)
+        : true;
 
   function reset() {
     setTransport(null);
     setStep("transport");
     setProjectName("");
+    setPorts([]);
+    setPort("");
+    setHost("");
   }
   function handleClose() {
     reset();
@@ -75,11 +116,74 @@ export default function ConnectEcuWizard({ isOpen, onClose }: ConnectEcuWizardPr
           </div>
         )}
 
-        {step === "params" && (
-          <PlaceholderStep
-            phase="Phase 2"
-            text={`Connection settings for ${transport ? transportLabel(transport) : ""} (port / baud, or host / TCP port) go here — reusing the existing ConnectionDialog fields and port scan.`}
-          />
+        {step === "params" && isSerialTransport(transport) && (
+          <div style={{ display: "flex", flexDirection: "column", gap: "0.75rem" }}>
+            {transport === "bluetooth" && (
+              <p style={{ opacity: 0.7, fontSize: 12, margin: 0 }}>
+                Bluetooth ECUs appear as a serial (COM) port — pair the device in your OS
+                first, then pick its port below.
+              </p>
+            )}
+            <div>
+              <label style={{ display: "block", marginBottom: "0.25rem" }}>Port</label>
+              <div style={{ display: "flex", gap: "0.5rem" }}>
+                <select
+                  value={port}
+                  onChange={(e) => setPort(e.target.value)}
+                  style={{ flex: 1 }}
+                >
+                  {ports.length === 0 ? (
+                    <option value="">No ports found</option>
+                  ) : (
+                    ports.map((p) => (
+                      <option key={p} value={p}>
+                        {p}
+                      </option>
+                    ))
+                  )}
+                </select>
+                <Button variant="secondary" onClick={scanPorts} disabled={scanningPorts}>
+                  {scanningPorts ? "Scanning…" : "Refresh"}
+                </Button>
+              </div>
+            </div>
+            <div>
+              <label style={{ display: "block", marginBottom: "0.25rem" }}>Baud rate</label>
+              <select value={baud} onChange={(e) => setBaud(parseInt(e.target.value))}>
+                {WIZARD_BAUD_RATES.map((b) => (
+                  <option key={b} value={b}>
+                    {b}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+        )}
+
+        {step === "params" && transport === "wifi" && (
+          <div style={{ display: "flex", flexDirection: "column", gap: "0.75rem" }}>
+            <p style={{ opacity: 0.7, fontSize: 12, margin: 0 }}>
+              For a networked ECU (e.g. rusEFI over WiFi), enter its host/IP and TCP port.
+            </p>
+            <div>
+              <label style={{ display: "block", marginBottom: "0.25rem" }}>Host / IP</label>
+              <input
+                type="text"
+                value={host}
+                placeholder="192.168.4.1"
+                onChange={(e) => setHost(e.target.value)}
+                style={{ width: "100%" }}
+              />
+            </div>
+            <div>
+              <label style={{ display: "block", marginBottom: "0.25rem" }}>TCP port</label>
+              <input
+                type="number"
+                value={tcpPort}
+                onChange={(e) => setTcpPort(parseInt(e.target.value) || 0)}
+              />
+            </div>
+          </div>
         )}
 
         {step === "connect" && (

--- a/crates/libretune-app/src/menus/buildMenuItems.ts
+++ b/crates/libretune-app/src/menus/buildMenuItems.ts
@@ -35,6 +35,7 @@ export interface BuildMenuItemsDeps {
   handleCreateRestorePoint: () => void;
   // Setters
   setNewProjectDialogOpen: (open: boolean) => void;
+  setConnectEcuWizardOpen: (open: boolean) => void;
   setImportProjectOpen: (open: boolean) => void;
   setSaveDialogOpen: (open: boolean) => void;
   setLoadDialogOpen: (open: boolean) => void;
@@ -76,7 +77,7 @@ export function buildMenuItems(deps: BuildMenuItemsDeps): TunerMenuItem[] {
     t, currentProject, tuneModified, status, ecuType, iniCapabilities, backendMenus, theme,
     sidebarVisible, showEcuMenus, tabs, openTarget, handleStdTarget, openHelpTopic, showToast,
     closeProject, handleCreateRestorePoint,
-    setNewProjectDialogOpen, setImportProjectOpen, setSaveDialogOpen, setLoadDialogOpen,
+    setNewProjectDialogOpen, setConnectEcuWizardOpen, setImportProjectOpen, setSaveDialogOpen, setLoadDialogOpen,
     setBurnDialogOpen, setFirmwareUpdateDialogOpen, setRestorePointsOpen, setTuneHistoryOpen, setSettingsDialogOpen,
     setMathChannelsDialogOpen, setAfrDelayTestOpen, setBaseMapDialogOpen, setTableComparisonOpen,
     setTuneFileDiffOpen, setDynoOverlayOpen, setPluginPanelOpen, agentPanelVisible, setAgentPanelVisible, setConnectionDialogOpen,
@@ -87,6 +88,7 @@ export function buildMenuItems(deps: BuildMenuItemsDeps): TunerMenuItem[] {
   const fileMenuItems: TunerMenuItem["items"] = currentProject
     ? [
         { id: "new-project", label: t('file.newProject'), onClick: () => setNewProjectDialogOpen(true) },
+        { id: "connect-ecu-wizard", label: "Connect ECU / New Project…", onClick: () => setConnectEcuWizardOpen(true) },
         { id: "import-project", label: t('file.importProject'), onClick: () => setImportProjectOpen(true) },
         { id: "close-project", label: t('file.closeProject'), onClick: closeProject },
         { id: "sep1", label: "", separator: true },
@@ -104,6 +106,7 @@ export function buildMenuItems(deps: BuildMenuItemsDeps): TunerMenuItem[] {
       ]
     : [
         { id: "new-project", label: t('file.newProject'), onClick: () => setNewProjectDialogOpen(true) },
+        { id: "connect-ecu-wizard", label: "Connect ECU / New Project…", onClick: () => setConnectEcuWizardOpen(true) },
         { id: "import-project", label: t('file.importProject'), onClick: () => setImportProjectOpen(true) },
         { id: "sep1", label: "", separator: true },
         { id: "settings", label: t('file.settings'), onClick: () => setSettingsDialogOpen(true) },

--- a/crates/libretune-app/src/utils/__tests__/connectEcuWizard.test.ts
+++ b/crates/libretune-app/src/utils/__tests__/connectEcuWizard.test.ts
@@ -8,7 +8,9 @@ import {
   stepTitle,
   isSerialTransport,
   paramsComplete,
+  bestLocalMatch,
   type WizardStep,
+  type WizardIniMatch,
 } from "../connectEcuWizard";
 
 describe("wizardSteps", () => {
@@ -81,6 +83,29 @@ describe("paramsComplete", () => {
 
   it("needs nothing for offline", () => {
     expect(paramsComplete("offline", base)).toBe(true);
+  });
+});
+
+describe("bestLocalMatch", () => {
+  const m = (name: string, match_type: WizardIniMatch["match_type"]): WizardIniMatch => ({
+    path: `/${name}.ini`,
+    name,
+    signature: name,
+    match_type,
+  });
+
+  it("prefers an exact match over partials", () => {
+    const matches = [m("a", "partial"), m("b", "exact"), m("c", "partial")];
+    expect(bestLocalMatch(matches)?.name).toBe("b");
+  });
+
+  it("falls back to the first partial match", () => {
+    expect(bestLocalMatch([m("a", "partial"), m("b", "partial")])?.name).toBe("a");
+  });
+
+  it("never auto-selects a full mismatch, and handles empty", () => {
+    expect(bestLocalMatch([m("a", "mismatch")])).toBeNull();
+    expect(bestLocalMatch([])).toBeNull();
   });
 });
 

--- a/crates/libretune-app/src/utils/__tests__/connectEcuWizard.test.ts
+++ b/crates/libretune-app/src/utils/__tests__/connectEcuWizard.test.ts
@@ -6,6 +6,8 @@ import {
   isLastStep,
   transportLabel,
   stepTitle,
+  isSerialTransport,
+  paramsComplete,
   type WizardStep,
 } from "../connectEcuWizard";
 
@@ -50,6 +52,35 @@ describe("isLastStep", () => {
     expect(isLastStep("resolveIni", "usb")).toBe(false);
     expect(isLastStep("name", "offline")).toBe(true);
     expect(isLastStep("transport", "offline")).toBe(false);
+  });
+});
+
+describe("isSerialTransport", () => {
+  it("treats USB and Bluetooth as serial, WiFi and offline as not", () => {
+    expect(isSerialTransport("usb")).toBe(true);
+    expect(isSerialTransport("bluetooth")).toBe(true);
+    expect(isSerialTransport("wifi")).toBe(false);
+    expect(isSerialTransport("offline")).toBe(false);
+  });
+});
+
+describe("paramsComplete", () => {
+  const base = { port: "", baud: 115200, host: "", tcpPort: 29000 };
+
+  it("requires a port for serial transports", () => {
+    expect(paramsComplete("usb", base)).toBe(false);
+    expect(paramsComplete("usb", { ...base, port: "COM3" })).toBe(true);
+    expect(paramsComplete("bluetooth", { ...base, port: "COM7" })).toBe(true);
+  });
+
+  it("requires host and a positive port for WiFi", () => {
+    expect(paramsComplete("wifi", base)).toBe(false);
+    expect(paramsComplete("wifi", { ...base, host: "192.168.1.10" })).toBe(true);
+    expect(paramsComplete("wifi", { ...base, host: "192.168.1.10", tcpPort: 0 })).toBe(false);
+  });
+
+  it("needs nothing for offline", () => {
+    expect(paramsComplete("offline", base)).toBe(true);
   });
 });
 

--- a/crates/libretune-app/src/utils/__tests__/connectEcuWizard.test.ts
+++ b/crates/libretune-app/src/utils/__tests__/connectEcuWizard.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import {
+  wizardSteps,
+  nextStep,
+  prevStep,
+  isLastStep,
+  transportLabel,
+  stepTitle,
+  type WizardStep,
+} from "../connectEcuWizard";
+
+describe("wizardSteps", () => {
+  it("walks the full flow for a live transport", () => {
+    const expected: WizardStep[] = ["transport", "params", "connect", "resolveIni", "name"];
+    expect(wizardSteps("usb")).toEqual(expected);
+    expect(wizardSteps("bluetooth")).toEqual(expected);
+    expect(wizardSteps("wifi")).toEqual(expected);
+    expect(wizardSteps(null)).toEqual(expected);
+  });
+
+  it("skips connection steps when offline", () => {
+    expect(wizardSteps("offline")).toEqual(["transport", "name"]);
+  });
+});
+
+describe("nextStep / prevStep", () => {
+  it("advances through a live flow and clamps at the end", () => {
+    expect(nextStep("transport", "usb")).toBe("params");
+    expect(nextStep("params", "usb")).toBe("connect");
+    expect(nextStep("connect", "usb")).toBe("resolveIni");
+    expect(nextStep("resolveIni", "usb")).toBe("name");
+    expect(nextStep("name", "usb")).toBe("name"); // clamps
+  });
+
+  it("goes back and clamps at the start", () => {
+    expect(prevStep("name", "usb")).toBe("resolveIni");
+    expect(prevStep("params", "usb")).toBe("transport");
+    expect(prevStep("transport", "usb")).toBe("transport"); // clamps
+  });
+
+  it("jumps straight to name (and back) on the offline path", () => {
+    expect(nextStep("transport", "offline")).toBe("name");
+    expect(prevStep("name", "offline")).toBe("transport");
+  });
+});
+
+describe("isLastStep", () => {
+  it("is true only on the final step of the active path", () => {
+    expect(isLastStep("name", "usb")).toBe(true);
+    expect(isLastStep("resolveIni", "usb")).toBe(false);
+    expect(isLastStep("name", "offline")).toBe(true);
+    expect(isLastStep("transport", "offline")).toBe(false);
+  });
+});
+
+describe("labels", () => {
+  it("labels transports and steps", () => {
+    expect(transportLabel("usb")).toMatch(/USB/);
+    expect(transportLabel("offline")).toMatch(/No connection/);
+    expect(stepTitle("resolveIni")).toMatch(/definition/i);
+  });
+});

--- a/crates/libretune-app/src/utils/connectEcuWizard.ts
+++ b/crates/libretune-app/src/utils/connectEcuWizard.ts
@@ -27,6 +27,40 @@ export function wizardSteps(transport: WizardTransport | null): WizardStep[] {
   return ["transport", "params", "connect", "resolveIni", "name"];
 }
 
+/** Whether a transport talks over a serial port (USB or a Bluetooth COM port). */
+export function isSerialTransport(transport: WizardTransport | null): boolean {
+  return transport === "usb" || transport === "bluetooth";
+}
+
+/** Common baud rates offered for serial connections. */
+export const WIZARD_BAUD_RATES = [9600, 38400, 57600, 115200, 230400, 460800, 921600];
+
+/** Connection parameters collected on the "params" step. */
+export interface WizardConnectionParams {
+  /** Serial / Bluetooth COM port. */
+  port: string;
+  /** Serial / Bluetooth baud rate. */
+  baud: number;
+  /** WiFi / TCP host. */
+  host: string;
+  /** WiFi / TCP port. */
+  tcpPort: number;
+}
+
+/**
+ * Whether the connection parameters for a transport are complete enough to
+ * attempt a connection. Serial/Bluetooth need a port; WiFi needs host + port;
+ * offline needs nothing.
+ */
+export function paramsComplete(
+  transport: WizardTransport | null,
+  p: WizardConnectionParams,
+): boolean {
+  if (isSerialTransport(transport)) return p.port.trim().length > 0;
+  if (transport === "wifi") return p.host.trim().length > 0 && p.tcpPort > 0;
+  return true;
+}
+
 /** The step after `current`, or `current` itself when already at the last step. */
 export function nextStep(current: WizardStep, transport: WizardTransport | null): WizardStep {
   const steps = wizardSteps(transport);

--- a/crates/libretune-app/src/utils/connectEcuWizard.ts
+++ b/crates/libretune-app/src/utils/connectEcuWizard.ts
@@ -1,0 +1,80 @@
+/**
+ * State model for the "Connect ECU" wizard (Phase 1 — navigation skeleton).
+ *
+ * The wizard guides a first-time ECU connection: pick a transport, enter the
+ * connection parameters, connect and read the ECU's firmware signature, resolve
+ * the matching INI definition (local → online → manual), then name and create
+ * the project. This module holds only the *step ordering* logic so it can be
+ * unit-tested without any UI or Tauri backend. Later phases fill each step in.
+ */
+
+/** How the user connects to the ECU. */
+export type WizardTransport = "usb" | "bluetooth" | "wifi" | "offline";
+
+/** The ordered steps of the wizard. */
+export type WizardStep = "transport" | "params" | "connect" | "resolveIni" | "name";
+
+/**
+ * The steps that apply for a given transport.
+ *
+ * The "offline" path skips everything connection-related and goes straight from
+ * choosing the transport to naming the project (the user picks an INI by hand,
+ * matching today's New Project behaviour). A live transport walks the full
+ * connect → detect → resolve flow.
+ */
+export function wizardSteps(transport: WizardTransport | null): WizardStep[] {
+  if (transport === "offline") return ["transport", "name"];
+  return ["transport", "params", "connect", "resolveIni", "name"];
+}
+
+/** The step after `current`, or `current` itself when already at the last step. */
+export function nextStep(current: WizardStep, transport: WizardTransport | null): WizardStep {
+  const steps = wizardSteps(transport);
+  const i = steps.indexOf(current);
+  if (i < 0) return steps[0];
+  return steps[Math.min(i + 1, steps.length - 1)];
+}
+
+/** The step before `current`, or `current` itself when already at the first step. */
+export function prevStep(current: WizardStep, transport: WizardTransport | null): WizardStep {
+  const steps = wizardSteps(transport);
+  const i = steps.indexOf(current);
+  if (i <= 0) return steps[0];
+  return steps[i - 1];
+}
+
+/** Whether `current` is the final step for this transport. */
+export function isLastStep(current: WizardStep, transport: WizardTransport | null): boolean {
+  const steps = wizardSteps(transport);
+  return steps.indexOf(current) === steps.length - 1;
+}
+
+/** Human labels for the transports. */
+export function transportLabel(t: WizardTransport): string {
+  switch (t) {
+    case "usb":
+      return "USB / Serial";
+    case "bluetooth":
+      return "Bluetooth";
+    case "wifi":
+      return "WiFi / Network (TCP)";
+    case "offline":
+      return "No connection right now";
+  }
+}
+
+/** Short title shown in the wizard header for each step. */
+export function stepTitle(step: WizardStep): string {
+  switch (step) {
+    case "transport":
+      return "How do you want to connect?";
+    case "params":
+      return "Connection settings";
+    case "connect":
+      return "Connecting & detecting ECU";
+    case "resolveIni":
+      return "ECU definition";
+    case "name":
+      return "Name your project";
+  }
+}

--- a/crates/libretune-app/src/utils/connectEcuWizard.ts
+++ b/crates/libretune-app/src/utils/connectEcuWizard.ts
@@ -61,6 +61,26 @@ export function paramsComplete(
   return true;
 }
 
+/** A local INI candidate matched against the ECU signature. */
+export interface WizardIniMatch {
+  path: string;
+  name: string;
+  signature: string;
+  match_type: "exact" | "partial" | "mismatch";
+}
+
+/**
+ * Pick the best local INI for a signature: an exact match wins, otherwise the
+ * first partial match. Full mismatches are never auto-selected.
+ */
+export function bestLocalMatch(matches: WizardIniMatch[]): WizardIniMatch | null {
+  return (
+    matches.find((m) => m.match_type === "exact") ??
+    matches.find((m) => m.match_type === "partial") ??
+    null
+  );
+}
+
 /** The step after `current`, or `current` itself when already at the last step. */
 export function nextStep(current: WizardStep, transport: WizardTransport | null): WizardStep {
   const steps = wizardSteps(transport);


### PR DESCRIPTION
## Description

First slice of a guided **"Connect a new ECU"** flow, modelled on how TunerStudio / rusEFI Console onboard a controller: choose a transport (USB / Bluetooth / WiFi / offline), then walk **connect → detect firmware signature → resolve INI (local → online → manual) → name the project**.

This PR lands only the **navigable skeleton + menu entry** (Phase 1). Each connection/resolve step shows a clear "coming in a later phase" placeholder; the real logic will **reuse existing building blocks** — `ConnectionDialog`, `connect_to_ecu`, `search_online_inis` / `download_ini`, `import_ini`, project creation — so this is orchestration, not new backend.

Part of a phased plan (Phase 2: transport/connection params; Phase 3: signature read + auto-resolve INI; Phase 4: project creation + offline branch; Phase 5: polish).

## Type of Change
- [ ] Bug fix
- [x] New feature (non-breaking; behind a new, opt-in menu entry)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Changes Made
- New `ConnectEcuWizard` dialog (multi-step shell) + **File → "Connect ECU / New Project…"** menu entry, wired through `buildMenuItems` / `App` / `DialogOverlays` (existing dialog pattern).
- Step-ordering logic in `utils/connectEcuWizard.ts` — a pure module that also handles the **offline branch** (skips the connection steps) — with full vitest coverage.

## Testing
- [ ] I have tested these changes locally
- [ ] New and existing tests pass (`cargo test`)
- [ ] The UI works correctly with these changes

> **Draft:** Phase 1 skeleton — the flow is navigable but steps 2–5 are placeholders. Frontend-only. `vitest` (7/7 for the step logic) and `tsc --noEmit` pass locally. Opening as draft to agree on the UX/approach before wiring the connection + auto-resolve logic. Happy to fold this into an issue/discussion if preferred.

## Checklist
- [ ] Code compiles without errors
- [ ] No new clippy warnings
- [ ] Code is formatted
- [x] TypeScript compiles without errors (`npx tsc --noEmit`)
- [ ] Documentation updated if needed
- [x] Commit messages follow conventional format