### PR TITLE
fix(ini): drop redundant borrow failing clippy -D warnings (unblock main)

### DIFF
--- a/crates/libretune-core/src/project/online_repository.rs
+++ b/crates/libretune-core/src/project/online_repository.rs
@@ -267,7 +267,7 @@ impl OnlineIniRepository {
                 "[online-ini] {} -> {} body: {}",
                 entry.download_url,
                 status,
-                &body.chars().take(300).collect::<String>()
+                body.chars().take(300).collect::<String>()
             );
             return Err(io::Error::other(format!("Download failed: {}", status)));
         }


### PR DESCRIPTION
## Summary

One-character fix to unblock `main`, which has been CI-red since 18:02 UTC today.

GitHub's CI runners rolled to the newer stable Rust toolchain mid-day. The newer clippy promotes two pre-existing patterns in `online_repository.rs` (landed this morning in #184) to errors:

1. `cargo fmt --check` — long match arms in `raw_url_prefix` → **already fixed** as a drive-by in #213 (`32fc9d3`)
2. `cargo clippy --workspace -- -D warnings` — `clippy::useless_borrows_in_formatting` (a redundant `&` in an `eprintln!` arg) at line 264 → **this PR** removes the `&`

Evidence: main's post-#185 CI run [32285102464](https://github.com/RallyPat/LibreTune/actions/runs/32285102464) failed the ubuntu Rust job with exit 101 on exactly this lint, and Format Check on the fmt half.

## Verification

- `cargo clippy --workspace -- -D warnings` — clean (was: 1 error)
- `cargo fmt --all -- --check` — clean
- No behavior change (formatting of an error-path log line only)
