### PR TITLE
fix(dialogs): TunerStudio-style compact form width, and stop clipping wide content

### DIFF
--- a/crates/libretune-app/src/components/dialogs/DialogRenderer.css
+++ b/crates/libretune-app/src/components/dialogs/DialogRenderer.css
@@ -118,6 +118,11 @@
 
 .dialog-view .dialog-row-container--table-settings .dialog-column:last-child .table-editor-2d.embedded {
   width: auto;
+  /* Flex items default to min-width: auto (their content's intrinsic
+     width), which overrides the grid column's own min-width: 0 and lets a
+     wide table (many RPM/load columns) blow out the whole row instead of
+     scrolling inside .editor-content's overflow: auto. */
+  min-width: 0;
 }
 
 /* Single column within row (for West/East positioning) */

--- a/crates/libretune-app/src/components/dialogs/DialogRenderer.css
+++ b/crates/libretune-app/src/components/dialogs/DialogRenderer.css
@@ -48,6 +48,20 @@
   width: 100%;
 }
 
+/* Simple field-list dialogs (e.g. Vehicle Information) have no explicit
+   multi-column layout, so the "label fills remaining space, value pinned to
+   a fixed-width column" grid (see .settings-field below) stretches the gap
+   between label and input across the entire tab width — much wider than
+   TunerStudio's ~700px modal, where the same grid looks tight and tidy.
+   Cap those to the same comfortable form width used by .nested-panel.
+   Excluded via :has() — every other place in this file that opts a
+   sub-element into full width (multi-column split, embedded 2D table,
+   hardware-test grid, wide command-button panel) needs the container to
+   stay uncapped for that to actually reach full width. */
+.dialog-view .dialog-container:not(:has(.dialog-row-container)):not(:has(.nested-panel--multi)):not(:has(.table-editor-2d)):not(:has(.hardware-test-layout)):not(:has(.nested-panel--compact-commands)) {
+  max-width: 720px;
+}
+
 /* Multi-column layout support for dialogs with East/West positioned panels.
    Default: equal split so dense settings panels (fan + water pump) share space. */
 .dialog-view .dialog-row-container {

--- a/crates/libretune-app/src/components/dialogs/DialogRenderer.css
+++ b/crates/libretune-app/src/components/dialogs/DialogRenderer.css
@@ -58,7 +58,7 @@
    sub-element into full width (multi-column split, embedded 2D table,
    hardware-test grid, wide command-button panel) needs the container to
    stay uncapped for that to actually reach full width. */
-.dialog-view .dialog-container:not(:has(.dialog-row-container)):not(:has(.nested-panel--multi)):not(:has(.table-editor-2d)):not(:has(.hardware-test-layout)):not(:has(.nested-panel--compact-commands)) {
+.dialog-view .dialog-container:not(:has(.dialog-row-container)):not(:has(.nested-panel--multi)):not(:has(.table-editor-2d)):not(:has(.hardware-test-layout)):not(:has(.nested-panel--compact-commands)):not(:has(.curve-editor)) {
   max-width: 720px;
 }
 


### PR DESCRIPTION
Simple field-list dialogs (Vehicle Information, etc.) have no explicit multi-column layout, but .dialog-container is deliberately unconstrained width (needed by dense multi-column dialogs). The "label fills remaining space, value pinned to a fixed-width column" grid then stretches the gap between a short label and its input across the full tab width — much wider than TunerStudio's ~700px modal, where the identical grid looks tight and tidy instead of sparse.

Caps .dialog-container to 720px (the same width already used by .nested-panel), but only when the dialog doesn't need full width for something else — excluded via :has(): multi-column row split, wide nested panel (Trigger/Cam-style), embedded 2D table, hardware-test grid, wide command-button panel, or an embedded curve editor (chart + side table).

Two follow-up fixes included after live testing surfaced real regressions from the cap itself:

Embedded curve+table panels (Priming pulse, Dwell, Dwell voltage correction) are ~732px by design (chart 500px + a 220px side table from an earlier fix) — 12px over the new cap, so they were getting clipped instead of excluded. Added .curve-editor to the exclusion list.

"Config left, table right" dialogs (Second Ignition Table, etc.) already have a scrollable .editor-content, but the wrapping .table-editor-2d.embedded had no min-width: 0 — a flex item's min-width defaults to auto (its content's intrinsic width), which overrides the grid column's own min-width: 0 and let a table with many RPM/load columns force the whole row wider than the tab instead of scrolling inside it.

CSS-only change. Verified by inspection (brace-balanced) and live in the running dev build across all three scenarios (plain field dialog, curve+table dialog, config+wide-table dialog) via hot-reload.