### PR TITLE
feat(table): TunerStudio-compatible per-table .table file import/export

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/mod.rs
+++ b/crates/libretune-app/src-tauri/src/commands/mod.rs
@@ -66,6 +66,7 @@ pub mod string_context;
 pub mod sync_ecu_data;
 pub mod system;
 pub mod table_compare;
+pub mod table_file_io;
 pub mod table_internals;
 pub mod table_ops;
 pub mod table_update;

--- a/crates/libretune-app/src-tauri/src/commands/table_file_io.rs
+++ b/crates/libretune-app/src-tauri/src/commands/table_file_io.rs
@@ -1,0 +1,90 @@
+//! Per-table import/export to TunerStudio's `.table` file format.
+//!
+//! Distinct from csv_io.rs, which dumps/restores the *entire* tune as a flat
+//! CSV — this is the TunerStudio-compatible "Save Table to File" / "Load
+//! Table from File" a user reaches from a single table's toolbar.
+
+use crate::state::AppState;
+use crate::{
+    get_table_data_internal, update_constant_array_internal, update_table_z_values_internal,
+};
+use libretune_core::table_file::{parse_table_file, write_table_file};
+
+/// Export one table's current X/Y bins and Z-value grid to a `.table` file.
+#[tauri::command]
+pub async fn export_table_to_file(
+    state: tauri::State<'_, AppState>,
+    table_name: String,
+    path: String,
+) -> Result<(), String> {
+    let data = get_table_data_internal(&state, &table_name).await?;
+
+    let (x_bins_name, y_bins_name) = {
+        let def_guard = state.definition.lock().await;
+        let def = def_guard.as_ref().ok_or("Definition not loaded")?;
+        let table = def
+            .get_table_by_name_or_map(&table_name)
+            .ok_or_else(|| format!("Table {} not found", table_name))?;
+        (
+            table.x_bins.clone(),
+            table.y_bins.clone().unwrap_or_default(),
+        )
+    };
+
+    let xml = write_table_file(
+        &x_bins_name,
+        &y_bins_name,
+        &data.x_bins,
+        &data.y_bins,
+        &data.z_values,
+    )
+    .map_err(|e| e.to_string())?;
+
+    std::fs::write(&path, xml).map_err(|e| format!("Failed to write {}: {}", path, e))
+}
+
+/// Import a `.table` file into the named table. The file's dimensions must
+/// match the table's *current* size exactly — unlike TunerStudio, this does
+/// not resample/interpolate a mismatched grid onto the table's axes, so a
+/// resized table's file won't silently apply at the wrong scale.
+#[tauri::command]
+pub async fn import_table_from_file(
+    state: tauri::State<'_, AppState>,
+    table_name: String,
+    path: String,
+) -> Result<crate::TableData, String> {
+    let xml =
+        std::fs::read_to_string(&path).map_err(|e| format!("Failed to read {}: {}", path, e))?;
+    let parsed = parse_table_file(&xml).map_err(|e| e.to_string())?;
+
+    let current = get_table_data_internal(&state, &table_name).await?;
+    if parsed.cols != current.x_bins.len() || parsed.rows != current.y_bins.len() {
+        return Err(format!(
+            "{} is {}x{} in this project, but the file is {}x{}. Resize the table to match before importing.",
+            table_name,
+            current.x_bins.len(),
+            current.y_bins.len(),
+            parsed.cols,
+            parsed.rows,
+        ));
+    }
+
+    let (x_bins_name, y_bins_name, is_3d) = {
+        let def_guard = state.definition.lock().await;
+        let def = def_guard.as_ref().ok_or("Definition not loaded")?;
+        let table = def
+            .get_table_by_name_or_map(&table_name)
+            .ok_or_else(|| format!("Table {} not found", table_name))?;
+        (table.x_bins.clone(), table.y_bins.clone(), table.is_3d())
+    };
+
+    update_constant_array_internal(&state, &x_bins_name, parsed.x_bins).await?;
+    if is_3d {
+        if let Some(y_bins_name) = y_bins_name {
+            update_constant_array_internal(&state, &y_bins_name, parsed.y_bins).await?;
+        }
+    }
+    update_table_z_values_internal(&state, &table_name, parsed.z_values).await?;
+
+    get_table_data_internal(&state, &table_name).await
+}

