### PR TITLE
fix(dialogs): evaluate dynamic field units instead of showing the raw expression

### DIFF
--- a/crates/libretune-app/src/components/dialogs/fields/DialogField.tsx
+++ b/crates/libretune-app/src/components/dialogs/fields/DialogField.tsx
@@ -115,6 +115,32 @@ export default function DialogField({
     }
   }, [fieldEnabledCondition, constant?.visibility_condition, context, name, selectedBit, numValue, constant?.value_type]);
 
+  // Some INIs give a constant a braced expression as its units instead of a
+  // fixed string — rusEFI does this for every temperature field, e.g.
+  // "{ bitStringValue(unitsLabels, useMetricOnInterface) }" so the displayed
+  // unit follows the user's C/F preference. Evaluate it live rather than
+  // showing the literal expression text.
+  const [displayUnits, setDisplayUnits] = useState<string>('');
+
+  useEffect(() => {
+    const raw = constant?.units ?? '';
+    if (!raw.trim().startsWith('{')) {
+      setDisplayUnits(raw);
+      return;
+    }
+    let cancelled = false;
+    invoke<string>('evaluate_string_expression', { expression: raw, context })
+      .then((value) => {
+        if (!cancelled) setDisplayUnits(value);
+      })
+      .catch(() => {
+        if (!cancelled) setDisplayUnits(raw);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [constant?.units, context]);
+
   if (!constant) return <div className="field-loading">Loading {label}...</div>;
 
   // Always show field (don't hide based on condition) - condition controls enable/disable instead
@@ -252,7 +278,7 @@ export default function DialogField({
               disabled={true}
               style={{ opacity: 0.7 }}
             />
-            <span className="field-unit">{constant.units}</span>
+            <span className="field-unit">{displayUnits}</span>
           </div>
           <div style={{ color: 'orange', padding: '4px', fontSize: '0.85em' }}>
             Warning: No bit_options defined in INI for this constant
@@ -402,7 +428,7 @@ export default function DialogField({
             }
           }}
         />
-        <span className="field-unit">{constant.units}</span>
+        <span className="field-unit">{displayUnits}</span>
       </div>
     </div>
   );


### PR DESCRIPTION
## Description

Some INI constants give their `units` field a braced expression instead of a fixed string — rusEFI does this for every temperature field, e.g. `stft_minClt`'s units is `{ bitStringValue(unitsLabels, useMetricOnInterface) }` so the displayed unit follows the user's C/F preference. `DialogField.tsx` rendered `constant.units` verbatim, so any field like this showed the literal expression text (e.g. "Minimum CLT 60 {bitStringValue(unitsLabels, ...") instead of "C" or "F".

This is the same class of bug as the indicator/label fixes earlier this session (#223, #225, #226): a braced INI value meant to be evaluated live was instead rendered as raw text. 58 constants in the real rusEFI INI use this pattern for their units, mostly temperature fields.

## Fix

Evaluate `constant.units` via `evaluate_string_expression` (the same existing backend command used for dynamic labels) whenever it starts with `{`, falling back to the raw string on error — mirroring the pattern already used for indicator/command-button labels.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing
- `npx tsc --noEmit`
- `npx vitest run` — 198/199 passing; the one failure (`App.integration.test.tsx` connection-info timeout) is pre-existing and unrelated to this change.
- Verified live against the real "Short term fuel trim/Closed loop" dialog: "Minimum CLT" now shows "60 C" instead of the raw expression text.
