### PR TITLE
fix(autotune): stop dropping most samples, and exclude fuel-cut and railed readings

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/realtime_stream.rs
+++ b/crates/libretune-app/src-tauri/src/commands/realtime_stream.rs
@@ -338,6 +338,14 @@ pub(crate) async fn feed_autotune_data(
         .or_else(|| data.get("mapaccaen"))
         .map(|v| *v > 0.5);
 
+    // Overrun fuel cut. Same channel names the AFR delay test looks for, so
+    // both features agree about when the injectors are off. During a cut the
+    // wideband reads full lean and the sample says nothing about VE.
+    let fuel_cut_active = data
+        .get("DFCOOn")
+        .or_else(|| data.get("dfco"))
+        .map(|v| *v > 0.5);
+
     // Create the data point
     let data_point = VEDataPoint {
         rpm,
@@ -350,6 +358,7 @@ pub(crate) async fn feed_autotune_data(
         tps,
         tps_rate,
         accel_enrich_active,
+        fuel_cut_active,
         timestamp_ms: current_time_ms,
     };
 

--- a/crates/libretune-core/src/autotune/mod.rs
+++ b/crates/libretune-core/src/autotune/mod.rs
@@ -183,6 +183,13 @@ impl Default for AutoTuneState {
     }
 }
 
+/// Wideband readings outside this range are the sensor at a stop rather than
+/// a mixture: no running engine sustains them, and a railed reading carries no
+/// information about the VE table. Deliberately wider than any tuning target
+/// so a genuinely rich or lean cell is still analysed.
+pub const AFR_RAIL_LOW: f64 = 10.0;
+pub const AFR_RAIL_HIGH: f64 = 19.5;
+
 /// Data point from ECU for VE analysis
 #[derive(Debug, Clone)]
 pub struct VEDataPoint {
@@ -197,6 +204,12 @@ pub struct VEDataPoint {
     pub tps: f64,                          // Current TPS value (%)
     pub tps_rate: f64,                     // TPS change rate (%/sec)
     pub accel_enrich_active: Option<bool>, // ECU accel enrichment flag (if available)
+    /// ECU overrun fuel-cut flag (DFCO), when the INI exposes one.
+    ///
+    /// During a cut the injectors are off, so the wideband reads full lean and
+    /// the mixture says nothing about the VE table. `None` means the channel
+    /// was not found; the AFR-rail check below still catches most of it.
+    pub fuel_cut_active: Option<bool>,
     // Lambda delay correlation
     pub timestamp_ms: u64, // Timestamp for delay correlation
 }
@@ -208,12 +221,17 @@ impl Default for VEDataPoint {
             map: 0.0,
             maf: 0.0,
             load: 0.0,
-            afr: 0.0,
+            // Stoich, not 0.0: a default point should be a VALID one. Zero
+            // AFR is physically impossible and now trips the sensor-rail
+            // check, which would make every default-constructed point fail
+            // filtering for a reason that has nothing to do with the test.
+            afr: 14.7,
             ve: 0.0,
             clt: 0.0,
             tps: 0.0,
             tps_rate: 0.0,
             accel_enrich_active: None,
+            fuel_cut_active: None,
             timestamp_ms: 0,
         }
     }
@@ -360,7 +378,34 @@ impl AutoTuneState {
         }
     }
 
