### PR TITLE
fix(dialogs): evaluate command-button labels instead of showing raw text

### DIFF
--- a/crates/libretune-app/src/components/dialogs/fields/CommandButton.tsx
+++ b/crates/libretune-app/src/components/dialogs/fields/CommandButton.tsx
@@ -21,7 +21,26 @@ export function CommandButton({
   const [isExecuting, setIsExecuting] = useState(false);
   const [showWarning, setShowWarning] = useState(false);
   const [warningsDisabled, setWarningsDisabled] = useState(false);
+  const [displayLabel, setDisplayLabel] = useState(comp.label ?? '');
   const { showToast } = useToast();
+
+  // Many INI-defined "buttons" are actually live status readouts (no
+  // `command`, a label like "{ bitStringValue(stftStateList, 2) }"). Without
+  // this they rendered the raw braced expression text instead of the
+  // evaluated state — evaluate_string_expression passes plain labels through
+  // unchanged, so this is safe to run on every label.
+  useEffect(() => {
+    if (!comp.label) {
+      setDisplayLabel('');
+      return;
+    }
+    invoke<string>('evaluate_string_expression', { expression: comp.label, context })
+      .then(setDisplayLabel)
+      .catch((err) => {
+        console.error('Error evaluating command button label:', err);
+        setDisplayLabel(comp.label ?? '');
+      });
+  }, [comp.label, context]);
 
   // Load warning preference from localStorage
   useEffect(() => {
@@ -55,7 +74,7 @@ export function CommandButton({
         new Promise((_, reject) => setTimeout(() => reject(new Error('Command timed out')), timeoutMs)),
       ]);
 
-      showToast(`${comp.label ?? comp.command} sent to ECU`, 'success');
+      showToast(`${displayLabel || comp.command} sent to ECU`, 'success');
     } catch (err) {
       console.error('Command execution failed:', err);
       alert(`Command failed: ${err}`);
@@ -98,7 +117,7 @@ export function CommandButton({
           onClick={handleClick}
           disabled={!isEnabled || isExecuting}
         >
-          {isExecuting ? 'Executing...' : comp.label}
+          {isExecuting ? 'Executing...' : displayLabel}
         </button>
       </div>
 


### PR DESCRIPTION
## Reported

Comparing TunerStudio and LibreTune side by side on the "Short term fuel trim/Closed loop" dialog: TunerStudio's INPUT/LEARNING STATE panel shows named state boxes (Tuning, RPM, Cranking Delay, Clt, ...), while LibreTune showed the same green boxes with the literal unevaluated text "{ bitStringValue(stftStateList, 2) }" and so on.

## Root cause

Many INI commandButton fields have no command at all — they're live status readouts whose label is a braced expression the host is expected to evaluate (e.g. bitStringValue against the current state bitfield), not literal text. CommandButton.tsx rendered comp.label as-is; nothing ever ran it through the expression evaluator.

The backend already exposes evaluate_string_expression (wraps evaluate_display_string, the same function already used for gauge titles and table axis labels elsewhere in this app) which passes plain text through unchanged and evaluates a braced label into its current value. CommandButton.tsx just never called it.

## Fix

Runs every command-button label through evaluate_string_expression, re-evaluating whenever the channel-value context updates so these boxes track live ECU state the same way TunerStudio's do. Falls back to the raw label text if evaluation fails.

## Testing

tsc --noEmit clean. Full vitest suite: 198/199 passing, the one failure is the pre-existing App.integration.test.tsx timeout unrelated to this change.