### PR TITLE
ci: replace flaky legacy pipelines with a lean gated flow

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,35 @@
+# cargo-audit / rustsec configuration (project-local)
+# Prefer fixing or upgrading; only ignore with a tracked reason.
+
+[advisories]
+ignore = [
+    # proc-macro-error — unmaintained (transitive)
+    "RUSTSEC-2024-0370",
+    # instant — unmaintained / yanked cluster (transitive)
+    "RUSTSEC-2024-0411",
+    "RUSTSEC-2024-0412",
+    "RUSTSEC-2024-0413",
+    "RUSTSEC-2024-0414",
+    "RUSTSEC-2024-0415",
+    "RUSTSEC-2024-0416",
+    "RUSTSEC-2024-0417",
+    "RUSTSEC-2024-0418",
+    "RUSTSEC-2024-0419",
+    "RUSTSEC-2024-0420",
+    "RUSTSEC-2024-0429",
+    # Remaining known transitive noise tracked in CI historically
+    "RUSTSEC-2025-0057",
+    "RUSTSEC-2025-0075",
+    "RUSTSEC-2025-0080",
+    "RUSTSEC-2025-0081",
+    "RUSTSEC-2025-0098",
+    "RUSTSEC-2025-0100",
+    "RUSTSEC-2026-0049",
+    "RUSTSEC-2026-0185",
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
+    "RUSTSEC-2026-0204",
+    "RUSTSEC-2026-0098",
+    "RUSTSEC-2026-0099",
+    "RUSTSEC-2026-0104",
+]

