### PR TITLE
fix(ini): indicatorPanel without an explicit columns count was dropped

### DIFF
--- a/crates/libretune-app/src/components/dialogs/fields/Indicator.tsx
+++ b/crates/libretune-app/src/components/dialogs/fields/Indicator.tsx
@@ -21,10 +21,30 @@ export function Indicator({
     }
   }, [comp.expression, context]);
 
+  // label_on/label_off can themselves be braced expressions (same pattern
+  // as IndicatorPanelRenderer's tiles) — evaluate the raw label rather than
+  // showing e.g. "{ bitStringValue(stftStateList, 2) }" verbatim.
+  const rawLabel = isOn ? comp.label_on : comp.label_off;
+  const [evaluatedLabel, setEvaluatedLabel] = useState(rawLabel);
+
+  useEffect(() => {
+    if (!rawLabel?.trim().startsWith('{')) {
+      setEvaluatedLabel(rawLabel);
+      return;
+    }
+    let cancelled = false;
+    invoke<string>('evaluate_string_expression', { expression: rawLabel, context })
+      .then((value) => { if (!cancelled) setEvaluatedLabel(value); })
+      .catch(() => { if (!cancelled) setEvaluatedLabel(rawLabel); });
+    return () => {
+      cancelled = true;
+    };
+  }, [rawLabel, context]);
+
   return (
     <div className="indicator-field">
       <div className={`indicator-light ${isOn ? 'on' : 'off'}`} />
-      <span className="indicator-label">{isOn ? comp.label_on : comp.label_off}</span>
+      <span className="indicator-label">{evaluatedLabel}</span>
     </div>
   );
 }

--- a/crates/libretune-core/src/ini/parser.rs
+++ b/crates/libretune-core/src/ini/parser.rs
@@ -2380,11 +2380,18 @@ fn parse_user_defined_entry(
             }
         }
         "indicatorpanel" => {
-            // Format: indicatorPanel = name, columns [, {visibility_condition}]
+            // Format: indicatorPanel = name [, columns] [, {visibility_condition}]
+            // `columns` is optional in the wild (e.g. rusEFI's
+            // fuelClosedLoopIndicatorsPanel omits it) — requiring it dropped
+            // the whole panel silently, which also left current_dialog
+            // pointing at whatever dialog was last opened (this arm only
+            // clears it inside the block below), so the indicator lines
+            // meant for this panel got misattributed there as bare
+            // single-indicator fields instead.
             let parts = split_ini_line(value);
-            if parts.len() >= 2 {
+            if !parts.is_empty() {
                 let name = parts[0].to_string();
-                let columns = parts[1].parse::<u8>().unwrap_or(2);
+                let columns = parts.get(1).and_then(|p| p.parse::<u8>().ok()).unwrap_or(2);
 
                 // Check for visibility condition (last part in braces)
                 let visibility_condition = parts
@@ -3526,6 +3533,52 @@ maxUnusedRuntimeRange = 42
 "#;
         let def = parse_ini(content).expect("Should parse successfully");
         assert_eq!(def.protocol.max_unused_runtime_range, 42);
+    }
+
+    #[test]
+    fn indicator_panel_without_a_columns_count_still_registers() {
+        // Verbatim shape from a real rusEFI INI: indicatorPanel omitting the
+        // `, columns` parameter (unlike its sibling panels, which all give
+        // one) used to be silently dropped entirely — `columns` was treated
+        // as required, not optional as its own doc comment claimed. Losing
+        // the panel also stranded its `indicator =` lines: with
+        // current_indicator_panel never set, they fell through to the
+        // "attach to current_dialog" fallback and landed as bare fields on
+        // whatever dialog was last opened, instead of on this panel.
+        let content = r#"
+[UserDefined]
+	dialog = someOtherDialog, "Unrelated"
+		field = "Unrelated field", someConstant
+
+	indicatorPanel = fuelClosedLoopIndicatorsPanel
+		indicator = { stftCorrectionState != 0 }, { Correction using bitStringValue(stftBinIdxList, stftCorrectionBinIdx) region }, { Not active: bitStringValue(stftStateList, stftCorrectionState) }, green, black, white, black
+		indicator = { isTuningNow }, "No tuning happening", "Tuning Detected", white, black, green, black
+"#;
+        let def = parse_ini(content).expect("Should parse successfully");
+
+        let panel = def
+            .indicator_panels
+            .get("fuelClosedLoopIndicatorsPanel")
+            .expect("panel should be registered even without an explicit columns count");
+        assert_eq!(panel.columns, 2, "missing columns should default to 2");
+        assert_eq!(panel.indicators.len(), 2);
+        assert_eq!(
+            panel.indicators[1].label_on, "Tuning Detected",
+            "indicator lines after a columns-less panel header must attach to that panel"
+        );
+
+        // The earlier dialog must not have picked up these indicators as
+        // stray fields — that was the visible symptom (they rendered as
+        // unstyled bullet rows with the raw, unevaluated expression text).
+        let other_dialog = def
+            .dialogs
+            .get("someOtherDialog")
+            .expect("dialog should exist");
+        assert_eq!(
+            other_dialog.components.len(),
+            1,
+            "only the field explicitly declared in this dialog should be on it"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Reported (with screenshots): the "Short term fuel trim/Closed loop" dialog showed "Panel 'fuelClosedLoopIndicatorsPanel' could not be loaded", and two rows with raw unevaluated expression text ("{ Correction using bitStringValue(...) }") floating below it instead of colored status tiles.

## Root cause

Confirmed against the real rusEFI INI. indicatorPanel = name, columns is documented, in this parser's own comment, as columns being optional, but the code required parts.len() >= 2 to do anything at all. A bare indicatorPanel = fuelClosedLoopIndicatorsPanel (no comma, no column count, unlike its sibling panels which all give one) fell through the whole match arm doing nothing.

That both dropped the panel entirely, hence "could not be loaded", and left current_dialog pointing at whatever dialog was last opened, since this arm only clears it inside the block that never ran. The two indicator = lines meant for the panel then fell through to the "attach to current_dialog" fallback instead, landing as bare single-indicator fields on an unrelated dialog, rendered by Indicator.tsx. That component has the same bug class as the CommandButton (#223) and IndicatorPanelRenderer (#225) fixes: it never evaluated braced label_on/label_off text either.

## Fix

Two changes:

parser.rs: columns now genuinely defaults to 2 when omitted, matching the comment already above it, instead of requiring it to be present.

Indicator.tsx: evaluates a braced label through evaluate_string_expression, same pattern as the other two components.

## Testing

New regression test parses the real panel's shape verbatim (columns omitted) and asserts it registers with 2 indicators, and that an unrelated dialog opened just before it does not pick up stray fields. cargo test -p libretune-core: 411 passing (410 plus this one). cargo test -p libretune-app --lib: 58 passing. cargo clippy --workspace -- -D warnings clean. cargo fmt --check clean. tsc --noEmit clean.