### PR TITLE
fix(tabs): auto-scroll active tab into view and wire up the overflow …

### DIFF
--- a/crates/libretune-app/src/components/tuner-ui/TabBar.css
+++ b/crates/libretune-app/src/components/tuner-ui/TabBar.css
@@ -156,18 +156,75 @@
   color: #fff;
 }
 
+.tabbar-overflow-wrap {
+  position: relative;
+  flex-shrink: 0;
+}
+
 .tabbar-overflow {
   display: flex;
   align-items: center;
   justify-content: center;
   width: 24px;
+  height: 100%;
   color: var(--text-secondary);
   background: transparent;
+  border: none;
   border-left: 1px solid var(--border-subtle);
   font-size: 10px;
+  cursor: pointer;
 }
 
 .tabbar-overflow:hover {
   background: var(--bg-hover);
   color: var(--text-primary);
+}
+
+.tabbar-overflow-menu {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  z-index: 50;
+  min-width: 220px;
+  max-width: 360px;
+  max-height: 360px;
+  overflow-y: auto;
+  background: var(--bg-elevated, var(--bg-tab));
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  padding: 4px 0;
+}
+
+.tabbar-overflow-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 6px 10px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.tabbar-overflow-item:hover {
+  background: var(--bg-hover);
+}
+
+.tabbar-overflow-item-active {
+  background: var(--bg-tab-active);
+}
+
+.tabbar-overflow-item-title {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: var(--font-size-sm);
+  color: var(--text-primary);
+}
+
+.tabbar-overflow-item .tab-close {
+  opacity: 0.6;
+}
+
+.tabbar-overflow-item:hover .tab-close {
+  opacity: 1;
 }

--- a/crates/libretune-app/src/components/tuner-ui/TabBar.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/TabBar.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useCallback, DragEvent, MouseEvent } from 'react';
+import React, { useRef, useState, useCallback, useEffect, DragEvent, MouseEvent } from 'react';
 import { ExternalLink } from 'lucide-react';
 import './TabBar.css';
 
@@ -31,7 +31,34 @@ export function TabBar({
 }: TabBarProps) {
   const [draggedId, setDraggedId] = useState<string | null>(null);
   const [dropTargetId, setDropTargetId] = useState<string | null>(null);
+  const [overflowOpen, setOverflowOpen] = useState(false);
   const tabsRef = useRef<HTMLDivElement>(null);
+  const overflowRef = useRef<HTMLDivElement>(null);
+
+  // Keep the active tab in view — without this, a tab opened while many
+  // others are already open can end up scrolled out of the visible strip
+  // with no visual feedback that it opened at all (the tab bar scrolls
+  // horizontally but never scrolls itself, and the old "▾ More tabs"
+  // button was dead — no onClick — so there was no way to reach it either).
+  useEffect(() => {
+    if (!activeTabId || !tabsRef.current) return;
+    const el = tabsRef.current.querySelector<HTMLElement>(
+      `[data-tab-id="${CSS.escape(activeTabId)}"]`,
+    );
+    el?.scrollIntoView({ behavior: 'smooth', inline: 'nearest', block: 'nearest' });
+  }, [activeTabId, tabs.length]);
+
+  // Close the overflow dropdown on an outside click.
+  useEffect(() => {
+    if (!overflowOpen) return;
+    const handleClick = (e: globalThis.MouseEvent) => {
+      if (overflowRef.current && !overflowRef.current.contains(e.target as Node)) {
+        setOverflowOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [overflowOpen]);
 
   const handleDragStart = useCallback((e: DragEvent, tabId: string) => {
     setDraggedId(tabId);
@@ -112,6 +139,7 @@ export function TabBar({
         {tabs.map((tab) => (
           <div
             key={tab.id}
+            data-tab-id={tab.id}
             className={`tab ${tab.id === activeTabId ? 'tab-active' : ''} ${
               tab.id === draggedId ? 'tab-dragging' : ''
             } ${tab.id === dropTargetId ? 'tab-drop-target' : ''}`}
@@ -156,10 +184,47 @@ export function TabBar({
         ))}
       </div>
       
-      {/* Tab overflow menu - shown when tabs don't fit */}
-      <button className="tabbar-overflow" title="More tabs">
-        ▾
-      </button>
+      {/* Tab overflow menu: lists every open tab, so one is always reachable
+          even when the strip has scrolled it out of view. */}
+      <div className="tabbar-overflow-wrap" ref={overflowRef}>
+        <button
+          className="tabbar-overflow"
+          title="More tabs"
+          onClick={() => setOverflowOpen((open) => !open)}
+        >
+          ▾
+        </button>
+        {overflowOpen && (
+          <div className="tabbar-overflow-menu" role="menu">
+            {tabs.map((tab) => (
+              <div
+                key={tab.id}
+                className={`tabbar-overflow-item ${tab.id === activeTabId ? 'tabbar-overflow-item-active' : ''}`}
+                role="menuitem"
+                onClick={() => {
+                  onTabSelect(tab.id);
+                  setOverflowOpen(false);
+                }}
+              >
+                {tab.icon && <TabIcon icon={tab.icon} />}
+                <span className="tabbar-overflow-item-title">{tab.title}</span>
+                {tab.closable !== false && (
+                  <button
+                    className="tab-close"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onTabClose(tab.id);
+                    }}
+                    aria-label={`Close ${tab.title}`}
+                  >
+                    ×
+                  </button>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Reported: after opening several tables/dialogs, opening more silently did nothing, and closing the visible tabs didn't help either.

Root cause: .tabbar-tabs scrolls horizontally (overflow-x: auto) but never scrolls itself, and the "▾ More tabs" button had no onClick at all — pure dead code. So once enough tabs were open to overflow the strip, every subsequent tab still opened correctly (added to state, made active), but scrolled outside the visible area with no way to reach it: the intended "more tabs" button did nothing, and there's no auto-scroll to reveal a newly-activated tab. It looked exactly like "nothing opens", and closing only the tabs still visible up front left the (invisible) rest still occupying the overflowed strip.

The active tab now scrolls into view whenever it changes (covers both clicking an already-open tab and a newly-created one becoming active).

The overflow button now opens a dropdown listing every open tab (with its own close button), so any tab is reachable regardless of scroll position — not just a horizontal-scroll-and-hope affordance.

Verified: tsc clean.