### PR TITLE
fix(ini): resolve expression-valued scale/translate instead of silently using 1.0

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/constant_values.rs
+++ b/crates/libretune-app/src-tauri/src/commands/constant_values.rs
@@ -171,6 +171,8 @@ mod tests {
             bit_options: Vec::new(),
             is_pc_variable: false,
             dynamic_size: None,
+            scale_expr: None,
+            translate_expr: None,
         };
 
         // Build a cache with a single page, load raw bytes, write reqFuel=126.
@@ -231,6 +233,8 @@ mod tests {
             .collect(),
             is_pc_variable: false,
             dynamic_size: None,
+            scale_expr: None,
+            translate_expr: None,
         };
 
         let mut def = EcuDefinition::default();

--- a/crates/libretune-app/src-tauri/src/commands/load_tune.rs
+++ b/crates/libretune-app/src-tauri/src/commands/load_tune.rs
@@ -8,6 +8,60 @@ use libretune_core::tune::{PageState, TuneCache, TuneFile};
 use std::path::PathBuf;
 use tauri::Emitter;
 
+/// Resolve INI scale/translate fields that are `{expression}` rather than a
+/// literal, now that tune values are known.
+///
+/// Speeduino's load axes scale by `{fuelLoadRes}`, which depends on the
+/// `algorithm` constant — unknowable while parsing the INI, so the field falls
+/// back to 1.0 and every load axis renders in raw storage units (8-50 instead
+/// of 16-100 kPa), which also mis-bins anything that looks a cell up by load.
+/// Run after the cache has been populated from the tune.
+pub(crate) async fn resolve_scales_from_tune(state: &AppState) {
+    // Read values under an immutable borrow, then re-lock mutably to apply —
+    // the definition mutex cannot be held both ways at once.
+    let values = {
+        let def_guard = state.definition.lock().await;
+        let Some(def) = def_guard.as_ref() else {
+            return;
+        };
+        if !def
+            .constants
+            .values()
+            .any(|c| c.scale_expr.is_some() || c.translate_expr.is_some())
+        {
+            return; // nothing deferred in this INI
+        }
+        let endianness = def.endianness;
+        let cache_guard = state.tune_cache.lock().await;
+        let tune_guard = state.current_tune.lock().await;
+        def.constants
+            .iter()
+            .filter(|(_, c)| c.shape == libretune_core::ini::Shape::Scalar)
+            .map(|(name, c)| {
+                let v = crate::commands::constant_values::read_constant_from_cache_or_tune(
+                    name,
+                    c,
+                    endianness,
+                    tune_guard.as_ref(),
+                    cache_guard.as_ref(),
+                );
+                (name.clone(), v)
+            })
+            .collect::<std::collections::HashMap<String, f64>>()
+    };
+
+    let mut def_guard = state.definition.lock().await;
+    if let Some(def) = def_guard.as_mut() {
+        let n = def.resolve_dynamic_scales(&values);
+        if n > 0 {
+            eprintln!(
+                "[INFO] Resolved {} expression-valued INI scale/translate field(s)",
+                n
+            );
+        }
+    }
+}
+
 #[tauri::command]
 pub async fn load_tune(
     state: tauri::State<'_, AppState>,
@@ -595,6 +649,11 @@ pub async fn load_tune(
     *state.current_tune.lock().await = Some(tune.clone());
     *state.current_tune_path.lock().await = Some(PathBuf::from(path));
     *state.tune_modified.lock().await = false;
+
+    // Tune values are now in place, so `{expression}` scales can be resolved.
+    // Must run before any table is read: a load axis read beforehand would be
+    // scaled by the 1.0 parse-time fallback.
+    resolve_scales_from_tune(&state).await;
 
     // If a project is open, save the tune to the project's CurrentTune.msq
     // This ensures it will be auto-loaded next time the project is opened

--- a/crates/libretune-app/src-tauri/src/commands/project_lifecycle.rs
+++ b/crates/libretune-app/src-tauri/src/commands/project_lifecycle.rs
@@ -161,6 +161,13 @@ pub async fn create_project(
 
     let mut proj_guard = state.current_project.lock().await;
     *proj_guard = Some(project);
+    drop(proj_guard);
+
+    // This function inlines its own copy of the tune-apply ("same logic as
+    // load_tune"), so it must also run the deferred-scale resolution that
+    // load_tune runs — otherwise a project opened offline keeps the 1.0
+    // parse-time fallback and load axes render at raw scale.
+    crate::commands::load_tune::resolve_scales_from_tune(&state).await;
 
     Ok(response)
 }
@@ -650,6 +657,12 @@ pub async fn open_project(
         let cache = TuneCache::from_definition(&def_clone);
         *state.tune_cache.lock().await = Some(cache);
     }
+
+    // open_project inlines its own tune-apply ("same logic as load_tune"), so
+    // it must also run load_tune's deferred-scale resolution — without it a
+    // project opened offline keeps the 1.0 parse-time fallback and every
+    // expression-scaled axis (Speeduino load axes) renders at raw scale.
+    crate::commands::load_tune::resolve_scales_from_tune(&state).await;
 
     Ok(response)
 }

--- a/crates/libretune-app/src-tauri/src/commands/sync_ecu_data.rs
+++ b/crates/libretune-app/src-tauri/src/commands/sync_ecu_data.rs
@@ -294,6 +294,13 @@ pub async fn sync_ecu_data(
         }
     }
 
