### PR TITLE
fix(sidebar): highlight the currently open item in the project tree

### DIFF
--- a/crates/libretune-app/src/components/tuner-ui/Sidebar.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/Sidebar.tsx
@@ -14,6 +14,8 @@ interface SidebarProps {
   searchIndex?: Record<string, string[]>;
   /** Current project name for display in header */
   projectName?: string;
+  /** id of the currently open tab/dialog — highlighted in the tree so it's clear what's open */
+  activeItemId?: string | null;
 }
 
 /** Recursively filter tree nodes by search query, preserving parent folders when children match */
@@ -100,7 +102,7 @@ function highlightMatch(label: string, query: string): React.ReactNode {
   );
 }
 
-export function Sidebar({ items, width, onResize, onItemSelect, searchIndex, projectName }: SidebarProps) {
+export function Sidebar({ items, width, onResize, onItemSelect, searchIndex, projectName, activeItemId }: SidebarProps) {
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
   const [searchQuery, setSearchQuery] = useState('');
   const [savedExpandedIds, setSavedExpandedIds] = useState<Set<string> | null>(null);
@@ -364,6 +366,7 @@ export function Sidebar({ items, width, onResize, onItemSelect, searchIndex, pro
               onItemDoubleClick={handleDoubleClick}
               level={0}
               searchQuery={searchQuery}
+              activeItemId={activeItemId}
             />
           </>
         )}
@@ -384,6 +387,7 @@ interface TreeViewProps {
   onItemDoubleClick: (item: SidebarNode) => void;
   level: number;
   searchQuery?: string;
+  activeItemId?: string | null;
 }
 
 function TreeView({
@@ -393,6 +397,7 @@ function TreeView({
   onItemDoubleClick,
   level,
   searchQuery = '',
+  activeItemId,
 }: TreeViewProps) {
   return (
     <ul className="tree-list" role="tree">
@@ -400,11 +405,13 @@ function TreeView({
         const hasChildren = item.children && item.children.length > 0;
         const isExpanded = expandedIds.has(item.id);
         const isDisabled = item.disabled === true;
+        const isSelected = !hasChildren && item.id === activeItemId;
 
         return (
           <li key={item.id} className="tree-item" role="treeitem">
             <div
-              className={`tree-item-row ${isDisabled ? 'tree-item-disabled' : ''}`}
+              className={`tree-item-row ${isDisabled ? 'tree-item-disabled' : ''} ${isSelected ? 'selected' : ''}`}
+              aria-selected={isSelected}
               style={{ paddingLeft: level * 16 + 8 }}
               draggable={!hasChildren}
               onDragStart={(e) => {
@@ -446,6 +453,7 @@ function TreeView({
                 onItemDoubleClick={onItemDoubleClick}
                 level={level + 1}
                 searchQuery={searchQuery}
+                activeItemId={activeItemId}
               />
             )}
           </li>

--- a/crates/libretune-app/src/components/tuner-ui/TunerLayout.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/TunerLayout.tsx
@@ -166,6 +166,7 @@ export function TunerLayout({
             onItemSelect={onSidebarItemSelect}
             searchIndex={searchIndex}
             projectName={projectName}
+            activeItemId={activeTabId}
           />
         )}
         


### PR DESCRIPTION
## Description

`Sidebar.tsx` never tracked which tree item was currently selected — clicking into a dialog or table left no trace in the tree once the tab opened, even though the CSS already had a `.tree-item-row.selected` rule (`background: var(--bg-selected)`, a colored left border) sitting unused because nothing ever applied the class.

`TunerLayout` already threads `activeTabId` through to the tab bar for the same purpose, so this reuses it: tab ids are set to the sidebar node's own `id` in `openTarget.ts` (`setTabs([...tabs, { id: name, ... }])` where `name` is the sidebar item's id), so `activeTabId === node.id` reliably identifies the open item.

## Changes

- `Sidebar.tsx`: added an `activeItemId` prop, threaded through `TreeView`'s recursive calls, and applied the existing `selected` class (plus `aria-selected`) to the matching leaf row.
- `TunerLayout.tsx`: passes `activeItemId={activeTabId}` to `<Sidebar>`.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing
- `npx tsc --noEmit`
- `npx vitest run` — 198/199 passing; the one failure (`App.integration.test.tsx` connection-info timeout) is pre-existing and unrelated to this change.
- Verified live: opening any dialog/table from the sidebar now highlights that row until a different item is opened.
