### PR TITLE
fix(table): stop interpolate shortcut from stealing focus to search

### DIFF
--- a/crates/libretune-app/src/components/tuner-ui/TableEditor.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/TableEditor.tsx
@@ -759,6 +759,13 @@ export function TableEditor({
         handleCellDoubleClick(row, col);
         break;
     }
+    // Keep handled keys (notably "/") from also reaching document-level
+    // shortcuts like Sidebar's "/ focuses search" — preventDefault alone
+    // doesn't stop native bubbling, so search was stealing focus right
+    // after an interpolate, breaking arrow-key navigation in the table.
+    if (e.defaultPrevented) {
+      e.stopPropagation();
+    }
   }, [
     selection, editingCell, data, finishEdit, getSelectedCells, setEqual,
     adjustValues, scaleValues, interpolate, interpolateHorizontal, interpolateVertical,


### PR DESCRIPTION
Fixes #193.

## Root cause

Reported: pressing "/" to interpolate a 2D table selection worked, but immediately afterward the sidebar search box became focused, and arrow keys stopped navigating the table until the user clicked back into it.

TableEditor's handleKeyDown calls e.preventDefault() for every shortcut it handles (including "/" for interpolate), but never e.stopPropagation(). preventDefault() only cancels the key's default browser action, it does not stop the native keydown event from continuing to bubble up the DOM. Sidebar.tsx registers a global document-level "/ focuses search" shortcut, guarded only by checking that the currently focused element isn't an INPUT or TEXTAREA — a table cell is neither, so after TableEditor's own handler ran, the same keydown reached Sidebar's listener and stole focus into the search box.

## Fix

After the switch in TableEditor's handleKeyDown, stop propagation if the event was already handled (e.defaultPrevented is true for every case in the switch). This closes the gap for "/" specifically and for any other table shortcut that could collide with a future global listener the same way, not just this one reported case.

## Testing

tsc --noEmit clean. Full vitest suite: 198/199 passing, the one failure is the pre-existing App.integration.test.tsx timeout unrelated to this change (confirmed failing identically without this fix). CSS/behavior not touched outside the one stopPropagation call, so no visual change.