### PR TITLE
fix(settings): stop HotkeyEditor infinite re-render loop in Settings dialog

### DIFF
--- a/crates/libretune-app/src/components/dialogs/HotkeyEditor.tsx
+++ b/crates/libretune-app/src/components/dialogs/HotkeyEditor.tsx
@@ -206,26 +206,41 @@ export default function HotkeyEditor({ onClose, onSave, bindings: initialBinding
   useEffect(() => {
     if (initialBindings && Object.keys(initialBindings).length > 0) {
       setHotkeys((prev) => {
-        const updated = { ...prev };
+        let changed = false;
+        const updated: Record<string, HotkeyEntry> = { ...prev };
         Object.entries(initialBindings).forEach(([action, binding]) => {
-          if (updated[action]) {
-            updated[action].currentBinding = binding;
+          const entry = updated[action];
+          if (entry && entry.currentBinding !== binding) {
+            updated[action] = { ...entry, currentBinding: binding };
+            changed = true;
           }
         });
-        return updated;
+        // Return the SAME reference when nothing changed so React bails out
+        // instead of re-rendering. Returning a fresh-but-equal object here
+        // fed the onChange <-> bindings-prop feedback loop below and produced
+        // "Maximum update depth exceeded".
+        return changed ? updated : prev;
       });
     }
   }, [initialBindings]);
 
-  // Notify parent of changes
-  useEffect(() => {
-    if (onChange && Object.keys(hotkeys).length > 0) {
-      const bindings: Record<string, string> = Object.fromEntries(
-        Object.entries(hotkeys).map(([id, entry]) => [id, entry.currentBinding])
+  // Report the given entries to the parent as a flat bindings map.
+  // Called ONLY from user-action handlers (edit / reset / import) — never
+  // from an effect. An effect watching `hotkeys` used to call onChange on
+  // every change, including the ones caused by applying the `bindings` prop,
+  // which fed the parent <-> child setState loop ("Maximum update depth
+  // exceeded") whenever saved bindings differed from the defaults.
+  const notifyParent = useCallback(
+    (entries: Record<string, HotkeyEntry>) => {
+      if (!onChange) return;
+      onChange(
+        Object.fromEntries(
+          Object.entries(entries).map(([id, entry]) => [id, entry.currentBinding])
+        )
       );
-      onChange(bindings);
-    }
-  }, [hotkeys, onChange]);
+    },
+    [onChange]
+  );
 
   // Detect keybinding conflicts
   const detectConflicts = useCallback((updatedHotkeys: Record<string, HotkeyEntry>) => {
@@ -265,8 +280,9 @@ export default function HotkeyEditor({ onClose, onSave, bindings: initialBinding
       };
       setHotkeys(updated);
       detectConflicts(updated);
+      notifyParent(updated);
     },
-    [hotkeys, detectConflicts]
+    [hotkeys, detectConflicts, notifyParent]
   );
 
   // Reset to defaults
@@ -280,7 +296,8 @@ export default function HotkeyEditor({ onClose, onSave, bindings: initialBinding
     setHotkeys(reset);
     detectConflicts(reset);
     setConflictWarning(null);
-  }, [hotkeys, detectConflicts]);
+    notifyParent(reset);
+  }, [hotkeys, detectConflicts, notifyParent]);
 
   // Export bindings
   const handleExport = useCallback(async () => {

--- a/crates/libretune-app/src/components/dialogs/__tests__/HotkeyEditor.test.tsx
+++ b/crates/libretune-app/src/components/dialogs/__tests__/HotkeyEditor.test.tsx
@@ -1,0 +1,75 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useState } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import HotkeyEditor from '../HotkeyEditor';
+
+/**
+ * Regression tests for the settings-dialog hotkey tab lock-up.
+ *
+ * HotkeyEditor used to sync child -> parent with an effect watching `hotkeys`
+ * and parent -> child with an effect applying the `bindings` prop. When the
+ * loaded bindings differed from the built-in defaults, each effect undid the
+ * other's work with fresh object references every pass, and React aborted
+ * with "Maximum update depth exceeded" (the Settings dialog then churned
+ * forever). The fix reports changes to the parent only from user-action
+ * handlers, so merely rendering with non-default bindings must be stable.
+ */
+
+/** Mirrors how SettingsDialog hosts the editor: state in, state out. */
+function Host({ initial }: { initial: Record<string, string> }) {
+  const [bindings, setBindings] = useState(initial);
+  return <HotkeyEditor bindings={bindings} onChange={setBindings} />;
+}
+
+describe('HotkeyEditor', () => {
+  it('renders without an update loop when saved bindings differ from defaults', () => {
+    // A loaded binding that differs from the built-in default for the same
+    // action is what used to start the ping-pong between the two effects.
+    // If the loop regresses, render() itself throws before these assertions.
+    render(<Host initial={{ 'table.setEqual': 'Ctrl+Equals' }} />);
+
+    // The customized binding must actually be applied...
+    expect(screen.getByText('Ctrl+Equals')).toBeTruthy();
+    // ...and some default binding must still be present.
+    expect(screen.getByText('ArrowUp')).toBeTruthy();
+  });
+
+  it('applies empty bindings and still renders the default table', () => {
+    render(<Host initial={{}} />);
+    expect(screen.getByText('ArrowUp')).toBeTruthy();
+  });
+
+  it('does not notify the parent spontaneously on mount', () => {
+    const onChange = vi.fn();
+    render(<HotkeyEditor bindings={{ 'table.setEqual': '=' }} onChange={onChange} />);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('notifies the parent when the user edits a binding', () => {
+    const onChange = vi.fn();
+    render(<HotkeyEditor bindings={{ 'table.setEqual': '=' }} onChange={onChange} />);
+
+    // Click the binding chip to enter edit mode, then type.
+    fireEvent.click(screen.getByText('='));
+    const input = screen.getByPlaceholderText('Press keys or type binding');
+    fireEvent.change(input, { target: { value: 'Ctrl+Equals' } });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const reported = onChange.mock.calls[0][0] as Record<string, string>;
+    expect(reported['table.setEqual']).toBe('Ctrl+Equals');
+    // Every action is included in the report, not just the edited one.
+    expect(Object.keys(reported).length).toBeGreaterThan(1);
+  });
+
+  it('notifies the parent when the user resets to defaults', () => {
+    const onChange = vi.fn();
+    render(<HotkeyEditor bindings={{ 'table.setEqual': 'Ctrl+Equals' }} onChange={onChange} />);
+
+    fireEvent.click(screen.getByText('Reset to Defaults'));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const reported = onChange.mock.calls[0][0] as Record<string, string>;
+    expect(reported['table.setEqual']).toBe('=');
+  });
+});


### PR DESCRIPTION
## Summary

Opening **Settings → Keyboard Shortcuts** with saved bindings that differ from the built-in defaults locked the dialog in a `setState` ping-pong — React's `Maximum update depth exceeded` warning fired continuously (~every 6 s), freezing the hotkeys tab and burning CPU until the dialog was closed.

## Root cause

`HotkeyEditor` had two coupled effects:

1. **props → state:** applies the `bindings` prop into internal `hotkeys` state (deps `[initialBindings]`)
2. **state → props:** reports `hotkeys` back to the parent via `onChange` (deps `[hotkeys, onChange]`)

`SettingsDialog` hosts it exactly as the loop requires: `bindings={hotkeyBindings}` / `onChange={setHotkeyBindings}`. When the loaded bindings differ from the built-in defaults, each effect undoes the other's work — and because every step produces a **fresh object reference** (`{...prev}`, `Object.fromEntries`), React's same-reference bail-out never fires. Even identical *values* loop forever.

## Fix

- **Deleted the auto-reporting effect.** The parent is now notified explicitly from the user-action handlers only: binding edit, reset-to-defaults, per-row reset — via a small `notifyParent` helper. Rendering and applying props no longer touch parent state at all.
- The props-apply effect now **returns the same state reference** when the incoming bindings change nothing, so React skips the re-render (also stops the loop if the prop ref changes for unrelated reasons).
- Removed an in-place mutation of shared entry objects in the apply path (`updated[action].currentBinding = ...` → new entry object).

## Tests

5 new regression tests in `HotkeyEditor.test.tsx`:

- render with non-default bindings under a host that echoes `onChange` back (reproduces the loop on the old code — `render()` itself throws `Maximum update depth exceeded`)
- empty-bindings render still shows the default table
- no spontaneous `onChange` on mount
- one `onChange` per user edit, reporting **all** actions
- `onChange` on reset-to-defaults, reporting default values

`vitest run`: **204/204 pass** (199 existing + 5 new). `tsc --noEmit` clean.
