### PR TITLE
feat(ui): responsive foundation — window floor, breakpoint convention…

### DIFF
--- a/crates/libretune-app/src-tauri/tauri.conf.json
+++ b/crates/libretune-app/src-tauri/tauri.conf.json
@@ -13,8 +13,10 @@
     "windows": [
       {
         "title": "LibreTune - Free and Open Source Tuning Suite",
-        "width": 800,
-        "height": 600
+        "width": 1280,
+        "height": 800,
+        "minWidth": 1024,
+        "minHeight": 700
       }
     ],
     "security": {

--- a/crates/libretune-app/src/components/tuner-ui/StatusBar.css
+++ b/crates/libretune-app/src/components/tuner-ui/StatusBar.css
@@ -5,7 +5,7 @@
 .statusbar {
   display: flex;
   align-items: center;
-  height: 38px;
+  height: var(--statusbar-height);
   background: var(--bg-statusbar);
   border-top: 1px solid var(--border-subtle);
   padding: 0 var(--space-3);

--- a/crates/libretune-app/src/themes/variables.css
+++ b/crates/libretune-app/src/themes/variables.css
@@ -46,7 +46,7 @@
   /* Layout dimensions */
   --menubar-height: 24px;
   --toolbar-height: 32px;
-  --statusbar-height: 22px;
+  --statusbar-height: 38px;
   --sidebar-width: 240px;
   --tab-height: 28px;
   
@@ -55,6 +55,19 @@
   --transition-normal: 0.2s ease;
   --transition-slow: 0.3s ease;
 }
+
+/*
+ * Breakpoint convention (documentation only — CSS custom properties can't be
+ * referenced inside @media/@container conditions in any engine, so this is a
+ * convention to reuse literal values by, not a var()). Based on the values
+ * already established across the codebase's existing @media/@container
+ * rules before this file was touched:
+ *   600px — small dialogs/popovers stack or shrink to ~90-100% width
+ *   768px — two-pane panels stack into one column
+ *   900px — the app shell starts shedding optional side panels
+ * Reuse these three values for any new responsive rule instead of picking
+ * an arbitrary number.
+ */
 
 /* =============================================
    SEMANTIC TOKEN ALIASES


### PR DESCRIPTION
Part of a broader pass making the app's chrome adapt across screen resolutions (audited via 3 parallel codebase sweeps: CSS fixed-widths, app shell/design tokens, table/dashboard/toolbar).

tauri.conf.json: window had no minWidth/minHeight at all, and its default size (800x600) was smaller than the app comfortably needs — the dashboard system alone assumes ~600px of content width before it starts scaling down. Sets a better default (1280x800) and a floor (1024x700) so the shell can't be squeezed into something unusable.

themes/variables.css: documents the breakpoint convention already established in practice across the codebase's existing @media rules (600 / 768 / 900px, used 5x/4x/2x respectively) so new responsive rules reuse it instead of picking arbitrary numbers. (CSS custom properties can't be referenced inside @media conditions in any engine, so this is a documented convention, not a var().)

StatusBar.css hardcoded height: 38px while its own --statusbar-height token said 22px and was referenced nowhere — the token was wrong, not the bar (38px is what's actually been rendering correctly all along), so updated the token to match reality and made StatusBar.css reference it.