### PR TITLE
fix(afr-delay): measure at half the settled excursion, sample through settle, refuse concurrent runs

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/afr_delay_test.rs
+++ b/crates/libretune-app/src-tauri/src/commands/afr_delay_test.rs
@@ -40,7 +40,9 @@ use std::sync::Mutex as StdMutex;
 use std::time::{Duration, Instant};
 use tauri::{AppHandle, Emitter};
 
-use libretune_core::autotune::delay_measure::{detect_delay, AfrSample, DelayTable};
+use libretune_core::autotune::delay_measure::{
+    detect_delay, AfrSample, DelayRejection, DelayTable,
+};
 
 use crate::state::AppState;
 
@@ -172,6 +174,29 @@ fn emit(app: &AppHandle, p: DelayTestProgress) {
     let _ = app.emit("afr_delay_test:progress", p);
 }
 
+/// Set while a run owns the WUE slot, so a second run cannot start.
+///
+/// The baseline is read from the tune cache, which the running test itself
+/// updates when it applies the enriched value. A second invocation starting
+/// mid-step therefore reads the ENRICHED value as its baseline, and every
+/// "restore" it performs writes that value back — leaving the engine
+/// permanently rich in RAM while reporting "WUE slot restored". The abort flag
+/// and the sample buffer are process-wide statics too, so concurrent runs
+/// would also abort each other and interleave their measurements.
+///
+/// The dialog disables its own button, but the command is reachable from a
+/// second window, a retry after a perceived hang, or a script.
+static RUNNING: AtomicBool = AtomicBool::new(false);
+
+/// Clears [`RUNNING`] however the run ends, including on an early `?` return.
+struct RunGuard;
+
+impl Drop for RunGuard {
+    fn drop(&mut self) {
+        RUNNING.store(false, Ordering::SeqCst);
+    }
+}
+
 /// Shared abort flag so [`abort_afr_delay_test`] can stop a run in progress.
 static ABORT: std::sync::OnceLock<Arc<AtomicBool>> = std::sync::OnceLock::new();
 
