### PR TITLE
fix(dashboard): disable Tauri's native drag-drop so HTML5 DnD works

### DIFF
--- a/crates/libretune-app/src-tauri/tauri.conf.json
+++ b/crates/libretune-app/src-tauri/tauri.conf.json
@@ -16,7 +16,8 @@
         "width": 1280,
         "height": 800,
         "minWidth": 1024,
-        "minHeight": 700
+        "minHeight": 700,
+        "dragDropEnabled": false
       }
     ],
     "security": {


### PR DESCRIPTION
Fixes #196.

## Root cause

Reported: dragging a gauge from the Dashboard designer's "Gauge Palette" onto the canvas did nothing.

The palette/canvas drop already correctly use the browser's own HTML5 drag-and-drop API: draggable plus onDragStart/onDragOver/onDrop reading a custom application/json payload, in GaugePalette.tsx and useDesignerDrop.ts. Nothing was broken in that code.

Tauri 2's window-level drag-drop handling defaults to enabled (dragDropEnabled unset), which intercepts drag events at the OS/WebView level for its own native file-drop feature. This is a well-documented conflict: leaving it enabled silently breaks in-page HTML5 drag-and-drop, exactly matching "nothing happens" on drop. Nothing in this codebase, frontend or backend, listens for Tauri's native drag-drop event, so no feature relies on it.

## Fix

Sets dragDropEnabled: false on the window config so the WebView's native HTML5 DnD reaches the page instead of being swallowed by Tauri.

## Testing

Verified cargo check accepts the key against the real Tauri v2 schema (JSON-only change, no Rust or TypeScript touched).