+    // Page data from the ECU is the other source of the constants that
+    // `{expression}` scales depend on (e.g. `algorithm` feeding
+    // `{fuelLoadRes}`), so resolve them here too — connecting to an ECU
+    // without loading a tune file must not leave load axes on the 1.0
+    // parse-time fallback.
+    crate::commands::load_tune::resolve_scales_from_tune(&state).await;
+
     if pages_failed == 0 {
         let _ = app.emit("tune:loaded", "ecu-sync");
     }

--- a/crates/libretune-core/src/ini/constants.rs
+++ b/crates/libretune-core/src/ini/constants.rs
@@ -75,6 +75,34 @@ pub struct Constant {
     /// Present when the INI sizes this array with `{const}` refs (resizable tables).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub dynamic_size: Option<DynamicSizeRefs>,
+
+    /// Raw INI text of the scale field when it is an expression rather than a
+    /// literal, e.g. Speeduino's `{fuelLoadRes}` (which resolves to 2.0 or 0.5
+    /// depending on the `algorithm` constant). Such a field cannot be resolved
+    /// at parse time because it depends on tune values, so the expression is
+    /// kept here and applied by [`resolve_dynamic_scale`] once those are known.
+    /// Without it the field silently fell back to 1.0 and every affected axis
+    /// displayed raw storage units (a Speeduino load axis read 8-50 instead of
+    /// 16-100 kPa).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scale_expr: Option<String>,
+
+    /// Same as [`Constant::scale_expr`], for the translate field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub translate_expr: Option<String>,
+}
+
+/// Extract a deferred expression from an INI numeric field.
+///
+/// Returns `Some(expr)` when the field is a `{...}` expression that cannot be
+/// parsed as a literal, and `None` when it is a plain number (or empty).
+pub fn deferred_expr(field: &str) -> Option<String> {
+    let t = field.trim();
+    if t.parse::<f64>().is_ok() {
+        return None;
+    }
+    let inner = t.strip_prefix('{')?.strip_suffix('}')?.trim();
+    (!inner.is_empty()).then(|| inner.to_string())
 }
 
 impl Constant {
@@ -102,6 +130,8 @@ impl Constant {
             bit_options: Vec::new(),
             is_pc_variable: false,
             dynamic_size: None,
+            scale_expr: None,
+            translate_expr: None,
         }
     }
 
@@ -158,6 +188,8 @@ impl Default for Constant {
             bit_options: Vec::new(),
             is_pc_variable: false,
             dynamic_size: None,
+            scale_expr: None,
+            translate_expr: None,
         }
     }
 }
@@ -247,12 +279,17 @@ pub fn parse_constant_line(
         constant.units = parts[units_idx].trim_matches('"').to_string();
     }
 
