### PR TITLE
fix(ini): serialize the two DEFAULT_SYMBOLS parser tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2423,6 +2423,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "serial_test",
  "serialport",
  "tempfile",
  "thiserror 2.0.18",
@@ -4233,6 +4234,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
 dependencies = [
  "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",

--- a/crates/libretune-core/Cargo.toml
+++ b/crates/libretune-core/Cargo.toml
@@ -74,6 +74,7 @@ encoding_rs = "0.8"
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
+serial_test = "3.2.0"
 tempfile = "3.24.0"
 tokio = { workspace = true, features = ["test-util", "macros"] }
 tracing-subscriber = { workspace = true }

--- a/crates/libretune-core/src/ini/parser.rs
+++ b/crates/libretune-core/src/ini/parser.rs
@@ -3278,12 +3278,19 @@ fn parse_constants_extensions_entry(def: &mut EcuDefinition, key: &str, value: &
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     /// An INI picks metric units with `#if CELSIUS`. TunerStudio defines that
     /// from the project's `ecuSettings`; nothing carried it into LibreTune, so
     /// the Fahrenheit `#else` arm always won and a 23 degC cold start read 73
     /// on the gauge under a generic "TEMP" label.
+    ///
+    /// Serialized against [`a_definition_remembers_the_symbols_it_was_parsed_with`]:
+    /// both tests toggle the process-wide `DEFAULT_SYMBOLS` seed, and cargo
+    /// runs tests in parallel by default, so without this they can interleave
+    /// and flip each other's seed between `set_default_symbols` and `parse_ini`.
     #[test]
+    #[serial(default_symbols)]
     fn celsius_symbol_selects_the_metric_branch() {
         let ini = concat!(
             "[Constants]
@@ -3332,6 +3339,7 @@ mod tests {
     /// plausible. Keeping the answer on the definition also means this holds
     /// with other parses running concurrently.
     #[test]
+    #[serial(default_symbols)]
     fn a_definition_remembers_the_symbols_it_was_parsed_with() {
         let ini = "[Constants]
 page = 1


### PR DESCRIPTION
## Summary
- `celsius_symbol_selects_the_metric_branch` and `a_definition_remembers_the_symbols_it_was_parsed_with` (in `crates/libretune-core/src/ini/parser.rs`) both mutate the process-wide `DEFAULT_SYMBOLS` seed via `set_default_symbols`.
- `cargo test` runs tests in parallel by default, so the two could interleave and flip each other's seed between a test's `set_default_symbols` call and its matching `parse_ini`, occasionally failing an assertion with the wrong unit (`left: Some("F"), right: Some("C")`).
- Observed failing PR #235's CI run (unrelated diff — confirms it's test isolation, not a real regression).
- Adds `serial_test` as a dev-dependency and marks both tests `#[serial(default_symbols)]` so they never run concurrently.

## Test plan
- [x] `cargo test --lib ini::parser::tests::` — 28 passed
- [x] `cargo test --lib` (full `libretune-core` suite) — 412 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qvvy1zKr6aNghrKHP1MtKo