### PR TITLE
fix(dialogs): collapse the two-column field grid inside xAxis rows

### DIFF
--- a/crates/libretune-app/src/components/dialogs/DialogComponentsLayout.tsx
+++ b/crates/libretune-app/src/components/dialogs/DialogComponentsLayout.tsx
@@ -22,6 +22,9 @@ export interface DialogComponentsLayoutProps {
   onOptimisticUpdate?: (name: string, value: number) => void;
   onFieldFocus?: (info: FieldInfo) => void;
   showAllHelpIcons?: boolean;
+  /** From DialogDefinition.layout_hint — "xAxis" rows unpositioned
+   * top-level panels side by side instead of stacking them. */
+  layoutHint?: string;
 }
 
 export function DialogComponentsLayout({
@@ -33,6 +36,7 @@ export function DialogComponentsLayout({
   onOptimisticUpdate,
   onFieldFocus,
   showAllHelpIcons,
+  layoutHint,
 }: DialogComponentsLayoutProps) {
   const { components: tableLaidOut, hasTableSplit: _tableSplit } = useMemo(
     () => applyTableSettingsLayout(dialogName, components),
@@ -73,6 +77,17 @@ export function DialogComponentsLayout({
           const items = row.unpositioned.map((comp, i) =>
             renderComponent(comp, `unpositioned-${rowIndex}-${i}`),
           );
+          if (
+            layoutHint === 'xAxis' &&
+            row.unpositioned.length > 1 &&
+            row.unpositioned.every((comp) => comp.type === 'Panel')
+          ) {
+            return (
+              <div key={`row-${rowIndex}`} className="dialog-row-xaxis">
+                {items}
+              </div>
+            );
+          }
           if (hardwareTestLayout && items.length > 0) {
             const { compact, auxiliary } = partitionHardwareTestComponents(row.unpositioned);
             const wrapCell = (comp: DialogComponent, key: string) => {

--- a/crates/libretune-app/src/components/dialogs/DialogRenderer.css
+++ b/crates/libretune-app/src/components/dialogs/DialogRenderer.css
@@ -58,8 +58,26 @@
    sub-element into full width (multi-column split, embedded 2D table,
    hardware-test grid, wide command-button panel) needs the container to
    stay uncapped for that to actually reach full width. */
-.dialog-view .dialog-container:not(:has(.dialog-row-container)):not(:has(.nested-panel--multi)):not(:has(.table-editor-2d)):not(:has(.hardware-test-layout)):not(:has(.nested-panel--compact-commands)):not(:has(.curve-editor)) {
+.dialog-view .dialog-container:not(:has(.dialog-row-container)):not(:has(.nested-panel--multi)):not(:has(.table-editor-2d)):not(:has(.hardware-test-layout)):not(:has(.nested-panel--compact-commands)):not(:has(.curve-editor)):not(:has(.dialog-row-xaxis)) {
   max-width: 720px;
+}
+
+/* dialog = name, "title", xAxis — top-level unpositioned panels side by
+   side (TunerStudio's own layout for e.g. Short term fuel trim/Closed
+   loop: Bank 1 | Settings | Bank 2). Wraps instead of squeezing on a
+   narrow window, same responsive approach used elsewhere in this file. */
+.dialog-view .dialog-row-xaxis {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: start;
+  gap: 12px;
+  width: 100%;
+  container-type: inline-size;
+}
+
+.dialog-view .dialog-row-xaxis > * {
+  flex: 1 1 280px;
+  min-width: 0;
 }
 
 /* Multi-column layout support for dialogs with East/West positioned panels.

--- a/crates/libretune-app/src/components/dialogs/DialogRenderer.css
+++ b/crates/libretune-app/src/components/dialogs/DialogRenderer.css
@@ -109,6 +109,15 @@
   }
 }
 
+/* A settings panel nested inside an xAxis row (three-way split) only ever
+   gets ~1/3 of the dialog's width — nowhere near enough for the two-column
+   field grid's 220px-per-column minimum without wrapping/overlapping long
+   labels ("Detect Tuning and Suspend"). Force single column here regardless
+   of exact pixel width; TunerStudio renders these same panels as one column. */
+.dialog-view .dialog-row-xaxis .panel-content--multi {
+  grid-template-columns: 1fr;
+}
+
 .dialog-view .dialog-row-container--settings-split {
   grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
 }

--- a/crates/libretune-app/src/components/dialogs/DialogRenderer.tsx
+++ b/crates/libretune-app/src/components/dialogs/DialogRenderer.tsx
@@ -111,6 +111,7 @@ export default function DialogRenderer({ definition, onBack, openTable, context,
           onOptimisticUpdate={onOptimisticUpdate}
           onFieldFocus={handleFieldFocus}
           showAllHelpIcons={showAllHelpIcons}
+          layoutHint={definition.layout_hint}
         />
       </div>
       

--- a/crates/libretune-app/src/components/dialogs/fields/Indicator.tsx
+++ b/crates/libretune-app/src/components/dialogs/fields/Indicator.tsx
@@ -21,10 +21,30 @@ export function Indicator({
     }
   }, [comp.expression, context]);
 
+  // label_on/label_off can themselves be braced expressions (same pattern
+  // as IndicatorPanelRenderer's tiles) — evaluate the raw label rather than
+  // showing e.g. "{ bitStringValue(stftStateList, 2) }" verbatim.
+  const rawLabel = isOn ? comp.label_on : comp.label_off;
+  const [evaluatedLabel, setEvaluatedLabel] = useState(rawLabel);
+
+  useEffect(() => {
+    if (!rawLabel?.trim().startsWith('{')) {
+      setEvaluatedLabel(rawLabel);
+      return;
+    }
+    let cancelled = false;
+    invoke<string>('evaluate_string_expression', { expression: rawLabel, context })
+      .then((value) => { if (!cancelled) setEvaluatedLabel(value); })
+      .catch(() => { if (!cancelled) setEvaluatedLabel(rawLabel); });
+    return () => {
+      cancelled = true;
+    };
+  }, [rawLabel, context]);
+
   return (
     <div className="indicator-field">
       <div className={`indicator-light ${isOn ? 'on' : 'off'}`} />
-      <span className="indicator-label">{isOn ? comp.label_on : comp.label_off}</span>
+      <span className="indicator-label">{evaluatedLabel}</span>
     </div>
   );
 }

--- a/crates/libretune-app/src/components/dialogs/types.ts
+++ b/crates/libretune-app/src/components/dialogs/types.ts
@@ -27,6 +27,9 @@ export interface DialogDefinition {
   name: string;
   title: string;
   components: DialogComponent[];
+  /** From `dialog = name, "title", <hint>` — "xAxis" arranges top-level,
+   * unpositioned panels in a horizontal row instead of stacking them. */
+  layout_hint?: string;
 }
 
 export interface Constant {

--- a/crates/libretune-core/src/ini/mod.rs
+++ b/crates/libretune-core/src/ini/mod.rs
@@ -400,6 +400,7 @@ impl EcuDefinition {
             name: name.to_string(),
             title: title.to_string(),
             components,
+            layout_hint: None,
         })
     }
 

--- a/crates/libretune-core/src/ini/parser.rs
+++ b/crates/libretune-core/src/ini/parser.rs
@@ -2368,10 +2368,20 @@ fn parse_user_defined_entry(
                     .map(|s| s.trim_matches('"').to_string())
                     .unwrap_or_else(|| name.clone());
 
+                // Format: dialog = name, "title" [, layoutHint] [, {condition}]
+                // layoutHint (e.g. "xAxis") is the first remaining part that
+                // isn't a braced condition.
+                let layout_hint = parts
+                    .iter()
+                    .skip(2)
+                    .find(|p| !p.trim().starts_with('{'))
+                    .map(|p| p.trim().to_string());
+
                 let dialog = DialogDefinition {
                     name: name.clone(),
                     title,
                     components: Vec::new(),
+                    layout_hint,
                 };
                 def.dialogs.insert(name.clone(), dialog);
                 *current_dialog = Some(name);
@@ -3579,6 +3589,31 @@ maxUnusedRuntimeRange = 42
             1,
             "only the field explicitly declared in this dialog should be on it"
         );
+    }
+
+    #[test]
+    fn dialog_captures_its_layout_hint() {
+        // TunerStudio's "Short term fuel trim/Closed loop" dialog uses
+        // exactly this: dialog = name, "title", xAxis to lay its child
+        // panels out in a row instead of stacking them.
+        let content = r#"
+[UserDefined]
+	dialog = fuelClosedLoopDialog, "Short term fuel trim/Closed loop", xAxis
+		panel = fuelClosedLoopBank1
+
+	dialog = plainDialog, "No hint"
+		field = "Label", someConstant
+"#;
+        let def = parse_ini(content).expect("Should parse successfully");
+
+        let with_hint = def
+            .dialogs
+            .get("fuelClosedLoopDialog")
+            .expect("dialog should exist");
+        assert_eq!(with_hint.layout_hint.as_deref(), Some("xAxis"));
+
+        let without_hint = def.dialogs.get("plainDialog").expect("dialog should exist");
+        assert_eq!(without_hint.layout_hint, None);
     }
 
     #[test]

--- a/crates/libretune-core/src/ini/parser.rs
+++ b/crates/libretune-core/src/ini/parser.rs
@@ -2380,11 +2380,18 @@ fn parse_user_defined_entry(
             }
         }
         "indicatorpanel" => {
-            // Format: indicatorPanel = name, columns [, {visibility_condition}]
+            // Format: indicatorPanel = name [, columns] [, {visibility_condition}]
+            // `columns` is optional in the wild (e.g. rusEFI's
+            // fuelClosedLoopIndicatorsPanel omits it) — requiring it dropped
+            // the whole panel silently, which also left current_dialog
+            // pointing at whatever dialog was last opened (this arm only
+            // clears it inside the block below), so the indicator lines
+            // meant for this panel got misattributed there as bare
+            // single-indicator fields instead.
             let parts = split_ini_line(value);
-            if parts.len() >= 2 {
+            if !parts.is_empty() {
                 let name = parts[0].to_string();
-                let columns = parts[1].parse::<u8>().unwrap_or(2);
+                let columns = parts.get(1).and_then(|p| p.parse::<u8>().ok()).unwrap_or(2);
 
                 // Check for visibility condition (last part in braces)
                 let visibility_condition = parts
@@ -3526,6 +3533,52 @@ maxUnusedRuntimeRange = 42
 "#;
         let def = parse_ini(content).expect("Should parse successfully");
         assert_eq!(def.protocol.max_unused_runtime_range, 42);
+    }
+
+    #[test]
+    fn indicator_panel_without_a_columns_count_still_registers() {
+        // Verbatim shape from a real rusEFI INI: indicatorPanel omitting the
+        // `, columns` parameter (unlike its sibling panels, which all give
+        // one) used to be silently dropped entirely — `columns` was treated
+        // as required, not optional as its own doc comment claimed. Losing
+        // the panel also stranded its `indicator =` lines: with
+        // current_indicator_panel never set, they fell through to the
+        // "attach to current_dialog" fallback and landed as bare fields on
+        // whatever dialog was last opened, instead of on this panel.
+        let content = r#"
+[UserDefined]
+	dialog = someOtherDialog, "Unrelated"
+		field = "Unrelated field", someConstant
+
+	indicatorPanel = fuelClosedLoopIndicatorsPanel
+		indicator = { stftCorrectionState != 0 }, { Correction using bitStringValue(stftBinIdxList, stftCorrectionBinIdx) region }, { Not active: bitStringValue(stftStateList, stftCorrectionState) }, green, black, white, black
+		indicator = { isTuningNow }, "No tuning happening", "Tuning Detected", white, black, green, black
+"#;
+        let def = parse_ini(content).expect("Should parse successfully");
+
+        let panel = def
+            .indicator_panels
+            .get("fuelClosedLoopIndicatorsPanel")
+            .expect("panel should be registered even without an explicit columns count");
+        assert_eq!(panel.columns, 2, "missing columns should default to 2");
+        assert_eq!(panel.indicators.len(), 2);
+        assert_eq!(
+            panel.indicators[1].label_on, "Tuning Detected",
+            "indicator lines after a columns-less panel header must attach to that panel"
+        );
+
+        // The earlier dialog must not have picked up these indicators as
+        // stray fields — that was the visible symptom (they rendered as
+        // unstyled bullet rows with the raw, unevaluated expression text).
+        let other_dialog = def
+            .dialogs
+            .get("someOtherDialog")
+            .expect("dialog should exist");
+        assert_eq!(
+            other_dialog.components.len(),
+            1,
+            "only the field explicitly declared in this dialog should be on it"
+        );
     }
 
     #[test]

--- a/crates/libretune-core/src/ini/types.rs
+++ b/crates/libretune-core/src/ini/types.rs
@@ -581,6 +581,14 @@ pub struct DialogDefinition {
     pub title: String,
     /// Components within the dialog
     pub components: Vec<DialogComponent>,
+    /// Layout hint from `dialog = name, "title", <hint>` (e.g. "xAxis" —
+    /// arrange top-level, unpositioned panels in a horizontal row instead
+    /// of the default vertical stack). Only "xAxis" is currently acted on
+    /// by the renderer; other values (seen in the wild: "border", used with
+    /// per-panel West/East/North/South/Center positions, which this app
+    /// already supports separately) are captured but not yet interpreted.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub layout_hint: Option<String>,
 }
 
 /// Components that can exist inside a dialog


### PR DESCRIPTION
## Description

Follow-up to #227. Panels with 8+ fields (`PanelComponents.tsx`: `multiColumn = fieldCount >= 8`) render as a two-column grid, sized on the assumption of near-full dialog width (`.panel-content--multi` needs `minmax(220px, 1fr)` per column). Nested inside an `xAxis` row's ~1/3-width column, that only leaves ~100-140px for each field's label after the input column and gap — long labels like "Detect Tuning and Suspend" or "Ignore error magnitude" wrapped to several lines and visually overlapped the neighboring field.

This is exactly what showed up once #226 fixed most of these "Short term fuel trim" settings fields from being wrongly hidden (they were previously invisible, so the cramped 2-column grid never got tested with real content) and #227 nested this panel inside the "Short term fuel trim/Closed loop" dialog's 3-way `xAxis` split.

There's already a `@container (max-width: 440px)` query that collapses this grid to one column, but the xAxis column's actual rendered width (~485px) sits just above that threshold, so it never kicked in — and even where it's a bit wider, splitting into two ~220px+ columns is still too cramped for these specific labels.

## Fix

Force `.panel-content--multi` to a single column whenever it's nested inside `.dialog-row-xaxis`, regardless of exact pixel width. TunerStudio itself renders this dialog as a single column, so this also matches the reference layout more closely.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Notes for reviewers

Stacked on #227 (the `xAxis` layout support this fix depends on) — this branch is based on `feat/dialog-xaxis-layout-hint`. The diff against `main` will include #226/#227's commits until those merge; the only new commit here is the single-column-collapse one.

## Testing
- CSS-only change; verified live against the real "Short term fuel trim/Closed loop" dialog — the settings column now renders as a single, readable list with no overlapping text.