-    /// Find the data point from the buffer that best matches the lambda delay
+    /// Mean spacing between buffered samples, in milliseconds.
+    ///
+    /// The stream's real cadence, not the configured one: single-shot reads
+    /// contend with the realtime poll for the connection lock and land at
+    /// 5-9 Hz on hardware, against a nominal 20 Hz.
+    fn mean_sample_gap_ms(&self) -> Option<u64> {
+        let n = self.data_buffer.len();
+        if n < 2 {
+            return None;
+        }
+        let first = self.data_buffer.front()?.timestamp_ms;
+        let last = self.data_buffer.back()?.timestamp_ms;
+        last.checked_sub(first).map(|span| span / (n as u64 - 1))
+    }
+
+    /// Find the data point from the buffer that best matches the lambda delay.
+    ///
+    /// The match tolerance follows the stream's actual sample spacing instead
+    /// of a fixed 50 ms. With samples every T ms the nearest one to any target
+    /// inside the buffer is at most T/2 away, so a fixed 50 ms window rejects
+    /// good matches as soon as T exceeds ~100 ms — and on this hardware T is
+    /// 111-200 ms, so roughly a third to a half of all samples were dropped
+    /// with nothing to show for it but a throttled debug line. That is the
+    /// "AutoTune runs but recommendations never accumulate" symptom.
+    ///
+    /// Scaling to the cadence keeps the check meaningful: a genuine gap in the
+    /// buffer (a dropout, or a delay reaching past the buffered history) is
+    /// still far larger than a sample interval and still rejected.
     fn find_delayed_data_point(
         &self,
         current_timestamp_ms: u64,
@@ -381,8 +426,14 @@ impl AutoTuneState {
             }
         }
 
