### PR TITLE
fix(dialogs): evaluate indicatorPanel labels instead of showing raw text

### DIFF
--- a/crates/libretune-app/src/components/dialogs/fields/IndicatorPanelRenderer.tsx
+++ b/crates/libretune-app/src/components/dialogs/fields/IndicatorPanelRenderer.tsx
@@ -1,4 +1,5 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { invoke } from '@tauri-apps/api/core';
 import { useShallow } from 'zustand/react/shallow';
 import { useRealtimeStore } from '../../../stores/realtimeStore';
 import {
@@ -72,6 +73,41 @@ export function IndicatorPanelRenderer({
     return values;
   }, [panel.indicators, realtimeSlice, context]);
 
+  // Some INIs (e.g. rusEFI's STFT status panels) give an indicator a braced
+  // expression as its label instead of a fixed string — "{
+  // bitStringValue(stftStateList, 2) }" is meant to show the live state
+  // name, not that literal text. Only the labels that are actually dynamic
+  // get sent for evaluation; the common case (a plain quoted label) never
+  // makes a round trip.
+  const dynamicLabels = useMemo(() => {
+    const set = new Set<string>();
+    for (const ind of panel.indicators) {
+      if (ind.label_off.trim().startsWith('{')) set.add(ind.label_off);
+      if (ind.label_on.trim().startsWith('{')) set.add(ind.label_on);
+    }
+    return Array.from(set);
+  }, [panel.indicators]);
+
+  const [evaluatedLabels, setEvaluatedLabels] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    if (dynamicLabels.length === 0) return;
+    let cancelled = false;
+    const mergedContext = { ...context, ...realtimeSlice };
+    Promise.all(
+      dynamicLabels.map((label) =>
+        invoke<string>('evaluate_string_expression', { expression: label, context: mergedContext })
+          .then((value): [string, string] => [label, value])
+          .catch(() => [label, label] as [string, string]),
+      ),
+    ).then((entries) => {
+      if (!cancelled) setEvaluatedLabels(Object.fromEntries(entries));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [dynamicLabels, context, realtimeSlice]);
+
   const statusTiles = useMemo(
     () => usesStatusTiles(panel.indicators),
     [panel.indicators],
@@ -95,7 +131,8 @@ export function IndicatorPanelRenderer({
       <div className="indicator-panel-grid" style={gridStyle}>
         {panel.indicators.map((ind, i) => {
           const isOn = indicatorValues[ind.expression] || false;
-          const label = isOn ? ind.label_on : ind.label_off;
+          const rawLabel = isOn ? ind.label_on : ind.label_off;
+          const label = evaluatedLabels[rawLabel] ?? rawLabel;
 
           if (statusTiles) {
             return (


### PR DESCRIPTION
Follow-up to the CommandButton label fix (#223) — same class of bug, different rendering component.

## Root cause

Confirmed against the real INI, not guessed: rusEFI's STFT status panels declare indicators like

indicatorPanel = fuelClosedLoopInputIndicatorsPanelBank1, 2
indicator = { stftLearningState1 == 2 }, { bitStringValue(stftStateList, 2) }, { bitStringValue(stftStateList, stftLearningState1) }, green, black, red, black

The off/on label fields are braced expressions meant to show the live state name, exactly matching what was reported: colored tiles showing the literal text "{ bitStringValue(stftStateList, 2) }" instead of the state name TunerStudio shows in the same panel.

IndicatorPanelRenderer.tsx rendered ind.label_off and ind.label_on as-is.

## Fix

Now evaluates any label that looks like a braced expression through evaluate_string_expression, the same backend command the CommandButton fix uses, re-running whenever the indicator's own live context changes. Only labels that are actually dynamic get sent for evaluation — a plain quoted label, the common case for most indicatorPanels elsewhere, never makes a round trip.

## Note

A separate, unrelated issue found in the same dialog is a genuine typo in this specific rusEFI INI: a missing comma on one field = line merges the label and constant name, so the "Startup delay" field's enable-condition gets misread as its constant name. That is a data error in the upstream INI, not a LibreTune bug, so it is not touched here.

## Testing

tsc --noEmit clean. Full vitest suite: 198/199 passing, the one failure is the pre-existing App.integration.test.tsx timeout unrelated to this change.