### PR TITLE
fix(protocol): reliable legacy writes — chunking, pacing, and read-back verify

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/table_update.rs
+++ b/crates/libretune-app/src-tauri/src/commands/table_update.rs
@@ -121,7 +121,21 @@ pub async fn update_table_data(
                      drive on this tune until it is re-sent and verified: {e}"
                 ));
             }
-            // Anything else (not connected, timeout, dropped adapter) keeps
+            // The write went out but could not be read back. On a legacy ECU
+            // this is the buffer-overrun signature itself (the read command
+            // was eaten as table data), so it must fail as loudly as a
+            // mismatch — this exact case was once a WARN line while a
+            // corrupted ignition table sat in a running engine.
+            Err(
+                e @ libretune_core::protocol::ProtocolError::WriteVerificationUnavailable { .. },
+            ) => {
+                return Err(format!(
+                    "Table {table_name} was sent but the ECU's copy could not \
+                     be confirmed — re-send it before trusting or burning \
+                     this tune: {e}"
+                ));
+            }
+            // A write that never went out (not connected, port gone) keeps
             // the existing offline-tolerant behaviour: the edit is already in
             // the local tune cache above.
             Err(e) => {

--- a/crates/libretune-app/src-tauri/src/commands/table_update.rs
+++ b/crates/libretune-app/src-tauri/src/commands/table_update.rs
@@ -104,9 +104,29 @@ pub async fn update_table_data(
             data: raw_data.clone(),
         };
 
-        // Don't fail if ECU write fails - offline mode should still work
-        if let Err(e) = conn.write_memory(params) {
-            eprintln!("[WARN] Failed to write to ECU (offline mode?): {}", e);
+        // Read the table straight back. A legacy-protocol write is
+        // fire-and-forget, so "the write returned Ok" only ever meant "the
+        // bytes left the host" — which is how a corrupted ignition table
+        // reached a running engine on 18 Aug 2026 with both writes reported
+        // successful. Chunking stops that particular overrun; the read-back is
+        // what turns the next silent divergence into a visible error.
+        match conn.write_memory_verified(params) {
+            Ok(()) => {}
+            // The ECU is holding something other than what was sent. This is
+            // not a connectivity problem and must not be swallowed: the tune
+            // on screen no longer matches the tune the engine is running.
+            Err(e @ libretune_core::protocol::ProtocolError::WriteVerificationFailed { .. }) => {
+                return Err(format!(
+                    "ECU did not store table {table_name} as written — do not \
+                     drive on this tune until it is re-sent and verified: {e}"
+                ));
+            }
+            // Anything else (not connected, timeout, dropped adapter) keeps
+            // the existing offline-tolerant behaviour: the edit is already in
+            // the local tune cache above.
+            Err(e) => {
+                eprintln!("[WARN] Failed to write to ECU (offline mode?): {}", e);
+            }
         }
     }
 

--- a/crates/libretune-core/src/protocol/connection.rs
+++ b/crates/libretune-core/src/protocol/connection.rs
@@ -17,6 +17,15 @@ use crate::ini::{AdaptiveTiming, AdaptiveTimingConfig, EcuType, Endianness, Prot
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
+/// Extra quiet time added to the declared burn window, on top of
+/// `pageActivationDelay`. See [`Connection::burn`] for why the declared value
+/// on its own is not enough.
+const BURN_SETTLE_MS: u64 = 600;
+
+/// Minimum quiet time after a legacy write frame before the ECU will service
+/// anything else. See [`Connection::inter_frame_delay`].
+const LEGACY_WRITE_SETTLE_MS: u64 = 30;
+
 /// Parse a command string with escape sequences into raw bytes
 /// Handles: \xNN (hex), \n, \r, \t, \\, \0, and regular characters
 fn parse_command_string(s: &str) -> Vec<u8> {
@@ -1662,10 +1671,46 @@ impl Connection {
         blocking_factor.saturating_sub(8).max(1)
     }
 
+    /// How long to leave the link idle after handing the ECU a write frame of
+    /// `frame_len` bytes, before sending it anything else.
+    ///
+    /// A legacy write is answered by silence, so the host has no signal that
+    /// the ECU has finished with a frame and must simply wait long enough. Two
+    /// things set how long. The frame's own wire time is a floor — on a real
+    /// UART a 250-byte frame occupies a 115200 link for about 22 ms, and USB
+    /// CDC, which every modern Speeduino is reached through, delivers it at USB
+    /// speed instead and removes that natural spacing. On top of that the
+    /// firmware needs a service window to apply the bytes it just received;
+    /// until it has, the next command on the wire is consumed as table data.
+    ///
+    /// The window was measured directly against the bench simulator on
+    /// 19 Aug 2026, replaying the frames with no app in the loop and sweeping
+    /// the gap: at 10 ms the following page read was swallowed as table data
+    /// and the read returned nothing; 20 ms was the first clean value; 30 ms
+    /// and above were clean, which is what the raw-protocol reference writer
+    /// has always used and why it has never reproduced the corruption. Note
+    /// that this is not the same as the chunking bug — LibreTune's frames were
+    /// correctly sized and 22.8 ms apart, and the *last* frame's 10.5 ms tail
+    /// gap alone was enough to corrupt the table.
+    ///
+    /// A modern CRC ECU acknowledges the write, and that acknowledgement is
+    /// proof it is done with the frame, so there is nothing to guess at there.
+    fn inter_frame_delay(&self, frame_len: usize) -> Duration {
+        let baud = self.config.baud_rate.max(1) as u64;
+        // 10 bits per byte on the wire: 8 data, start, stop.
+        let wire_ms = (frame_len as u64 * 10 * 1000).div_ceil(baud);
+        let ini_ms = self.get_effective_min_wait();
+        let floor = if self.use_modern_protocol {
+            5
+        } else {
+            LEGACY_WRITE_SETTLE_MS
+        };
+        Duration::from_millis(wire_ms.max(ini_ms).max(floor))
+    }
+
     /// Write a full page to ECU, respecting blocking factor (same chunking as `read_page`).
     pub fn write_page(&mut self, page: u8, data: &[u8]) -> Result<(), ProtocolError> {
         let chunk_size = self.effective_write_chunk();
-        let inter_chunk_ms = self.get_effective_min_wait().max(5);
 
         let mut offset = 0usize;
         while offset < data.len() {
@@ -1712,9 +1757,8 @@ impl Connection {
             }
 
             offset = end;
-            if offset < data.len() {
-                std::thread::sleep(Duration::from_millis(inter_chunk_ms));
-            }
+            // write_memory paces each frame it sends; a second delay here
+            // would only double the cost of every bulk page write.
         }
 
         Ok(())
@@ -1748,9 +1792,7 @@ impl Connection {
                 })?;
                 offset += take;
                 remaining = tail;
-                if !remaining.is_empty() {
-                    std::thread::sleep(Duration::from_millis(self.get_effective_min_wait().max(5)));
-                }
+                // Pacing is handled once, after the frame actually goes out.
             }
             return Ok(());
         }
@@ -1800,6 +1842,7 @@ impl Connection {
             params.offset,
             &params.data,
         )?;
+        let cmd_len = cmd.len();
 
         let result = if self.use_modern_protocol {
             // Modern protocol: wrap in CRC packet
@@ -1819,6 +1862,12 @@ impl Connection {
 
         if result.is_ok() {
             self.last_written_page = Some(params.page);
+            // Leave the link idle long enough for the ECU to drain this frame
+            // before anything else — the next chunk, a burn, a read-back, or a
+            // realtime poll — is put on the wire. Nothing downstream can tell
+            // that the buffer is still full, because a legacy write is
+            // answered by silence either way.
+            std::thread::sleep(self.inter_frame_delay(cmd_len));
         }
         result
     }
@@ -1936,14 +1985,32 @@ impl Connection {
         // Wait for flash write to complete
         // Flash writes typically take 1-3 seconds depending on ECU
         // Use page_activation_delay as minimum, but ensure at least 2 seconds for safety
-        let delay = self
+        let declared = self
             .protocol_settings
             .as_ref()
             .map(|p| p.page_activation_delay.max(2000))
-            .unwrap_or(2000);
-
-        tracing::debug!("burn: waiting {}ms for flash write to complete", delay);
-        std::thread::sleep(Duration::from_millis(delay as u64));
+            .unwrap_or(2000) as u64;
+        // The ECU starts its busy window when it *processes* the burn, not when
+        // we put the command on the wire, so waiting exactly the declared
+        // window can return while the ECU is still deaf. During that window it
+        // is not servicing serial at all: bytes pile into the 257-byte receive
+        // buffer unread. Measured on the bench 18 Aug 2026 — a 2000 ms wait
+        // against a 2000 ms window let the next table write's first frame land
+        // inside the window, where it sat unserviced until the second frame
+        // overflowed the buffer, losing 13 bytes and leaving the ECU consuming
+        // following commands as table data. The raw-protocol reference writer
+        // has always waited 2.6 s here and has never reproduced it.
+        let settle = BURN_SETTLE_MS;
+        tracing::debug!(
+            "burn: waiting {}ms ({}ms declared + {}ms settle) for flash write to complete",
+            declared + settle,
+            declared,
+            settle
+        );
+        std::thread::sleep(Duration::from_millis(declared + settle));
+        // Anything that arrived while the ECU was deaf is noise to us and, more
+        // importantly, may be a partial frame to it.
+        self.clear_rx_buffer();
 
         tracing::debug!("burn: flash write complete for page {}", page);
         // Successful burn clears the auto-burn-on-page-change tracker.
@@ -2728,6 +2795,10 @@ mod tests {
         bursts: Vec<usize>,
         /// Bytes lost to the ring, summed over all bursts.
         dropped: usize,
+        /// Idle time on the link before each burst — how long this ECU was
+        /// given to drain the previous frame.
+        gaps: Vec<Duration>,
+        last_burst: Option<Instant>,
         /// Bytes waiting to go back to the host.
         out: VecDeque<u8>,
         /// Store the complement of whatever is written to this (page, offset),
@@ -2742,6 +2813,8 @@ mod tests {
                 state: MegaState::Idle,
                 bursts: Vec::new(),
                 dropped: 0,
+                gaps: Vec::new(),
+                last_burst: None,
                 out: VecDeque::new(),
                 corrupt_at: None,
             }
@@ -2754,6 +2827,10 @@ mod tests {
         /// One burst from the host: fill the ring, drop the overflow, then let
         /// the command handler drain what survived.
         fn burst(&mut self, bytes: &[u8]) {
+            let now = Instant::now();
+            self.gaps
+                .push(self.last_burst.map_or(Duration::ZERO, |t| now - t));
+            self.last_burst = Some(now);
             self.bursts.push(bytes.len());
             let kept = bytes.len().min(MEGA_RX_CAPACITY);
             self.dropped += bytes.len() - kept;
@@ -2962,6 +3039,64 @@ mod tests {
         assert_eq!(c.dropped, 0, "no byte may be dropped by the ECU ring");
         assert_eq!(&c.page(1)[..256], &ignition[..], "ignition table corrupted");
         assert_eq!(&c.page(2)[..256], &ve[..], "VE table lost or corrupted");
+
+        // Correctly sized frames are not enough on their own: the bench sweep
+        // showed a following command sent 10.5 ms after a write frame gets
+        // eaten as table data. Every frame here must be followed by at least
+        // the ECU's measured service window.
+        let settle = Duration::from_millis(LEGACY_WRITE_SETTLE_MS);
+        for (i, gap) in c.gaps.iter().enumerate().skip(1) {
+            let prev = c.bursts[i - 1];
+            assert!(
+                *gap >= settle,
+                "frame {i} followed a {prev}-byte frame after only {gap:?}, \
+                 inside the ECU's {settle:?} service window"
+            );
+        }
+    }
+
+    /// The pacing rule. The bench sweep put the ECU's service window at 20 ms
+    /// (10 ms corrupts, 20 ms is the first clean value), so a small trailing
+    /// frame must not be allowed to scale the delay down — that 20-byte second
+    /// chunk followed by a read 10.5 ms later is exactly what corrupted the
+    /// ignition table with correctly sized frames.
+    #[test]
+    fn legacy_write_frames_are_paced_for_the_ecus_service_window() {
+        let core = Arc::new(Mutex::new(MegaCore::new()));
+        let mut conn = speeduino_conn(&core);
+
+        assert_eq!(conn.config.baud_rate, 115_200, "test assumes a 115200 link");
+        let settle = Duration::from_millis(LEGACY_WRITE_SETTLE_MS);
+        assert!(
+            settle >= Duration::from_millis(20),
+            "below the measured floor"
+        );
+        assert!(conn.inter_frame_delay(250) >= settle);
+        assert!(
+            conn.inter_frame_delay(20) >= settle,
+            "a short trailing frame still needs the full service window"
+        );
+
+        // A slow link needs proportionally more: wire time takes over.
+        conn.config.baud_rate = 9_600;
+        assert!(conn.inter_frame_delay(250) >= Duration::from_millis(260));
+
+        // The INI's own inter-write delay still wins when it is the larger.
+        conn.config.baud_rate = 115_200;
+        let mut proto = ProtocolSettings::default();
+        proto.blocking_factor = SPEEDUINO_BLOCKING_FACTOR;
+        proto.inter_write_delay = 100;
+        conn.set_protocol(proto, Endianness::Big);
+        conn.use_modern_protocol = false;
+        assert_eq!(conn.inter_frame_delay(8), Duration::from_millis(100));
+
+        // A CRC ECU acknowledges the write, so it needs no blind wait.
+        conn.use_modern_protocol = true;
+        let mut proto = ProtocolSettings::default();
+        proto.blocking_factor = SPEEDUINO_BLOCKING_FACTOR;
+        conn.set_protocol(proto, Endianness::Big);
+        conn.use_modern_protocol = true;
+        assert!(conn.inter_frame_delay(20) < settle);
     }
 
     /// Chunking closes the overrun we know about. The read-back is what makes

--- a/crates/libretune-core/src/protocol/connection.rs
+++ b/crates/libretune-core/src/protocol/connection.rs
@@ -1635,19 +1635,36 @@ impl Connection {
         }
     }
 
-    /// Write a full page to ECU, respecting blocking factor (same chunking as `read_page`).
-    pub fn write_page(&mut self, page: u8, data: &[u8]) -> Result<(), ProtocolError> {
+    /// The largest payload one write frame may carry.
+    ///
+    /// `blockingFactor` is the ECU's serial buffer less the envelope — Speeduino
+    /// spells this out in its own INI ("257-6=251"). The command header (byte,
+    /// identifier, offset, count) is carried *inside* that payload, so it comes
+    /// off the top as well.
+    ///
+    /// Both `write_memory` and `write_page` chunk, so they must agree: when
+    /// `write_page` split at the full blocking factor it handed `write_memory`
+    /// chunks 8 bytes too large, which then re-split every one of them into a
+    /// full frame plus an 8-byte runt — an extra round-trip and an extra pacing
+    /// delay per chunk on every bulk page write.
+    fn effective_write_chunk(&self) -> usize {
         let blocking_factor = self
             .protocol_settings
             .as_ref()
             .map(|p| p.blocking_factor)
             .unwrap_or(256)
-            .max(1);
+            .max(1) as usize;
+        blocking_factor.saturating_sub(8).max(1)
+    }
+
+    /// Write a full page to ECU, respecting blocking factor (same chunking as `read_page`).
+    pub fn write_page(&mut self, page: u8, data: &[u8]) -> Result<(), ProtocolError> {
+        let chunk_size = self.effective_write_chunk();
         let inter_chunk_ms = self.get_effective_min_wait().max(5);
 
         let mut offset = 0usize;
         while offset < data.len() {
-            let end = (offset + blocking_factor as usize).min(data.len());
+            let end = (offset + chunk_size).min(data.len());
             let chunk = &data[offset..end];
             let params = WriteMemoryParams {
                 page,
@@ -1711,15 +1728,7 @@ impl Connection {
     /// this directly with unbounded payloads, so the guard belongs here, not
     /// in each caller.
     pub fn write_memory(&mut self, params: WriteMemoryParams) -> Result<(), ProtocolError> {
-        let max_chunk = self
-            .protocol_settings
-            .as_ref()
-            .map(|p| p.blocking_factor)
-            .unwrap_or(256)
-            .max(1) as usize;
-        // Frame overhead (command byte, identifier, offset, count) also
-        // occupies the ECU buffer; keep the whole frame under the limit.
-        let max_data = max_chunk.saturating_sub(8).max(1);
+        let max_data = self.effective_write_chunk();
         if params.data.len() > max_data {
             let mut offset = params.offset as usize;
             let mut remaining = params.data.as_slice();
@@ -2576,6 +2585,34 @@ mod tests {
         assert_eq!(parse_command_string("Q"), vec![b'Q']);
         assert_eq!(parse_command_string("S"), vec![b'S']);
         assert_eq!(parse_command_string("Hello"), b"Hello".to_vec());
+    }
+
+    /// `write_page` and `write_memory` both chunk, so they must use the same
+    /// budget. Speeduino declares `blockingFactor = 251` and pages up to 384
+    /// bytes: splitting at the full 251 handed `write_memory` a chunk 8 bytes
+    /// over its own limit, which re-split it into 243 + an 8-byte runt frame.
+    #[test]
+    fn page_and_memory_writes_chunk_to_the_same_size() {
+        let mut conn = Connection::new(ConnectionConfig::default());
+        let mut proto = ProtocolSettings::default();
+        proto.blocking_factor = 251;
+        conn.set_protocol(proto, Endianness::Big);
+
+        let chunk = conn.effective_write_chunk();
+        assert_eq!(chunk, 243, "251 less the 8-byte command header");
+
+        // A 288-byte page must go out in exactly two frames, with no runt.
+        let frames: Vec<usize> = (0..288)
+            .step_by(chunk)
+            .map(|o| chunk.min(288 - o))
+            .collect();
+        assert_eq!(frames, vec![243, 45]);
+        for f in &frames {
+            assert!(
+                *f <= chunk,
+                "frame of {f} exceeds what write_memory accepts"
+            );
+        }
     }
 
     #[test]

--- a/crates/libretune-core/src/protocol/connection.rs
+++ b/crates/libretune-core/src/protocol/connection.rs
@@ -376,9 +376,6 @@ pub struct Connection {
     /// blocking I/O polling loops abort early so `disconnect()` can complete even
     /// while another thread is mid-read (Issue #71: "disconnect does nothing").
     cancel: Arc<AtomicBool>,
-    /// Whether `write_memory_verified` reads back after writing. See
-    /// [`set_verify_writes`](Connection::set_verify_writes).
-    verify_writes: bool,
 }
 
 impl Connection {
@@ -403,7 +400,6 @@ impl Connection {
             last_written_page: None,
             ecu_type: EcuType::Unknown,
             cancel: Arc::new(AtomicBool::new(false)),
-            verify_writes: true,
         }
     }
 
@@ -437,7 +433,6 @@ impl Connection {
             last_written_page: None,
             ecu_type: EcuType::Unknown,
             cancel: Arc::new(AtomicBool::new(false)),
-            verify_writes: true,
         }
     }
 
@@ -1589,8 +1584,12 @@ impl Connection {
 
             Ok(payload[1..].to_vec())
         } else {
-            // Legacy protocol: send raw command
-            self.send_raw_command(&cmd)
+            // Legacy protocol: the reply length is exactly the requested
+            // count, so let the read return as soon as it has arrived instead
+            // of waiting out the inter-character timeout — the read-back
+            // verify does one of these per written chunk, under the
+            // connection lock, while the realtime poll waits.
+            self.send_raw_command_expecting(&cmd, Some(params.length as usize))
         }
     }
 
@@ -1705,7 +1704,20 @@ impl Connection {
         } else {
             LEGACY_WRITE_SETTLE_MS
         };
-        Duration::from_millis(wire_ms.max(ini_ms).max(floor))
+        let settle = ini_ms.max(floor);
+        // On unix, write_and_wait has already slept out the transmit time, so
+        // the ECU-side quiet window is simply `settle`. Elsewhere the write
+        // returns as soon as the OS takes the bytes: over USB CDC the wire
+        // time is negligible, but through a real UART bridge (FTDI, BT-SPP)
+        // the frame is still draining — taking max() there would leave only
+        // settle-minus-wire-time of true quiet, inside the measured
+        // corruption zone. Summing is cheap insurance: at worst it doubles a
+        // ~22 ms allowance per 250-byte frame.
+        if cfg!(unix) {
+            Duration::from_millis(wire_ms.max(settle))
+        } else {
+            Duration::from_millis(wire_ms + settle)
+        }
     }
 
     /// Write a full page to ECU, respecting blocking factor (same chunking as `read_page`).
@@ -1872,14 +1884,6 @@ impl Connection {
         result
     }
 
-    /// Whether [`write_memory_verified`](Self::write_memory_verified) actually
-    /// reads back. On by default; callers that are writing continuously (a
-    /// live slider, a bulk restore that verifies by page CRC afterwards) can
-    /// turn it off to save the extra round-trip.
-    pub fn set_verify_writes(&mut self, enabled: bool) {
-        self.verify_writes = enabled;
-    }
-
     /// As [`write_memory`](Self::write_memory), but read the region straight
     /// back and fail if the ECU is not holding what was sent.
     ///
@@ -1899,28 +1903,43 @@ impl Connection {
         let expected = params.data.clone();
         self.write_memory(params)?;
 
-        if !self.verify_writes || expected.is_empty() {
+        // A modern-protocol write is acknowledged frame by frame
+        // (`check_write_response_status`), so the ECU has already confirmed
+        // storage; reading back would double the traffic for no added signal.
+        // Legacy is answered by silence, which is what the read-back is for.
+        if self.use_modern_protocol || expected.is_empty() {
             return Ok(());
         }
 
         // Read back in the same frame sizes the write used, so a mismatch
         // points at a real ECU-side difference rather than an oversized read.
+        // From here on a failure is not "offline": the write already went out,
+        // and an ECU that ate the read command as table data answers exactly
+        // like a dead link — silence. Report it as unverified, never as a
+        // routine connection warning.
         let chunk = self.effective_write_chunk();
         let mut actual = Vec::with_capacity(expected.len());
         let mut at = offset as usize;
         while actual.len() < expected.len() {
             let take = chunk.min(expected.len() - actual.len());
-            let part = self.read_memory(ReadMemoryParams {
-                page,
-                offset: at as u16,
-                length: take as u16,
-                can_id: 0,
-            })?;
+            let part = self
+                .read_memory(ReadMemoryParams {
+                    page,
+                    offset: at as u16,
+                    length: take as u16,
+                    can_id: 0,
+                })
+                .map_err(|e| ProtocolError::WriteVerificationUnavailable {
+                    page,
+                    offset: at as u16,
+                    reason: e.to_string(),
+                })?;
             if part.len() < take {
-                return Err(ProtocolError::ProtocolError(format!(
-                    "read-back of page {page} offset {at} returned {} of {take} bytes",
-                    part.len()
-                )));
+                return Err(ProtocolError::WriteVerificationUnavailable {
+                    page,
+                    offset: at as u16,
+                    reason: format!("read-back returned {} of {take} bytes", part.len()),
+                });
             }
             actual.extend_from_slice(&part[..take]);
             at += take;
@@ -2733,26 +2752,26 @@ mod tests {
     /// over its own limit, which re-split it into 243 + an 8-byte runt frame.
     #[test]
     fn page_and_memory_writes_chunk_to_the_same_size() {
-        let mut conn = Connection::new(ConnectionConfig::default());
-        let mut proto = ProtocolSettings::default();
-        proto.blocking_factor = 251;
-        conn.set_protocol(proto, Endianness::Big);
+        let core = Arc::new(Mutex::new(MegaCore::new()));
+        let mut conn = speeduino_conn(&core);
+        assert_eq!(
+            conn.effective_write_chunk(),
+            243,
+            "251 less the 7-byte command header, plus one byte of margin"
+        );
 
-        let chunk = conn.effective_write_chunk();
-        assert_eq!(chunk, 243, "251 less the 8-byte command header");
+        // A 288-byte page must reach the wire as exactly two frames — 243+7
+        // and 45+7 header bytes — with no runt. Asserting on the simulated
+        // ECU's actual bursts is what catches `write_page` splitting at the
+        // raw blocking factor again: that put a 258-byte frame on the wire
+        // (over the 257-byte ring) followed by an 8-byte runt.
+        let data: Vec<u8> = (0..288u32).map(|i| i as u8).collect();
+        conn.write_page(3, &data).expect("write_page");
 
-        // A 288-byte page must go out in exactly two frames, with no runt.
-        let frames: Vec<usize> = (0..288)
-            .step_by(chunk)
-            .map(|o| chunk.min(288 - o))
-            .collect();
-        assert_eq!(frames, vec![243, 45]);
-        for f in &frames {
-            assert!(
-                *f <= chunk,
-                "frame of {f} exceeds what write_memory accepts"
-            );
-        }
+        let c = core.lock().unwrap();
+        assert_eq!(c.bursts, vec![250, 52], "wire frames (data + 7B header)");
+        assert_eq!(c.dropped, 0, "no frame may overrun the Mega RX ring");
+        assert_eq!(&c.page(3)[..288], &data[..], "page must arrive intact");
     }
 
     // ---------------------------------------------------------------------
@@ -2971,11 +2990,15 @@ mod tests {
         conn
     }
 
-    /// The harness has to be able to see the bug, or the regression test below
-    /// proves nothing. Drive the simulated Mega with the frame the pre-fix code
-    /// actually sent and confirm it reproduces what the bench recorded on
-    /// 18 Aug 2026: six bytes dropped, the next command's header written into
-    /// the ignition table's top row, and the write behind it lost entirely.
+    /// Characterisation test of the HARNESS, not of production code: it drives
+    /// the simulated Mega directly with the frame the pre-fix code used to
+    /// send, bypassing `Connection` entirely. It exists so the regression
+    /// tests below mean something — a harness that cannot see the bug proves
+    /// nothing. It cannot fail from reverting the fix; the tests that can are
+    /// `table_writes_survive_the_mega_rx_limit` and its siblings.
+    /// Expected signature is what the bench recorded on 18 Aug 2026: six
+    /// bytes dropped, the next command's header written into the ignition
+    /// table's top row, and the write behind it lost entirely.
     #[test]
     fn mega_rx_limit_eats_the_frame_tail_and_the_next_command() {
         let core = Arc::new(Mutex::new(MegaCore::new()));
@@ -3088,7 +3111,15 @@ mod tests {
         proto.inter_write_delay = 100;
         conn.set_protocol(proto, Endianness::Big);
         conn.use_modern_protocol = false;
-        assert_eq!(conn.inter_frame_delay(8), Duration::from_millis(100));
+        // On unix the wire time is already slept out by write_and_wait, so the
+        // delay is exactly the INI value; elsewhere the frame's ~1 ms wire
+        // time is added on top. Either way the INI value must dominate an
+        // 8-byte frame's wire time — and not be doubled or dropped.
+        let d = conn.inter_frame_delay(8);
+        assert!(
+            d >= Duration::from_millis(100) && d <= Duration::from_millis(105),
+            "INI inter-write delay must win for a short frame, got {d:?}"
+        );
 
         // A CRC ECU acknowledges the write, so it needs no blind wait.
         conn.use_modern_protocol = true;

--- a/crates/libretune-core/src/protocol/connection.rs
+++ b/crates/libretune-core/src/protocol/connection.rs
@@ -367,6 +367,9 @@ pub struct Connection {
     /// blocking I/O polling loops abort early so `disconnect()` can complete even
     /// while another thread is mid-read (Issue #71: "disconnect does nothing").
     cancel: Arc<AtomicBool>,
+    /// Whether `write_memory_verified` reads back after writing. See
+    /// [`set_verify_writes`](Connection::set_verify_writes).
+    verify_writes: bool,
 }
 
 impl Connection {
@@ -391,6 +394,7 @@ impl Connection {
             last_written_page: None,
             ecu_type: EcuType::Unknown,
             cancel: Arc::new(AtomicBool::new(false)),
+            verify_writes: true,
         }
     }
 
@@ -424,6 +428,7 @@ impl Connection {
             last_written_page: None,
             ecu_type: EcuType::Unknown,
             cancel: Arc::new(AtomicBool::new(false)),
+            verify_writes: true,
         }
     }
 
@@ -1818,6 +1823,72 @@ impl Connection {
         result
     }
 
+    /// Whether [`write_memory_verified`](Self::write_memory_verified) actually
+    /// reads back. On by default; callers that are writing continuously (a
+    /// live slider, a bulk restore that verifies by page CRC afterwards) can
+    /// turn it off to save the extra round-trip.
+    pub fn set_verify_writes(&mut self, enabled: bool) {
+        self.verify_writes = enabled;
+    }
+
+    /// As [`write_memory`](Self::write_memory), but read the region straight
+    /// back and fail if the ECU is not holding what was sent.
+    ///
+    /// A legacy-protocol write is fire-and-forget: the ECU sends no status, so
+    /// `write_memory` returning `Ok` means only "the bytes left the host". That
+    /// is not the same as "the ECU stored them", and the difference has already
+    /// bitten this project — an oversized frame had its tail dropped and the
+    /// following write consumed as data, leaving a corrupted ignition table in
+    /// RAM while both writes reported success. Chunking closes that particular
+    /// hole; reading back is what catches the next one.
+    pub fn write_memory_verified(
+        &mut self,
+        params: WriteMemoryParams,
+    ) -> Result<(), ProtocolError> {
+        let page = params.page;
+        let offset = params.offset;
+        let expected = params.data.clone();
+        self.write_memory(params)?;
+
+        if !self.verify_writes || expected.is_empty() {
+            return Ok(());
+        }
+
+        // Read back in the same frame sizes the write used, so a mismatch
+        // points at a real ECU-side difference rather than an oversized read.
+        let chunk = self.effective_write_chunk();
+        let mut actual = Vec::with_capacity(expected.len());
+        let mut at = offset as usize;
+        while actual.len() < expected.len() {
+            let take = chunk.min(expected.len() - actual.len());
+            let part = self.read_memory(ReadMemoryParams {
+                page,
+                offset: at as u16,
+                length: take as u16,
+                can_id: 0,
+            })?;
+            if part.len() < take {
+                return Err(ProtocolError::ProtocolError(format!(
+                    "read-back of page {page} offset {at} returned {} of {take} bytes",
+                    part.len()
+                )));
+            }
+            actual.extend_from_slice(&part[..take]);
+            at += take;
+        }
+
+        if let Some(i) = (0..expected.len()).find(|&i| expected[i] != actual[i]) {
+            return Err(ProtocolError::WriteVerificationFailed {
+                page,
+                offset: offset.saturating_add(i as u16),
+                expected: expected[i],
+                actual: actual[i],
+            });
+        }
+
+        Ok(())
+    }
+
     /// Burn current page to flash using INI-defined command format
     pub fn burn(&mut self, params: BurnParams) -> Result<(), ProtocolError> {
         let page = params.page as usize;
@@ -2435,7 +2506,7 @@ mod tests {
 
     #![allow(clippy::field_reassign_with_default)]
     use super::*;
-    use std::collections::HashMap;
+    use std::collections::{HashMap, VecDeque};
     use std::sync::Mutex;
 
     /// The early-return condition is the whole safety surface of the
@@ -2631,6 +2702,8 @@ mod tests {
         Idle,
         /// Bytes gathered after the `M`: page, offset, count, big-endian pairs.
         Header(Vec<u8>),
+        /// The same six fields after an `r`, which answers with page bytes.
+        ReadHeader(Vec<u8>),
         Data {
             page: u16,
             at: usize,
@@ -2655,7 +2728,11 @@ mod tests {
         bursts: Vec<usize>,
         /// Bytes lost to the ring, summed over all bursts.
         dropped: usize,
-        ack: usize,
+        /// Bytes waiting to go back to the host.
+        out: VecDeque<u8>,
+        /// Store the complement of whatever is written to this (page, offset),
+        /// standing in for any reason the ECU might not hold what was sent.
+        corrupt_at: Option<(u16, usize)>,
     }
 
     impl MegaCore {
@@ -2665,7 +2742,8 @@ mod tests {
                 state: MegaState::Idle,
                 bursts: Vec::new(),
                 dropped: 0,
-                ack: 0,
+                out: VecDeque::new(),
+                corrupt_at: None,
             }
         }
 
@@ -2684,12 +2762,15 @@ mod tests {
             }
             // Legacy writes are fire-and-forget, but the line is never truly
             // silent; the host reads *something* back and calls the write good.
-            self.ack += 1;
+            if self.out.is_empty() {
+                self.out.push_back(0x00);
+            }
         }
 
         fn step(&mut self, b: u8) {
             self.state = match std::mem::replace(&mut self.state, MegaState::Idle) {
                 MegaState::Idle if b == b'M' => MegaState::Header(Vec::with_capacity(6)),
+                MegaState::Idle if b == b'r' => MegaState::ReadHeader(Vec::with_capacity(6)),
                 MegaState::Idle => MegaState::Idle,
                 MegaState::Header(mut h) => {
                     h.push(b);
@@ -2703,10 +2784,26 @@ mod tests {
                         }
                     }
                 }
+                MegaState::ReadHeader(mut h) => {
+                    h.push(b);
+                    if h.len() < 6 {
+                        MegaState::ReadHeader(h)
+                    } else {
+                        let page = u16::from_be_bytes([h[0], h[1]]);
+                        let at = u16::from_be_bytes([h[2], h[3]]) as usize;
+                        let count = u16::from_be_bytes([h[4], h[5]]) as usize;
+                        let img = self.pages.entry(page).or_insert_with(|| vec![0u8; 1024]);
+                        let end = (at + count).min(img.len());
+                        let slice = img[at.min(end)..end].to_vec();
+                        self.out.extend(slice);
+                        MegaState::Idle
+                    }
+                }
                 MegaState::Data { page, at, left } => {
+                    let flip = self.corrupt_at == Some((page, at));
                     let img = self.pages.entry(page).or_insert_with(|| vec![0u8; 1024]);
                     if at < img.len() {
-                        img[at] = b;
+                        img[at] = if flip { !b } else { b };
                     }
                     if left > 1 {
                         MegaState::Data {
@@ -2737,12 +2834,11 @@ mod tests {
     impl Read for MegaChannel {
         fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
             let mut core = self.0.lock().unwrap();
-            if core.ack == 0 || buf.is_empty() {
-                return Ok(0);
+            let n = core.out.len().min(buf.len());
+            for slot in buf.iter_mut().take(n) {
+                *slot = core.out.pop_front().unwrap();
             }
-            core.ack -= 1;
-            buf[0] = 0x00;
-            Ok(1)
+            Ok(n)
         }
     }
 
@@ -2760,7 +2856,7 @@ mod tests {
             Ok(Box::new(MegaChannel(Arc::clone(&self.0))))
         }
         fn bytes_to_read(&mut self) -> std::io::Result<u32> {
-            Ok(self.0.lock().unwrap().ack as u32)
+            Ok(self.0.lock().unwrap().out.len() as u32)
         }
     }
 
@@ -2861,6 +2957,60 @@ mod tests {
         assert_eq!(c.dropped, 0, "no byte may be dropped by the ECU ring");
         assert_eq!(&c.page(1)[..256], &ignition[..], "ignition table corrupted");
         assert_eq!(&c.page(2)[..256], &ve[..], "VE table lost or corrupted");
+    }
+
+    /// Chunking closes the overrun we know about. The read-back is what makes
+    /// the next silent divergence visible, so it has to actually catch one:
+    /// a single byte the ECU did not store as sent must fail the write rather
+    /// than return Ok, and it must name the cell.
+    #[test]
+    fn verified_write_catches_a_byte_the_ecu_did_not_store() {
+        let core = Arc::new(Mutex::new(MegaCore::new()));
+        core.lock().unwrap().corrupt_at = Some((1, 100));
+        let mut conn = speeduino_conn(&core);
+
+        let table: Vec<u8> = (0..256u32).map(|i| 40 + (i % 30) as u8).collect();
+        let err = conn
+            .write_memory_verified(WriteMemoryParams {
+                can_id: 0,
+                page: 1,
+                offset: 0,
+                data: table.clone(),
+            })
+            .expect_err("a byte the ECU did not store must fail the write");
+
+        match err {
+            ProtocolError::WriteVerificationFailed {
+                page,
+                offset,
+                expected,
+                actual,
+            } => {
+                assert_eq!((page, offset), (1, 100));
+                assert_eq!(expected, table[100]);
+                assert_eq!(actual, !table[100]);
+            }
+            other => panic!("expected a verification failure, got {other:?}"),
+        }
+    }
+
+    /// The same write, with nothing wrong at the ECU, must pass silently —
+    /// otherwise the check would be unusable in the table editor.
+    #[test]
+    fn verified_write_passes_when_the_ecu_agrees() {
+        let core = Arc::new(Mutex::new(MegaCore::new()));
+        let mut conn = speeduino_conn(&core);
+
+        let table: Vec<u8> = (0..256u32).map(|i| 40 + (i % 30) as u8).collect();
+        conn.write_memory_verified(WriteMemoryParams {
+            can_id: 0,
+            page: 1,
+            offset: 0,
+            data: table.clone(),
+        })
+        .expect("an honest ECU must verify clean");
+
+        assert_eq!(&core.lock().unwrap().page(1)[..256], &table[..]);
     }
 
     #[test]

--- a/crates/libretune-core/src/protocol/connection.rs
+++ b/crates/libretune-core/src/protocol/connection.rs
@@ -2435,6 +2435,8 @@ mod tests {
 
     #![allow(clippy::field_reassign_with_default)]
     use super::*;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
 
     /// The early-return condition is the whole safety surface of the
     /// expected-length read: returning too soon yields a truncated message,
@@ -2613,6 +2615,252 @@ mod tests {
                 "frame of {f} exceeds what write_memory accepts"
             );
         }
+    }
+
+    // ---------------------------------------------------------------------
+    // Mega2560 RX-limit regression (bench simulator acceptance behavior 5)
+    // ---------------------------------------------------------------------
+
+    /// Speeduino's own INI: "Serial buffer is 257 bytes and there are 6 bytes
+    /// of overhead ... payload is therefore 257-6=251".
+    const MEGA_RX_CAPACITY: usize = 257;
+    const SPEEDUINO_BLOCKING_FACTOR: u32 = 251;
+
+    /// What the `M` handler is in the middle of when the next byte arrives.
+    enum MegaState {
+        Idle,
+        /// Bytes gathered after the `M`: page, offset, count, big-endian pairs.
+        Header(Vec<u8>),
+        Data {
+            page: u16,
+            at: usize,
+            left: usize,
+        },
+    }
+
+    /// The Mega2560's serial front end as the bench simulator models it
+    /// (`LibreTune-test/sim-ecu`, `MEGA_RX_CAPACITY 257`, acceptance behavior 5).
+    ///
+    /// Two properties matter and neither is obvious from the protocol spec.
+    /// The RX ring holds 257 bytes and drops the rest of an over-long burst
+    /// without complaint, and the `M` handler is a state machine that keeps
+    /// taking whatever bytes arrive next as table data when a frame promised
+    /// more than turned up. One oversized write therefore corrupts the page it
+    /// was aimed at *and* eats the command behind it, with nothing on the wire
+    /// to say so.
+    struct MegaCore {
+        pages: HashMap<u16, Vec<u8>>,
+        state: MegaState,
+        /// Length of each burst the host handed to the port.
+        bursts: Vec<usize>,
+        /// Bytes lost to the ring, summed over all bursts.
+        dropped: usize,
+        ack: usize,
+    }
+
+    impl MegaCore {
+        fn new() -> Self {
+            Self {
+                pages: HashMap::new(),
+                state: MegaState::Idle,
+                bursts: Vec::new(),
+                dropped: 0,
+                ack: 0,
+            }
+        }
+
+        fn page(&self, page: u16) -> &[u8] {
+            self.pages.get(&page).map(|p| p.as_slice()).unwrap_or(&[])
+        }
+
+        /// One burst from the host: fill the ring, drop the overflow, then let
+        /// the command handler drain what survived.
+        fn burst(&mut self, bytes: &[u8]) {
+            self.bursts.push(bytes.len());
+            let kept = bytes.len().min(MEGA_RX_CAPACITY);
+            self.dropped += bytes.len() - kept;
+            for &b in &bytes[..kept] {
+                self.step(b);
+            }
+            // Legacy writes are fire-and-forget, but the line is never truly
+            // silent; the host reads *something* back and calls the write good.
+            self.ack += 1;
+        }
+
+        fn step(&mut self, b: u8) {
+            self.state = match std::mem::replace(&mut self.state, MegaState::Idle) {
+                MegaState::Idle if b == b'M' => MegaState::Header(Vec::with_capacity(6)),
+                MegaState::Idle => MegaState::Idle,
+                MegaState::Header(mut h) => {
+                    h.push(b);
+                    if h.len() < 6 {
+                        MegaState::Header(h)
+                    } else {
+                        MegaState::Data {
+                            page: u16::from_be_bytes([h[0], h[1]]),
+                            at: u16::from_be_bytes([h[2], h[3]]) as usize,
+                            left: u16::from_be_bytes([h[4], h[5]]) as usize,
+                        }
+                    }
+                }
+                MegaState::Data { page, at, left } => {
+                    let img = self.pages.entry(page).or_insert_with(|| vec![0u8; 1024]);
+                    if at < img.len() {
+                        img[at] = b;
+                    }
+                    if left > 1 {
+                        MegaState::Data {
+                            page,
+                            at: at + 1,
+                            left: left - 1,
+                        }
+                    } else {
+                        MegaState::Idle
+                    }
+                }
+            };
+        }
+    }
+
+    struct MegaChannel(Arc<Mutex<MegaCore>>);
+
+    impl Write for MegaChannel {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().burst(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl Read for MegaChannel {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            let mut core = self.0.lock().unwrap();
+            if core.ack == 0 || buf.is_empty() {
+                return Ok(0);
+            }
+            core.ack -= 1;
+            buf[0] = 0x00;
+            Ok(1)
+        }
+    }
+
+    impl CommunicationChannel for MegaChannel {
+        fn set_timeout(&mut self, _timeout: Duration) -> std::io::Result<()> {
+            Ok(())
+        }
+        fn clear_input_buffer(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+        fn clear_output_buffer(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+        fn try_clone(&self) -> std::io::Result<Box<dyn CommunicationChannel>> {
+            Ok(Box::new(MegaChannel(Arc::clone(&self.0))))
+        }
+        fn bytes_to_read(&mut self) -> std::io::Result<u32> {
+            Ok(self.0.lock().unwrap().ack as u32)
+        }
+    }
+
+    /// One `M` frame carrying a whole 16x16 table, exactly as the pre-fix code
+    /// built it: 7 header bytes plus 256 data bytes.
+    fn oversized_table_frame(page: u16, table: &[u8]) -> Vec<u8> {
+        let mut f = vec![b'M'];
+        f.extend_from_slice(&page.to_be_bytes());
+        f.extend_from_slice(&0u16.to_be_bytes());
+        f.extend_from_slice(&(table.len() as u16).to_be_bytes());
+        f.extend_from_slice(table);
+        f
+    }
+
+    fn speeduino_conn(core: &Arc<Mutex<MegaCore>>) -> Connection {
+        let mut conn = Connection::new(ConnectionConfig::default());
+        conn.channel = Some(Box::new(MegaChannel(Arc::clone(core))));
+        conn.config.auto_burn_on_page_change = false;
+
+        let mut proto = ProtocolSettings::default();
+        proto.blocking_factor = SPEEDUINO_BLOCKING_FACTOR;
+        proto.inter_write_delay = 0;
+        proto.block_read_timeout = 100;
+        proto.page_chunk_write_commands = vec!["M%2i%2o%2c%v".to_string(); 8];
+        proto.page_read_commands = vec!["r%2i%2o%2c".to_string(); 8];
+        // Speeduino's legacy framing puts these fields on the wire big-endian;
+        // the observed corruption bytes (4D 00 02 ...) only decode that way.
+        conn.set_protocol(proto, Endianness::Big);
+        conn.use_modern_protocol = false;
+        conn
+    }
+
+    /// The harness has to be able to see the bug, or the regression test below
+    /// proves nothing. Drive the simulated Mega with the frame the pre-fix code
+    /// actually sent and confirm it reproduces what the bench recorded on
+    /// 18 Aug 2026: six bytes dropped, the next command's header written into
+    /// the ignition table's top row, and the write behind it lost entirely.
+    #[test]
+    fn mega_rx_limit_eats_the_frame_tail_and_the_next_command() {
+        let core = Arc::new(Mutex::new(MegaCore::new()));
+
+        let ignition: Vec<u8> = (0..256u32).map(|i| 40 + (i % 30) as u8).collect();
+        let ve: Vec<u8> = (0..256u32).map(|i| 60 + (i % 40) as u8).collect();
+
+        {
+            let mut c = core.lock().unwrap();
+            c.burst(&oversized_table_frame(1, &ignition)); // 263 bytes
+            c.burst(&oversized_table_frame(2, &ve)); // 263 bytes
+        }
+
+        let c = core.lock().unwrap();
+        assert_eq!(c.bursts, vec![263, 263]);
+        assert_eq!(c.dropped, 12, "6 bytes lost off the tail of each frame");
+
+        // The last six cells of the ignition table hold the next command's
+        // header instead of spark advance: 'M', page 2 big-endian, offset 0,
+        // and the high byte of the 256-byte count. Raw 0x4D, 0x00 and 0x02 are
+        // 37, -40 and -38 degrees once the table's +40 offset comes off — a
+        // detonation-relevant edit nobody asked for, in the 100 kPa row.
+        assert_eq!(&c.page(1)[250..256], &[0x4D, 0x00, 0x02, 0x00, 0x00, 0x01]);
+        assert_ne!(&c.page(1)[250..256], &ignition[250..256]);
+
+        // ...and the VE write never happened at all.
+        assert!(
+            c.page(2).is_empty() || c.page(2)[..256].iter().all(|&b| b == 0),
+            "the following write should have been consumed as table data"
+        );
+    }
+
+    /// The fix: no matter how large a payload a caller hands `write_memory`,
+    /// nothing longer than the Mega can hold reaches the wire, so both tables
+    /// land byte-exact. Reintroducing the bug (dropping the chunking branch in
+    /// `write_memory`) turns this into the corruption pinned above.
+    #[test]
+    fn table_writes_survive_the_mega_rx_limit() {
+        let core = Arc::new(Mutex::new(MegaCore::new()));
+        let mut conn = speeduino_conn(&core);
+
+        let ignition: Vec<u8> = (0..256u32).map(|i| 40 + (i % 30) as u8).collect();
+        let ve: Vec<u8> = (0..256u32).map(|i| 60 + (i % 40) as u8).collect();
+
+        for (page, table) in [(1u8, &ignition), (2u8, &ve)] {
+            conn.write_memory(WriteMemoryParams {
+                can_id: 0,
+                page,
+                offset: 0,
+                data: table.clone(),
+            })
+            .expect("write_memory should succeed");
+        }
+
+        let c = core.lock().unwrap();
+        assert!(
+            c.bursts.iter().all(|&n| n <= MEGA_RX_CAPACITY),
+            "a frame overran the Mega's {MEGA_RX_CAPACITY}-byte buffer: {:?}",
+            c.bursts
+        );
+        assert_eq!(c.dropped, 0, "no byte may be dropped by the ECU ring");
+        assert_eq!(&c.page(1)[..256], &ignition[..], "ignition table corrupted");
+        assert_eq!(&c.page(2)[..256], &ve[..], "VE table lost or corrupted");
     }
 
     #[test]

--- a/crates/libretune-core/src/protocol/connection.rs
+++ b/crates/libretune-core/src/protocol/connection.rs
@@ -1752,8 +1752,13 @@ impl Connection {
             let response = self.send_packet(packet)?;
             check_write_response_status(&response)
         } else {
-            // Legacy protocol: send raw command
-            self.send_raw_command(&cmd)?;
+            // Legacy protocol: value writes (Speeduino 'M', MS 'w') define no
+            // response, exactly like legacy burn above. Waiting for one stalls
+            // every write for the full serial timeout (~2 s), and the timeout
+            // is then misreported as a write failure — single edits appear to
+            // fail (they actually landed), and write_page's retry loop treats
+            // the phantom failure as fatal and aborts bulk writes partway.
+            self.send_raw_command_no_response(&cmd)?;
             Ok(())
         };
 

--- a/crates/libretune-core/src/protocol/connection.rs
+++ b/crates/libretune-core/src/protocol/connection.rs
@@ -2847,6 +2847,11 @@ mod tests {
             Ok(())
         }
         fn clear_input_buffer(&mut self) -> std::io::Result<()> {
+            // A real port drops whatever is still sitting in RX, and the
+            // command path relies on that: a fire-and-forget write leaves its
+            // unread ack behind, which would otherwise arrive as the first
+            // byte of the next read's payload.
+            self.0.lock().unwrap().out.clear();
             Ok(())
         }
         fn clear_output_buffer(&mut self) -> std::io::Result<()> {

--- a/crates/libretune-core/src/protocol/connection.rs
+++ b/crates/libretune-core/src/protocol/connection.rs
@@ -1698,8 +1698,49 @@ impl Connection {
         Ok(())
     }
 
-    /// Write memory to ECU using INI-defined command format
+    /// Write memory to ECU using INI-defined command format.
+    ///
+    /// Payloads larger than the INI's `blockingFactor` are split into
+    /// sequential writes here rather than trusting callers to pre-chunk. The
+    /// ECU's serial RX buffer is exactly what `blockingFactor` declares (257
+    /// bytes minus protocol overhead on a Mega2560); a longer frame gets its
+    /// tail silently dropped by the ECU, which then consumes the next bytes on
+    /// the wire as if they were table data — observed on a running engine as a
+    /// partially-applied, corrupted VE table (drove visibly jerkily) when a
+    /// 263-byte full-table write went out unchunked. Six command paths call
+    /// this directly with unbounded payloads, so the guard belongs here, not
+    /// in each caller.
     pub fn write_memory(&mut self, params: WriteMemoryParams) -> Result<(), ProtocolError> {
+        let max_chunk = self
+            .protocol_settings
+            .as_ref()
+            .map(|p| p.blocking_factor)
+            .unwrap_or(256)
+            .max(1) as usize;
+        // Frame overhead (command byte, identifier, offset, count) also
+        // occupies the ECU buffer; keep the whole frame under the limit.
+        let max_data = max_chunk.saturating_sub(8).max(1);
+        if params.data.len() > max_data {
+            let mut offset = params.offset as usize;
+            let mut remaining = params.data.as_slice();
+            while !remaining.is_empty() {
+                let take = remaining.len().min(max_data);
+                let (head, tail) = remaining.split_at(take);
+                self.write_memory(WriteMemoryParams {
+                    can_id: params.can_id,
+                    page: params.page,
+                    offset: offset as u16,
+                    data: head.to_vec(),
+                })?;
+                offset += take;
+                remaining = tail;
+                if !remaining.is_empty() {
+                    std::thread::sleep(Duration::from_millis(self.get_effective_min_wait().max(5)));
+                }
+            }
+            return Ok(());
+        }
+
         // Auto-burn safety policy (spec §6.2): if the previous write targeted a different
         // page, burn it to flash before writing to the new page. Prevents partial-flash
         // corruption on power loss.

--- a/crates/libretune-core/src/protocol/error.rs
+++ b/crates/libretune-core/src/protocol/error.rs
@@ -67,6 +67,20 @@ pub enum ProtocolError {
         actual: u8,
     },
 
+    /// A write went out but the read-back could not complete, so the write is
+    /// unverified. On a legacy ECU this is itself the corruption signature: a
+    /// buffer-overrun ECU consumes the read command as table data and answers
+    /// with silence. Must not be treated as "offline" — the write was sent.
+    #[error(
+        "write to page {page} offset {offset} could not be verified \
+         (read-back failed: {reason}) — treat the write as unconfirmed"
+    )]
+    WriteVerificationUnavailable {
+        page: u8,
+        offset: u16,
+        reason: String,
+    },
+
     #[error("Port not found: {0}")]
     PortNotFound(String),
 

--- a/crates/libretune-core/src/protocol/error.rs
+++ b/crates/libretune-core/src/protocol/error.rs
@@ -52,6 +52,21 @@ pub enum ProtocolError {
     #[error("Protocol error: {0}")]
     ProtocolError(String),
 
+    /// A write was read straight back and the ECU did not hold what was sent.
+    /// Distinct from a failed write: the command was accepted, so nothing else
+    /// on the wire reports a problem, and the tune the tuner is looking at no
+    /// longer matches the tune the engine is running.
+    #[error(
+        "ECU did not store what was written to page {page} offset {offset}: \
+         sent {expected:02X?}, read back {actual:02X?}"
+    )]
+    WriteVerificationFailed {
+        page: u8,
+        offset: u16,
+        expected: u8,
+        actual: u8,
+    },
+
     #[error("Port not found: {0}")]
     PortNotFound(String),
 


### PR DESCRIPTION
## Description
Legacy-protocol writes to Speeduino were unreliable in four stacked ways, found while chasing a corrupted ignition table that reached a bench engine with every write reporting success:

1. **Value writes waited for a reply that legacy `M`/`w` never sends** — every write blocked ~2 s and was then misreported as `Connection timeout` (the write had actually landed). Writes are now fire-and-forget, like legacy burn already was.
2. **`write_memory` sent oversized frames.** A whole 256-byte table went out as one 263-byte frame; the Mega2560's RX ring holds 257, drops the tail silently, and its `M` handler then consumes the *next command's bytes* as table data. Observed result: `4D 00 02 00 00 01` written into the top row of an ignition table (37/−40/−38 ° after the +40 offset) and the following page write lost entirely. `write_memory` now chunks by `blockingFactor` minus the command header, and `write_page` uses the same budget instead of handing it chunks 8 bytes too large.
3. **Chunking alone was not enough.** With correctly sized frames the corruption still reproduced: a legacy write needs a quiet service window afterwards or the next command is eaten. Measured by replaying frames raw against the bench ECU while sweeping the gap: 10 ms corrupts, 20 ms is the first clean value, 30 ms is what the reference writer has always used. Every legacy write frame now gets `max(wire time, INI interWriteDelay, 30 ms)`, never scaled down for short frames — the fatal case was the *small* trailing chunk's 10.5 ms gap. Burn additionally gets a settle margin past `pageActivationDelay` and clears stale RX afterwards.
4. **`Ok` only ever meant "the bytes left the host".** `write_memory_verified` (used by `update_table_data`, on by default) reads the span back in the same frame sizes and fails loudly with the first differing cell. Verification mismatch is a hard error — the tune on screen no longer matches the engine; connectivity errors keep the existing offline-tolerant warning.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues
The pacing sleep is a plain `thread::sleep` after the frame goes out, so it also takes effect on Windows, where the previous `write_and_wait` min-wait path was a no-op.

## Changes Made
- `write_memory`: fire-and-forget on legacy, self-chunking, per-frame pacing
- `write_page`: chunk budget unified with `write_memory` (no more 8-byte runt frames)
- `write_memory_verified` + `WriteVerificationFailed` error; wired into `update_table_data`
- `burn`: settle margin + RX clear after the busy window
- In-process simulated Mega2560 (RX ring capacity + `M`-handler state machine) with regression tests that reproduce the exact bench corruption signature, plus pacing and verify tests

## Testing
- [x] I have tested these changes locally
- [x] New and existing tests pass (`cargo test`)
- [ ] The UI works correctly with these changes

Gates run on the branch tip: `cargo fmt --all -- --check` clean, `cargo clippy --workspace -- -D warnings` clean, `cargo test --workspace` green (395 tests in libretune-core alone), `npx tsc --noEmit` clean.

Worth knowing before the fix: because legacy writes waited for a reply that never comes, `write_page`'s retry classified every phantom timeout as transient — **each legacy chunk was put on the wire three times, two seconds apart, then reported as a hard failure.** The triple-send was itself a corruption mechanism.

Cost note: burn's settle margin adds 600 ms per burned page; a full 15-page sync with per-page burns spends ~9 s extra. That is deliberate — the margin is what stopped the post-burn frame-eating on the bench.

Bench evidence (Speeduino-signature simulator on COM4, scripted connect → full-page writes → burn cycles): control build corrupted the audited pages 3/3 cycles with the documented eaten-tail signature; with these fixes, every completed cycle was byte-exact (11/12; the single miss was an unrelated pre-existing app-layer stall that aborted before writing, tracked separately). The regression tests were verified to fail with the fix reverted. Not yet re-validated on a real engine.

## Checklist
- [x] Code compiles without errors
- [x] No new clippy warnings (`cargo clippy`)
- [x] Code is formatted (`cargo fmt`)
- [x] TypeScript compiles without errors (`npx tsc --noEmit`)
- [ ] Documentation updated if needed
- [x] Commit messages follow conventional format

🤖 Generated with [Claude Code](https://claude.com/claude-code)