-    // Parse scale, translate, min, max, digits
+    // Parse scale, translate, min, max, digits.
+    // scale/translate may be `{expr}` referencing other constants (Speeduino's
+    // `{fuelLoadRes}`); those are kept for deferred resolution instead of
+    // silently collapsing to the literal fallback.
     let scale_idx = units_idx + 1;
     if parts.len() > scale_idx {
+        constant.scale_expr = deferred_expr(parts[scale_idx]);
         constant.scale = parts[scale_idx].parse().unwrap_or(1.0);
     }
     if parts.len() > scale_idx + 1 {
+        constant.translate_expr = deferred_expr(parts[scale_idx + 1]);
         constant.translate = parts[scale_idx + 1].parse().unwrap_or(0.0);
     }
     if parts.len() > scale_idx + 2 {

--- a/crates/libretune-core/src/ini/mod.rs
+++ b/crates/libretune-core/src/ini/mod.rs
@@ -464,6 +464,82 @@ impl EcuDefinition {
         format!("{:016x}", hasher.finish())
     }
 
+    /// Resolve `scale`/`translate` fields that the INI expresses as
+    /// `{expression}` rather than a literal.
+    ///
+    /// These cannot be resolved while parsing because they depend on tune
+    /// values: Speeduino's load axes use `{fuelLoadRes}`, which is
+    /// `((algorithm == 0) || (algorithm == 2)) ? 2.000 : 0.500` — the correct
+    /// factor is only known once `algorithm` has been read from the ECU or
+    /// tune file. Until then the field falls back to its literal default of
+    /// 1.0, which renders a speed-density load axis in raw storage units (8-50
+    /// instead of 16-100 kPa) and mis-bins anything that looks a cell up by
+    /// load.
+    ///
+    /// `values` maps constant name to current value (display units). Call
+    /// after a tune is loaded, and again if a constant that feeds one of these
+    /// expressions changes. Returns the number of constants updated.
+    pub fn resolve_dynamic_scales(
+        &mut self,
+        values: &std::collections::HashMap<String, f64>,
+    ) -> usize {
+        // A scale expression usually names a computed helper rather than a
+        // constant (`{fuelLoadRes}`), and those helpers live among the output
+        // channels, so evaluate them into the context first. Two passes let a
+        // helper depend on another helper without ordering assumptions.
+        let mut context = values.clone();
+        for _ in 0..2 {
+            for (name, channel) in &self.output_channels {
+                let Some(expr) = channel.expression.as_ref() else {
+                    continue;
+                };
+                if values.contains_key(name) {
+                    continue; // a real measured value always wins
+                }
+                let mut parser = expression::Parser::new(expr);
+                if let Ok(ast) = parser.parse() {
+                    if let Ok(v) = expression::evaluate(&ast, &context, None) {
+                        let v = v.as_f64();
+                        if v.is_finite() {
+                            context.insert(name.clone(), v);
+                        }
+                    }
+                }
+            }
+        }
+
+        let mut updated = 0;
+        for constant in self.constants.values_mut() {
+            for (source, target) in [
+                (constant.scale_expr.clone(), true),
+                (constant.translate_expr.clone(), false),
+            ] {
+                let Some(src) = source else { continue };
+                let mut parser = expression::Parser::new(&src);
+                let Ok(ast) = parser.parse() else { continue };
+                let Ok(value) = expression::evaluate(&ast, &context, None) else {
+                    continue;
+                };
+                let v = value.as_f64();
+                if !v.is_finite() {
+                    continue;
+                }
+                if target {
+                    // A zero scale would render every value as 0; treat it as
+                    // an unresolved expression rather than trusting it.
+                    if v != 0.0 && constant.scale != v {
+                        constant.scale = v;
+                        updated += 1;
+                    }
+                } else if constant.translate != v {
+                    constant.translate = v;
+                    updated += 1;
+                }
+            }
+        }
+        updated
+    }
+
     /// Generate a constant manifest for saving with tune files
     pub fn generate_constant_manifest(&self) -> Vec<crate::tune::ConstantManifestEntry> {
         let mut manifest = Vec::new();
@@ -600,6 +676,58 @@ impl Default for EcuDefinition {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The real Speeduino case: a load axis whose scale is `{fuelLoadRes}`,
+    /// itself `((algorithm == 0) || (algorithm == 2)) ? 2.000 : 0.500`. Before
+    /// deferred resolution the scale silently stayed 1.0 and the axis read in
+    /// raw storage units (8-50 instead of 16-100 kPa).
+    #[test]
+    fn resolves_expression_scale_from_tune_values() {
+        let mut def = EcuDefinition::default();
+
+        let mut bins = Constant::new("fuelLoadBins", 1, 272, DataType::U08);
+        bins.shape = Shape::Array1D(16);
+        bins.scale_expr = Some("fuelLoadRes".to_string());
+        bins.scale = 1.0; // parse-time fallback
+        def.constants.insert(bins.name.clone(), bins);
+
+        def.output_channels.insert(
+            "fuelLoadRes".to_string(),
+            OutputChannel {
+                name: "fuelLoadRes".to_string(),
+                expression: Some(
+                    "((algorithm == 0) || (algorithm == 2)) ? 2.000 : 0.500".to_string(),
+                ),
+                ..Default::default()
+            },
+        );
+
+        // algorithm 0 = MAP / speed density -> 2.0
+        let mut values = std::collections::HashMap::new();
+        values.insert("algorithm".to_string(), 0.0);
+        assert_eq!(def.resolve_dynamic_scales(&values), 1);
+        assert_eq!(def.constants["fuelLoadBins"].scale, 2.0);
+
+        // algorithm 1 = TPS / alpha-N -> 0.5 (the else branch)
+        values.insert("algorithm".to_string(), 1.0);
+        assert_eq!(def.resolve_dynamic_scales(&values), 1);
+        assert_eq!(def.constants["fuelLoadBins"].scale, 0.5);
+
+        // Idempotent: re-resolving with unchanged inputs updates nothing.
+        assert_eq!(def.resolve_dynamic_scales(&values), 0);
+    }
+
+    /// A literal scale must never be treated as a deferred expression.
+    #[test]
+    fn literal_scale_is_not_deferred() {
+        assert_eq!(constants::deferred_expr("1.0"), None);
+        assert_eq!(constants::deferred_expr(" 0.5 "), None);
+        assert_eq!(
+            constants::deferred_expr("{fuelLoadRes}").as_deref(),
+            Some("fuelLoadRes")
+        );
+        assert_eq!(constants::deferred_expr("{}"), None);
+    }
 
     #[test]
     fn test_default_definition() {


### PR DESCRIPTION
## Description
A constant's `scale` and `translate` are parsed with `parse().unwrap_or(...)`, so a field the INI expresses as `{expression}` rather than a literal falls back to 1.0 / 0.0 with no diagnostic.

Speeduino scales its load axes by `{fuelLoadRes}`:

```
fuelLoadRes = { ((algorithm == 0) || (algorithm == 2)) ? 2.000 : 0.500 }
```

so on a speed-density tune **every load axis renders at half scale** — a VE table whose real axis is 16–100 kPa displays as 8–50. Anything that resolves a cell by load uses those bins: the table editor's axis labels, and AutoTune's binning. The stock Speeduino INI has **28 such fields**.

The failure is silent by construction: the fallback is a perfectly ordinary number, so nothing errors and nothing logs. It only surfaces when someone notices an axis reading half what the ECU is doing.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues
Same class as #149, which resolved `{expression}` **gauge ranges**. This is the **constants** path, which #149 did not touch — no file overlap between the two.

## Changes Made
These expressions cannot be resolved during parsing, because they depend on tune values (`algorithm` comes from the ECU or the MSQ). So the expression text is kept and applied once values exist:

- `Constant` gains `scale_expr` / `translate_expr`, populated by `deferred_expr()` when the field is `{...}` rather than a literal.
- `EcuDefinition::resolve_dynamic_scales(values)` evaluates them, first evaluating computed output channels into the context so a scale can name a helper like `fuelLoadRes`. A resolved scale of **0 is rejected** rather than trusted — it would render every value as 0.
- Called after `load_tune` populates the cache, and after `sync_ecu_data`, so connecting without loading a tune file is covered too.

## Testing
- [x] I have tested these changes locally
- [x] New and existing tests pass (`cargo test`)
- [ ] The UI works correctly with these changes

`cargo test --workspace`: **732 passed, 0 failed**. `cargo fmt --all -- --check` clean.

Verified against the stock Speeduino 202501 INI with `algorithm=0`: `fuelLoadBins` scale 1.0 → 2.0, axis 16/26/30/…/100 kPa, matching a real car's 26 kPa idle MAP and 100 kPa atmospheric. Confirmed independently on 20 Aug on the ignition table, whose `mapBins1` uses the same mechanism via `{ignLoadRes}` — its load axis read 5–50 where the true axis is 10–100 kPa.

Two notes for the reviewer:

1. Rebasing onto current `main` required adding the two new fields to the `Constant` struct literals in `constant_values.rs` tests (added after this fix was first written). No behaviour change.
2. `cargo clippy --workspace -- -D warnings` currently reports 2 errors on **pristine `main`** with the Rust 1.97 toolchain (`useless_borrows_in_formatting` in `project/online_repository.rs`, and one more) — pre-existing and untouched by this branch. I left them alone rather than mixing an unrelated lint fix into this PR; happy to send that separately.

## Checklist
- [x] Code compiles without errors
- [x] No new clippy warnings (`cargo clippy`) — see note 2
- [x] Code is formatted (`cargo fmt`)
- [ ] Documentation updated if needed
- [x] Commit messages follow conventional format

🤖 Generated with [Claude Code](https://claude.com/claude-code)