--- a/.github/actions/collect-tauri-artifacts/action.yml
+++ b/.github/actions/collect-tauri-artifacts/action.yml
@@ -1,0 +1,107 @@
+name: Collect Tauri artifacts
+description: Copy built Tauri bundles into a destination folder; fail if nothing found
+
+inputs:
+  platform:
+    description: linux | windows | macos
+    required: true
+  dest:
+    description: Destination directory (created if missing)
+    required: true
+  require_files:
+    description: If true, fail when no artifacts are copied
+    required: false
+    default: "true"
+
+runs:
+  using: composite
+  steps:
+    - name: Collect artifacts
+      shell: bash
+      run: |
+        set -euo pipefail
+        DEST="${{ inputs.dest }}"
+        PLATFORM="${{ inputs.platform }}"
+        mkdir -p "$DEST"
+        ROOT="${GITHUB_WORKSPACE:-$(pwd)}"
+        # Workspace Cargo.toml lives at repo root → bundles under $ROOT/target
+        # Older layouts sometimes wrote under crates/libretune-app/src-tauri/target
+        SEARCH_ROOTS=(
+          "$ROOT/target"
+          "$ROOT/crates/libretune-app/src-tauri/target"
+        )
+
+        copied=0
+        copy_glob() {
+          local pattern="$1"
+          local dest_name="${2:-}"
+          # nullglob-like: expand safely
+          shopt -s nullglob
+          local matches=($pattern)
+          shopt -u nullglob
+          local f
+          for f in "${matches[@]}"; do
+            if [ -f "$f" ]; then
+              if [ -n "$dest_name" ]; then
+                cp "$f" "$DEST/$dest_name"
+              else
+                cp "$f" "$DEST/$(basename "$f")"
+              fi
+              echo "copied: $f"
+              copied=$((copied + 1))
+            fi
+          done
+        }
+
+        case "$PLATFORM" in
+          linux)
+            for root in "${SEARCH_ROOTS[@]}"; do
+              copy_glob "$root/*/release/bundle/appimage/*.AppImage"
+              copy_glob "$root/*/release/bundle/deb/*.deb"
+              copy_glob "$root/*/release/bundle/rpm/*.rpm"
+            done
+            ;;
+          windows)
+            for root in "${SEARCH_ROOTS[@]}"; do
+              copy_glob "$root/*/release/bundle/nsis/*.exe"
+              copy_glob "$root/*/release/bundle/msi/*.msi"
+              # Portable / --no-bundle builds
+              if [ -f "$root/x86_64-pc-windows-msvc/release/libretune-app.exe" ]; then
+                cp "$root/x86_64-pc-windows-msvc/release/libretune-app.exe" \
+                  "$DEST/LibreTune-portable.exe"
+                echo "copied portable exe"
+                copied=$((copied + 1))
+              fi
+            done
+            ;;
+          macos)
+            for root in "${SEARCH_ROOTS[@]}"; do
+              copy_glob "$root/*/release/bundle/dmg/*.dmg"
+              shopt -s nullglob
+              apps=("$root"/*/release/bundle/macos/*.app)
+              shopt -u nullglob
+              for app in "${apps[@]+"${apps[@]}"}"; do
+                [ -d "$app" ] || continue
+                zip_name="$DEST/$(basename "$app" .app).zip"
+                abs_zip="$(cd "$(dirname "$zip_name")" && pwd)/$(basename "$zip_name")"
+                (
+                  cd "$(dirname "$app")"
+                  zip -r "$abs_zip" "$(basename "$app")"
+                )
+                echo "zipped: $app -> $zip_name"
+                copied=$((copied + 1))
+              done
+            done
+            ;;
+          *)
+            echo "Unknown platform: $PLATFORM"
+            exit 1
+            ;;
+        esac
+
+        echo "=== Artifacts in $DEST ==="
+        ls -lh "$DEST" || true
+        if [ "$copied" -eq 0 ] && [ "${{ inputs.require_files }}" = "true" ]; then
+          echo "ERROR: no Tauri artifacts found for platform=$PLATFORM"
+          exit 1
+        fi

--- a/.github/actions/setup-linux-deps/action.yml
+++ b/.github/actions/setup-linux-deps/action.yml
@@ -1,0 +1,61 @@
+name: Setup Linux deps
+description: Install WebKit/GTK/udev packages with apt retries and hard timeouts
+
+inputs:
+  extra_packages:
+    description: Extra apt packages (space-separated)
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Install system dependencies
+      shell: bash
+      run: |
+        set -euo pipefail
+        packages=(
+          libwebkit2gtk-4.1-dev
+          libappindicator3-dev
+          librsvg2-dev
+          patchelf
+          libgtk-3-dev
+          libudev-dev
+        )
+        if [ -n "${{ inputs.extra_packages }}" ]; then
+          # shellcheck disable=SC2206
+          packages+=(${{ inputs.extra_packages }})
+        fi
+
+        apt_update() {
+          # Hard cap: hung mirrors were cancelling whole CI at ~6h
+          sudo timeout 120 apt-get update -y
+        }
+
+        apt_install() {
+          sudo timeout 300 env DEBIAN_FRONTEND=noninteractive \
+            apt-get install -y --no-install-recommends "$@"
+        }
+
+        attempt=1
+        max_attempts=3
+        until apt_update; do
+          if [ "$attempt" -ge "$max_attempts" ]; then
+            echo "apt-get update failed/timed out after $max_attempts attempts"
+            exit 1
+          fi
+          echo "apt-get update failed (attempt $attempt/$max_attempts), retrying in 15s..."
+          attempt=$((attempt + 1))
+          sleep 15
+        done
+
+        attempt=1
+        until apt_install "${packages[@]}"; do
+          if [ "$attempt" -ge "$max_attempts" ]; then
+            echo "apt-get install failed/timed out after $max_attempts attempts"
+            exit 1
+          fi
+          echo "apt-get install failed (attempt $attempt/$max_attempts), retrying in 15s..."
+          attempt=$((attempt + 1))
+          sleep 15
+        done

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,0 +1,28 @@
+name: Setup Rust
+description: Install Rust toolchain and enable Swatinem rust-cache (no target/ blob cache)
+
+inputs:
+  components:
+    description: Comma-separated rustup components
+    required: false
+    default: ""
+  cache_key:
+    description: Extra rust-cache key suffix
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        components: ${{ inputs.components }}
+
+    - name: Cache Rust build
+      uses: Swatinem/rust-cache@v2
+      with:
+        shared-key: ${{ inputs.cache_key }}
+        cache-targets: "true"
+        # Key includes Cargo.lock + workspace fingerprint; safe incremental reuse
+        # within the same lockfile revision (unlike hashing target/ on lock alone).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,97 +6,70 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
-  
+  CARGO_INCREMENTAL: "0"
 
 jobs:
-  rust-check:
-    name: Rust Check & Test
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+  format:
+    name: Format
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+  rust-linux:
+    name: Rust (Linux)
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: ./.github/actions/setup-rust
         with:
           components: clippy
+          cache_key: rust-linux
 
-      - name: Install system dependencies (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libgtk-3-dev libudev-dev
+      - uses: ./.github/actions/setup-linux-deps
 
-      - name: Cache cargo registry
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Build
-        run: cargo build --workspace
-
-      - name: Run tests
+      - name: Test
         run: cargo test --workspace
-
-      - name: Verify build info format
-        if: runner.os == 'Linux'
-        run: cargo test --package libretune-app --test build_info -- --nocapture
 
       - name: Clippy
         run: cargo clippy --workspace -- -D warnings
 
-  security-audit:
-    name: Security Audit
-    runs-on: ubuntu-latest
+      - name: Verify build info format
+        run: cargo test --package libretune-app --test build_info -- --nocapture
+
+  rust-windows:
+    name: Rust (Windows)
+    runs-on: windows-latest
+    timeout-minutes: 35
     steps:
       - uses: actions/checkout@v5
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-rust
+        with:
+          cache_key: rust-windows
 
-      - name: Install cargo-audit
-        run: cargo install cargo-audit
+      - name: Test
+        run: cargo test --workspace
 
-      - name: Run security audit
-        run: |
-          cargo audit \
-            --ignore RUSTSEC-2024-0370 \
-            --ignore RUSTSEC-2024-0411 \
-            --ignore RUSTSEC-2024-0412 \
-            --ignore RUSTSEC-2024-0413 \
-            --ignore RUSTSEC-2024-0414 \
-            --ignore RUSTSEC-2024-0415 \
-            --ignore RUSTSEC-2024-0416 \
-            --ignore RUSTSEC-2024-0417 \
-            --ignore RUSTSEC-2024-0418 \
-            --ignore RUSTSEC-2024-0419 \
-            --ignore RUSTSEC-2024-0420 \
-            --ignore RUSTSEC-2024-0429 \
-            --ignore RUSTSEC-2025-0057 \
-            --ignore RUSTSEC-2025-0075 \
-            --ignore RUSTSEC-2025-0080 \
-            --ignore RUSTSEC-2025-0081 \
-            --ignore RUSTSEC-2025-0098 \
-            --ignore RUSTSEC-2025-0100 \
-            --ignore RUSTSEC-2026-0049 \
-            --ignore RUSTSEC-2026-0185 \
-            --ignore RUSTSEC-2026-0194 \
-            --ignore RUSTSEC-2026-0195 \
-            --ignore RUSTSEC-2026-0204 \
-            --ignore RUSTSEC-2026-0098 \
-            --ignore RUSTSEC-2026-0099 \
-            --ignore RUSTSEC-2026-0104
-
-  frontend-check:
-    name: Frontend Check
+  frontend:
+    name: Frontend
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: crates/libretune-app
@@ -106,8 +79,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: '24'
-          cache: 'npm'
+          node-version: "24"
+          cache: npm
           cache-dependency-path: crates/libretune-app/package-lock.json
 
       - name: Install dependencies
@@ -116,132 +89,52 @@ jobs:
       - name: Type check
         run: npx tsc --noEmit
 
+      - name: Unit tests
+        run: npm run test:run
+
       - name: Build
         run: npm run build
 
-      - name: Run unit tests
-        run: npm run test:run
-
-  format:
-    name: Format Check
+  security-audit:
+    name: Security Audit
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v5
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
+      - uses: dtolnay/rust-toolchain@stable
 
-      - name: Check formatting
-        run: cargo fmt --all -- --check
-  appimage-validation:
-    name: AppImage Structure Validation
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
+
+      - name: Run security audit
+        run: cargo audit
+
+  # Single required status for branch protection (avoids requiring every matrix job by name).
+  ci:
+    name: CI
+    if: always()
+    needs: [format, rust-linux, rust-windows, frontend, security-audit]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v5
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install system dependencies
+      - name: All required jobs passed
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libgtk-3-dev libudev-dev libfuse2
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: '24'
-          cache: 'npm'
-          cache-dependency-path: crates/libretune-app/package-lock.json
-
-      - name: Install dependencies
-        working-directory: crates/libretune-app
-        run: npm ci
-
-      - name: Build Tauri AppImage
-        working-directory: crates/libretune-app
-        run: npm run tauri build -- --target x86_64-unknown-linux-gnu 2>&1 | grep -i appimage || true
-
-      - name: Find and validate AppImage
-        run: |
-          # Locate built AppImage
-          # Use absolute path to avoid issues when changing directories
-          APPIMAGE=$(find "$GITHUB_WORKSPACE/target" -name "*.AppImage" -type f | head -1)
-          if [ -z "$APPIMAGE" ]; then
-            echo "⚠ Warning: AppImage not found, skipping validation"
-            echo "This may occur in some CI environments, validation can be tested locally"
-            exit 0
-          fi
-          
-          echo "Found AppImage: $APPIMAGE"
-          
-          # Extract AppImage to validate structure
-          chmod +x "$APPIMAGE"
-          mkdir -p appimage-extract
-          cd appimage-extract
-          
-          echo "Extracting AppImage..."
-          # Try extraction, ensure FUSE fallback if needed
-          "$APPIMAGE" --appimage-extract > /dev/null 2>&1
-          
-          if [ ! -d "squashfs-root" ]; then
-            echo "✗ FAIL: AppImage extraction failed - squashfs-root directory not created"
-            echo "Contents of extraction directory:"
-            ls -la
-            exit 1
-          fi
-
-          # Patch the extracted AppDir structure to ensure it meets requirements
-          # This simulates the post-processing done in release builds
-          echo "Patching extracted AppDir..."
-          chmod +x ../scripts/patch-appimage.sh
-          ../scripts/patch-appimage.sh squashfs-root
-          
-          # Check for critical issues
-          ERRORS=0
-          
-          # 1. Verify lib/x86_64-linux-gnu symlink exists (for WebKit paths)
-          if [ ! -L "squashfs-root/lib/x86_64-linux-gnu" ]; then
-            echo "✗ FAIL: Missing lib/x86_64-linux-gnu symlink"
-            ERRORS=$((ERRORS + 1))
-          else
-            echo "✓ PASS: lib/x86_64-linux-gnu symlink present"
-          fi
-          
-          # 2. Check for excluded conflicting Wayland libraries (should not be present after patching)
-          CONFLICTING_LIBS=("libwayland-egl.so.1" "libwayland-client.so.0" "libwayland-server.so.0" 
-                            "libwayland-cursor.so.0" "libepoxy.so.0")
-          for lib in "${CONFLICTING_LIBS[@]}"; do
-            if [ -f "squashfs-root/usr/lib/$lib" ] || [ -f "squashfs-root/usr/lib/x86_64-linux-gnu/$lib" ]; then
-              echo "⚠ WARNING: Found conflicting library $lib (may cause Wayland issues)"
+          set -euo pipefail
+          results=(
+            "${{ needs.format.result }}"
+            "${{ needs.rust-linux.result }}"
+            "${{ needs.rust-windows.result }}"
+            "${{ needs.frontend.result }}"
+            "${{ needs.security-audit.result }}"
+          )
+          for r in "${results[@]}"; do
+            echo "dependency result: $r"
+            if [ "$r" != "success" ]; then
+              echo "CI failed because a required job did not succeed"
+              exit 1
             fi
           done
-          
-          # 3. Verify ICU libraries are present
-          ICU_LIBS=("libicudata.so.74" "libicui18n.so.74" "libicuuc.so.74")
-          for lib in "${ICU_LIBS[@]}"; do
-            if [ -f "squashfs-root/usr/lib/$lib" ] || [ -f "squashfs-root/usr/lib/x86_64-linux-gnu/$lib" ]; then
-              echo "✓ PASS: ICU library $lib found"
-            else
-              echo "⚠ INFO: ICU library $lib not required for this build"
-            fi
-          done
-          
-          # 4. Verify WebKit binary location
-          if [ -f "squashfs-root/usr/bin/libretune-app" ]; then
-            echo "✓ PASS: Main binary found at usr/bin/libretune-app"
-          else
-            echo "⚠ INFO: Binary location check skipped"
-          fi
-          
-          # Report results
-          echo ""
-          if [ $ERRORS -eq 0 ]; then
-            echo "✓ AppImage structure validation passed"
-            exit 0
-          else
-            echo "✗ AppImage structure validation failed with $ERRORS error(s)"
-            exit 1
-          fi
+          echo "CI passed"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,115 +2,103 @@ name: Nightly Build
 
 on:
   schedule:
-    - cron: '0 3 * * *'  # Run at 3 AM UTC daily
-  workflow_dispatch:  # Allow manual triggering
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: nightly-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
-  contents: write  # Required for creating/updating releases
+  contents: write
 
 env:
   CARGO_TERM_COLOR: always
-  NIGHTLY_DATE: ${{ github.run_id }}
+  CARGO_INCREMENTAL: "0"
 
 jobs:
   check-changes:
     name: Check for Recent Changes
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       has_changes: ${{ steps.check.outputs.has_changes }}
       date_stamp: ${{ steps.date.outputs.date }}
     steps:
       - uses: actions/checkout@v5
         with:
-          fetch-depth: 0  # Need full history to check commits
+          fetch-depth: 0
 
       - name: Get date stamp
         id: date
-        run: echo "date=$(date +%Y%m%d)" >> $GITHUB_OUTPUT
+        run: echo "date=$(date +%Y%m%d)" >> "$GITHUB_OUTPUT"
 
       - name: Check for commits in last 24 hours
         id: check
         run: |
           COMMIT_COUNT=$(git log --since="24 hours ago" --oneline | wc -l)
-          if [ "$COMMIT_COUNT" -gt 0 ] || [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            echo "has_changes=true" >> $GITHUB_OUTPUT
+          if [ "$COMMIT_COUNT" -gt 0 ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
             echo "Found $COMMIT_COUNT commits in last 24 hours (or manual trigger)"
           else
-            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
             echo "No commits in last 24 hours, skipping nightly build"
           fi
 
   test:
-    name: Run Tests
+    name: Gate (Linux)
     needs: check-changes
     if: needs.check-changes.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 35
     steps:
       - uses: actions/checkout@v5
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libgtk-3-dev libudev-dev
-
-      - name: Cache cargo registry
-        uses: actions/cache@v5
+      - uses: ./.github/actions/setup-rust
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          components: clippy
+          cache_key: nightly-gate
 
-      - name: Build
-        run: cargo build --workspace
+      - uses: ./.github/actions/setup-linux-deps
 
-      - name: Run tests
+      - name: Test
         run: cargo test --workspace
+
+      - name: Clippy
+        run: cargo clippy --workspace -- -D warnings
 
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: '24'
-          cache: 'npm'
+          node-version: "24"
+          cache: npm
           cache-dependency-path: crates/libretune-app/package-lock.json
-
-      - name: Install frontend dependencies
-        working-directory: crates/libretune-app
-        run: npm ci
 
       - name: Frontend type check
         working-directory: crates/libretune-app
-        run: npx tsc --noEmit
+        run: |
+          npm ci
+          npx tsc --noEmit
 
   build-linux:
     name: Build Linux
     needs: [check-changes, test]
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-rust
+        with:
+          cache_key: nightly-linux
 
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libwebkit2gtk-4.1-dev \
-            libappindicator3-dev \
-            librsvg2-dev \
-            patchelf \
-            libgtk-3-dev \
-            libudev-dev
+      - uses: ./.github/actions/setup-linux-deps
 
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: '24'
-          cache: 'npm'
+          node-version: "24"
+          cache: npm
           cache-dependency-path: crates/libretune-app/package-lock.json
 
       - name: Install frontend dependencies
@@ -128,59 +116,36 @@ jobs:
         working-directory: crates/libretune-app
         run: npx tauri build --target x86_64-unknown-linux-gnu
 
-      - name: Prepare artifacts directory
-        working-directory: crates/libretune-app
-        run: |
-          mkdir -p artifacts/linux
-
-      - name: Copy Linux artifacts
-        working-directory: crates/libretune-app
-        run: |
-          # Copy AppImage if it exists (check both possible locations)
-          if [ -d "../../target/x86_64-unknown-linux-gnu/release/bundle/appimage" ]; then
-            cp ../../target/x86_64-unknown-linux-gnu/release/bundle/appimage/*.AppImage artifacts/linux/ 2>/dev/null || true
-          elif [ -d "src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/appimage" ]; then
-            cp src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/appimage/*.AppImage artifacts/linux/ 2>/dev/null || true
-          fi
-          # Copy DEB if it exists
-          if [ -d "../../target/x86_64-unknown-linux-gnu/release/bundle/deb" ]; then
-            cp ../../target/x86_64-unknown-linux-gnu/release/bundle/deb/*.deb artifacts/linux/ 2>/dev/null || true
-          elif [ -d "src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/deb" ]; then
-            cp src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/deb/*.deb artifacts/linux/ 2>/dev/null || true
-          fi
-          # Copy RPM if it exists
-          if [ -d "../../target/x86_64-unknown-linux-gnu/release/bundle/rpm" ]; then
-            cp ../../target/x86_64-unknown-linux-gnu/release/bundle/rpm/*.rpm artifacts/linux/ 2>/dev/null || true
-          elif [ -d "src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/rpm" ]; then
-            cp src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/rpm/*.rpm artifacts/linux/ 2>/dev/null || true
-          fi
-          # List what we found
-          echo "=== Artifacts copied ==="
-          ls -lh artifacts/linux/ || echo "No artifacts found"
+      - uses: ./.github/actions/collect-tauri-artifacts
+        with:
+          platform: linux
+          dest: crates/libretune-app/artifacts/linux
 
       - name: Upload Linux artifacts
         uses: actions/upload-artifact@v6
         with:
           name: linux-x86_64-${{ needs.check-changes.outputs.date_stamp }}
           path: crates/libretune-app/artifacts/linux/*
-          if-no-files-found: warn
+          if-no-files-found: error
           retention-days: 7
 
   build-windows:
     name: Build Windows
     needs: [check-changes, test]
     runs-on: windows-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-rust
+        with:
+          cache_key: nightly-windows
 
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: '24'
-          cache: 'npm'
+          node-version: "24"
+          cache: npm
           cache-dependency-path: crates/libretune-app/package-lock.json
 
       - name: Install frontend dependencies
@@ -191,49 +156,36 @@ jobs:
         working-directory: crates/libretune-app
         run: npx tauri build --target x86_64-pc-windows-msvc --no-bundle
 
-      - name: Prepare artifacts directory
-        working-directory: crates/libretune-app
-        run: |
-          mkdir artifacts\windows
-
-      - name: Copy Windows portable exe
-        working-directory: crates/libretune-app
-        shell: cmd
-        run: |
-          REM Copy portable exe (check workspace root first, then local)
-          if exist "..\..\target\x86_64-pc-windows-msvc\release\libretune-app.exe" (
-            copy "..\..\target\x86_64-pc-windows-msvc\release\libretune-app.exe" "artifacts\windows\LibreTune-nightly-portable.exe" >nul 2>&1
-          )
-          if exist "src-tauri\target\x86_64-pc-windows-msvc\release\libretune-app.exe" (
-            copy "src-tauri\target\x86_64-pc-windows-msvc\release\libretune-app.exe" "artifacts\windows\LibreTune-nightly-portable.exe" >nul 2>&1
-          )
-          REM List what we found
-          echo === Artifacts copied ===
-          dir artifacts\windows\ || echo No artifacts found
+      - uses: ./.github/actions/collect-tauri-artifacts
+        with:
+          platform: windows
+          dest: crates/libretune-app/artifacts/windows
 
       - name: Upload Windows artifacts
         uses: actions/upload-artifact@v6
         with:
           name: windows-x86_64-${{ needs.check-changes.outputs.date_stamp }}
           path: crates/libretune-app/artifacts/windows/*
-          if-no-files-found: warn
+          if-no-files-found: error
           retention-days: 7
 
   build-macos:
     name: Build macOS
     needs: [check-changes, test]
     runs-on: macos-latest
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v5
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-rust
+        with:
+          cache_key: nightly-macos
 
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: '24'
-          cache: 'npm'
+          node-version: "24"
+          cache: npm
           cache-dependency-path: crates/libretune-app/package-lock.json
 
       - name: Install frontend dependencies
@@ -260,80 +212,38 @@ jobs:
         working-directory: crates/libretune-app
         run: npx tauri build --target x86_64-apple-darwin
 
-      - name: Prepare artifacts directory
-        working-directory: crates/libretune-app
-        run: |
-          mkdir -p artifacts/macos
-
-      - name: Copy and package macOS artifacts
-        working-directory: crates/libretune-app
-        run: |
-          # Copy DMG files (check workspace root first, then local)
-          for dmg in ../../target/*/release/bundle/dmg/*.dmg; do
-            if [ -f "$dmg" ]; then
-              cp "$dmg" "artifacts/macos/$(basename "$dmg")"
-            fi
-          done
-          # Also check local src-tauri/target
-          for dmg in src-tauri/target/*/release/bundle/dmg/*.dmg; do
-            if [ -f "$dmg" ]; then
-              cp "$dmg" "artifacts/macos/$(basename "$dmg")"
-            fi
-          done
-          # Zip .app bundles to preserve permissions (check workspace root first)
-          for app_bundle in ../../target/*/release/bundle/macos/*.app; do
-            if [ -d "$app_bundle" ]; then
-              zip_name="artifacts/macos/$(basename "$app_bundle" .app).zip"
-              mkdir -p artifacts/macos
-              echo "Zipping $app_bundle to $zip_name"
-              abs_zip_path="$(pwd)/$zip_name"
-              cd "$(dirname "$app_bundle")"
-              zip -r "$abs_zip_path" "$(basename "$app_bundle")"
-              cd - > /dev/null
-            fi
-          done
-          # Also check local src-tauri/target
-          for app_bundle in src-tauri/target/*/release/bundle/macos/*.app; do
-            if [ -d "$app_bundle" ]; then
-              zip_name="artifacts/macos/$(basename "$app_bundle" .app).zip"
-              mkdir -p artifacts/macos
-              echo "Zipping $app_bundle to $zip_name"
-              abs_zip_path="$(pwd)/$zip_name"
-              cd "$(dirname "$app_bundle")"
-              zip -r "$abs_zip_path" "$(basename "$app_bundle")"
-              cd - > /dev/null
-            fi
-          done
-          # List what we found
-          echo "=== Artifacts copied ==="
-          ls -lh artifacts/macos/ || echo "No artifacts found"
+      - uses: ./.github/actions/collect-tauri-artifacts
+        with:
+          platform: macos
+          dest: crates/libretune-app/artifacts/macos
 
       - name: Upload macOS artifacts
         uses: actions/upload-artifact@v6
         with:
           name: macos-universal-${{ needs.check-changes.outputs.date_stamp }}
           path: crates/libretune-app/artifacts/macos/*
-          if-no-files-found: warn
+          if-no-files-found: error
           retention-days: 7
 
   upload-nightly:
     name: Upload Nightly Release
     needs: [check-changes, build-linux, build-windows, build-macos]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v6
         with:
           path: artifacts
-          pattern: '*'
+          pattern: "*"
           merge-multiple: false
 
       - name: Prepare release files
         run: |
+          set -euo pipefail
           mkdir -p release
           DATE_STAMP="${{ needs.check-changes.outputs.date_stamp }}"
-          
-          # Rename Linux artifacts
+
           for f in artifacts/linux-x86_64-*/*.AppImage; do
             [ -f "$f" ] && cp "$f" "release/LibreTune-nightly-${DATE_STAMP}-linux-x86_64.AppImage"
           done
@@ -343,46 +253,46 @@ jobs:
           for f in artifacts/linux-x86_64-*/*.rpm; do
             [ -f "$f" ] && cp "$f" "release/LibreTune-nightly-${DATE_STAMP}-linux-x86_64.rpm"
           done
-          
-          # Rename Windows artifacts
           for f in artifacts/windows-x86_64-*/*.exe; do
             [ -f "$f" ] && cp "$f" "release/LibreTune-nightly-${DATE_STAMP}-windows-x86_64-portable.exe"
           done
-          
-          # Rename macOS artifacts
           for f in artifacts/macos-universal-*/*.dmg; do
             [ -f "$f" ] && cp "$f" "release/$(basename "$f" .dmg)-nightly-${DATE_STAMP}.dmg"
           done
           for f in artifacts/macos-universal-*/*.zip; do
             [ -f "$f" ] && cp "$f" "release/$(basename "$f" .zip)-nightly-${DATE_STAMP}.zip"
           done
-          
+
           echo "=== Release files ==="
           ls -lh release/
+          if [ -z "$(ls -A release)" ]; then
+            echo "ERROR: no release files prepared"
+            exit 1
+          fi
 
       - name: Create/Update Nightly Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: nightly
           name: Nightly Build
           prerelease: true
           body: |
             ## Nightly Build - ${{ needs.check-changes.outputs.date_stamp }}
-            
+
             ⚠️ **This is an automated nightly build. Use at your own risk.**
-            
+
             Built from commit: ${{ github.sha }}
             Build date: ${{ needs.check-changes.outputs.date_stamp }}
-            
+
             ### Downloads
             - **Linux**: AppImage (portable), DEB, RPM
             - **Windows**: Portable EXE (no installation required)
             - **macOS**: DMG (ARM64 and Intel)
-            
+
             ### Notes
             - This release is automatically updated each night when there are new commits
             - For stable releases, see the [Releases](https://github.com/RallyPat/LibreTune/releases) page
           files: release/*
-          fail_on_unmatched_files: false
+          fail_on_unmatched_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,16 +3,22 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'  # Trigger on version tags like v1.0.0
-  workflow_dispatch:  # Allow manual triggering
+      - "v*"
+  workflow_dispatch:
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
 
 jobs:
   create-release:
     name: Create Release
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       tag_name: ${{ steps.get_version.outputs.VERSION || 'manual' }}
     steps:
@@ -23,34 +29,27 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         run: |
           VERSION=${GITHUB_REF#refs/tags/}
-          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
 
   build-linux:
     name: Build Linux
     needs: create-release
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-rust
+        with:
+          cache_key: release-linux
 
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libwebkit2gtk-4.1-dev \
-            libappindicator3-dev \
-            librsvg2-dev \
-            patchelf \
-            libgtk-3-dev \
-            libudev-dev
+      - uses: ./.github/actions/setup-linux-deps
 
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: '24'
-          cache: 'npm'
+          node-version: "24"
+          cache: npm
           cache-dependency-path: crates/libretune-app/package-lock.json
 
       - name: Install frontend dependencies
@@ -61,59 +60,36 @@ jobs:
         working-directory: crates/libretune-app
         run: npx tauri build --target x86_64-unknown-linux-gnu
 
-      - name: Prepare artifacts directory
-        working-directory: crates/libretune-app
-        run: |
-          mkdir -p artifacts/linux
-
-      - name: Copy Linux artifacts
-        working-directory: crates/libretune-app
-        run: |
-          # Copy AppImage if it exists (check both possible locations)
-          if [ -d "../../target/x86_64-unknown-linux-gnu/release/bundle/appimage" ]; then
-            cp ../../target/x86_64-unknown-linux-gnu/release/bundle/appimage/*.AppImage artifacts/linux/ 2>/dev/null || true
-          elif [ -d "src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/appimage" ]; then
-            cp src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/appimage/*.AppImage artifacts/linux/ 2>/dev/null || true
-          fi
-          # Copy DEB if it exists
-          if [ -d "../../target/x86_64-unknown-linux-gnu/release/bundle/deb" ]; then
-            cp ../../target/x86_64-unknown-linux-gnu/release/bundle/deb/*.deb artifacts/linux/ 2>/dev/null || true
-          elif [ -d "src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/deb" ]; then
-            cp src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/deb/*.deb artifacts/linux/ 2>/dev/null || true
-          fi
-          # Copy RPM if it exists
-          if [ -d "../../target/x86_64-unknown-linux-gnu/release/bundle/rpm" ]; then
-            cp ../../target/x86_64-unknown-linux-gnu/release/bundle/rpm/*.rpm artifacts/linux/ 2>/dev/null || true
-          elif [ -d "src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/rpm" ]; then
-            cp src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/rpm/*.rpm artifacts/linux/ 2>/dev/null || true
-          fi
-          # List what we found
-          echo "=== Artifacts copied ==="
-          ls -lh artifacts/linux/ || echo "No artifacts found"
+      - uses: ./.github/actions/collect-tauri-artifacts
+        with:
+          platform: linux
+          dest: crates/libretune-app/artifacts/linux
 
       - name: Upload Linux artifacts
         uses: actions/upload-artifact@v6
         with:
           name: linux-x86_64
           path: crates/libretune-app/artifacts/linux/*
-          if-no-files-found: warn
+          if-no-files-found: error
           retention-days: 30
 
   build-windows:
     name: Build Windows
     needs: create-release
     runs-on: windows-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-rust
+        with:
+          cache_key: release-windows
 
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: '24'
-          cache: 'npm'
+          node-version: "24"
+          cache: npm
           cache-dependency-path: crates/libretune-app/package-lock.json
 
       - name: Install frontend dependencies
@@ -124,56 +100,36 @@ jobs:
         working-directory: crates/libretune-app
         run: npx tauri build --target x86_64-pc-windows-msvc
 
-      - name: Prepare artifacts directory
-        working-directory: crates/libretune-app
-        run: |
-          mkdir artifacts\windows
-
-      - name: Copy Windows artifacts
-        working-directory: crates/libretune-app
-        shell: cmd
-        run: |
-          REM Copy NSIS installer if it exists (check workspace root first, then local)
-          if exist "..\..\target\x86_64-pc-windows-msvc\release\bundle\nsis" (
-            for %%f in ("..\..\target\x86_64-pc-windows-msvc\release\bundle\nsis\*.exe") do copy "%%f" "artifacts\windows\" >nul 2>&1
-          )
-          if exist "src-tauri\target\x86_64-pc-windows-msvc\release\bundle\nsis" (
-            for %%f in ("src-tauri\target\x86_64-pc-windows-msvc\release\bundle\nsis\*.exe") do copy "%%f" "artifacts\windows\" >nul 2>&1
-          )
-          REM Copy MSI installer if it exists
-          if exist "..\..\target\x86_64-pc-windows-msvc\release\bundle\msi" (
-            for %%f in ("..\..\target\x86_64-pc-windows-msvc\release\bundle\msi\*.msi") do copy "%%f" "artifacts\windows\" >nul 2>&1
-          )
-          if exist "src-tauri\target\x86_64-pc-windows-msvc\release\bundle\msi" (
-            for %%f in ("src-tauri\target\x86_64-pc-windows-msvc\release\bundle\msi\*.msi") do copy "%%f" "artifacts\windows\" >nul 2>&1
-          )
-          REM List what we found
-          echo === Artifacts copied ===
-          dir artifacts\windows\ || echo No artifacts found
+      - uses: ./.github/actions/collect-tauri-artifacts
+        with:
+          platform: windows
+          dest: crates/libretune-app/artifacts/windows
 
       - name: Upload Windows artifacts
         uses: actions/upload-artifact@v6
         with:
           name: windows-x86_64
           path: crates/libretune-app/artifacts/windows/*
-          if-no-files-found: warn
+          if-no-files-found: error
           retention-days: 30
 
   build-macos:
     name: Build macOS
     needs: create-release
     runs-on: macos-latest
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v5
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-rust
+        with:
+          cache_key: release-macos
 
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: '24'
-          cache: 'npm'
+          node-version: "24"
+          cache: npm
           cache-dependency-path: crates/libretune-app/package-lock.json
 
       - name: Install frontend dependencies
@@ -193,90 +149,44 @@ jobs:
         working-directory: crates/libretune-app
         run: npx tauri build --target x86_64-apple-darwin
 
-      - name: Prepare artifacts directory
-        working-directory: crates/libretune-app
-        run: |
-          mkdir -p artifacts/macos
-
-      - name: Copy and package macOS artifacts
-        working-directory: crates/libretune-app
-        run: |
-          # Copy DMG files (check workspace root first, then local)
-          for dmg in ../../target/*/release/bundle/dmg/*.dmg; do
-            if [ -f "$dmg" ]; then
-              cp "$dmg" "artifacts/macos/$(basename "$dmg")"
-            fi
-          done
-          # Also check local src-tauri/target
-          for dmg in src-tauri/target/*/release/bundle/dmg/*.dmg; do
-            if [ -f "$dmg" ]; then
-              cp "$dmg" "artifacts/macos/$(basename "$dmg")"
-            fi
-          done
-          # Zip .app bundles to preserve permissions (check workspace root first)
-          for app_bundle in ../../target/*/release/bundle/macos/*.app; do
-            if [ -d "$app_bundle" ]; then
-              zip_name="artifacts/macos/$(basename "$app_bundle" .app).zip"
-              # Ensure artifacts directory exists (we're in crates/libretune-app)
-              mkdir -p artifacts/macos
-              echo "Zipping $app_bundle to $zip_name"
-              # Use absolute path for zip output to avoid path issues after cd
-              abs_zip_path="$(pwd)/$zip_name"
-              cd "$(dirname "$app_bundle")"
-              zip -r "$abs_zip_path" "$(basename "$app_bundle")"
-              cd - > /dev/null
-            fi
-          done
-          # Also check local src-tauri/target
-          for app_bundle in src-tauri/target/*/release/bundle/macos/*.app; do
-            if [ -d "$app_bundle" ]; then
-              zip_name="artifacts/macos/$(basename "$app_bundle" .app).zip"
-              # Ensure artifacts directory exists (we're in crates/libretune-app)
-              mkdir -p artifacts/macos
-              echo "Zipping $app_bundle to $zip_name"
-              # Use absolute path for zip output to avoid path issues after cd
-              abs_zip_path="$(pwd)/$zip_name"
-              cd "$(dirname "$app_bundle")"
-              zip -r "$abs_zip_path" "$(basename "$app_bundle")"
-              cd - > /dev/null
-            fi
-          done
-          # List what we found
-          echo "=== Artifacts copied ==="
-          ls -lh artifacts/macos/ || echo "No artifacts found"
+      - uses: ./.github/actions/collect-tauri-artifacts
+        with:
+          platform: macos
+          dest: crates/libretune-app/artifacts/macos
 
       - name: Upload macOS artifacts
         uses: actions/upload-artifact@v6
         with:
           name: macos-universal
           path: crates/libretune-app/artifacts/macos/*
-          if-no-files-found: warn
+          if-no-files-found: error
           retention-days: 30
 
   upload-release:
     name: Upload Release Assets
     needs: [create-release, build-linux, build-windows, build-macos]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v6
         with:
           path: artifacts
-          pattern: '*'
+          pattern: "*"
           merge-multiple: false
 
       - name: Get tag name
         id: tag
         run: |
           if [[ "${{ github.ref }}" == refs/tags/* ]]; then
-            echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+            echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
           else
-            echo "tag=manual-$(date +%Y%m%d-%H%M%S)" >> $GITHUB_OUTPUT
+            echo "tag=manual-$(date +%Y%m%d-%H%M%S)" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create Release (only for tags)
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
           name: Release ${{ steps.tag.outputs.tag }}
@@ -287,13 +197,15 @@ jobs:
           draft: false
           prerelease: false
           generate_release_notes: true
+          fail_on_unmatched_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Upload artifacts (manual build)
-        if: "!startsWith(github.ref, 'refs/tags/')"
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         uses: actions/upload-artifact@v6
         with:
           name: build-artifacts
           path: artifacts/**
+          if-no-files-found: error
           retention-days: 7


### PR DESCRIPTION
Trim PR CI to Linux+Windows Rust, frontend, fmt, and audit; drop the soft-pass AppImage job and macOS from PR. Add timeouts, apt hang guards, concurrency cancel, Swatinem rust-cache, and hard-fail artifact collection for nightly/release.