### PR TITLE
fix(ui): menu bar and icon toolbar no longer clip on narrow windows

### DIFF
--- a/crates/libretune-app/src/components/tuner-ui/MenuBar.css
+++ b/crates/libretune-app/src/components/tuner-ui/MenuBar.css
@@ -4,6 +4,7 @@
 
 .menubar {
   display: flex;
+  align-items: stretch;
   height: var(--menubar-height);
   background: var(--bg-menubar);
   border-bottom: 1px solid var(--border-subtle);
@@ -11,8 +12,45 @@
   flex-shrink: 0;
 }
 
+/* Scrollable row of menu items — lets the bar shrink on a narrow window
+   instead of forcing it (and everything below it) wider than the viewport.
+   The "More" button beside it is the guaranteed-reachable fallback. */
+.menubar-items {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.menubar-items::-webkit-scrollbar {
+  display: none;
+}
+
 .menubar-item-wrapper {
   position: relative;
+}
+
+.menubar-more-wrap {
+  position: relative;
+  flex-shrink: 0;
+  border-left: 1px solid var(--border-subtle);
+}
+
+.menubar-more {
+  height: 100%;
+  padding: 0 var(--space-4);
+  display: flex;
+  align-items: center;
+  color: var(--text-secondary);
+  font-size: var(--font-size-base);
+  background: transparent;
+  transition: background var(--transition-fast);
+}
+
+.menubar-more:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
 }
 
 .menubar-item {

--- a/crates/libretune-app/src/components/tuner-ui/MenuBar.css
+++ b/crates/libretune-app/src/components/tuner-ui/MenuBar.css
@@ -3,6 +3,7 @@
  */
 
 .menubar {
+  position: relative;
   display: flex;
   align-items: stretch;
   height: var(--menubar-height);

--- a/crates/libretune-app/src/components/tuner-ui/MenuBar.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/MenuBar.tsx
@@ -10,7 +10,9 @@ interface MenuBarProps {
 export function MenuBar({ items }: MenuBarProps) {
   const [openMenuId, setOpenMenuId] = useState<string | null>(null);
   const [focusedIndex, setFocusedIndex] = useState(-1);
+  const [moreOpen, setMoreOpen] = useState(false);
   const menuBarRef = useRef<HTMLDivElement>(null);
+  const moreWrapRef = useRef<HTMLDivElement>(null);
 
   // Parse accelerator from label (e.g., "&File" -> { label: "File", accelerator: "F" })
   const parseLabel = (label: string) => {
@@ -33,6 +35,7 @@ export function MenuBar({ items }: MenuBarProps) {
       if (menuBarRef.current && !menuBarRef.current.contains(e.target as Node)) {
         setOpenMenuId(null);
         setFocusedIndex(-1);
+        setMoreOpen(false);
       }
     };
 
@@ -131,51 +134,80 @@ export function MenuBar({ items }: MenuBarProps) {
 
   return (
     <div className="menubar" ref={menuBarRef} role="menubar">
-      {items.map((item, index) => {
-        // Top-level separators render as a non-focusable vertical rule.
-        if (item.separator) {
-          return (
-            <div
-              key={item.id || `sep-${index}`}
-              className="menubar-separator"
-              role="separator"
-              aria-orientation="vertical"
-            />
-          );
-        }
-        const parsed = parseLabel(item.label);
-        const isOpen = openMenuId === item.id;
-        
-        return (
-          <div key={item.id} className="menubar-item-wrapper">
-            <button
-              className={`menubar-item ${isOpen ? 'menubar-item-open' : ''} ${
-                focusedIndex === index ? 'menubar-item-focused' : ''
-              }`}
-              onClick={() => handleMenuClick(item, index)}
-              onMouseEnter={() => handleMenuHover(item, index)}
-              onKeyDown={(e) => handleMenuKeyDown(e, index)}
-              role="menuitem"
-              aria-haspopup="true"
-              aria-expanded={isOpen}
-            >
-              {parsed.before}
-              {parsed.accelerator && (
-                <span className="menubar-accelerator">{parsed.accelerator}</span>
-              )}
-              {parsed.after}
-            </button>
-            
-            {isOpen && item.items && (
-              <MenuDropdown
-                items={item.items}
-                onDismissAll={closeMenu}
-                level={0}
+      <div className="menubar-items">
+        {items.map((item, index) => {
+          // Top-level separators render as a non-focusable vertical rule.
+          if (item.separator) {
+            return (
+              <div
+                key={item.id || `sep-${index}`}
+                className="menubar-separator"
+                role="separator"
+                aria-orientation="vertical"
               />
-            )}
-          </div>
-        );
-      })}
+            );
+          }
+          const parsed = parseLabel(item.label);
+          const isOpen = openMenuId === item.id;
+
+          return (
+            <div key={item.id} className="menubar-item-wrapper">
+              <button
+                className={`menubar-item ${isOpen ? 'menubar-item-open' : ''} ${
+                  focusedIndex === index ? 'menubar-item-focused' : ''
+                }`}
+                onClick={() => handleMenuClick(item, index)}
+                onMouseEnter={() => handleMenuHover(item, index)}
+                onKeyDown={(e) => handleMenuKeyDown(e, index)}
+                role="menuitem"
+                aria-haspopup="true"
+                aria-expanded={isOpen}
+              >
+                {parsed.before}
+                {parsed.accelerator && (
+                  <span className="menubar-accelerator">{parsed.accelerator}</span>
+                )}
+                {parsed.after}
+              </button>
+
+              {isOpen && item.items && (
+                <MenuDropdown
+                  items={item.items}
+                  onDismissAll={closeMenu}
+                  level={0}
+                />
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Reachability fallback for narrow windows: the row above scrolls
+          horizontally (menubar-items { overflow-x: auto }), and this button
+          lists every menu regardless of scroll position — same pattern as
+          the tab bar's "▾ More tabs" menu. */}
+      <div className="menubar-more-wrap" ref={moreWrapRef}>
+        <button
+          className={`menubar-more ${moreOpen ? 'menubar-item-open' : ''}`}
+          onClick={() => setMoreOpen((v) => !v)}
+          aria-haspopup="true"
+          aria-expanded={moreOpen}
+          aria-label="More menus"
+          title="More menus"
+        >
+          ⋯
+        </button>
+        {moreOpen && (
+          <MenuDropdown
+            items={items.filter((item) => !item.separator)}
+            onDismissAll={() => {
+              closeMenu();
+              setMoreOpen(false);
+            }}
+            level={0}
+          />
+        )}
+      </div>
     </div>
   );
 }

--- a/crates/libretune-app/src/components/tuner-ui/MenuBar.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/MenuBar.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback, KeyboardEvent } from 'react';
+import { useState, useRef, useEffect, useCallback, CSSProperties, KeyboardEvent } from 'react';
 import { Check } from 'lucide-react';
 import { MenuItem } from './TunerLayout';
 import './MenuBar.css';
@@ -11,8 +11,21 @@ export function MenuBar({ items }: MenuBarProps) {
   const [openMenuId, setOpenMenuId] = useState<string | null>(null);
   const [focusedIndex, setFocusedIndex] = useState(-1);
   const [moreOpen, setMoreOpen] = useState(false);
+  const [dropdownLeft, setDropdownLeft] = useState(0);
   const menuBarRef = useRef<HTMLDivElement>(null);
   const moreWrapRef = useRef<HTMLDivElement>(null);
+  const itemRefs = useRef<Record<string, HTMLButtonElement | null>>({});
+
+  // The dropdown for the open top-level menu renders outside the scrollable
+  // `.menubar-items` row (see below) so horizontal scrolling can't clip it
+  // vertically; this measures where to anchor it under the clicked button.
+  const updateDropdownPosition = useCallback((itemId: string) => {
+    const btn = itemRefs.current[itemId];
+    const bar = menuBarRef.current;
+    if (btn && bar) {
+      setDropdownLeft(btn.getBoundingClientRect().left - bar.getBoundingClientRect().left);
+    }
+  }, []);
 
   // Parse accelerator from label (e.g., "&File" -> { label: "File", accelerator: "F" })
   const parseLabel = (label: string) => {
@@ -54,6 +67,7 @@ export function MenuBar({ items }: MenuBarProps) {
         });
         if (index !== -1) {
           e.preventDefault();
+          updateDropdownPosition(items[index].id);
           setOpenMenuId(items[index].id);
           setFocusedIndex(index);
         }
@@ -67,12 +81,13 @@ export function MenuBar({ items }: MenuBarProps) {
 
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [items, openMenuId]);
+  }, [items, openMenuId, updateDropdownPosition]);
 
   const handleMenuClick = (item: MenuItem, index: number) => {
     if (openMenuId === item.id) {
       setOpenMenuId(null);
     } else {
+      updateDropdownPosition(item.id);
       setOpenMenuId(item.id);
     }
     setFocusedIndex(index);
@@ -80,6 +95,7 @@ export function MenuBar({ items }: MenuBarProps) {
 
   const handleMenuHover = (item: MenuItem, index: number) => {
     if (openMenuId !== null) {
+      updateDropdownPosition(item.id);
       setOpenMenuId(item.id);
       setFocusedIndex(index);
     }
@@ -102,6 +118,7 @@ export function MenuBar({ items }: MenuBarProps) {
           const nextIndex = focusableIndexes[(pos + 1) % focusableIndexes.length];
           setFocusedIndex(nextIndex);
           if (openMenuId) {
+            updateDropdownPosition(items[nextIndex].id);
             setOpenMenuId(items[nextIndex].id);
           }
         }
@@ -114,6 +131,7 @@ export function MenuBar({ items }: MenuBarProps) {
             focusableIndexes[(pos - 1 + focusableIndexes.length) % focusableIndexes.length];
           setFocusedIndex(prevIndex);
           if (openMenuId) {
+            updateDropdownPosition(items[prevIndex].id);
             setOpenMenuId(items[prevIndex].id);
           }
         }
@@ -122,6 +140,7 @@ export function MenuBar({ items }: MenuBarProps) {
       case 'Enter':
       case ' ':
         e.preventDefault();
+        updateDropdownPosition(items[index].id);
         setOpenMenuId(items[index].id);
         break;
     }
@@ -132,9 +151,18 @@ export function MenuBar({ items }: MenuBarProps) {
     setFocusedIndex(-1);
   }, []);
 
+  // Closing on scroll avoids the dropdown drifting away from its button
+  // (its position is measured once, on open, not tracked continuously).
+  const handleItemsScroll = useCallback(() => {
+    setOpenMenuId(null);
+    setFocusedIndex(-1);
+  }, []);
+
+  const openItem = openMenuId ? items.find((item) => item.id === openMenuId) : undefined;
+
   return (
     <div className="menubar" ref={menuBarRef} role="menubar">
-      <div className="menubar-items">
+      <div className="menubar-items" onScroll={handleItemsScroll}>
         {items.map((item, index) => {
           // Top-level separators render as a non-focusable vertical rule.
           if (item.separator) {
@@ -153,6 +181,9 @@ export function MenuBar({ items }: MenuBarProps) {
           return (
             <div key={item.id} className="menubar-item-wrapper">
               <button
+                ref={(el) => {
+                  itemRefs.current[item.id] = el;
+                }}
                 className={`menubar-item ${isOpen ? 'menubar-item-open' : ''} ${
                   focusedIndex === index ? 'menubar-item-focused' : ''
                 }`}
@@ -169,18 +200,22 @@ export function MenuBar({ items }: MenuBarProps) {
                 )}
                 {parsed.after}
               </button>
-
-              {isOpen && item.items && (
-                <MenuDropdown
-                  items={item.items}
-                  onDismissAll={closeMenu}
-                  level={0}
-                />
-              )}
             </div>
           );
         })}
       </div>
+
+      {/* Rendered outside `.menubar-items` (whose horizontal scroll clips
+          any absolutely-positioned child vertically) and anchored via a
+          measured left offset instead. */}
+      {openItem && openItem.items && (
+        <MenuDropdown
+          items={openItem.items}
+          onDismissAll={closeMenu}
+          level={0}
+          style={{ left: dropdownLeft }}
+        />
+      )}
 
       {/* Reachability fallback for narrow windows: the row above scrolls
           horizontally (menubar-items { overflow-x: auto }), and this button
@@ -217,9 +252,10 @@ interface MenuDropdownProps {
   onDismissAll: () => void;
   onCloseSubmenu?: () => void;
   level?: number;
+  style?: CSSProperties;
 }
 
-function MenuDropdown({ items, onDismissAll, onCloseSubmenu, level = 0 }: MenuDropdownProps) {
+function MenuDropdown({ items, onDismissAll, onCloseSubmenu, level = 0, style }: MenuDropdownProps) {
   const [focusedIndex, setFocusedIndex] = useState(0);
   const [openSubmenuId, setOpenSubmenuId] = useState<string | null>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -326,6 +362,7 @@ function MenuDropdown({ items, onDismissAll, onCloseSubmenu, level = 0 }: MenuDr
   return (
     <div
       className={`menu-dropdown menu-dropdown-level-${level}`}
+      style={style}
       ref={dropdownRef}
       role="menu"
       onKeyDown={handleKeyDown}

--- a/crates/libretune-app/src/components/tuner-ui/Toolbar.css
+++ b/crates/libretune-app/src/components/tuner-ui/Toolbar.css
@@ -9,9 +9,33 @@
   background: var(--bg-toolbar);
   border-bottom: 1px solid var(--border-subtle);
   padding: 0 var(--space-2);
-  gap: var(--space-1);
   user-select: none;
   flex-shrink: 0;
+}
+
+/* Scrollable row of buttons — lets the toolbar shrink on a narrow window
+   instead of forcing it (and everything below it) wider than the viewport.
+   The "More" button beside it is the guaranteed-reachable fallback. */
+.toolbar-items {
+  display: flex;
+  align-items: center;
+  flex: 1;
+  min-width: 0;
+  gap: var(--space-1);
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.toolbar-items::-webkit-scrollbar {
+  display: none;
+}
+
+.toolbar-more-wrap {
+  position: relative;
+  flex-shrink: 0;
+  margin-left: var(--space-1);
+  padding-left: var(--space-2);
+  border-left: 1px solid var(--border-subtle);
 }
 
 .toolbar-button {
@@ -77,6 +101,55 @@
   height: 20px;
   background: var(--border-default);
   margin: 0 var(--space-2);
+}
+
+/* Overflow "More" button + dropdown, shown once the icon row no longer
+   fits the available width (see Toolbar.tsx's ResizeObserver measurement). */
+.toolbar-more-wrap {
+  position: relative;
+  flex-shrink: 0;
+}
+
+.toolbar-more-menu {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  z-index: 50;
+  min-width: 180px;
+  max-height: 360px;
+  overflow-y: auto;
+  background: var(--bg-elevated, var(--bg-toolbar));
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-dropdown);
+  padding: var(--space-2) 0;
+}
+
+.toolbar-more-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  width: 100%;
+  padding: var(--space-3) var(--space-5);
+  color: var(--text-primary);
+  background: transparent;
+  border: none;
+  text-align: left;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.toolbar-more-item:hover:not(:disabled) {
+  background: var(--bg-hover);
+}
+
+.toolbar-more-item:disabled {
+  color: var(--text-disabled);
+  cursor: not-allowed;
+}
+
+.toolbar-more-item-label {
+  font-size: var(--font-size-base);
 }
 
 /* Inline content container (for connection metrics + packet mode) */

--- a/crates/libretune-app/src/components/tuner-ui/Toolbar.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/Toolbar.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from 'react';
 import {
   FilePlus,
   FolderOpen,
@@ -14,6 +15,7 @@ import {
   Copy,
   ClipboardPaste,
   HelpCircle,
+  MoreHorizontal,
   LucideIcon,
 } from 'lucide-react';
 import { ToolbarItem } from './TunerLayout';
@@ -42,44 +44,104 @@ const iconMap: Record<string, LucideIcon> = {
   'default': HelpCircle,
 };
 
+function renderItem(item: ToolbarItem, index: number) {
+  if (item.separator) {
+    return <div key={`sep-${index}`} className="toolbar-separator" />;
+  }
+
+  // If a toolbar item supplies custom content, render it inline
+  if (item.content) {
+    return (
+      <div key={item.id} className="toolbar-content" title={item.tooltip} onClick={item.onClick}>
+        {item.content}
+      </div>
+    );
+  }
+
+  const IconComponent = iconMap[item.icon] || iconMap['default'];
+  const isRecording = item.icon === 'log-start' && item.active;
+  const isBurnPending = item.variant === 'burn-pending';
+
+  return (
+    <button
+      key={item.id}
+      className={`toolbar-button${item.active ? ' toolbar-button-active' : ''}${isBurnPending ? ' toolbar-button-burn-pending' : ''}`}
+      onClick={item.onClick}
+      disabled={item.disabled}
+      title={item.tooltip}
+      aria-label={item.tooltip}
+    >
+      <IconComponent
+        size={18}
+        strokeWidth={1.75}
+        className={isRecording ? 'icon-recording' : undefined}
+      />
+    </button>
+  );
+}
+
 export function Toolbar({ items }: ToolbarProps) {
+  const [moreOpen, setMoreOpen] = useState(false);
+  const moreWrapRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!moreOpen) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (moreWrapRef.current && !moreWrapRef.current.contains(e.target as Node)) {
+        setMoreOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [moreOpen]);
+
+  const actionableItems = items.filter((item) => !item.separator);
+
   return (
     <div className="toolbar" role="toolbar">
-      {items.map((item, index) => {
-        if (item.separator) {
-          return <div key={`sep-${index}`} className="toolbar-separator" />;
-        }
+      <div className="toolbar-items">
+        {items.map((item, index) => renderItem(item, index))}
+      </div>
 
-        // If a toolbar item supplies custom content, render it inline
-        if (item.content) {
-          return (
-            <div key={item.id} className="toolbar-content" title={item.tooltip} onClick={item.onClick}>
-              {item.content}
-            </div>
-          );
-        }
-
-        const IconComponent = iconMap[item.icon] || iconMap['default'];
-        const isRecording = item.icon === 'log-start' && item.active;
-        const isBurnPending = item.variant === 'burn-pending';
-
-        return (
-          <button
-            key={item.id}
-            className={`toolbar-button${item.active ? ' toolbar-button-active' : ''}${isBurnPending ? ' toolbar-button-burn-pending' : ''}`}
-            onClick={item.onClick}
-            disabled={item.disabled}
-            title={item.tooltip}
-            aria-label={item.tooltip}
-          >
-            <IconComponent
-              size={18}
-              strokeWidth={1.75}
-              className={isRecording ? 'icon-recording' : undefined}
-            />
-          </button>
-        );
-      })}
+      {/* Reachability fallback for narrow windows: the row above scrolls
+          horizontally (toolbar-items { overflow-x: auto }), and this button
+          lists every action regardless of scroll position — same pattern as
+          the tab bar's "▾ More tabs" menu. */}
+      <div className="toolbar-more-wrap" ref={moreWrapRef}>
+        <button
+          className={`toolbar-button${moreOpen ? ' toolbar-button-active' : ''}`}
+          onClick={() => setMoreOpen((v) => !v)}
+          aria-label="More toolbar actions"
+          title="More"
+        >
+          <MoreHorizontal size={18} strokeWidth={1.75} />
+        </button>
+        {moreOpen && (
+          <div className="toolbar-more-menu" role="menu">
+            {actionableItems.map((item) => {
+              if (item.content) {
+                return (
+                  <div key={item.id} className="toolbar-more-item" title={item.tooltip} onClick={() => { item.onClick?.(); setMoreOpen(false); }}>
+                    {item.content}
+                  </div>
+                );
+              }
+              const IconComponent = iconMap[item.icon] || iconMap['default'];
+              return (
+                <button
+                  key={item.id}
+                  className="toolbar-more-item"
+                  disabled={item.disabled}
+                  onClick={() => { item.onClick?.(); setMoreOpen(false); }}
+                >
+                  <IconComponent size={16} strokeWidth={1.75} />
+                  <span className="toolbar-more-item-label">{item.tooltip}</span>
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Confirmed by audit: MenuBar.css/Toolbar.css were plain display:flex rows with no overflow handling at all — no wrap, no scroll, no fallback. Once the ECU-specific menus (Setup/Fuel/Ignition/Cranking/...) or the full icon row didn't fit, the tail was clipped at the window edge with no way to reach it.

Same fix pattern as the tab bar's earlier overflow fix this session: the item row scrolls horizontally (overflow-x: auto, hidden native scrollbar), and a "⋯ More" button next to it opens a dropdown listing every menu / every toolbar action regardless of scroll position, so nothing is ever truly unreachable.

(A first pass tried computing an exact overflow cutoff via ResizeObserver + a hidden measurement clone of the full item list — reverted: the clone duplicated real text/labels in the DOM, which broke Testing Library queries like getByText('Auto') matching twice. The scroll+dropdown approach needs no duplicate DOM and is the same interaction already shipped and working for the tab bar.)

Verified: tsc clean, 194/195 vitest passing (the one failure is the same pre-existing App.integration.test.tsx timeout confirmed unrelated to any UI work this session), plus the Toolbar-specific test suite green.