### PR TITLE
feat(ini): auto-search online for a matching INI on signature mismatch

### DIFF
--- a/crates/libretune-app/src/components/dialogs/SignatureMismatchDialog.tsx
+++ b/crates/libretune-app/src/components/dialogs/SignatureMismatchDialog.tsx
@@ -62,6 +62,22 @@ export default function SignatureMismatchDialog({
   const [searchError, setSearchError] = useState<string | null>(null);
   const [browsing, setBrowsing] = useState(false);
 
+  // Auto-offer the online match on a genuine mismatch — TunerStudio does
+  // this automatically rather than requiring the user to dig for a
+  // "Search Online" button. Pre-fetches results as soon as a mismatch is
+  // reported (not just when the user opens the online tab), and jumps
+  // straight to that tab when there's no local match at all, since the
+  // local tab has nothing useful to show in that case. Still requires an
+  // explicit click to actually download anything (see handleDownload) —
+  // this only automates the *search*, never applies an INI on its own.
+  useEffect(() => {
+    if (!mismatchInfo) return;
+    if (mismatchInfo.matching_inis.length === 0) {
+      setShowOnlineSearch(true);
+    }
+    checkConnectivity();
+  }, [mismatchInfo?.ecu_signature]);
+
   // Check internet connectivity when online search is opened
   useEffect(() => {
     if (showOnlineSearch && hasInternet === null) {


### PR DESCRIPTION
Completes gap (2) from #181.

## Background

On connect, a signature mismatch already auto-offers local INI matches (find_matching_inis_internal, backend side). Reaching an online match required the user to manually click "Search Online..." inside SignatureMismatchDialog every time, even when the local repository had nothing useful to suggest.

## Changes Made

The dialog now kicks off the same online search (check_internet_connectivity plus search_online_inis) automatically as soon as a mismatch is reported, keyed off the ECU signature so it re-runs for each new mismatch rather than once per dialog mount. When there is no local match at all, it also switches straight to the online tab instead of showing an empty "no matches found" local view first.

This only automates the search, matching the online-source coverage that already exists (Speeduino, rusEFI, FOME). Actually applying an INI still requires an explicit Download click, same as before — no silent INI swaps.

## Testing

tsc --noEmit clean. Full vitest suite: 198/199 passing, the one failure is the pre-existing App.integration.test.tsx timeout unrelated to this change.