--- a/crates/libretune-app/src-tauri/src/lib.rs
+++ b/crates/libretune-app/src-tauri/src/lib.rs
@@ -154,6 +154,7 @@ use commands::start_autotune::start_autotune;
 use commands::sync_ecu_data::sync_ecu_data;
 use commands::system::{get_build_info, get_serial_ports};
 use commands::table_compare::compare_tables;
+use commands::table_file_io::{export_table_to_file, import_table_from_file};
 use commands::table_ops::{
     add_offset, fill_region, interpolate_cells, interpolate_linear, rebin_table, resize_table_size,
     scale_cells, set_cells_equal, smooth_table,
@@ -248,6 +249,8 @@ pub fn run() {
             stop_realtime_stream,
             get_table_data,
             get_table_info,
+            export_table_to_file,
+            import_table_from_file,
             get_curve_data,
             get_tables,
             get_curves,

--- a/crates/libretune-app/src/components/tables/TableEditor2D.tsx
+++ b/crates/libretune-app/src/components/tables/TableEditor2D.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { invoke } from '@tauri-apps/api/core';
+import { open, save } from '@tauri-apps/plugin-dialog';
 import { ArrowLeft, Save, Zap, ExternalLink, AlertTriangle, Palette, MapPin, Crosshair, Box, Scaling } from 'lucide-react';
 import TableToolbar from './TableToolbar';
 import TableGrid, { SelectionRange } from './TableGrid';
@@ -690,6 +691,47 @@ export default function TableEditor2D({
     }
   };
 
+  // TunerStudio-compatible .table file import/export for this one table.
+  // import_table_from_file already writes the result to the tune/ECU cache
+  // on the backend; this just brings the local editor state (and undo
+  // stack) in sync with what was just written.
+  const handleExportTable = useCallback(async () => {
+    try {
+      const path = await save({
+        title: 'Save Table to File',
+        defaultPath: `${table_name}.table`,
+        filters: [{ name: 'TunerStudio Table', extensions: ['table'] }],
+      });
+      if (!path) return;
+      await invoke('export_table_to_file', { tableName: table_name, path });
+    } catch (err) {
+      showToast(`Failed to save table: ${err instanceof Error ? err.message : String(err)}`, 'error');
+    }
+  }, [table_name, showToast]);
+
+  const handleImportTable = useCallback(async () => {
+    try {
+      const path = await open({
+        title: 'Load Table from File',
+        filters: [{ name: 'TunerStudio Table', extensions: ['table'] }],
+        multiple: false,
+        directory: false,
+      });
+      if (!path) return;
+      const result = await invoke<BackendTableData>('import_table_from_file', {
+        tableName: table_name,
+        path,
+      });
+      setLocalXBins(result.x_bins);
+      setLocalYBins(result.y_bins);
+      setLocalZValues(result.z_values);
+      pushHistory(result.z_values, result.x_bins, result.y_bins);
+      onValuesChange?.(result.z_values);
+    } catch (err) {
+      showToast(`Failed to load table: ${err instanceof Error ? err.message : String(err)}`, 'error');
+    }
+  }, [table_name, showToast, pushHistory, onValuesChange]);
+
   const handleSetEqual = async () => {
     const values = selectedCellsCoords.map(([x, y]) => {
       return { x, y, value: localZValues[y][x] };
@@ -1314,6 +1356,8 @@ export default function TableEditor2D({
           onToggle3D={() => setShow3D(!show3D)}
           onGenerate={generatableKind ? () => setShowGenerateDialog(true) : undefined}
           generatableLabel={generatableKind ? generatableTableLabel(generatableKind) : undefined}
+          onImportTable={handleImportTable}
+          onExportTable={handleExportTable}
         />
       )}
 

--- a/crates/libretune-app/src/components/tables/TableToolbar.tsx
+++ b/crates/libretune-app/src/components/tables/TableToolbar.tsx
@@ -14,7 +14,9 @@ import {
   Palette,
   Box,
   Scaling,
-  Wand2
+  Wand2,
+  Upload,
+  Download
 } from 'lucide-react';
 
 interface TableToolbarProps {
@@ -42,6 +44,9 @@ interface TableToolbarProps {
   /** Generate the whole table from engine specs (VE/ignition/AFR only). */
   onGenerate?: () => void;
   generatableLabel?: string;
+  /** TunerStudio-compatible per-table .table file import/export. */
+  onImportTable?: () => void;
+  onExportTable?: () => void;
 }
 
 export default function TableToolbar({ 
@@ -68,6 +73,8 @@ export default function TableToolbar({
   onToggle3D,
   onGenerate,
   generatableLabel,
+  onImportTable,
+  onExportTable,
 }: TableToolbarProps) {
   return (
     <div className="ts-toolbar">
@@ -218,7 +225,7 @@ export default function TableToolbar({
           </button>
         )}
         {onToggle3D && (
-          <button 
+          <button
             className={`ts-toolbar-btn ${show3D ? 'ts-toolbar-btn-active' : ''}`}
             title="Toggle 3D View"
             onClick={onToggle3D}
@@ -227,6 +234,32 @@ export default function TableToolbar({
           </button>
         )}
       </div>
+
+      {(onImportTable || onExportTable) && (
+        <>
+          <div className="ts-toolbar-divider" />
+          <div className="ts-toolbar-group">
+            {onImportTable && (
+              <button
+                className="ts-toolbar-btn"
+                title="Load Table from File... (.table)"
+                onClick={onImportTable}
+              >
+                <Upload size={14} />
+              </button>
+            )}
+            {onExportTable && (
+              <button
+                className="ts-toolbar-btn"
+                title="Save Table to File... (.table)"
+                onClick={onExportTable}
+              >
+                <Download size={14} />
+              </button>
+            )}
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/crates/libretune-app/src/components/tuner-ui/TableEditor.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/TableEditor.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useRef, useEffect, KeyboardEvent, useMemo } from 'react';
 import { invoke } from '@tauri-apps/api/core';
+import { open, save } from '@tauri-apps/plugin-dialog';
 import { useChannels } from '../../stores/realtimeStore';
 import { useHeatmapSettings } from '../../utils/useHeatmapSettings';
 import { contrastTextColor } from '../../utils/heatmapColors';
@@ -10,6 +11,7 @@ import TableToolbar from './table-editor/TableToolbar';
 import TableContextMenu from './table-editor/TableContextMenu';
 import GenerateTableDialog from '../dialogs/GenerateTableDialog';
 import { classifyGeneratableTable, generatableTableLabel } from '../../utils/tableGenerator';
+import { toTunerTableData, BackendTableData } from '../../types/app';
 
 export interface TableData {
   name: string;
@@ -133,7 +135,41 @@ export function TableEditor({
   // TunerStudio-style per-table generator (VE / ignition / AFR only).
   const generatableKind = useMemo(() => classifyGeneratableTable(data.name), [data.name]);
   const [showGenerateDialog, setShowGenerateDialog] = useState(false);
-  
+
+  // TunerStudio-compatible .table file import/export for this one table.
+  const handleExportTable = useCallback(async () => {
+    try {
+      const path = await save({
+        title: 'Save Table to File',
+        defaultPath: `${data.name}.table`,
+        filters: [{ name: 'TunerStudio Table', extensions: ['table'] }],
+      });
+      if (!path) return;
+      await invoke('export_table_to_file', { tableName: data.name, path });
+    } catch (err) {
+      alert(`Failed to save table: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }, [data.name]);
+
+  const handleImportTable = useCallback(async () => {
+    try {
+      const path = await open({
+        title: 'Load Table from File',
+        filters: [{ name: 'TunerStudio Table', extensions: ['table'] }],
+        multiple: false,
+        directory: false,
+      });
+      if (!path) return;
+      const result = await invoke<BackendTableData>('import_table_from_file', {
+        tableName: data.name,
+        path,
+      });
+      onChange(toTunerTableData(result));
+    } catch (err) {
+      alert(`Failed to load table: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }, [data.name, onChange]);
+
   // Store original data on first render
   useEffect(() => {
     if (!originalData) {
@@ -913,6 +949,8 @@ export function TableEditor({
         onToggle3D={() => setShow3D(!show3D)}
         onGenerate={generatableKind ? () => setShowGenerateDialog(true) : undefined}
         generatableLabel={generatableKind ? generatableTableLabel(generatableKind) : undefined}
+        onImportTable={handleImportTable}
+        onExportTable={handleExportTable}
       />
 
       {/* 3D View */}

--- a/crates/libretune-app/src/components/tuner-ui/table-editor/TableToolbar.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/table-editor/TableToolbar.tsx
@@ -1,4 +1,4 @@
-import { Copy, Clipboard, Undo2, Redo2, Flame, Crosshair, Box, Wand2 } from 'lucide-react';
+import { Copy, Clipboard, Undo2, Redo2, Flame, Crosshair, Box, Wand2, Upload, Download } from 'lucide-react';
 import '../TableEditor.css';
 
 interface TableToolbarProps {
@@ -27,6 +27,9 @@ interface TableToolbarProps {
   /** Generate the whole table from engine specs (VE/ignition/AFR only). */
   onGenerate?: () => void;
   generatableLabel?: string;
+  /** TunerStudio-compatible per-table .table file import/export. */
+  onImportTable?: () => void;
+  onExportTable?: () => void;
 }
 
 export default function TableToolbar({
@@ -54,6 +57,8 @@ export default function TableToolbar({
   onToggle3D,
   onGenerate,
   generatableLabel,
+  onImportTable,
+  onExportTable,
 }: TableToolbarProps) {
   return (
     <div className="table-toolbar">
@@ -217,6 +222,32 @@ export default function TableToolbar({
           >
             <Wand2 size={14} /> Generate
           </button>
+        </>
+      )}
+
+      {(onImportTable || onExportTable) && (
+        <>
+          <div className="table-toolbar-separator" />
+          {onImportTable && (
+            <button
+              className="table-toolbar-btn"
+              onClick={onImportTable}
+              title="Load Table from File... (.table)"
+              aria-label="Load Table from File"
+            >
+              <Upload size={14} />
+            </button>
+          )}
+          {onExportTable && (
+            <button
+              className="table-toolbar-btn"
+              onClick={onExportTable}
+              title="Save Table to File... (.table)"
+              aria-label="Save Table to File"
+            >
+              <Download size={14} />
+            </button>
+          )}
         </>
       )}
     </div>

--- a/crates/libretune-core/src/lib.rs
+++ b/crates/libretune-core/src/lib.rs
@@ -58,6 +58,7 @@ pub mod port_editor;
 pub mod project;
 pub mod protocol;
 pub mod realtime;
+pub mod table_file;
 pub mod table_ops;
 pub mod tune;
 pub mod tune_view;

--- a/crates/libretune-core/src/table_file.rs
+++ b/crates/libretune-core/src/table_file.rs
@@ -1,0 +1,329 @@
+//! TunerStudio `.table` file format — reader/writer.
+//!
+//! A single-table export/import format (`<tableData>` XML), distinct from
+//! the full-tune `.msq` format: one table's X/Y axis bins plus its Z-value
+//! grid, nothing else. Verified against two real TunerStudio-exported
+//! `.table` files (a 16x16 ignition table and a 2x8 injector dead-time
+//! table) rather than guessed from documentation, which doesn't describe
+//! the format in any detail.
+
+use quick_xml::events::{BytesDecl, BytesEnd, BytesStart, BytesText, Event};
+use quick_xml::Reader;
+use quick_xml::Writer;
+use quick_xml::XmlVersion;
+
+#[derive(Debug, thiserror::Error)]
+pub enum TableFileError {
+    #[error("XML error: {0}")]
+    Xml(#[from] quick_xml::Error),
+    #[error("XML attribute error: {0}")]
+    XmlAttr(#[from] quick_xml::events::attributes::AttrError),
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("XML encoding error: {0}")]
+    Encoding(#[from] quick_xml::encoding::EncodingError),
+    #[error("not a TunerStudio table file (missing <tableData>)")]
+    NotATableFile,
+    #[error("malformed table file: {0}")]
+    Malformed(String),
+}
+
+/// A parsed `.table` file, in the same shape `TableData` (the Tauri command
+/// struct) already uses, so the caller can validate/apply it directly.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ParsedTableFile {
+    pub cols: usize,
+    pub rows: usize,
+    pub x_bins: Vec<f64>,
+    pub y_bins: Vec<f64>,
+    pub z_values: Vec<Vec<f64>>,
+}
+
+/// Write a single table to TunerStudio's `.table` XML format.
+///
+/// `x_name`/`y_name` land in the `name` attribute TunerStudio puts on
+/// `<xAxis>`/`<yAxis>` (the axis's own constant name, e.g. "rpmBins") —
+/// informational only, nothing on import depends on it matching anything.
+pub fn write_table_file(
+    x_name: &str,
+    y_name: &str,
+    x_bins: &[f64],
+    y_bins: &[f64],
+    z_values: &[Vec<f64>],
+) -> Result<String, TableFileError> {
+    let cols = x_bins.len();
+    let rows = y_bins.len();
+    let mut writer = Writer::new_with_indent(Vec::new(), b' ', 4);
+
+    writer.write_event(Event::Decl(BytesDecl::new(
+        "1.0",
+        Some("UTF-8"),
+        Some("no"),
+    )))?;
+
+    let mut root = BytesStart::new("tableData");
+    root.push_attribute(("xmlns", "http://www.EFIAnalytics.com/:table"));
+    writer.write_event(Event::Start(root))?;
+
+    let mut bib = BytesStart::new("bibliography");
+    bib.push_attribute(("author", "LibreTune"));
+    bib.push_attribute(("company", "LibreTune, open source"));
+    bib.push_attribute(("writeDate", chrono_like_now().as_str()));
+    writer.write_event(Event::Empty(bib))?;
+
+    let mut version = BytesStart::new("versionInfo");
+    version.push_attribute(("fileFormat", "1.0"));
+    writer.write_event(Event::Empty(version))?;
+
+    let mut table = BytesStart::new("table");
+    table.push_attribute(("cols", cols.to_string().as_str()));
+    table.push_attribute(("rows", rows.to_string().as_str()));
+    writer.write_event(Event::Start(table))?;
+
+    let mut x_axis = BytesStart::new("xAxis");
+    x_axis.push_attribute(("cols", cols.to_string().as_str()));
+    x_axis.push_attribute(("name", x_name));
+    writer.write_event(Event::Start(x_axis))?;
+    for v in x_bins {
+        writer.write_event(Event::Text(BytesText::new(&format!("{}\n", v))))?;
+    }
+    writer.write_event(Event::End(BytesEnd::new("xAxis")))?;
+
+    let mut y_axis = BytesStart::new("yAxis");
+    y_axis.push_attribute(("name", y_name));
+    y_axis.push_attribute(("rows", rows.to_string().as_str()));
+    writer.write_event(Event::Start(y_axis))?;
+    for v in y_bins {
+        writer.write_event(Event::Text(BytesText::new(&format!("{}\n", v))))?;
+    }
+    writer.write_event(Event::End(BytesEnd::new("yAxis")))?;
+
+    let mut z_elem = BytesStart::new("zValues");
+    z_elem.push_attribute(("cols", cols.to_string().as_str()));
+    z_elem.push_attribute(("rows", rows.to_string().as_str()));
+    writer.write_event(Event::Start(z_elem))?;
+    for row in z_values {
+        let line = row
+            .iter()
+            .map(|v| v.to_string())
+            .collect::<Vec<_>>()
+            .join(" ");
+        writer.write_event(Event::Text(BytesText::new(&format!("{}\n", line))))?;
+    }
+    writer.write_event(Event::End(BytesEnd::new("zValues")))?;
+
+    writer.write_event(Event::End(BytesEnd::new("table")))?;
+    writer.write_event(Event::End(BytesEnd::new("tableData")))?;
+
+    let result = writer.into_inner();
+    Ok(String::from_utf8_lossy(&result).to_string())
+}
+
+/// Parse a `.table` file. Tolerant of the exact xmlns URI (TunerStudio
+/// builds have shipped more than one — "usEasyDocs.com" and
+/// "EFIAnalytics.com" have both been observed in the wild) and of
+/// attribute order, since only the element/attribute *names* are load-bearing.
+pub fn parse_table_file(xml: &str) -> Result<ParsedTableFile, TableFileError> {
+    let mut reader = Reader::from_str(xml);
+    reader.config_mut().trim_text(true);
+
+    let mut cols: Option<usize> = None;
+    let mut rows: Option<usize> = None;
+    let mut x_bins = Vec::new();
+    let mut y_bins = Vec::new();
+    let mut z_values = Vec::new();
+    let mut in_x_axis = false;
+    let mut in_y_axis = false;
+    let mut in_z_values = false;
+    let mut saw_table_data = false;
+
+    let mut buf = Vec::new();
+    loop {
+        match reader.read_event_into(&mut buf)? {
+            Event::Eof => break,
+            Event::Start(e) | Event::Empty(e) => {
+                let name = e.name();
+                let local = name.as_ref();
+                match local {
+                    b"tableData" => saw_table_data = true,
+                    b"table" => {
+                        for attr in e.attributes() {
+                            let attr = attr?;
+                            match attr.key.as_ref() {
+                                b"cols" => {
+                                    cols = attr
+                                        .normalized_value(XmlVersion::Implicit1_0)
+                                        .ok()
+                                        .and_then(|v| v.parse().ok())
+                                }
+                                b"rows" => {
+                                    rows = attr
+                                        .normalized_value(XmlVersion::Implicit1_0)
+                                        .ok()
+                                        .and_then(|v| v.parse().ok())
+                                }
+                                _ => {}
+                            }
+                        }
+                    }
+                    b"xAxis" => in_x_axis = true,
+                    b"yAxis" => in_y_axis = true,
+                    b"zValues" => in_z_values = true,
+                    _ => {}
+                }
+            }
+            Event::End(e) => match e.name().as_ref() {
+                b"xAxis" => in_x_axis = false,
+                b"yAxis" => in_y_axis = false,
+                b"zValues" => in_z_values = false,
+                _ => {}
+            },
+            Event::Text(t) => {
+                let text = t.decode()?.into_owned();
+                if in_x_axis {
+                    x_bins.extend(parse_whitespace_separated_floats(&text));
+                } else if in_y_axis {
+                    y_bins.extend(parse_whitespace_separated_floats(&text));
+                } else if in_z_values {
+                    for line in text.lines() {
+                        let row = parse_whitespace_separated_floats(line);
+                        if !row.is_empty() {
+                            z_values.push(row);
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+        buf.clear();
+    }
+
+    if !saw_table_data {
+        return Err(TableFileError::NotATableFile);
+    }
+
+    let cols = cols.ok_or_else(|| TableFileError::Malformed("missing <table cols=...>".into()))?;
+    let rows = rows.ok_or_else(|| TableFileError::Malformed("missing <table rows=...>".into()))?;
+
+    if x_bins.len() != cols {
+        return Err(TableFileError::Malformed(format!(
+            "xAxis has {} values, table declares {} cols",
+            x_bins.len(),
+            cols
+        )));
+    }
+    if y_bins.len() != rows {
+        return Err(TableFileError::Malformed(format!(
+            "yAxis has {} values, table declares {} rows",
+            y_bins.len(),
+            rows
+        )));
+    }
+    if z_values.len() != rows || z_values.iter().any(|r| r.len() != cols) {
+        return Err(TableFileError::Malformed(format!(
+            "zValues is not a {}x{} grid",
+            cols, rows
+        )));
+    }
+
+    Ok(ParsedTableFile {
+        cols,
+        rows,
+        x_bins,
+        y_bins,
+        z_values,
+    })
+}
+
+fn parse_whitespace_separated_floats(text: &str) -> Vec<f64> {
+    text.split_whitespace()
+        .filter_map(|tok| tok.parse::<f64>().ok())
+        .collect()
+}
+
+/// A writeDate string in the same shape TunerStudio's own exports use
+/// (`Fri Aug 14 21:39:32 COT 2026`) — informational only, nothing parses it
+/// back on import. Hand-rolled instead of pulling in a date/time crate for
+/// one cosmetic field.
+fn chrono_like_now() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    format!("epoch {} UTC", secs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Verbatim content from a real TunerStudio-exported 2x8 table
+    // (injectorsDeadTime), used here to lock the parser to the real format
+    // rather than to our own writer's idea of it.
+    const REAL_EXPORT: &str = r#"<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<tableData xmlns="http://www.EFIAnalytics.com/:table">
+<bibliography author="EFI Analytics - philip.tobin@yahoo.com" company="EFI Analytics, copyright 2010, All Rights Reserved." writeDate="Fri Aug 14 22:08:01 COT 2026"/>
+<versionInfo fileFormat="1.0"/>
+<table cols="8" rows="2">
+<xAxis cols="8" name="VBatt">
+         6.00
+         8.00
+         10.00
+         11.00
+         12.00
+         13.00
+         14.00
+         15.00
+      </xAxis>
+<yAxis name="pressureCorrectionReference" rows="2">
+         206.80
+         413.70
+      </yAxis>
+<zValues cols="8" rows="2">
+         4.0 2.4 1.65 1.25 1.05 0.85 0.79 0.70
+         3.08 1.65 1.15 1.19 0.99 0.76 0.64 0.6
+      </zValues>
+</table>
+</tableData>
+"#;
+
+    #[test]
+    fn parses_a_real_tunerstudio_export() {
+        let parsed = parse_table_file(REAL_EXPORT).expect("parses");
+        assert_eq!(parsed.cols, 8);
+        assert_eq!(parsed.rows, 2);
+        assert_eq!(
+            parsed.x_bins,
+            vec![6.0, 8.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0]
+        );
+        assert_eq!(parsed.y_bins, vec![206.80, 413.70]);
+        assert_eq!(parsed.z_values[0][0], 4.0);
+        assert_eq!(parsed.z_values[1][7], 0.6);
+    }
+
+    #[test]
+    fn round_trips_through_our_own_writer() {
+        let x_bins = vec![600.0, 1200.0, 3000.0];
+        let y_bins = vec![10.0, 50.0];
+        let z_values = vec![vec![1.0, 2.0, 3.0], vec![4.0, 5.0, 6.0]];
+        let xml = write_table_file("rpmBins", "loadBins", &x_bins, &y_bins, &z_values).unwrap();
+        let parsed = parse_table_file(&xml).unwrap();
+        assert_eq!(parsed.x_bins, x_bins);
+        assert_eq!(parsed.y_bins, y_bins);
+        assert_eq!(parsed.z_values, z_values);
+    }
+
+    #[test]
+    fn rejects_a_non_table_file() {
+        let err = parse_table_file("<notATable/>").unwrap_err();
+        assert!(matches!(err, TableFileError::NotATableFile));
+    }
+
+    #[test]
+    fn rejects_dimension_mismatch() {
+        // cols says 8 but xAxis only has 2 values.
+        let bad = REAL_EXPORT.replace(r#"cols="8""#, r#"cols="9""#);
+        assert!(parse_table_file(&bad).is_err());
+    }
+}


### PR DESCRIPTION
Load Table from File / Save Table to File for VE, ignition, and any other single table, matching TunerStudio's own workflow. This is distinct from csv_io.rs's existing full-tune CSV dump/restore, which exports every constant in the tune, not one table's grid.

## Root cause / gap

There was no way to import or export a single table the way TunerStudio does. The only existing export was a flat CSV of the entire tune.

## Format verification

The .table format isn't documented in enough detail to implement blind, so it's verified against two real files exported by TunerStudio itself (a 16x16 ignition table and a 2x8 injector dead-time table) rather than guessed: a tableData XML document with bibliography/versionInfo housekeeping and xAxis/yAxis/zValues elements. libretune-core/src/table_file.rs's tests lock the parser to that real content, not to our own writer's idea of the format.

## Changes Made

Backend: export_table_to_file and import_table_from_file (new commands/table_file_io.rs) reuse the same internal helpers the rest of the table pipeline already uses (get_table_data_internal, update_constant_array_internal, update_table_z_values_internal) rather than duplicating tune-writing logic.

Import requires the file's dimensions to exactly match the table's current size. Unlike TunerStudio, it does not resample/interpolate a mismatched grid onto different axes, so a resized table's file can't silently apply at the wrong scale — it returns a clear resize-first error instead.

Frontend: wired into both table toolbars this app has, TableEditor.tsx (full-tab tables) and TableEditor2D.tsx (dialog-embedded tables, e.g. VE Table opened from a dialog), since both are real, commonly-used surfaces for the same tables. Reuses the existing BackendTableData/toTunerTableData adapter so the imported result lands in the same shape the rest of the app already expects.

## Testing

cargo test -p libretune-core: 410 passing, including 4 new tests for the file format (one parses a real TunerStudio export verbatim, one round-trips our own writer, two reject malformed input). cargo test -p libretune-app --lib: 58 passing. cargo clippy --workspace -- -D warnings clean. cargo fmt --check clean. tsc --noEmit clean. vitest: 198/199, the one failure is the pre-existing App.integration.test.tsx timeout, unrelated to this change.