### PR TITLE
fix(table): stop hiding Y-axis bin labels on tables past 12 rows

### DIFF
--- a/crates/libretune-app/src/components/tables/TableGrid.tsx
+++ b/crates/libretune-app/src/components/tables/TableGrid.tsx
@@ -55,7 +55,13 @@ function formatBinLabel(val: number): string {
   return val.toFixed(1);
 }
 
-/** How often to paint axis labels so they don't overlap (~36px apart). */
+/**
+ * How often to paint X-axis labels so a wide number doesn't bleed into the
+ * next column. Y-axis rows don't need this: each row label already sits in
+ * its own CSS Grid row, which never overlaps a neighboring row regardless of
+ * how short the row is — thinning it only hid real bin values for no reason
+ * (half the rows going blank on anything much past 12 bins).
+ */
 function axisLabelStep(count: number, cellPx: number): number {
   if (count <= 12) return 1;
   const maxLabels = Math.max(6, Math.floor((count * cellPx) / 36));
@@ -437,7 +443,6 @@ export default function TableGrid({
   const dataCol = fitPx ? `${fitPx.col}px` : compact ? '3.5rem' : '3rem';
   const colPx = fitPx?.col ?? (compact ? 56 : 48);
   const xLabelStep = axisLabelStep(x_size, colPx);
-  const yLabelStep = axisLabelStep(y_size, fitPx?.row ?? 32);
   const showCellNumbers = colPx >= 26;
   const cellDecimals = colPx < 34 ? 0 : 1;
   const gridTemplateColumns = `${axisCol} repeat(${x_size}, ${dataCol})`;
@@ -524,17 +529,13 @@ export default function TableGrid({
         ) : (
           <div
             key={`y-${y}`}
-            className={`axis-bin-label y-bin ${isYHeaderSelected ? 'selected' : ''}${
-              shouldShowAxisLabel(y, y_size, yLabelStep) ? '' : ' axis-bin-label--tick'
-            }`}
+            className={`axis-bin-label y-bin ${isYHeaderSelected ? 'selected' : ''}`}
             title={formatBinLabel(y_bins[y])}
             onMouseDown={e => handleHeaderMouseDown(e, 'y', y)}
             onMouseEnter={() => handleHeaderMouseEnter('y', y)}
             onDoubleClick={() => handleHeaderDoubleClick('y', y)}
           >
-            {shouldShowAxisLabel(y, y_size, yLabelStep)
-              ? formatBinLabel(y_bins[y])
-              : ''}
+            {formatBinLabel(y_bins[y])}
           </div>
         );
 


### PR DESCRIPTION
Fixes #194.

## Root cause

Reported (with a screenshot): a VE table opened as an embedded dialog panel showed roughly half its Y-axis row labels blank, while every row's data cells were fully populated with distinct values. TableGrid.tsx is the renderer for dialog-embedded tables (distinct from the plain full-tab TableEditor.tsx, which has no such issue).

axisLabelStep()/shouldShowAxisLabel() thin out axis labels once a table has more than 12 bins, assuming roughly 36px of vertical space is needed per label to avoid overlap. The skipped labels get the .axis-bin-label--tick class, which sets color: transparent — same border, background, and hit target, invisible number. That matches exactly what was reported.

That guard makes sense for the X-axis: a wide multi-digit number (for example "16000") can genuinely overflow into the next narrow column. It does not apply to the Y-axis: each row's label already sits in its own CSS Grid row, which cannot overlap a neighboring row no matter how short the row is. Thinning it only hid real bin values for no reason on any table past 12 rows, which is exactly what the reported roughly 30-row table hit.

## Fix

Y-axis labels always render now. X-axis thinning is untouched.

## Testing

tsc --noEmit clean. Full vitest suite: 198/199 passing, the one failure is the pre-existing App.integration.test.tsx timeout unrelated to this change.