@@ -194,6 +219,10 @@ pub async fn abort_afr_delay_test() -> Result<(), String> {
 /// settle (up to 15 s combined — long enough that the Abort button appears
 /// dead, over an engine being held rich). Returns true if an abort was
 /// requested during (or before) the wait.
+///
+/// Used for the settle window when there is no AFR channel to sample: with
+/// channels present the settle is sampled instead, and `sample_window` runs
+/// the same per-tick abort check.
 async fn sleep_abortable(total_ms: u64) -> bool {
     const TICK_MS: u64 = 50;
     let mut remaining = total_ms;
@@ -453,6 +482,16 @@ pub async fn run_afr_delay_test(
     settle_ms: u64,
     repeats: u32,
 ) -> Result<String, String> {
+    // Refuse to start a second run: see RUNNING for why a concurrent one can
+    // leave the engine rich. Claim the slot before anything else touches the
+    // ECU, and release it on every exit path via the guard.
+    if RUNNING.swap(true, Ordering::SeqCst) {
+        return Err(
+            "An AFR delay test is already running. Stop it before starting another.".to_string(),
+        );
+    }
+    let _run_guard = RunGuard;
+
     // Enrichment only: take the magnitude, then clamp. A negative input cannot
     // survive this, so no combination of arguments leans the engine out.
     let step_percent = step_percent.abs().clamp(MIN_STEP_PERCENT, MAX_STEP_PERCENT);
@@ -726,8 +765,21 @@ pub async fn run_afr_delay_test(
             }
             Some(Err(rej)) => {
                 settling.rejection = Some(rej.label().to_string());
+                // "No response" and "still moving" both usually mean the hold
+                // was short relative to the transport delay at this operating
+                // point — the response simply had not arrived (or not finished
+                // arriving) before enrichment was removed. Sampling continues
+                // through the settle window below, so the next step's report
+                // can say so with a number instead of leaving the operator to
+                // guess which knob is wrong.
+                let hint = matches!(
+                    rej,
+                    DelayRejection::NoResponse | DelayRejection::ResponseNotSettled
+                )
+                .then(|| format!(" — try a hold longer than {} ms", hold_ms))
+                .unwrap_or_default();
                 settling.message = format!(
-                    "step {step}/{repeats}: no measurement ({}), settling",
+                    "step {step}/{repeats}: no measurement ({}{hint}), settling",
                     rej.label()
                 );
             }
@@ -737,8 +789,55 @@ pub async fn run_afr_delay_test(
         }
         emit(&app, settling);
 
-        if step < repeats && sleep_abortable(settle_ms).await {
-            break;
+        // Keep sampling through the settle window instead of sleeping through
+        // it. The mixture returning to baseline is the second half of the same
+        // event, and on a step whose delay approached the hold length the
+        // response is still arriving here — sampling is what lets the next
+        // report distinguish "the sensor saw nothing" from "the hold ended
+        // before the exhaust gas got here". The samples are appended to the
+        // step's trace so the UI overlay shows the full pulse.
+        if step < repeats && channels.is_none() {
+            // Nothing to sample without an AFR channel, so just wait — still
+            // abortable within a tick.
+            if sleep_abortable(settle_ms).await {
+                break;
+            }
+        } else if step < repeats {
+            let mut tail = StepSamples::default();
+            let aborted_in_settle = sample_window(
+                &state,
+                epoch,
+                channels.as_ref(),
+                settle_ms,
+                &mut tail,
+                &mut point,
+                None,
+            )
+            .await;
+            if !tail.afr.is_empty() {
+                let mut recovery = DelayTestProgress::plain(
+                    "settling",
+                    step,
+                    reported_total,
+                    baseline,
+                    baseline,
+                    format!("step {step}/{repeats} settled"),
+                );
+                recovery.trace = tail
+                    .afr
+                    .iter()
+                    .zip(tail.ctx.iter())
+                    .map(|(s, c)| TracePoint {
+                        t_ms: s.t_ms as i64 - anchor_ms as i64,
+                        afr: s.afr,
+                        pw: c.pw,
+                    })
+                    .collect();
+                emit(&app, recovery);
+            }
+            if aborted_in_settle {
+                break;
+            }
         }
     }
 

--- a/crates/libretune-core/src/autotune/delay_measure.rs
+++ b/crates/libretune-core/src/autotune/delay_measure.rs
@@ -23,12 +23,30 @@ pub struct AfrSample {
 /// A successful delay extraction for one enrichment step.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct DelayMeasurement {
-    /// Milliseconds from the step anchor to the detected AFR response edge.
+    /// Milliseconds from the step anchor to half the settled excursion.
+    ///
+    /// A step response is the cumulative distribution of transit times, so its
+    /// half-height is the *median* transit — the transport delay. The leading
+    /// edge is only the fastest path through the manifold and sits in the
+    /// noise: on 80 real steps the fixed-threshold leading edge gave a median
+    /// of 268 ms and scattered 8-2117 ms, while half-excursion on the same
+    /// steps gave 435 ms with an IQR of +/-30 ms.
     pub delay_ms: f64,
-    /// AFR drop actually observed at detection relative to baseline.
+    /// Baseline minus the SETTLED AFR — the size of the step the engine
+    /// actually delivered, not the depth at the trigger.
+    ///
+    /// The trigger depth is ~the threshold by construction and carries no
+    /// information; the settled excursion is what a commanded-vs-delivered
+    /// comparison needs (a fuel step of x% should move AFR by a predictable
+    /// amount, and the shortfall is the injector/flow story).
     pub excursion: f64,
-    /// Pre-step baseline the edge was measured against.
+    /// Pre-step baseline the response was measured against.
     pub baseline_afr: f64,
+    /// Milliseconds to the first sustained crossing of the noise threshold.
+    ///
+    /// Kept for comparison with historical numbers, which were all measured
+    /// this way. Biased short; do not use it as the delay.
+    pub leading_edge_ms: f64,
 }
 
 /// Why a step produced no measurement — surfaced to the UI so a silent
@@ -49,6 +67,11 @@ pub enum DelayRejection {
     /// or the mixture was drifting for reasons of its own. An effect cannot
     /// precede its cause, so there is no transport delay to report here.
     ResponsePrecedesStep,
+    /// AFR responded but was still moving when the hold ended, so there is no
+    /// settled level to take half of. Almost always the hold is short relative
+    /// to the transport delay at this operating point — the fix is a longer
+    /// hold, not a different threshold.
+    ResponseNotSettled,
 }
 
 impl DelayRejection {
@@ -59,6 +82,7 @@ impl DelayRejection {
             DelayRejection::UnstableBaseline => "baseline unstable — hold steadier",
             DelayRejection::NoResponse => "no AFR response detected",
             DelayRejection::ResponsePrecedesStep => "AFR already moving at the step",
+            DelayRejection::ResponseNotSettled => "still moving at end of hold — use a longer hold",
         }
     }
 }
@@ -74,6 +98,55 @@ const MIN_EXCURSION_AFR: f64 = 0.15;
 /// An edge only counts when the crossing is sustained for this many samples,
 /// so a single noise spike cannot fake a response.
 const SUSTAIN_SAMPLES: usize = 2;
+/// Tail of the hold window used to estimate the settled AFR, as a fraction of
+/// the window's duration.
+const PLATEAU_TAIL_FRAC: f64 = 0.30;
+/// The plateau must be flatter than this (MAD, AFR points) to count as
+/// settled. Looser than the baseline limit: a warm plateau under enrichment is
+/// noisier than an idle baseline, but a trace still in transit is far noisier
+/// than either.
+const MAX_PLATEAU_MAD: f64 = 0.30;
+
+/// First sustained crossing below `level`, interpolated across the crossing.
+///
+/// Returns (crossing_ms, sample_at_crossing). Reporting the sample time alone
+/// biases every measurement late by up to a full interval — 31 ms average at
+/// the ~16 Hz these logs actually run at, a large share of a high-flow delay.
+fn first_crossing(post: &[AfrSample], level: f64) -> Option<(f64, AfrSample)> {
+    let mut run = 0usize;
+    let mut edge: Option<AfrSample> = None;
+    let mut before_edge: Option<AfrSample> = None;
+    let mut prev: Option<AfrSample> = None;
+    for s in post {
+        if s.afr < level {
+            run += 1;
+            if run == 1 {
+                edge = Some(*s);
+                before_edge = prev;
+            }
+            if run >= SUSTAIN_SAMPLES {
+                let e = edge.expect("run >= 1 implies edge set");
+                let crossing_ms = match before_edge {
+                    Some(b) if b.afr > e.afr && b.t_ms < e.t_ms => {
+                        let span = (e.t_ms - b.t_ms) as f64;
+                        let frac = ((b.afr - level) / (b.afr - e.afr)).clamp(0.0, 1.0);
+                        b.t_ms as f64 + span * frac
+                    }
+                    // No usable prior sample (the crossing is the first sample
+                    // after the anchor): fall back to the sample's own time.
+                    _ => e.t_ms as f64,
+                };
+                return Some((crossing_ms, e));
+            }
+        } else {
+            run = 0;
+            edge = None;
+            before_edge = None;
+        }
+        prev = Some(*s);
+    }
+    None
+}
 
 fn median(values: &mut [f64]) -> f64 {
     values.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
@@ -114,70 +187,66 @@ pub fn detect_delay(
     }
 
     let threshold = (K_MAD * scatter).max(MIN_EXCURSION_AFR);
-    let trigger = baseline - threshold;
 
-    let mut run = 0usize;
-    let mut edge: Option<&AfrSample> = None;
-    // Sample immediately before the crossing, for sub-sample interpolation.
-    let mut before_edge: Option<&AfrSample> = None;
-    let mut prev: Option<&AfrSample> = None;
-    for s in post {
-        if s.afr < trigger {
-            run += 1;
-            if run == 1 {
-                edge = Some(s);
-                before_edge = prev;
-            }
-            if run >= SUSTAIN_SAMPLES {
-                let e = edge.expect("run >= 1 implies edge set");
+    // 1. Did anything happen at all? The noise-threshold crossing answers that
+    //    and gives the historical leading-edge figure for comparison.
+    let (leading_ms, _) =
+        first_crossing(post, baseline - threshold).ok_or(DelayRejection::NoResponse)?;
 
-                // The crossing happened somewhere between the last sample above
-                // the trigger and this first one below it, not exactly when the
-                // sample landed. Reporting the sample time alone biases every
-                // measurement late by half a sample interval on average — 31 ms
-                // at the ~16 Hz these logs actually run at, which is a large
-                // share of a high-flow delay. Interpolate linearly across the
-                // crossing instead.
-                let crossing_ms = match before_edge {
-                    Some(b) if b.afr > e.afr && b.t_ms < e.t_ms => {
-                        let span = (e.t_ms - b.t_ms) as f64;
-                        let frac = ((b.afr - trigger) / (b.afr - e.afr)).clamp(0.0, 1.0);
-                        b.t_ms as f64 + span * frac
-                    }
-                    // No usable prior sample (the crossing is the first sample
-                    // after the anchor): fall back to the sample's own time.
-                    _ => e.t_ms as f64,
-                };
-                // A crossing at or before the anchor is not a fast delay, it
-                // is a measurement of something that started earlier. Clamping
-                // it to zero used to record it as a valid 0 ms sample: on a
-                // 52-minute drive three such samples landed in two rpm/load
-                // bins and pulled both means to exactly 0.
-                //
-                // Zero is worse than a missing value, because this figure feeds
-                // AutoTune's historical-point lookup - a 0 ms delay makes it
-                // test the CURRENT sample for fuel cut, which is exactly the
-                // test that misses the tail of a cut still in the exhaust.
-                if crossing_ms <= anchor_ms as f64 {
-                    return Err(DelayRejection::ResponsePrecedesStep);
-                }
-                let delay_ms = crossing_ms - anchor_ms as f64;
-
-                return Ok(DelayMeasurement {
-                    delay_ms,
-                    excursion: baseline - e.afr,
-                    baseline_afr: baseline,
-                });
-            }
-        } else {
-            run = 0;
-            edge = None;
-            before_edge = None;
-        }
-        prev = Some(s);
+    // A crossing at or before the anchor is not a fast delay, it is a
+    // measurement of something that started earlier. Clamping it to zero used
+    // to record it as a valid 0 ms sample: on a 52-minute drive three such
+    // samples landed in two rpm/load bins and pulled both means to exactly 0.
+    //
+    // Zero is worse than a missing value, because this figure feeds AutoTune's
+    // historical-point lookup — a 0 ms delay makes it test the CURRENT sample
+    // for fuel cut, which is exactly the test that misses the tail of a cut
+    // still in the exhaust.
+    if leading_ms <= anchor_ms as f64 {
+        return Err(DelayRejection::ResponsePrecedesStep);
     }
 
-    Err(DelayRejection::NoResponse)
+    // 2. Where did it settle? The tail of the hold window is the plateau, and
+    //    it is only a plateau if it has stopped moving.
+    let (first_t, last_t) = (
+        post.first().map(|s| s.t_ms).unwrap_or(0) as f64,
+        post.last().map(|s| s.t_ms).unwrap_or(0) as f64,
+    );
+    let tail_start = last_t - (last_t - first_t) * PLATEAU_TAIL_FRAC;
+    let mut tail: Vec<f64> = post
+        .iter()
+        .filter(|s| s.t_ms as f64 >= tail_start)
+        .map(|s| s.afr)
+        .collect();
+    if tail.len() < MIN_BASELINE_SAMPLES {
+        return Err(DelayRejection::ResponseNotSettled);
+    }
+    let plateau = median(&mut tail);
+    if mad(&tail, plateau) > MAX_PLATEAU_MAD {
+        return Err(DelayRejection::ResponseNotSettled);
+    }
+
+    let excursion = baseline - plateau;
+    // The plateau has to be a real step, not the threshold scraped by noise.
+    if excursion < threshold {
+        return Err(DelayRejection::NoResponse);
+    }
+
+    // 3. The delay is where the response reaches half its settled size. A step
+    //    response is the CDF of transit times, so the half-height is the
+    //    median transit; the leading edge is only the fastest path.
+    let (half_ms, _) = first_crossing(post, baseline - excursion / 2.0)
+        .ok_or(DelayRejection::ResponseNotSettled)?;
+    if half_ms <= anchor_ms as f64 {
+        return Err(DelayRejection::ResponsePrecedesStep);
+    }
+
+    Ok(DelayMeasurement {
+        delay_ms: half_ms - anchor_ms as f64,
+        excursion,
+        baseline_afr: baseline,
+        leading_edge_ms: leading_ms - anchor_ms as f64,
+    })
 }
 
 /// Fixed coarse grid for aggregating measurements by operating point.
@@ -274,16 +343,28 @@ mod tests {
     /// close to where the AFR genuinely passed the trigger.
     #[test]
     fn crossing_is_interpolated_between_samples() {
-        // Baseline 14.70, MAD ~0 so the trigger is baseline - MIN_EXCURSION_AFR.
         let pre = trace(&[(0, 14.70), (60, 14.70), (120, 14.70), (180, 14.70)]);
-        // AFR is still at baseline at 240, then well past the trigger at 300:
-        // the true crossing lies between, nearer 300 the deeper the last sample.
-        let post = trace(&[(240, 14.70), (300, 14.30), (360, 14.10), (420, 14.05)]);
+        // Settles to 13.70, so the half level is 14.20 — crossed somewhere
+        // inside the 240-300 gap, nearer 300 the deeper the later sample.
+        let post = trace(&[
+            (240, 14.70),
+            (300, 14.10),
+            (360, 13.85),
+            (420, 13.72),
+            (480, 13.70),
+            (540, 13.70),
+            (600, 13.70),
+            (660, 13.70),
+            (720, 13.70),
+            (780, 13.70),
+            (840, 13.70),
+            (900, 13.70),
+        ]);
 
         let m = detect_delay(240, &pre, &post).expect("should measure");
         assert!(
             m.delay_ms > 0.0 && m.delay_ms < 60.0,
-            "interpolated crossing {:.0} ms must fall inside the 240-300 ms sample gap",
+            "interpolated crossing {:.0} ms must fall inside the 240-300 ms gap",
             m.delay_ms
         );
         // Reporting the raw sample time would have given exactly 60 ms.
@@ -327,22 +408,34 @@ mod tests {
             (120, 14.7),
             (160, 14.69),
         ]);
+        // Baseline 14.70 settling to 13.70: a 1.00 AFR step, so the delay is
+        // where the trace passes 14.20 — not where it first leaves the noise.
         let post = trace(&[
-            (200, 14.7),
-            (240, 14.71),
-            (280, 14.69),
-            (320, 14.68),
-            (380, 14.2), // edge
-            (420, 13.9),
-            (460, 13.7),
+            (200, 14.70),
+            (240, 14.70),
+            (280, 14.70),
+            (320, 14.60),
+            (360, 14.40),
+            (400, 14.15),
+            (440, 13.95),
+            (480, 13.80),
+            (520, 13.72),
+            (560, 13.70),
+            (600, 13.70),
+            (640, 13.70),
+            (680, 13.70),
         ]);
         let m = detect_delay(200, &pre, &post).expect("clean step must measure");
         assert!(
-            (m.delay_ms - 136.25).abs() < 0.5,
-            "interpolated crossing, got {}",
+            (m.delay_ms - 192.0).abs() < 1.0,
+            "half-excursion crossing, got {}",
             m.delay_ms
         );
-        assert!(m.excursion > 0.4);
+        assert!(
+            (m.excursion - 1.00).abs() < 0.05,
+            "excursion must be the SETTLED step, got {}",
+            m.excursion
+        );
         assert!((m.baseline_afr - 14.7).abs() < 0.05);
     }
 
@@ -369,18 +462,34 @@ mod tests {
     #[test]
     fn edge_anchors_at_the_sustained_run() {
         let pre = trace(&[(0, 14.7), (40, 14.7), (80, 14.7), (120, 14.7)]);
+        // A one-sample spike must not start the response; the real edge does.
         let post = trace(&[
             (200, 14.7),
             (240, 13.9), // spike, run resets after
             (280, 14.7),
-            (320, 14.0), // real edge starts
-            (360, 13.8),
+            (320, 14.3),
+            (360, 14.0),
+            (400, 13.85),
+            (440, 13.75),
+            (480, 13.70),
+            (520, 13.70),
+            (560, 13.70),
+            (600, 13.70),
         ]);
         let m = detect_delay(200, &pre, &post).expect("must measure");
+        // Had the lone spike at 240 ms started the run, the interpolated
+        // crossing would land ~7 ms after the anchor. The real edge begins at
+        // 320 ms, so both figures must be far past that.
         assert!(
-            (m.delay_ms - 88.6).abs() < 0.5,
-            "must anchor on the sustained run, got {}",
-            m.delay_ms
+            m.leading_edge_ms > 50.0,
+            "the leading edge must ignore the spike, got {}",
+            m.leading_edge_ms
+        );
+        assert!(
+            m.delay_ms >= m.leading_edge_ms,
+            "half-excursion {} cannot precede the leading edge {}",
+            m.delay_ms,
+            m.leading_edge_ms
         );
     }
 
@@ -439,5 +548,57 @@ mod tests {
         let top = &t.cells[LOAD_EDGES.len()][RPM_EDGES.len()];
         assert_eq!(top.n, 1);
         assert!((top.mean_ms - 90.0).abs() < 1e-9);
+    }
+    /// The whole point of the change: a step response is the CDF of transit
+    /// times, so its half-height is the median transit. The leading edge is
+    /// the fastest path and always arrives earlier — on real data it read
+    /// 268 ms median against 435 ms for half-excursion, and scattered
+    /// 8-2117 ms against an IQR of +/-30 ms.
+    #[test]
+    fn half_excursion_is_later_than_the_leading_edge() {
+        let pre = trace(&[(0, 14.70), (40, 14.70), (80, 14.70), (120, 14.70)]);
+        let post = trace(&[
+            (200, 14.70),
+            (240, 14.60),
+            (280, 14.45),
+            (320, 14.25),
+            (360, 14.05),
+            (400, 13.90),
+            (440, 13.78),
+            (480, 13.72),
+            (520, 13.70),
+            (560, 13.70),
+            (600, 13.70),
+            (640, 13.70),
+        ]);
+        let m = detect_delay(200, &pre, &post).expect("must measure");
+        assert!(
+            m.delay_ms > m.leading_edge_ms,
+            "half-excursion {:.0} must be later than leading edge {:.0}",
+            m.delay_ms,
+            m.leading_edge_ms
+        );
+    }
+
+    /// A hold shorter than the transport delay leaves the trace still falling
+    /// when enrichment ends. There is no settled level to halve, so the honest
+    /// answer is a rejection naming the cause — not a number biased by however
+    /// far the response happened to get.
+    #[test]
+    fn still_moving_at_end_of_hold_is_rejected() {
+        let pre = trace(&[(0, 14.7), (40, 14.7), (80, 14.7), (120, 14.7)]);
+        let post = trace(&[
+            (200, 14.70),
+            (240, 14.60),
+            (280, 14.35),
+            (320, 14.05),
+            (360, 13.75),
+            (400, 13.45),
+            (440, 13.15),
+        ]);
+        assert_eq!(
+            detect_delay(200, &pre, &post),
+            Err(DelayRejection::ResponseNotSettled)
+        );
     }
 }


### PR DESCRIPTION
## Description
Three defects in the AFR delay test, found while re-reading the measurement path against a real drive's traces and then validated end-to-end against a simulator with a **known** delay.

### 1. The delay was measured at the leading edge, not the median transit

A step response is the cumulative distribution of transit times, so its **half-height is the median transit** — the transport delay. The first crossing of a noise threshold is only the *fastest* path through the manifold, and it sits in the noise.

On the same 80 real steps:

| measure | median | scatter |
|---|---|---|
| fixed-threshold leading edge | 268 ms | 8–2117 ms |
| half-excursion | 435 ms | IQR ±30 ms |

`detect_delay` now estimates the settled plateau from the tail of the hold window and reports the crossing of half that excursion. The old figure is kept as `leading_edge_ms` so historical numbers stay comparable.

This also fixes what `excursion` **means**. It used to be the depth at the trigger sample — which is ~the threshold by construction and carries no information. It is now baseline minus the settled level: the step the engine actually delivered, which is what a commanded-vs-delivered comparison needs.

A trace still moving when the hold ends has no plateau to halve, so it is rejected as `ResponseNotSettled` rather than yielding a number biased by however far the response happened to get.

### 2. Sampling stopped at restore, so late responses looked like no response

A delay approaching the hold length read "no AFR response detected" with no hint that the hold was the problem — the exact symptom of a delay test that looks broken. The settle window is now sampled too: the recovery is the second half of the same event, the trace is emitted so the UI overlay shows the whole pulse, and `NoResponse` / `ResponseNotSettled` now say *"try a hold longer than N ms"*.

### 3. No in-progress guard — a second run could leave the engine rich

The baseline comes from the tune cache, which the running test updates when it applies the enriched value. A second invocation starting mid-step reads the **enriched** value as its baseline, and every "restore" it performs writes that value back — leaving the engine permanently rich in RAM while reporting "WUE slot restored". The abort flag and sample buffer are process-wide statics too, so concurrent runs would abort each other and interleave measurements.

A `RUNNING` flag now refuses the second call, released on every exit path by a `Drop` guard. The dialog disables its own button, but the command is reachable from a second window, a retry after a perceived hang, or a script.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues
Builds on the delay-test work in #144 / #176 / #177 / #188 / #189.

## Testing
- [x] I have tested these changes locally
- [x] New and existing tests pass (`cargo test`)
- [ ] The UI works correctly with these changes

`cargo test --workspace`: **732 passed, 0 failed**. `cargo fmt --all -- --check` clean, no new warnings.

**End-to-end against a simulator with ground truth.** The bench simulator models a pure 1000 ms transport delay plus an 80 ms first-order sensor lag, so half-excursion should read ≈ 1000 + 80·ln2 ≈ 1055 ms. Five steps at 8 % for 3 s:

```
populated cells: 1
   n=5 mean=1023 ms range=13 ms
median measured delay: 1023 ms
expected: ~1055 ms
error: -32 ms (-3.1%)
```

Five of five steps produced a measurement (no rejections), and the **spread across them was 13 ms** — against the 8–2117 ms the leading-edge detector scattered on real data.

The concurrent-run guard was verified the same way: with a run in flight, a second call was refused with "An AFR delay test is already running", the first run completed normally, and the WUE slot read back at 100 %.

Unit tests: the three existing cases encoded leading-edge semantics against traces that never settle, so they now assert half-excursion against settling traces; added coverage that half-excursion is strictly later than the leading edge, and that a trace still falling at the end of the hold is rejected rather than measured.

## Checklist
- [x] Code compiles without errors
- [x] No new clippy warnings (`cargo clippy`) — note: `main` currently has 2 pre-existing clippy errors under Rust 1.97 in `project/online_repository.rs`, untouched here
- [x] Code is formatted (`cargo fmt`)
- [ ] Documentation updated if needed
- [x] Commit messages follow conventional format

🤖 Generated with [Claude Code](https://claude.com/claude-code)
