### PR TITLE
fix(dialogs): fields with only an enable condition were being hidden,…

### DIFF
--- a/crates/libretune-app/src/components/dialogs/DialogRenderer.css
+++ b/crates/libretune-app/src/components/dialogs/DialogRenderer.css
@@ -566,13 +566,13 @@
 .dialog-view .indicator-tile {
   position: relative;
   display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
+  flex-direction: row;
+  justify-content: center;
   align-items: center;
-  min-height: 108px;
-  padding: 10px 8px;
+  min-height: 30px;
+  padding: 6px 8px;
   border: 1px solid rgba(0, 0, 0, 0.12);
-  border-radius: 12px;
+  border-radius: 4px;
   box-sizing: border-box;
   text-align: center;
   overflow: hidden;

--- a/crates/libretune-app/src/components/dialogs/PanelComponents.tsx
+++ b/crates/libretune-app/src/components/dialogs/PanelComponents.tsx
@@ -379,80 +379,58 @@ export function DialogFieldWrapper({
 }) {
   const [fieldVisible, setFieldVisible] = useState<boolean>(true);
   const [fieldEnabled, setFieldEnabled] = useState<boolean>(true);
-  
-  // Evaluate visibility condition (hides field if false)
-  useEffect(() => {
-    const visCondition =
-      comp.visibility_condition ||
-      (comp.condition && comp.enabled_condition ? comp.condition : undefined);
-    const enCondition =
-      comp.enabled_condition ||
-      (comp.condition && !comp.visibility_condition ? comp.condition : undefined);
 
-    const evaluate = (expression: string) =>
-      invoke<boolean>('evaluate_expression', {
-        expression,
-        context,
+  const evaluate = (expression: string) =>
+    invoke<boolean>('evaluate_expression', {
+      expression,
+      context,
+    });
+
+  // Evaluate visibility condition (hides field if false). Only an explicit
+  // `visibility_condition` hides a field — a lone `enabled_condition` (the
+  // common single-condition INI case, `field = "Label", name, { cond }`)
+  // must NOT hide it, only disable it below. TunerStudio keeps such fields
+  // visible-but-greyed-out, e.g. STFT's per-region settings stay visible
+  // even when the "Short term fuel trim" master switch is disabled.
+  useEffect(() => {
+    const visCondition = comp.visibility_condition;
+    if (!visCondition) {
+      setFieldVisible(true);
+      return;
+    }
+
+    evaluate(visCondition)
+      .then((result) => setFieldVisible(result))
+      .catch((err) => {
+        console.warn(
+          `[DialogFieldWrapper] Failed to evaluate visibility condition '${visCondition}' for '${comp.name}':`,
+          err,
+        );
+        setFieldVisible(true);
       });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [comp.visibility_condition, context, comp.name]);
 
-    if (visCondition) {
-      evaluate(visCondition)
-        .then((result) => setFieldVisible(result))
-        .catch((err) => {
-          console.warn(
-            `[DialogFieldWrapper] Failed to evaluate visibility condition '${visCondition}' for '${comp.name}':`,
-            err,
-          );
-          setFieldVisible(true);
-        });
-      return;
-    }
-
-    if (enCondition) {
-      evaluate(enCondition)
-        .then((result) => setFieldVisible(result))
-        .catch((err) => {
-          console.warn(
-            `[DialogFieldWrapper] Failed to evaluate enable condition '${enCondition}' for '${comp.name}':`,
-            err,
-          );
-          setFieldVisible(true);
-        });
-      return;
-    }
-
-    setFieldVisible(true);
-  }, [comp.visibility_condition, comp.condition, comp.enabled_condition, context, comp.name]);
-
-  // Evaluate enable condition (disables field if false when a separate visibility condition exists)
+  // Evaluate enable condition (disables field if false) — independent of
+  // whether a visibility condition is also present.
   useEffect(() => {
-    if (!comp.visibility_condition) {
+    const enCondition = comp.enabled_condition || comp.condition;
+    if (!enCondition) {
       setFieldEnabled(true);
       return;
     }
 
-    const enCondition =
-      comp.enabled_condition ||
-      (comp.condition && !comp.visibility_condition ? comp.condition : undefined);
-    if (enCondition) {
-      invoke<boolean>('evaluate_expression', {
-        expression: enCondition,
-        context,
-      })
-        .then((result) => {
-          setFieldEnabled(result);
-        })
-        .catch((err) => {
-          console.warn(
-            `[DialogFieldWrapper] Failed to evaluate enable condition '${enCondition}' for '${comp.name}':`,
-            err,
-          );
-          setFieldEnabled(true);
-        });
-    } else {
-      setFieldEnabled(true);
-    }
-  }, [comp.enabled_condition, comp.condition, comp.visibility_condition, context, comp.name]);
+    evaluate(enCondition)
+      .then((result) => setFieldEnabled(result))
+      .catch((err) => {
+        console.warn(
+          `[DialogFieldWrapper] Failed to evaluate enable condition '${enCondition}' for '${comp.name}':`,
+          err,
+        );
+        setFieldEnabled(true);
+      });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [comp.enabled_condition, comp.condition, context, comp.name]);
   
   // Hide field if visibility condition is false
   if (!fieldVisible || !comp.name) return null;

--- a/crates/libretune-app/src/components/dialogs/fields/IndicatorPanelRenderer.tsx
+++ b/crates/libretune-app/src/components/dialogs/fields/IndicatorPanelRenderer.tsx
@@ -86,7 +86,7 @@ export function IndicatorPanelRenderer({
     return {
       display: 'grid',
       gridTemplateColumns: `repeat(${columnCount}, minmax(0, 1fr))`,
-      gap: '8px',
+      gap: '6px',
     };
   }, [statusTiles, columns, panel.indicators.length]);
 


### PR DESCRIPTION
## Description

TunerStudio treats a single INI condition on a field (`field = "Label", name, { cond }`) as an **enable** condition — the field stays visible but greys out when `cond` is false. `DialogFieldWrapper`'s visibility effect instead fell back to using that same lone condition to decide **visibility**, so any such field vanished entirely whenever its condition was false, instead of just being disabled.

This is very visible on "Short term fuel trim/Closed loop": every settings field there (`Minimum CLT`, `After DFCO delay`, `Detect Tuning and Suspend`, `Minimum/Maximum AFR for learning`, `Adjustment deadband`, `Ignore error magnitude`) uses `{ isSTFT }` as its only condition. Since STFT starts disabled by default, all of them were being hidden, leaving only the on/off dropdown and one broken field visible — matching what TunerStudio itself would show as a full list of greyed-out fields.

Also reduced indicator-tile sizing, which was using a 108px minimum height originally sized for the gauge-cluster status tiles but applied everywhere — most tiles only hold a couple words of text (e.g. "Tuning", "RPM", "Cranking Delay"), so they rendered as oversized, mostly-empty squares instead of the compact rows TunerStudio uses.

## Changes

- `PanelComponents.tsx` (`DialogFieldWrapper`): visibility now depends only on an explicit `visibility_condition`; the enable effect now evaluates `enabled_condition`/`condition` independently of whether a visibility condition also exists. Previously a lone enable condition leaked into the visibility check, and the enable check was skipped entirely unless a separate visibility condition was also present.
- `DialogRenderer.css` / `IndicatorPanelRenderer.tsx`: `.indicator-tile` min-height 108px -> 30px, tighter padding, sharper corners (12px -> 4px radius), and a smaller grid gap (8px -> 6px) so tiles size to their text.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing
- `npx tsc --noEmit`
- `npx vitest run` — 198/199 passing; the one failure (`App.integration.test.tsx` connection-info timeout) is pre-existing and unrelated to this change.
- Verified live against the real "Short term fuel trim/Closed loop" dialog: all settings fields now show (greyed out while STFT is disabled) and the status tiles are compact.
