### PR TITLE
feat(curves): make the embedded chart + side table genuinely responsive

### DIFF
--- a/crates/libretune-app/src/components/curves/CurveEditor.css
+++ b/crates/libretune-app/src/components/curves/CurveEditor.css
@@ -128,12 +128,31 @@
 .curve-editor.embedded .curve-content {
   /* Chart beside the values table/gauge, matching TunerStudio's layout,
      instead of stacking them (which pushed a dialog with multiple curves
-     far below the fold). */
+     far below the fold). container-type lets the @container rule below
+     switch back to stacked once there's genuinely not enough width for
+     both side by side, rather than clipping or forcing the page wider. */
   flex-direction: row;
   padding: 8px;
   gap: 12px;
   overflow: visible;
   align-items: flex-start;
+  container-type: inline-size;
+}
+
+/* Chart (min 320px readable) + 220px table + 12px gap need ~552px; below
+   that there's no room to keep them side by side. */
+@container (max-width: 600px) {
+  .curve-editor.embedded .curve-content {
+    flex-direction: column;
+  }
+
+  .curve-editor.embedded .curve-chart-container {
+    max-width: 100%;
+  }
+
+  .curve-editor.embedded .curve-bottom-section {
+    width: 100%;
+  }
 }
 
 /* Chart container */
@@ -150,7 +169,15 @@
 }
 
 .curve-editor.embedded .curve-chart-container {
-  width: var(--curve-embedded-width, 500px);
+  /* CSS decides the available width (up to the 500px comfort size, down to
+     a 320px floor where the SVG stays readable); the component reads the
+     resulting rendered width via ResizeObserver to size the SVG/axes
+     instead of the other way around (a JS-computed width driving this
+     rule would be circular — the width IS the thing being measured). */
+  width: 100%;
+  max-width: 500px;
+  min-width: 320px;
+  flex-shrink: 1;
 }
 
 /* Side section for embedded mode (data table + compact live readout),

--- a/crates/libretune-app/src/components/curves/CurveEditor.css
+++ b/crates/libretune-app/src/components/curves/CurveEditor.css
@@ -126,7 +126,10 @@
 }
 
 .curve-editor.embedded .curve-content {
-  flex-direction: column;
+  /* Chart beside the values table/gauge, matching TunerStudio's layout,
+     instead of stacking them (which pushed a dialog with multiple curves
+     far below the fold). */
+  flex-direction: row;
   padding: 8px;
   gap: 12px;
   overflow: visible;
@@ -150,9 +153,11 @@
   width: var(--curve-embedded-width, 500px);
 }
 
-/* Bottom section for embedded mode (data table + compact live readout) */
+/* Side section for embedded mode (data table + compact live readout),
+   sitting next to the chart rather than spanning its full width. */
 .curve-editor.embedded .curve-bottom-section {
-  width: var(--curve-embedded-width, 500px);
+  width: 220px;
+  flex-shrink: 0;
 }
 
 .curve-bottom-section {
@@ -217,13 +222,16 @@
 }
 
 .curve-editor.embedded .curve-data-table {
-  max-height: 150px;
+  /* Matches the chart's embedded height so the table sits flush beside it;
+     extra rows scroll inside this box instead of growing the page. */
+  max-height: 280px;
   min-width: 0;
   flex: none;
 }
 
 .curve-editor.embedded .curve-bottom-section .curve-data-table {
-  max-height: none;
+  max-height: 280px;
+  overflow-y: auto;
 }
 
 .curve-bottom-section .curve-data-table table {

--- a/crates/libretune-app/src/components/curves/CurveEditor.tsx
+++ b/crates/libretune-app/src/components/curves/CurveEditor.tsx
@@ -194,6 +194,23 @@ export default function CurveEditor({
   // SVG container ref
   const svgRef = useRef<SVGSVGElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const chartContainerRef = useRef<HTMLDivElement>(null);
+  // Embedded mode's chart box is CSS-sized (width: 100%, capped 320-500px —
+  // see CurveEditor.css), not fixed — this tracks the box's actual rendered
+  // width so the SVG/axes can match it instead of assuming 500px.
+  const [measuredChartWidth, setMeasuredChartWidth] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!embedded) return;
+    const el = chartContainerRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver((entries) => {
+      const width = entries[0]?.contentRect.width;
+      if (width) setMeasuredChartWidth(width);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [embedded]);
 
   // Update local values when data changes
   useEffect(() => {
@@ -235,8 +252,11 @@ export default function CurveEditor({
     };
   }, [getCellColor]);
 
-  // Chart dimensions based on mode
-  const chartWidth = embedded ? 500 : 500;
+  // Chart dimensions based on mode. Embedded width comes from the actual
+  // rendered chart box (see the ResizeObserver above) — CSS decides the
+  // available space (100%, capped 320-500px), this just matches it; 500 is
+  // only a placeholder for the first render before the box is measured.
+  const chartWidth = embedded ? Math.round(measuredChartWidth ?? 500) : 500;
   const chartHeight = embedded ? 280 : 350;
   const padding = { top: 30, right: 20, bottom: 40, left: 50 };
 
@@ -790,11 +810,10 @@ Suggestion: {errorInfo.suggestion}
     });
 
   return (
-    <div 
+    <div
       className={`curve-editor ${embedded ? 'embedded' : 'standalone'}`}
       ref={containerRef}
       tabIndex={0} // Enable keyboard focus for undo/redo shortcuts
-      style={embedded ? ({ '--curve-embedded-width': `${chartWidth}px` } as React.CSSProperties) : undefined}
     >
       {/* Header - only for standalone mode */}
       {!embedded && (
@@ -838,7 +857,7 @@ Suggestion: {errorInfo.suggestion}
 
       <div className="curve-content">
         {/* Chart area */}
-        <div className="curve-chart-container" onContextMenu={handleContextMenu}>
+        <div className="curve-chart-container" ref={chartContainerRef} onContextMenu={handleContextMenu}>
           <svg
             ref={svgRef}
             width={chartWidth}


### PR DESCRIPTION
Stacked on #198 (not yet merged) — this PR's diff includes its 1 commit plus one new one on top; only the last commit is new here.

The embedded curve editor (chart + values table beside it, e.g. Dwell, Priming pulse) was ~732px minimum by construction (chart hardcoded at 500px in JS, side table fixed at 220px) — a hard floor that could only scroll or clip, never actually reflow to a narrower window. It was excluded from the earlier 720px dialog-width cap specifically to stop it clipping, but that only worked around the symptom.

Inverts the dependency: CSS now decides the chart box's available width (width: 100%, capped 320-500px) instead of a JS constant driving a --curve-embedded-width custom property that the box's own width rule read from (circular — the width was both the input and the output). The component reads the box's actual rendered width via ResizeObserver and uses that for the SVG/axis math, defaulting to 500 only for the first paint before it's measured.

Below ~600px of available width (chart's 320px floor + table's 220px + gap ≈ 552px), a @container query on .curve-content stacks the table below the chart instead of squeezing them side by side — same "available space decides the layout" pattern already used for .panel-content--multi at 440px in DialogRenderer.css.

Verified: tsc clean, 194/195 vitest passing (pre-existing unrelated timeout).