### PR TITLE
fix(ui): dialog/panel fixed-width sweep for narrow windows

### DIFF
--- a/crates/libretune-app/src/components/TuneHistoryPanel.css
+++ b/crates/libretune-app/src/components/TuneHistoryPanel.css
@@ -14,6 +14,7 @@
   background: var(--bg-surface);
   border-radius: 12px;
   width: 500px;
+  max-width: 95vw;
   max-height: 80vh;
   display: flex;
   flex-direction: column;
@@ -252,6 +253,7 @@
   background: var(--bg-surface);
   border-radius: 12px;
   width: 600px;
+  max-width: 95vw;
   max-height: 70vh;
   display: flex;
   flex-direction: column;

--- a/crates/libretune-app/src/components/dialogs/TuneFileDiffDialog.css
+++ b/crates/libretune-app/src/components/dialogs/TuneFileDiffDialog.css
@@ -1,8 +1,18 @@
 .tune-diff-content {
-  min-width: 880px;
   display: flex;
   flex-direction: column;
   gap: var(--space-3);
+}
+
+/* The 880px minimum is a comfort width for reading the diff table side by
+   side, not a hard requirement (.tune-diff-table itself is width: 100% and
+   has no minimum of its own) — only enforce it once the viewport can
+   actually afford it, so the dialog isn't forced wider than the window on
+   a narrow screen. */
+@media (min-width: 900px) {
+  .tune-diff-content {
+    min-width: 880px;
+  }
 }
 
 .tune-diff-files {

--- a/crates/libretune-app/src/components/dialogs/UserManualViewer.css
+++ b/crates/libretune-app/src/components/dialogs/UserManualViewer.css
@@ -53,6 +53,23 @@
   overflow: hidden;
 }
 
+/* Stack the nav above the article on a narrow window instead of squeezing
+   the article column into an unusably thin remainder. */
+@media (max-width: 768px) {
+  .manual-viewer-body {
+    flex-direction: column;
+    min-height: 0;
+    overflow-y: auto;
+  }
+
+  .manual-sidebar {
+    width: 100%;
+    max-height: 35vh;
+    border-right: none;
+    border-bottom: 1px solid var(--border-subtle);
+  }
+}
+
 .manual-sidebar-header {
   padding: var(--space-2) var(--space-3);
   border-bottom: 1px solid var(--border-subtle);

--- a/crates/libretune-app/src/components/tuner-ui/AutoTune.css
+++ b/crates/libretune-app/src/components/tuner-ui/AutoTune.css
@@ -327,9 +327,23 @@
 /* Settings Panel */
 .autotune-settings-panel {
   width: 280px;
+  flex-shrink: 0;
   overflow-y: auto;
   background: var(--bg-subtle);
   padding: 12px;
+}
+
+/* Same "config panel beside main content, stacks below it when narrow"
+   pattern already used by PortEditor.css's .assignments-panel. */
+@media (max-width: 768px) {
+  .autotune-content {
+    flex-direction: column;
+  }
+
+  .autotune-settings-panel {
+    width: 100%;
+    max-height: 40vh;
+  }
 }
 
 .autotune-stats {

--- a/crates/libretune-app/src/components/tuner-ui/AutoTuneLive.css
+++ b/crates/libretune-app/src/components/tuner-ui/AutoTuneLive.css
@@ -315,9 +315,23 @@
 /* Settings Panel */
 .autotune-settings-panel {
   width: 280px;
+  flex-shrink: 0;
   overflow-y: auto;
   background: var(--bg-subtle);
   padding: 12px;
+}
+
+/* Same "config panel beside main content, stacks below it when narrow"
+   pattern already used by PortEditor.css's .assignments-panel. */
+@media (max-width: 768px) {
+  .autotune-content {
+    flex-direction: column;
+  }
+
+  .autotune-settings-panel {
+    width: 100%;
+    max-height: 40vh;
+  }
 }
 
 .autotune-stats {


### PR DESCRIPTION
Several panels had a hardcoded pixel width and no responsive fallback at all, confirmed via audit and re-verified by reading each file directly (the audit had two false positives, corrected here: AfrDelayTestDialog.css already had max-width: 92vw, and PortEditor.css already had a working 768px stacking breakpoint further down the same file — neither touched).

Two real "two-pane, side panel doesn't stack" gaps, same pattern already proven in this codebase by PortEditor.css's .assignments-panel: AutoTune/AutoTuneLive's .autotune-settings-panel (280px) and UserManualViewer's .manual-sidebar (260px) now stack below the main content under 768px.

Three modal-style dialogs had a fixed width and no max-width safety net at all: TuneHistoryPanel's .tune-history-panel (500px) and .diff-modal (600/400px) — added max-width: 95vw, matching the pattern already used by DialogOverlays.tsx's Plugin Panel.

TuneFileDiffDialog.css's real gap turned out to be different from what the audit named (it flagged a 240px search input, which is fine as-is): the actual issue is .tune-diff-content's unconditional min-width: 880px, which forced the whole dialog wider than the window on a narrow screen even though the table inside it is width: 100% with no minimum of its own. Now only enforced above 900px viewport width.