-        // Only use if within 50ms of target time
-        if best_diff < 50 {
+        // Half a sample interval is the best any evenly-spaced stream can do;
+        // allow a little over that for jitter, and never tighten below the
+        // historical 50 ms for fast streams.
+        let tolerance = self
+            .mean_sample_gap_ms()
+            .map(|gap| (gap * 6 / 10).max(50))
+            .unwrap_or(50);
+        if best_diff <= tolerance {
             best_match.cloned()
         } else {
             None
@@ -411,6 +462,12 @@ impl AutoTuneState {
         }
         if bound(&filters.max_y_axis).is_some_and(|b| point.load > b) {
             return "load above max_y_axis";
+        }
+        if point.fuel_cut_active == Some(true) {
+            return "overrun fuel cut";
+        }
+        if !(AFR_RAIL_LOW..=AFR_RAIL_HIGH).contains(&point.afr) {
+            return "afr at sensor rail";
         }
         if point.tps_rate.abs() > filters.max_tps_rate {
             return "tps_rate above max_tps_rate";
@@ -739,6 +796,24 @@ impl AutoTuneState {
             }
         }
 
+        // Overrun fuel cut: injectors off, so the wideband reads full lean and
+        // the reading carries no VE information. Left in, these samples land in
+        // exactly the low-load cells the car passes through on every lift, and
+        // each one asks for the maximum enrichment the authority limit allows —
+        // a required-VE of ve * (21/14.7) is +43%, clamped to +20%, over and
+        // over. TunerStudio's VE Analyze excludes overrun for the same reason.
+        if point.fuel_cut_active == Some(true) {
+            return false;
+        }
+
+        // A railed wideband is not a measurement. Below ~10 or above ~19.5 AFR
+        // no engine is running a real mixture: it is the sensor at a stop, an
+        // unpowered heater, or a cut still washing out. Catches the fuel-cut
+        // case too when the ECU exposes no DFCO channel.
+        if !(AFR_RAIL_LOW..=AFR_RAIL_HIGH).contains(&point.afr) {
+            return false;
+        }
+
         // Transient filtering: reject if TPS is changing too fast
         if point.tps_rate.abs() > filters.max_tps_rate {
             return false;
@@ -874,6 +949,118 @@ mod tests {
     /// 100% of samples on Speeduino, whose `accelEnrich` channel is a
     /// percentage (100 = no enrichment) and was misread as a boolean.
     #[test]
+    /// During overrun the injectors are off: the wideband reads full lean
+    /// while rpm, load, CLT and a steady closed throttle all pass. Left in,
+    /// each such sample asks for the authority-limit maximum enrichment in
+    /// exactly the low-load cells the car crosses on every lift.
+    #[test]
+    fn fuel_cut_samples_are_rejected() {
+        let state = AutoTuneState::default();
+        let filters = AutoTuneFilters {
+            min_rpm: 0.0,
+            min_clt: -100.0,
+            max_tps_rate: 1000.0,
+            ..Default::default()
+        };
+        let mut point = VEDataPoint::default();
+        point.rpm = 2500.0;
+        point.clt = 80.0;
+        point.afr = 14.7;
+
+        point.fuel_cut_active = Some(true);
+        assert!(!state.passes_filters(&point, &filters), "a cut must reject");
+        assert_eq!(
+            AutoTuneState::rejection_reason(&point, &filters),
+            "overrun fuel cut"
+        );
+
+        point.fuel_cut_active = Some(false);
+        assert!(state.passes_filters(&point, &filters), "not cutting passes");
+
+        point.fuel_cut_active = None;
+        assert!(
+            state.passes_filters(&point, &filters),
+            "unknown must pass — many INIs expose no DFCO channel"
+        );
+    }
+
+    /// A railed sensor is not a mixture. This also covers the fuel-cut case on
+    /// ECUs that expose no DFCO channel at all.
+    #[test]
+    fn railed_wideband_readings_are_rejected() {
+        let state = AutoTuneState::default();
+        let filters = AutoTuneFilters {
+            min_rpm: 0.0,
+            min_clt: -100.0,
+            max_tps_rate: 1000.0,
+            ..Default::default()
+        };
+        let mut point = VEDataPoint::default();
+        point.rpm = 2500.0;
+        point.clt = 80.0;
+
+        for railed in [9.9, 10.0 - 0.01, 19.6, 22.0, 0.0] {
+            point.afr = railed;
+            assert!(
+                !state.passes_filters(&point, &filters),
+                "{railed} AFR is a rail, not a measurement"
+            );
+        }
+        for real in [11.5, 12.7, 14.7, 16.0, 19.4] {
+            point.afr = real;
+            assert!(
+                state.passes_filters(&point, &filters),
+                "{real} AFR is a usable mixture"
+            );
+        }
+    }
+
+    /// The match window must follow the stream's real cadence. At the 111-200
+    /// ms spacing single-shot reads actually achieve, a fixed 50 ms window
+    /// rejects samples that are as close as an evenly-spaced stream can ever
+    /// get — half an interval — which silently discarded a third to a half of
+    /// every session.
+    #[test]
+    fn delayed_match_tolerates_the_streams_real_sample_spacing() {
+        let mut state = AutoTuneState::default();
+        state.buffer_max_age_ms = 5_000;
+        // 150 ms spacing: the nearest sample to any target is up to 75 ms away,
+        // which the old fixed 50 ms window rejected outright.
+        for i in 0..20u64 {
+            let mut p = VEDataPoint::default();
+            p.timestamp_ms = i * 150;
+            p.rpm = 2000.0;
+            state.data_buffer.push_back(p);
+        }
+        assert_eq!(state.mean_sample_gap_ms(), Some(150));
+
+        // Worst case for evenly-spaced sampling: a target exactly BETWEEN two
+        // samples, 75 ms from each. No stream at this cadence can ever do
+        // better, yet the old fixed 50 ms window rejected it. Delay 975 ms
+        // from the newest sample (t=2850) targets t=1875, midway between the
+        // samples at 1800 and 1950.
+        assert!(
+            state.find_delayed_data_point(2850, 975).is_some(),
+            "a target midway between samples is the best this cadence can do              and must match"
+        );
+
+        // A genuine hole is still rejected. Rebuild the buffer with a dropout
+        // in the middle and aim at it: the nearest sample is then many
+        // intervals away, not half of one.
+        state.data_buffer.clear();
+        for t in (0..900u64).step_by(150).chain((2400..2900u64).step_by(150)) {
+            let mut p = VEDataPoint::default();
+            p.timestamp_ms = t;
+            p.rpm = 2000.0;
+            state.data_buffer.push_back(p);
+        }
+        // Target t=1650, sitting inside the 750-2400 ms dropout.
+        assert!(
+            state.find_delayed_data_point(2850, 1200).is_none(),
+            "a target inside a dropout must not match"
+        );
+    }
+
     fn accel_filter_rejects_only_known_active() {
         let state = AutoTuneState::default();
         let filters = AutoTuneFilters {


### PR DESCRIPTION
## Description
Three reasons VE Analyze accumulates far less than the data it is handed.

### 1. The delayed-sample match window was a fixed 50 ms

`find_delayed_data_point` accepted a buffered sample only if it landed within 50 ms of `now - delay`. With samples every T ms, the nearest one to any target inside the buffer is **at most T/2 away** — so a 50 ms window starts rejecting good matches as soon as T exceeds ~100 ms.

On real hardware T is **111–200 ms**, because the single-shot reads feeding this contend with the realtime poll for the connection lock. Roughly a third to a half of every session was therefore dropped in strict mode (the default), leaving only a throttled debug line behind. That is the "AutoTune runs but recommendations never accumulate" symptom.

The tolerance now follows the stream's measured cadence — `0.6 × mean sample gap`, floored at the historical 50 ms so fast streams are unchanged. A genuine hole (a dropout, or a delay reaching past the buffered history) is still many intervals wide and still rejected.

### 2. Overrun fuel cut was not excluded

During a cut the injectors are off, so the wideband reads full lean while rpm, load, CLT and a steady closed throttle all pass the filters. Each such sample asks for the maximum enrichment the authority limit allows — a required VE of `ve × (21/14.7)` is +43%, clamped to +20% — landing repeatedly in exactly the low-load cells the car crosses on every lift. TunerStudio's VE Analyze excludes overrun for the same reason.

`VEDataPoint` gains `fuel_cut_active`, populated from the same `DFCOOn` / `dfco` channels the AFR delay test already looks for, so both features agree about when the injectors are off.

### 3. A railed wideband was treated as a mixture

Below ~10 or above ~19.5 AFR, no running engine sustains a real mixture: it is the sensor at a stop, an unpowered heater, or a cut still washing out. Those readings carry no VE information. This also covers the fuel-cut case on ECUs that expose no DFCO channel at all.

Both new rejections are named in `rejection_reason`, so the diagnostic log says which filter dropped a sample rather than leaving it to inference.

`VEDataPoint::default()` now uses 14.7 rather than 0.0 for `afr`: a default point should be a *valid* one, and zero AFR is physically impossible — it would fail the new rail check for a reason unrelated to whatever a caller was testing. Only tests construct defaults.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Testing
- [x] I have tested these changes locally
- [x] New and existing tests pass (`cargo test`)
- [ ] The UI works correctly with these changes

`cargo test --workspace`: **733 passed, 0 failed**. `cargo fmt --all -- --check` clean.

Three new tests, each **mutation-verified** (reverting the fix fails the test):

| fix reverted | test that fails |
|---|---|
| tolerance back to fixed 50 ms | `delayed_match_tolerates_the_streams_real_sample_spacing` |
| fuel-cut check removed | `fuel_cut_samples_are_rejected` |
| rail check removed | `railed_wideband_readings_are_rejected` |

The tolerance test deliberately targets the **worst case for evenly-spaced sampling** — a target exactly midway between two samples, 75 ms from each at 150 ms spacing. No stream at that cadence can do better, and the old window rejected it outright. (My first version of this test placed the target exactly 50 ms out and passed under mutation; worth stating, since a tolerance test that does not sit at the boundary proves nothing.)

Two notes for the reviewer:

1. `ini::parser::tests` has a **pre-existing flake** under parallel execution — several tests mutate a process-global symbol table and race each other. Reproduced 1-in-3 on pristine `main` with no changes applied; unrelated to this PR, but it will occasionally redden CI.
2. `cargo clippy --workspace -- -D warnings` reports 2 errors on pristine `main` under Rust 1.97 (`project/online_repository.rs`), untouched here.

## Checklist
- [x] Code compiles without errors
- [x] No new clippy warnings (`cargo clippy`) — see note 2
- [x] Code is formatted (`cargo fmt`)
- [ ] Documentation updated if needed
- [x] Commit messages follow conventional format

🤖 Generated with [Claude Code](https://claude.com/claude-code)
