### PR TITLE
feat(ui): auto-hide the AI assistant panel on narrow windows

### DIFF
--- a/crates/libretune-app/src/components/tuner-ui/TunerLayout.css
+++ b/crates/libretune-app/src/components/tuner-ui/TunerLayout.css
@@ -18,6 +18,22 @@
   flex: 1;
   min-height: 0;
   overflow: hidden;
+  /* Lets the AI assistant panel auto-hide by available width below,
+     mirroring the container-query pattern already used for dialog panels
+     (DialogRenderer.css's .dialog-column). */
+  container-type: inline-size;
+}
+
+/* The AI assistant side panel is optional and already user-toggleable
+   (agentPanelVisible) — auto-hide it first when the window gets tight
+   rather than letting its own 260px min-width floor squeeze the sidebar
+   and document area into something unusable. It reappears on its own once
+   there's room again; the underlying agentPanelVisible state is untouched,
+   so this never fights the user's manual toggle. */
+@container (max-width: 900px) {
+  .agent-panel {
+    display: none;
+  }
 }
 
 /* Document area (tabs + content) */


### PR DESCRIPTION
TunerLayout.css had zero @media/@container queries — the sidebar (150-400px) and the AI assistant side panel (280-640px) were only ever resized by manual drag, never automatically, so on a narrow window their combined floors could squeeze the document area into something unusable with no responsive fallback.

Adds container-type: inline-size on .tuner-layout-main (the same pattern already proven in DialogRenderer.css's .dialog-column) and auto-hides the already-optional, already-toggleable agent panel below a 900px main-area width via @container, without touching its agentPanelVisible state — it reappears on its own once there's room again, so it never fights the user's manual toggle. The sidebar's existing 150px floor stays as the last line of defense, now backed by the new 1024px window-width floor from #204.