### PR TITLE
fix(app): string-context build deadlocked table writes on the connection lock

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/string_context.rs
+++ b/crates/libretune-app/src-tauri/src/commands/string_context.rs
@@ -200,9 +200,23 @@ pub async fn build_string_context_filtered(
     let def_guard = state.definition.lock().await;
     let tune_guard = state.current_tune.lock().await;
     let project_guard = state.current_project.lock().await;
-    let conn_guard = state.connection.lock().await;
     let demo = *state.demo_mode.lock().await;
     let streaming = state.streaming_task.lock().await.is_some();
+
+    // The connection is consulted for exactly one boolean, so never wait on
+    // its mutex here. This context builds while table writes hold the
+    // connection for seconds (paced, verified serial I/O), and blocking on it
+    // with `current_tune` held deadlocks those writes — they hold the
+    // connection and then take `current_tune` — until something tears one
+    // side down. A busy connection mutex means serial I/O is in flight,
+    // which is itself proof of "online".
+    let conn_online = match state.connection.try_lock() {
+        Ok(g) => g
+            .as_ref()
+            .map(|c| c.state() == ConnectionState::Connected)
+            .unwrap_or(false),
+        Err(_) => true,
+    };
 
     let string_values = string_map_from_tune(tune_guard.as_ref(), def_guard.as_ref(), filter);
     let bit_options = bit_options_map(def_guard.as_ref(), filter);
@@ -216,16 +230,11 @@ pub async fn build_string_context_filtered(
         .map(|p| p.path.display().to_string())
         .unwrap_or_default();
 
-    let is_online = demo && streaming
-        || conn_guard
-            .as_ref()
-            .map(|c| c.state() == ConnectionState::Connected)
-            .unwrap_or(false);
+    let is_online = demo && streaming || conn_online;
 
     let start_time = state.app_start_epoch;
     let cache = Arc::clone(&state.inc_table_cache);
 
-    drop(conn_guard);
     drop(project_guard);
     drop(tune_guard);
     drop(def_guard);

--- a/crates/libretune-app/src-tauri/src/tests.rs
+++ b/crates/libretune-app/src-tauri/src/tests.rs
@@ -336,6 +336,42 @@ mod concurrency_tests {
 
         writer.await.expect("writer task panicked");
     }
+
+    /// `build_string_context_filtered` used to `lock().await` the connection
+    /// while holding `current_tune` — the reverse order of every table and
+    /// constant writer, which holds the connection through seconds of paced
+    /// serial I/O and then takes `current_tune`. On the bench that AB-BA
+    /// deadlocked ~1/3 of write cycles for as long as nothing tore one side
+    /// down (the W2 ~90 s stall). The builder now try_locks the connection,
+    /// so it must complete while a writer-shaped task holds the connection
+    /// and then takes the tune lock. Reintroduce the blocking acquire and
+    /// this test times out.
+    #[tokio::test]
+    async fn string_context_builds_while_a_writer_holds_the_connection() {
+        let state = build_state_for_lock_tests();
+
+        let s1 = state.clone();
+        let writer = tokio::spawn(async move {
+            let _conn = s1.connection.lock().await;
+            tokio::time::sleep(Duration::from_millis(150)).await;
+            let _tune = s1.current_tune.lock().await;
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        });
+
+        // Let the writer take the connection first.
+        tokio::time::sleep(Duration::from_millis(30)).await;
+
+        let built = tokio::time::timeout(
+            Duration::from_secs(2),
+            crate::commands::string_context::build_string_context_filtered(&state, None),
+        )
+        .await;
+        assert!(
+            built.is_ok(),
+            "context build deadlocked against a connection-holding writer"
+        );
+        let _ = writer.await;
+    }
 }
 
 // New tests for signature comparison and normalization (unit tests)


### PR DESCRIPTION
## Description
A table or constant write would intermittently hang for ~90 seconds with serial comms healthy, roughly one write cycle in three on a scripted bench. It was an AB-BA deadlock:

- `build_string_context_filtered` (INI string-expression evaluation — gauge titles, menu/dialog conditions) acquired `current_tune` and then **blocked on the connection mutex**.
- Every table/constant writer takes the locks the other way: it holds the **connection** through seconds of serial I/O and then takes `current_tune`.

Once interleaved, neither side can proceed; the hang ended only when something external tore one side down. Proof that nothing in the app was timing out: with the test harness's invoke timeout at 90 s the stall lasted 90.0 s, and with the timeout lowered to 25 s the very same hold lasted 24.66 s — attributed to this site by a hold-duration tracer placed on all 85 `current_tune`/`tune_modified` lock sites.

Even without deadlocking, this site held `current_tune` for 2–2.7 s per call (the time spent waiting behind a paced write), starving `get_tune_info` and making the app feel sluggish around writes.

The connection is consulted for exactly one boolean (`isOnline()`), so the builder no longer waits on it: `try_lock`, and a busy connection mutex is treated as online — contention means serial I/O is in flight, which is itself the answer.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues
Same failure family as the long-standing intermittent UI hangs around writes. Builds on nothing; independent of #208/#209.

## Changes Made
- `build_string_context_filtered`: never awaits the connection mutex; `try_lock` with busy-means-online for the single boolean it needed
- Regression test: a writer-shaped task holds the connection then takes `current_tune` while the context builder runs — deadlocks (and fails at its 2 s timeout) if the blocking acquire is reintroduced. Verified by mutation.

## Testing
- [x] I have tested these changes locally
- [x] New and existing tests pass (`cargo test`)
- [ ] The UI works correctly with these changes

Gates on the branch tip: `cargo fmt --all -- --check` clean, `cargo clippy --workspace -- -D warnings` clean, `cargo test --workspace` green.

Bench evidence (scripted 12-cycle connect → write change set → burn → serial audit against a Speeduino-signature simulator): before the fix, 4/12 cycles stalled ~90 s; after, **12/12 cycles clean and byte-exact**, total run time nearly halved, and the lock tracer recorded zero holds over 1 s.

## Checklist
- [x] Code compiles without errors
- [x] No new clippy warnings (`cargo clippy`)
- [x] Code is formatted (`cargo fmt`)
- [x] TypeScript compiles without errors (`npx tsc --noEmit`)
- [ ] Documentation updated if needed
- [x] Commit messages follow conventional format

🤖 Generated with [Claude Code](https://claude.com/claude-code)
