### PR TITLE
docs: sync documentation, manual and changelog with current project state (Aug 2026)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,12 +40,12 @@ The project aims to provide professional ECU tuning workflow and functionality w
   - `TableEditor2D.tsx` - Main 2D table editor with toolbar
   - `TableEditor3D.tsx` - 3D visualization (canvas-based)
 - Backend: `crates/libretune-core/src/table_ops.rs`
-- Features: Set Equal, Increase/Decrease, Scale, Interpolate, Smooth, Re-bin, Copy/Paste, History Trail, Follow Mode
+- Features: Set Equal, Increase/Decrease, Scale, Interpolate, Smooth, Re-bin, Copy/Paste, History Trail, Follow Mode, per-table `.table` file import/export (TunerStudio-compatible; core reader/writer in `crates/libretune-core/src/table_file.rs`, commands in `commands/table_file_io.rs`)
 
 ### 2. AutoTune
 - Location: `crates/libretune-app/src/components/tuner-ui/AutoTune.tsx`
-- Backend: `crates/libretune-core/src/autotune.rs`
-- Features: Auto-tuning with recommendations, heat maps, cell locking, filters, authority limits
+- Backend: `crates/libretune-core/src/autotune/` (mod.rs, anomaly.rs, predictor.rs, health.rs, delay_measure.rs)
+- Features: Auto-tuning with recommendations, heat maps, cell locking, filters, authority limits, lambda-delay compensation (fixed / flow-scaled / per-cell), fuel-cut and railed-sensor exclusion, AFR Delay Test (Tools menu; `delay_measure.rs` + `commands/afr_delay_test.rs`)
 - **Documentation** (Feb 3, 2026):
   - Created comprehensive usage guide: `docs/src/features/autotune/usage-guide.md`
   - Added step-by-step workflow (Setup → Driving → Review → Apply)
@@ -173,7 +173,7 @@ The project aims to provide professional ECU tuning workflow and functionality w
 
 ### Backend (Rust)
 ```bash
-cd /home/pat/.gemini/antigravity/scratch/libretune
+# from the repository root
 cargo build -p libretune-core
 cargo test -p libretune-core
 cargo clippy -p libretune-core
@@ -183,10 +183,10 @@ cargo clippy -p libretune-core
 ```bash
 cd crates/libretune-app
 npm install
-npm run dev        # Development mode
+npm run dev        # Development mode (Vite only)
 npm run tauri dev  # Full Tauri app
 npm run build       # Production build
-npm run lint       # ESLint
+npm run test:run    # Vitest (frontend tests)
 npm run typecheck  # TypeScript checking
 ```
 
@@ -208,7 +208,7 @@ async fn command_name(param: Type) -> Result<ReturnType, String> {
 
 ## Component State Management
 - Use React hooks (useState, useEffect, useMemo)
-- Realtime data via `get_realtime_data()` command (100ms polling)
+- Realtime data via event-based streaming: backend emits `realtime:update` events → `useRealtimeStream` → Zustand store (`stores/realtimeStore.ts`); components subscribe per-channel (`useChannelValue` / `useChannels`)
 - Table data fetched on-demand via `get_table_data()`
 
 ## Tuning Best Practices (for AI agents)
@@ -289,7 +289,7 @@ Based on analysis of common ECU tuning software patterns:
 [x] Composite logger (Speeduino/rusEFI/MS2) - Backend + CompositeLoggerView.tsx
 [x] Action Engine Enforcement (validation against INI) - COMPLETED Feb 8, 2026
 [x] Math Channels / Expression Engine - Backend COMPLETED Feb 8, 2026
-[ ] rusEFI console support (text-based command interface) - COMPLETED Feb 1-2, 2026
+[x] rusEFI console support (text-based command interface) - COMPLETED Feb 1-2, 2026
   - [x] ECU type detection (Speeduino, RusEFI, FOME, epicEFI, MS2, MS3)
   - [x] Console command pass-through protocol (Step 3 - connection.rs)
   - [x] FOME fast comms with intelligent fallback (Step 5 - settings)
@@ -301,6 +301,30 @@ Based on analysis of common ECU tuning software patterns:
 
 Detailed session-by-session history has moved to [CHANGELOG.md](CHANGELOG.md).
 What follows is a high-level pointer to the most recent cleanup pass.
+
+### Dialog fidelity, `.table` IO, pin gating & AutoTune sampling (Aug 2026)
+
+- **Per-table `.table` import/export** — TunerStudio-compatible
+  single-table save/load (`table_file.rs` + `commands/table_file_io.rs`,
+  toolbar buttons in both table editors). Import requires exact dimension
+  match (no silent resampling).
+- **Auto online INI search on signature mismatch** — the mismatch dialog
+  searches online sources (Speeduino/rusEFI/FOME) automatically; downloads
+  remain explicit.
+- **AutoTune sample integrity** — match window follows stream cadence
+  (was dropping ⅓–½ of samples on real hardware); overrun fuel-cut and
+  railed wideband readings excluded with named rejection reasons.
+- **AFR delay test measures half-excursion (median) delay** — plus
+  settle-window sampling, an in-progress guard, and recovery traces drawn.
+- **Pin lint gating** — switched-off features don't claim pins, 'Board
+  Default' is not a pin, loading a tune isn't blocked by pin lint
+  (`commands/pin_conflicts.rs`).
+- **Dialog rendering fidelity** — enable-condition fields disabled not
+  hidden; command-button / indicatorPanel labels and dynamic units
+  evaluated; indicatorPanel without `columns` renders; xAxis layout hint
+  respected.
+- **CI modernized** — lean gated flow with reusable composite actions.
+- See the `2026-08-20` CHANGELOG block for details.
 
 ### std_* panel synthesis & offline constant reads (Aug 2026)
 
@@ -339,7 +363,8 @@ language. See `CHANGELOG.md` for full per-phase details.
   dialogs migrated; CSS hex sweep tokenized; lucide-react adopted; pop-out
   window theme parity.
 - **Phase 5**: `lib.rs` reduced from 14,475 → 419 lines; 72 command modules
-  under `crates/libretune-app/src-tauri/src/commands/`.
+  under `crates/libretune-app/src-tauri/src/commands/` (the count has since
+  grown to ~80).
 - **Phase 6**: Folder reorg (`src/contexts/` for cross-cutting providers);
   `DialogRenderer.tsx` split into `dialogs/types.ts` and `dialogs/fields/`.
 - **Phase 7**: `dashboard.rs` centralized under `dash/layout.rs`; default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,98 @@ relevant.
 
 ## [Unreleased]
 
+### 2026-08-20 — Dialog fidelity pass, `.table` file IO, pin-lint gating & AutoTune sample integrity
+
+#### Added
+- **Per-table `.table` file import/export (TunerStudio-compatible)** — the
+  single-table "Save Table to File" / "Load Table from File" workflow, next to
+  CSV (whole-tune) IO. New core reader/writer `crates/libretune-core/src/table_file.rs`
+  for the `<tableData>` XML format (verified against real TunerStudio-exported
+  files), plus `export_table_to_file` / `import_table_from_file` commands
+  (`commands/table_file_io.rs`) and toolbar buttons in both table editors.
+  Import requires the file's dimensions to match the table's current size
+  exactly — unlike TunerStudio it does not silently resample a mismatched
+  grid onto the table's axes.
+- **Online INI search runs automatically on signature mismatch** — the
+  Signature Mismatch dialog now kicks off the online search (Speeduino /
+  rusEFI / FOME sources) as soon as a mismatch is reported, keyed off the ECU
+  signature so it re-runs per mismatch, and jumps straight to the online tab
+  when there is no local match to show. Only the *search* is automated —
+  applying an INI still requires an explicit Download click.
+- **AFR Delay Test (Tools → AFR Delay Test…)** — automated exhaust
+  transport-delay measurement (shipped Aug 6, hardened in this pass; see
+  Fixed below). Steps fuel through `wueRates[9]`, overlays the sampled
+  pulse/AFR traces, and reports the measured delay so it can be entered as
+  AutoTune's `lambda_delay_ms`. Runs until stopped so a whole drive fills
+  the RPM/load map.
+- **INI `xAxis` layout hint respected for top-level panels** — dialog
+  panels carrying the INI's xAxis layout hint now lay their field grid out
+  accordingly instead of ignoring it.
+
+#### Fixed
+- **AutoTune dropped a third to a half of all samples in strict mode** — the
+  delayed-sample match window was a fixed 50 ms while real hardware samples
+  every 111–200 ms (single-shot reads contend with the realtime poll for the
+  connection lock), so good matches were rejected. The tolerance now follows
+  the stream's measured cadence (0.6× the mean sample gap, floored at the
+  historical 50 ms). This was the "AutoTune runs but recommendations never
+  accumulate" symptom.
+- **Overrun fuel-cut and railed wideband readings polluted AutoTune** —
+  samples taken during fuel cut (injectors off, wideband pinned lean) asked
+  for maximum enrichment in exactly the low-load cells every lift passes
+  through; readings below ~10 or above ~19.5 AFR are a sensor at a stop, not
+  a mixture. Both are now excluded, with named `rejection_reason`s in the
+  diagnostic log. `VEDataPoint::default()` now uses 14.7 rather than a
+  physically impossible 0.0 AFR.
+- **AFR delay test measured the leading edge, not the delay** — a step
+  response is the cumulative distribution of transit times, so its
+  half-height is the *median* transit (the transport delay); the leading
+  edge is just the fastest path through the manifold and sits in the noise
+  (median 268 ms scattering 8–2117 ms vs. 435 ms ± 30 ms IQR for
+  half-excursion on the same 80 steps). `detect_delay` now reports the
+  half-excursion crossing, keeps the old figure as `leading_edge_ms`,
+  rejects unsettled traces (`ResponseNotSettled`) with a "hold longer than
+  N ms" hint, samples the settle window so recovery traces are drawn, and
+  guards against concurrent runs (a second start mid-step previously read
+  the enriched value as its baseline and could leave the engine rich in RAM).
+- **Pin lint: a switched-off feature no longer claims its pin** — the
+  pre-burn conflict scan counted every pin selector in the INI, enabled or
+  not, so a bone-stock Speeduino tune raised an eight-line conflict warning
+  on every burn (sixteen Auxin selectors on two analog pins, knock_pin on
+  ignBypassPin with detection off, …). A pin field whose INI enable
+  condition evaluates false now drops out of the scan and out of the
+  assignment-denial check; unparseable conditions stay in the scan (a missed
+  conflict is worse than a spurious one). Also: `'Board Default'` is not a
+  pin, and loading a tune is no longer blocked by pin lint. Both behaviours
+  are pinned by tests.
+- **Dialog fields with only an enable condition were hidden instead of
+  disabled**, command-button and indicatorPanel labels showed raw
+  `{expression}` text instead of the evaluated result, dynamic units showed
+  the raw expression, `indicatorPanel` without an explicit `columns` count
+  was dropped entirely, indicator tiles overflowed their text, and the
+  two-column field grid inside `xAxis` rows collapsed into one column — all
+  fixed to match TunerStudio rendering.
+- **Sidebar now highlights the currently open item** in the project tree.
+- **Table editor**: the Interpolate shortcut (`/`) no longer steals focus
+  to the search box; Y-axis bin labels are no longer hidden on tables with
+  more than 12 rows.
+- **Dashboard drag-and-drop works in the Tauri webview** — Tauri's native
+  drag-drop handler was swallowing the HTML5 DnD events the gauge designer
+  relies on; it is now disabled for the webview.
+- **HotkeyEditor infinite re-render loop** in the Settings dialog (PR #230,
+  with a new regression test).
+- **INI parser**: expression-valued `scale`/`translate` are now resolved
+  instead of silently falling back to 1.0; the two `DEFAULT_SYMBOLS` parser
+  tests are serialized (they shared a process-global symbol table and
+  flaked under parallel execution).
+
+#### Changed
+- **CI modernized** — the flaky legacy pipelines were replaced with a lean
+  gated flow: reusable composite actions
+  (`.github/actions/setup-rust`, `setup-linux-deps`,
+  `collect-tauri-artifacts`) shared across `ci.yml` / `nightly.yml` /
+  `release.yml`, plus a new `.cargo/audit.toml` gating `cargo audit`.
+
 ### 2026-08-18 — Spark generator: combustion chamber & boost (psi)
 
 #### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thank you for your interest in contributing to LibreTune! This document provides
 ### Prerequisites
 
 - **Rust 1.75+** - Install via [rustup](https://rustup.rs)
-- **Node.js 18+** - For the Tauri frontend
+- **Node.js 20+** - For the Tauri frontend
 - **npm** - Comes with Node.js
 
 ### Development Setup

--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ Full-featured 2D grid editor with 3D surface visualization, keyboard navigation,
 Import existing .dash files or build layouts from scratch with 13 gauge types (analog dials, bar gauges, sweep gauges, digital readouts, line graphs, histograms, tachometers, and more). Drag-and-drop designer mode with three default dashboards included.
 
 ### AutoTune
-Live fuel table recommendations based on AFR targets with heat map visualization, cell locking, authority limits, transient filtering, and lambda delay compensation.
+Live fuel table recommendations based on AFR targets with heat map visualization, cell locking, authority limits, transient filtering, lambda delay compensation (fixed, flow-scaled, or measured via the built-in AFR Delay Test), and fuel-cut / railed-sensor exclusion.
 
 ### Diagnostics & Logging
 Data logger with configurable sample rates, playback controls, CSV import/export, math channels, and alert rules. Tooth logger and composite logger for trigger pattern analysis. Text-based ECU console for rusEFI/FOME/epicEFI.
 
 ### Data Management
-Project-based workflow with restore points, Git-based tune versioning, CSV export/import, TunerStudio project import, INI version tracking with automatic tune migration, and change annotations. Online INI search from Speeduino and rusEFI GitHub repos.
+Project-based workflow with restore points, Git-based tune versioning, CSV export/import, TunerStudio-compatible per-table `.table` import/export, TunerStudio project import, INI version tracking with automatic tune migration, and change annotations. Online INI search from Speeduino, rusEFI, and FOME GitHub repos, offered automatically on ECU signature mismatch.
 
 ### Additional
 - **AI Assistant**: Bring-your-own-LLM co-pilot (OpenAI / Anthropic / Google / local Ollama) that reads your tables, diagnoses problems, and *proposes* validated, authority-clamped changes for explicit review — nothing burns automatically. Docked side panel, pop-out-able.
@@ -168,7 +168,7 @@ libretune/
 │       │   └── stores/         # State stores
 │       └── src-tauri/          # Tauri backend (Rust)
 │           └── src/
-│               ├── commands/   # Tauri commands (~70 sub-modules)
+│               ├── commands/   # Tauri commands (~80 topic modules)
 │               └── state.rs    # Shared AppState
 ├── docs/                       # User manual (mdBook) + architecture.md
 ├── scripts/                    # Build and development scripts

--- a/crates/libretune-app/AGENTS.md
+++ b/crates/libretune-app/AGENTS.md
@@ -1,14 +1,62 @@
+# libretune-app — Notes for AI Agents
 
-### Enhanced Table Context Menu - Completed Feb 9, 2026
-- **Feature**: Rich context menu for 2D table editor with advanced operations
-- **UI Implementation** (`TableContextMenu.tsx`):
-  - Added specialized input interface for Scale/Offset operations
-  - Input mode tabs (Scale vs Offset) with sensible defaults
-  - Grouped operations into logical sections with icons
-  - Added new tools: Interpolate Horizontal/Vertical, Fill Right/Down, Nudge
-- **Logic Integration** (`TableEditor2D.tsx`):
-  - Implemented handlers for `add_offset`, `interpolate_linear`, `fill_region`
-  - Wired interactions to new backend commands
-- **Styling** (`TableComponents.css`):
-  - Added CSS for tabbed inputs, action buttons, and icons
-- **Status**: Backend tests passed, Frontend typecheck passed
+App-level companion to the root [AGENTS.md](../../AGENTS.md). See that file
+for project-wide conventions (backend-first, legal distinction, git rules).
+This file tracks app-crate specifics.
+
+## Crate layout
+
+- `src/` — React + Vite frontend (TypeScript)
+  - `components/` — UI: `common/` (shared Dialog/Button/FormField/EmptyState
+    primitives), `dialogs/` (INI-driven `DialogRenderer` + per-feature
+    dialogs), `dashboards/`, `gauges/`, `tables/`, `curves/`, `tuner-ui/`
+    (layout chrome), `hardware/` (port editor), `agent/` (AI panel)
+  - `contexts/` — cross-cutting providers (loading, toast, unit prefs)
+  - `hooks/`, `stores/` (Zustand realtime store), `services/`, `menus/`,
+    `i18n/` (en + pt-BR), `utils/`, `types/`, `themes/`
+- `src-tauri/` — Tauri host
+  - `src/lib.rs` — glue only: AppState + `invoke_handler!` manifest
+  - `src/commands/` — one module per topic (~80 files); add new commands
+    there and register them in `lib.rs`
+
+## Commands (npm)
+
+- `npm run dev` — Vite dev server (docs sync runs first)
+- `npm run tauri dev` — full Tauri app
+- `npm run build` — production bundle (docs sync runs first)
+- `npm run test:run` — Vitest
+- `npm run typecheck` — `tsc --noEmit` (there is no ESLint script)
+
+## Docs sync
+
+`public/manual/` is a generated copy of the mdBook manual (`docs/src/`),
+refreshed by `npm run docs:sync` (runs automatically on `dev`/`build`).
+Never edit `public/manual/` by hand — edit `docs/src/` and re-run the sync.
+
+## Frontend conventions
+
+- Realtime data arrives via `realtime:update` Tauri events →
+  `useRealtimeStream` → `stores/realtimeStore.ts`; components subscribe
+  per-channel (`useChannelValue` / `useChannels`) instead of polling.
+- TypeScript interfaces mirror the Rust command payloads.
+- All dialogs use the shared `Dialog` / `Button` / `FormField` primitives
+  from `components/common/`; avoid re-creating per-dialog overlays.
+- UI chrome text (menus, toolbar tooltips) goes through `t()` from
+  `src/i18n/`; INI-derived labels and channel names pass through verbatim.
+
+## Recent app-side work (Aug 2026)
+
+- Per-table `.table` import/export toolbar buttons (`TableEditor2D.tsx`,
+  `tuner-ui/TableEditor.tsx` → `commands/table_file_io.rs`)
+- Signature-mismatch dialog auto-searches online INI sources
+  (`dialogs/SignatureMismatchDialog.tsx`)
+- Dialog fidelity pass: enable-condition fields disabled not hidden,
+  command-button/indicatorPanel labels + dynamic units evaluated
+  (`dialogs/fields/*`, `dialogs/PanelComponents.tsx`)
+- AFR Delay Test dialog + trace overlay (`dialogs/AfrDelayTestDialog.tsx`,
+  `dialogs/DelayTraceOverlay.tsx`)
+- HotkeyEditor re-render loop fix + regression test
+  (`dialogs/__tests__/HotkeyEditor.test.tsx`)
+
+Detailed history: [CHANGELOG.md](../../CHANGELOG.md).
+

--- a/crates/libretune-app/public/manual/changelog.md
+++ b/crates/libretune-app/public/manual/changelog.md
@@ -44,8 +44,10 @@ All notable changes to LibreTune will be documented in this file.
 - FOME fast comms with intelligent fallback for optimized console communication
 - Dashboard tab protection (cannot be accidentally closed; recoverable via View → Dashboard)
 - Configurable status bar channels (Settings → Status Bar Channels, max 8)
-- INI signature mismatch dialog with local and online INI search
-- Online INI repository search from Speeduino and rusEFI GitHub repos
+- INI signature mismatch dialog with local and online INI search (the online search now runs automatically when a mismatch is reported; downloading still requires an explicit click)
+- Online INI repository search from Speeduino, rusEFI, and FOME GitHub repos
+- Per-table `.table` file import/export (TunerStudio-compatible "Save/Load Table to File" from the table toolbar)
+- AFR Delay Test (Tools → AFR Delay Test…) — automated exhaust transport-delay measurement that steps fuel and reports the delay to enter as AutoTune's lambda delay
 - Resilient ECU sync with partial failure handling and status bar indicator
 - CSV export/import for tune data
 - Reset tune to defaults
@@ -69,6 +71,14 @@ All notable changes to LibreTune will be documented in this file.
 - Java/JVM plugin system UI (deprecated; see DEPRECATION_NOTICE.md)
 
 ### Fixed
+- AutoTune no longer drops a third to a half of its samples on real hardware (delayed-sample match window now follows the stream's cadence), and excludes overrun fuel-cut and railed wideband readings
+- AFR delay test reports the median (half-excursion) transport delay instead of the noisy leading edge, refuses to run twice concurrently, and draws the settle/recovery window
+- Pin conflict scan ignores pins held only by switched-off features, treats "Board Default" as unassigned, and no longer blocks loading a tune
+- Dialog rendering fidelity: fields with an enable condition are disabled (not hidden), command-button / indicator-panel labels and dynamic units are evaluated instead of showing raw expressions, indicator panels without an explicit column count render correctly
+- Sidebar highlights the currently open item in the project tree
+- Table editor: Interpolate shortcut no longer steals focus to the search box; Y-axis labels visible on tables with more than 12 rows
+- Dashboard drag-and-drop works inside the Tauri webview
+- Settings dialog HotkeyEditor infinite re-render loop
 - Table operations (scale, smooth, interpolate, set equal, rebin) now properly connected to backend
 - AutoTune table lookup for rusEFI/epicEFI INIs (veTable1Map → veTable1Tbl resolution)
 - Realtime stream lock contention from get_all_constant_values blocking serial connection

--- a/crates/libretune-app/public/manual/contributing.md
+++ b/crates/libretune-app/public/manual/contributing.md
@@ -7,7 +7,7 @@ Thank you for your interest in contributing to LibreTune!
 ### Prerequisites
 
 - [Rust](https://rustup.rs/) (stable toolchain)
-- [Node.js](https://nodejs.org/) 18+ and npm
+- [Node.js](https://nodejs.org/) 20+ (required by Vite 7) and npm
 - [Tauri CLI](https://tauri.app/start/prerequisites/)
 
 ### Clone the Repository

--- a/crates/libretune-app/public/manual/features/autotune/setup.md
+++ b/crates/libretune-app/public/manual/features/autotune/setup.md
@@ -103,6 +103,14 @@ Engine exhaust takes time to reach the O2 sensor. AutoTune compensates:
 - **At redline**: ~50ms delay (fast exhaust flow)
 - LibreTune interpolates between these values
 
+The default curve tops out around 200 ms, but a real exhaust's dead time is
+commonly 400–1000 ms. For best results, measure your car with the
+[AFR Delay Test](../tools.md) (Tools → AFR Delay Test…) and enter the
+measured value as the fixed lambda delay in the AutoTune settings. A
+flow-scaled option is also available: it anchors the delay at idle/cruise
+and shortens it toward a floor as exhaust flow rises, modelling the physics
+(exhaust volume ÷ flow) instead of using one flat number.
+
 ## Best Practices
 
 1. **Start conservative** with low authority limits

--- a/crates/libretune-app/public/manual/features/table-editing.md
+++ b/crates/libretune-app/public/manual/features/table-editing.md
@@ -88,6 +88,29 @@ Changes the axis values and interpolates Z values automatically. Useful for adju
 - `Ctrl+V` - Paste values
 - `Ctrl+Shift+V` - Paste with options (add, multiply, etc.)
 
+## Table File Import/Export (.table)
+
+Individual tables can be saved to and loaded from TunerStudio-compatible
+`.table` files — handy for sharing a single table (a VE table, an ignition
+map, injector dead-times) between projects or with other tuners, without
+touching the rest of the tune.
+
+- **Save Table to File** — the download icon in the table toolbar writes the
+  table's current X/Y axis bins and value grid to a `.table` file.
+- **Load Table from File** — the upload icon reads a `.table` file back into
+  the open table, replacing its axis bins and values.
+
+Notes:
+
+- `.table` files interoperate with TunerStudio's "Save Table to File" /
+  "Load Table from File".
+- The file's dimensions must match the table's **current** size exactly.
+  Unlike TunerStudio, LibreTune does not resample a mismatched grid onto the
+  table's axes — resize (re-bin) the table first if the sizes differ, so a
+  file can never silently apply at the wrong scale.
+- Importing overwrites the table's axis bins and values; the rest of the tune
+  is untouched. Burn to ECU when you're happy with the result.
+
 ## Undo/Redo
 
 - `Ctrl+Z` - Undo last change

--- a/crates/libretune-app/public/manual/features/tools.md
+++ b/crates/libretune-app/public/manual/features/tools.md
@@ -268,6 +268,74 @@ Action Manager captures:
 
 ---
 
+## AFR Delay Test
+
+Automated measurement of your exhaust's transport delay — how long a fuelling
+change takes to show up at the wideband. AutoTune needs this value (its
+"lambda delay") to compare the AFR it reads against the fuel that was actually
+injected at that moment; guessing it too low is a classic cause of
+recommendations that oscillate.
+
+### Overview
+
+The test:
+
+1. Steps one byte of live tune memory — the warm-plateau warmup-enrichment
+   slot — a configurable amount **richer** for a timed hold.
+2. Records the AFR trace through the step and the recovery.
+3. Reports the time from the step to **half the settled excursion** (the
+   median transit time — the transport delay), not the noisy leading edge.
+4. Repeats, accumulating each measurement into an **rpm × load delay map**.
+
+### Opening the AFR Delay Test
+
+1. Connect to the ECU and open a project
+2. **Go to** Tools → **AFR Delay Test…**
+
+### Settings
+
+| Setting | Range | Meaning |
+|---------|-------|---------|
+| Step size | 3–20 % | How much richer the enrichment step makes the mixture |
+| Hold | 500–5000 ms | How long the step is held before restore |
+| Settle | 500–10000 ms | Recovery window sampled after the restore |
+| Repeats | 1–200 steps | Fixed number of steps (single operating point) |
+| Run until stopped | — | Continuous mode; keep driving and let the map fill |
+
+A single step cannot be timed accurately — the step-to-step scatter is larger
+than the response — so the reading only means something once several traces
+are stacked. The overlay draws every step's trace so you can see the scatter
+yourself.
+
+### The Delay Map
+
+Each successful step lands in a bin of the rpm × load table (mean delay and
+sample count per cell). **Run until stopped** is the most useful mode: start
+it before a drive and every steady operating point you pass through adds a
+measurement, so the map fills where you actually drive.
+
+### Safety
+
+- The step can only make the mixture **richer**, never leaner.
+- Changes are written to **live memory only** — nothing is burned, and
+  cycling the key restores the stored tune.
+- The stepped WUE slot is restored after every step and on Stop.
+- The test never touches the throttle — hold the engine steady yourself.
+
+### Interpreting Results
+
+- **"No measurement"** reasons are surfaced per step: an unstable baseline
+  (you moved the throttle), no response (step too small for the noise), or
+  the response not settling within the hold — the dialog will suggest a
+  longer hold when that's the problem.
+- When the map has enough coverage, take a representative value and enter it
+  as AutoTune's fixed lambda delay (see
+  [Setting Up AutoTune](./autotune/setup.md#lambda-delay-compensation)) — the
+  RPM-based default curve tops out around 200 ms, far short of a real
+  exhaust's dead time, which commonly measures 400–1000 ms.
+
+---
+
 ## Reset to Defaults
 
 Quickly reset tune to factory defaults for a clean start.

--- a/crates/libretune-app/public/manual/getting-started/connecting.md
+++ b/crates/libretune-app/public/manual/getting-started/connecting.md
@@ -104,11 +104,16 @@ The status bar shows your connection state:
 If the ECU signature doesn't match your INI file:
 
 1. A dialog will appear with options:
-   - **Search local repository** for matching INI files
-   - **Search online** for INI files (Speeduino/rusEFI GitHub repos)
+   - **Local matches** — INI files from your local repository whose
+     signature matches the ECU
+   - **Online matches** — searched automatically (Speeduino / rusEFI / FOME
+     GitHub repositories) as soon as the mismatch is reported; shown first
+     when no local match exists
    - **Continue anyway** (advanced users only)
-
 2. Select a matching INI file to update your project
+
+Nothing is downloaded or applied until you explicitly click **Download** —
+only the search itself is automatic.
 
 ## Troubleshooting
 

--- a/crates/libretune-app/public/manual/reference/supported-ecus.md
+++ b/crates/libretune-app/public/manual/reference/supported-ecus.md
@@ -72,10 +72,11 @@ LibreTune includes common INI files:
 Search GitHub repositories:
 1. Speeduino official repo
 2. rusEFI official repo
-3. Auto-download matching INI
+3. FOME official repo
+4. Auto-download matching INI
 
 ### Manual Import
-1. **File → Import ECU Definition**
+1. **Settings → ECU Definitions → Import**
 2. Select your INI file
 3. Added to local repository
 

--- a/crates/libretune-app/public/manual/reference/troubleshooting.md
+++ b/crates/libretune-app/public/manual/reference/troubleshooting.md
@@ -134,6 +134,23 @@ off every animation frame.
 4. Confirm wideband is working
 5. Review filter settings
 
+### Recommendations Never Accumulate
+
+**Symptoms**: AutoTune runs and data flows, but hit counts stay at zero or
+climb far slower than the session length suggests.
+
+**Solutions**:
+1. This was a fixed bug — on real hardware the delayed-sample match window
+   was too tight for the stream's actual cadence and silently dropped a
+   third to a half of all samples. Update to a current nightly.
+2. Samples taken during **overrun fuel cut** (lift-off) and **railed wideband
+   readings** (below ~10 or above ~19.5 AFR — sensor at a stop, unpowered
+   heater, or a cut still washing out) are excluded by design; each rejection
+   is named in the diagnostic log, so check which filter is dropping your
+   samples.
+3. If the wideband reads railed while the engine runs, fix the sensor/heater
+   first — those readings carry no mixture information.
+
 ### Erratic Recommendations
 
 **Symptoms**: Values jumping around

--- a/crates/libretune-app/public/manual/technical/README.md
+++ b/crates/libretune-app/public/manual/technical/README.md
@@ -5,22 +5,20 @@ This section provides in-depth technical documentation for LibreTune's core algo
 ## Contents
 
 ### Algorithms
-- **[AutoTune Algorithm](./autotune-algorithm.md)** - Lambda delay compensation, transient filtering, hit weighting, and recommendation calculation
+- **[AutoTune Algorithm](./autotune-algorithm.md)** - Lambda delay compensation, transient and fuel-cut filtering, hit weighting, and recommendation calculation
 - **[Table Operations](./table-operations.md)** - Interpolation, smoothing, scaling, and re-binning algorithms
-- **[Gauge Rendering](./gauge-rendering.md)** - Canvas-based rendering techniques, color spaces, and visual effects
 
 ### Data Formats
 - **[INI Parser](./ini-parser.md)** - ECU definition file parsing, expression evaluation, and validation
-- **[MSQ File Format](./msq-format.md)** - Tune file structure, XML schema, and serialization
-- **[Dashboard Format](./dashboard-format.md)** - TunerStudio-compatible XML format for gauges and layouts
 
 ### Communication
 - **[ECU Protocol](./ecu-protocol.md)** - Binary and text-based communication protocols, command structure, and error handling
-- **[Realtime Streaming](./realtime-streaming.md)** - Event-based data streaming architecture and performance optimization
 
 ### Core Systems
 - **[Version Control](./version-control.md)** - Git integration, tune fingerprinting, and migration detection
 - **[Lua Scripting](./lua-scripting.md)** - Sandboxed runtime, API reference, and security model
+- **[Plugin System](./plugin-system.md)** - WASM plugin host, permissions, and sandboxing
+- **[Port Editor](./port-editor.md)** - Pin assignment UI and conflict detection rules
 - **[AI Assistant](./ai-assistant.md)** - Bring-your-own-LLM agent loop, provider trait, validation extensions
 
 ## Philosophy
@@ -39,16 +37,20 @@ LibreTune's technical implementation follows these principles:
 crates/
 ├── libretune-core/          # Pure Rust library (no UI dependencies)
 │   ├── src/
-│   │   ├── autotune.rs      # AutoTune algorithm implementation
-│   │   ├── ini/             # INI parser and data structures
-│   │   ├── protocol/        # ECU communication protocols
-│   │   ├── table_ops.rs     # Table manipulation algorithms
-│   │   ├── dash/            # Dashboard format parser/writer
-│   │   ├── project/         # Project and version control
-│   │   └── lua/             # Lua scripting runtime
-│   └── tests/               # Unit and integration tests
+│   │   ├── autotune/         # AutoTune algorithms (incl. delay_measure.rs,
+│   │   │                    # the AFR transport-delay step test)
+│   │   ├── ini/              # INI parser and data structures
+│   │   ├── protocol/         # ECU communication protocols
+│   │   ├── table_ops.rs      # Table manipulation algorithms
+│   │   ├── table_file.rs     # TunerStudio .table single-table IO
+│   │   ├── pin_conflict.rs   # Pin conflict scan & gating rules
+│   │   ├── dash/             # Dashboard format parser/writer
+│   │   ├── project/          # Project and version control
+│   │   └── lua/              # Lua scripting runtime
+│   └── tests/                # Unit and integration tests
 └── libretune-app/           # Tauri desktop application
-    ├── src-tauri/           # Rust backend (Tauri commands)
+    ├── src-tauri/           # Rust backend (Tauri commands, one module per
+    │   │                    # topic under src/commands/)
     └── src/                 # React frontend (TypeScript)
 ```
 

--- a/crates/libretune-app/public/manual/technical/autotune-algorithm.md
+++ b/crates/libretune-app/public/manual/technical/autotune-algorithm.md
@@ -25,17 +25,28 @@ pub struct VEDataPoint {
     pub tps: f64,              // Throttle position (0-100%)
     pub tps_rate: f64,         // TPS change rate (%/sec)
     pub accel_enrich_active: Option<bool>,  // ECU acceleration enrichment flag
+    pub fuel_cut_active: Option<bool>,      // Overrun fuel-cut flag (DFCOOn/dfco channels)
     pub timestamp_ms: u64,     // Timestamp for correlation
 }
 ```
 
-**Data Collection Rate**: 100ms (10 Hz) from realtime stream
+**Data Collection Rate**: follows the realtime stream (10 Hz nominal, but
+111–200 ms is common on real hardware where single-shot reads contend with
+the realtime poll for the connection lock).
 
 ### 2. Lambda Delay Compensation
 
 The AFR sensor reading at time T corresponds to fuel injected at time T-Δ, where Δ is the lambda delay.
 
-**Delay Calculation** (RPM-dependent):
+**Delay resolution order** (first match wins):
+
+1. **Fixed measured delay** — `lambda_delay_ms > 0` in settings. This is
+   where a value from the [AFR Delay Test](../features/tools.md) belongs:
+   real exhausts commonly measure 400–1000 ms, far beyond the RPM curve.
+2. **Per-cell delay table** — `reference_tables.lambda_delay_table`
+   (`[row][col]` matching the VE table layout), when present.
+3. **RPM-based fallback curve** (default when nothing is configured):
+
 ```
 delay_ms = 200 - (150 * (rpm - 800) / (6000 - 800))
 ```
@@ -55,11 +66,36 @@ fn get_lambda_delay_ms(rpm: f64) -> u64 {
 }
 ```
 
+**Flow-scaled delay option**: when `lambda_delay_flow_scaled` is set,
+`lambda_delay_ms` anchors the low-flow (idle/cruise) end of a generated
+per-cell table that scales delay down toward `lambda_delay_floor_ms`
+(high-flow asymptote, default 120 ms) as exhaust flow — approximated by
+rpm·load·VE — rises. Transport delay ≈ exhaust-plumbing volume / flow, so
+this models the physics directly instead of using one flat number.
+
+**Correlation buffer sizing** follows whichever delay is in use: the buffer
+holds at least `configured delay + 500 ms` margin, never shrinking below the
+historical 500 ms, so a long measured delay is never starved of history.
+
 **Data Point Correlation**:
 1. Current AFR reading is buffered
 2. Historical data point is found: `timestamp_now - delay_ms`
-3. Historical RPM/MAP determines which VE cell to update
-4. Current AFR is used for correction calculation
+3. The match window is **0.6× the stream's measured mean sample gap**
+   (floored at the historical 50 ms) — with samples every T ms the nearest
+   one to any target is at most T/2 away, so a fixed 50 ms window used to
+   reject a third to a half of all samples on real hardware
+4. Historical RPM/MAP determines which VE cell to update
+5. Current AFR is used for correction calculation
+
+**Samples that carry no mixture information are rejected outright** (each
+with a named reason in the diagnostic log):
+- **Overrun fuel cut** (`fuel_cut_active == true`): injectors off, wideband
+  pinned lean — each such sample would otherwise demand maximum enrichment
+  in exactly the low-load cells every lift passes through.
+- **Railed wideband** (`afr < 10.0 || afr > 19.5`): no running engine
+  sustains those readings — it's the sensor at a stop, an unpowered heater,
+  or a cut still washing out. Also covers fuel cut on ECUs that expose no
+  DFCO channel.
 
 ### 3. Transient Filtering
 

--- a/crates/libretune-app/public/manual/technical/port-editor.md
+++ b/crates/libretune-app/public/manual/technical/port-editor.md
@@ -59,6 +59,22 @@ Pin colors indicate:
 - Displays number of conflicts (if any)
 - Maximum 3 warnings shown; click to expand
 
+### Conflict Detection Rules
+
+The pre-burn pin conflict scan follows these rules:
+
+- **A switched-off feature does not claim its pin.** Many INI pin fields
+  declare the condition under which they apply (e.g. the knock pin only
+  matters when knock detection is enabled). When that condition evaluates
+  false, the pin is treated as unassigned — it neither raises a conflict nor
+  blocks another function from using the pin. An unparseable condition keeps
+  the pin in the scan, because a missed conflict is worse than a spurious
+  one.
+- **"Board Default" is not a pin.** Selectors left on the board-default
+  value don't participate in conflict checks.
+- **Loading a tune is never blocked by pin lint.** Conflicts warn before a
+  burn; they don't stop you opening someone else's tune.
+
 ## Common Configurations
 
 ### 4-Cylinder Engine (Speeduino)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,7 +1,9 @@
 # LibreTune Architecture
 
 This document describes module boundaries and the high-level shape of the
-LibreTune codebase, current as of the Phase 1–8 cleanup pass (April 2026).
+LibreTune codebase. It was originally written at the Phase 1–8 cleanup pass
+(April 2026) and is updated as the codebase evolves (last reviewed August
+2026).
 
 ## Workspace layout
 
@@ -28,8 +30,12 @@ Pure domain logic, no UI, no Tauri, no async runtime in the public API.
 Public modules (post-Phase 7):
 
 - `action_scripting` — Lua-driven controller-command scripts.
+- `agent`, `llm` — AI-assistant orchestrator (tools, context, safety tiers)
+  and the LLM `Provider` trait with native OpenAI/Anthropic/Google
+  implementations over reqwest.
 - `autotune` — VE / AFR / dwell adaptation algorithms; recommendations and
-  authority limits live in `autotune/anomaly.rs` and friends.
+  authority limits live in `autotune/anomaly.rs`, the AFR transport-delay
+  step test in `autotune/delay_measure.rs`.
 - `basemap` — Built-in base-map generation logic.
 - `dash` — TunerStudio-compatible `.dash` / `.gauge` XML format and the
   single canonical dashboard runtime model (`DashFile`, `GaugeCluster`,
@@ -40,18 +46,27 @@ Public modules (post-Phase 7):
 - `ecu` — `EcuMemory`, `Value`, page model.
 - `ini` — INI parser + `EcuDefinition` (`Constant`, `OutputChannel`,
   `TableDefinition`, etc.).
+- `lua` — Sandboxed Lua scripting runtime (used by `action_scripting` and
+  the Lua console/scripting features).
+- `pin_conflict` — Pin conflict scan and gating rules (a switched-off
+  feature does not claim its pin; 'Board Default' is not a pin).
 - `plugin_api`, `plugin_system` — WASM plugin host + plugin-facing API.
   (The legacy Java plugin host has been removed; see Phase 3 in the
   changelog.)
+- `port_editor` — Port/pin assignment model behind the hardware
+  configuration UI.
 - `project` — Project model, repository, online-INI repository.
 - `protocol` — `Connection`, `ConnectionState`, transport abstractions
   (Serial, TCP, in-process simulator).
 - `realtime` — `Evaluator` derived-channel transform (raw output channels +
   `EcuDefinition` → computed channels). Pure transform; not part of the
   streaming/transport stack.
+- `table_file` — TunerStudio `.table` single-table XML reader/writer
+  (per-table import/export).
 - `table_ops` — Table re-binning, smoothing, interpolation, scaling,
   cell-equalize. Pure value-in / value-out helpers.
 - `tune` — `TuneFile`, `TuneCache`, `PageState`, migration.
+- `tune_view` — `.tuneView` format support for TunerStudio project import.
 - `unit_conversion` — Unit conversions used by both UI and analysis.
 
 The `prelude` module re-exports the most commonly used types so callers
@@ -67,7 +82,7 @@ glue:
 - A few shared helpers retained at crate root.
 - `tauri::generate_handler![…]` listing every command.
 
-All command bodies live under `src-tauri/src/commands/` (72 files). Each
+All command bodies live under `src-tauri/src/commands/` (~80 files). Each
 file owns a coherent slice of functionality, e.g.:
 
 - `connection.rs`, `metrics.rs`, `realtime_get.rs` — connection lifecycle
@@ -76,8 +91,11 @@ file owns a coherent slice of functionality, e.g.:
   templates, and import.
 - `tune_io.rs`, `tune_info.rs`, `tune_misc.rs`, `tune_health.rs`,
   `tune_migration.rs` — tune persistence, diffing, migration.
-- `table_ops.rs`, `table_compare.rs`, `csv_io.rs` — table editing
-  Tauri wrappers.
+- `table_ops.rs`, `table_compare.rs`, `csv_io.rs`, `table_file_io.rs` —
+  table editing Tauri wrappers (including per-table `.table` file
+  import/export).
+- `pin_conflicts.rs` — pre-burn pin conflict scan with feature-enable
+  gating.
 - `autotune_*.rs`, `base_map.rs`, `adaptive_timing.rs` — tuning
   primitives.
 - `settings.rs`, `hotkeys.rs`, `restore_points.rs` — user-facing settings

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,6 +43,10 @@ Public modules (post-Phase 7):
   validation, built-in templates).
 - `datalog` — Streaming log writer.
 - `demo` — Synthetic ECU for offline / demo mode.
+- `dynamic_table` — TunerStudio-style dynamically sized (resizable) tables:
+  resolves the active row/col counts from tune scalars, enforces the INI's
+  min/max and cell budget (`maximumElements`), and packs values row-major
+  with stride = current columns inside the fixed allocation.
 - `ecu` — `EcuMemory`, `Value`, page model.
 - `ini` — INI parser + `EcuDefinition` (`Constant`, `OutputChannel`,
   `TableDefinition`, etc.).

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -44,8 +44,10 @@ All notable changes to LibreTune will be documented in this file.
 - FOME fast comms with intelligent fallback for optimized console communication
 - Dashboard tab protection (cannot be accidentally closed; recoverable via View → Dashboard)
 - Configurable status bar channels (Settings → Status Bar Channels, max 8)
-- INI signature mismatch dialog with local and online INI search
-- Online INI repository search from Speeduino and rusEFI GitHub repos
+- INI signature mismatch dialog with local and online INI search (the online search now runs automatically when a mismatch is reported; downloading still requires an explicit click)
+- Online INI repository search from Speeduino, rusEFI, and FOME GitHub repos
+- Per-table `.table` file import/export (TunerStudio-compatible "Save/Load Table to File" from the table toolbar)
+- AFR Delay Test (Tools → AFR Delay Test…) — automated exhaust transport-delay measurement that steps fuel and reports the delay to enter as AutoTune's lambda delay
 - Resilient ECU sync with partial failure handling and status bar indicator
 - CSV export/import for tune data
 - Reset tune to defaults
@@ -69,6 +71,14 @@ All notable changes to LibreTune will be documented in this file.
 - Java/JVM plugin system UI (deprecated; see DEPRECATION_NOTICE.md)
 
 ### Fixed
+- AutoTune no longer drops a third to a half of its samples on real hardware (delayed-sample match window now follows the stream's cadence), and excludes overrun fuel-cut and railed wideband readings
+- AFR delay test reports the median (half-excursion) transport delay instead of the noisy leading edge, refuses to run twice concurrently, and draws the settle/recovery window
+- Pin conflict scan ignores pins held only by switched-off features, treats "Board Default" as unassigned, and no longer blocks loading a tune
+- Dialog rendering fidelity: fields with an enable condition are disabled (not hidden), command-button / indicator-panel labels and dynamic units are evaluated instead of showing raw expressions, indicator panels without an explicit column count render correctly
+- Sidebar highlights the currently open item in the project tree
+- Table editor: Interpolate shortcut no longer steals focus to the search box; Y-axis labels visible on tables with more than 12 rows
+- Dashboard drag-and-drop works inside the Tauri webview
+- Settings dialog HotkeyEditor infinite re-render loop
 - Table operations (scale, smooth, interpolate, set equal, rebin) now properly connected to backend
 - AutoTune table lookup for rusEFI/epicEFI INIs (veTable1Map → veTable1Tbl resolution)
 - Realtime stream lock contention from get_all_constant_values blocking serial connection

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -7,7 +7,7 @@ Thank you for your interest in contributing to LibreTune!
 ### Prerequisites
 
 - [Rust](https://rustup.rs/) (stable toolchain)
-- [Node.js](https://nodejs.org/) 18+ and npm
+- [Node.js](https://nodejs.org/) 20+ (required by Vite 7) and npm
 - [Tauri CLI](https://tauri.app/start/prerequisites/)
 
 ### Clone the Repository

--- a/docs/src/features/autotune/setup.md
+++ b/docs/src/features/autotune/setup.md
@@ -103,6 +103,14 @@ Engine exhaust takes time to reach the O2 sensor. AutoTune compensates:
 - **At redline**: ~50ms delay (fast exhaust flow)
 - LibreTune interpolates between these values
 
+The default curve tops out around 200 ms, but a real exhaust's dead time is
+commonly 400–1000 ms. For best results, measure your car with the
+[AFR Delay Test](../tools.md) (Tools → AFR Delay Test…) and enter the
+measured value as the fixed lambda delay in the AutoTune settings. A
+flow-scaled option is also available: it anchors the delay at idle/cruise
+and shortens it toward a floor as exhaust flow rises, modelling the physics
+(exhaust volume ÷ flow) instead of using one flat number.
+
 ## Best Practices
 
 1. **Start conservative** with low authority limits

--- a/docs/src/features/table-editing.md
+++ b/docs/src/features/table-editing.md
@@ -88,6 +88,29 @@ Changes the axis values and interpolates Z values automatically. Useful for adju
 - `Ctrl+V` - Paste values
 - `Ctrl+Shift+V` - Paste with options (add, multiply, etc.)
 
+## Table File Import/Export (.table)
+
+Individual tables can be saved to and loaded from TunerStudio-compatible
+`.table` files — handy for sharing a single table (a VE table, an ignition
+map, injector dead-times) between projects or with other tuners, without
+touching the rest of the tune.
+
+- **Save Table to File** — the download icon in the table toolbar writes the
+  table's current X/Y axis bins and value grid to a `.table` file.
+- **Load Table from File** — the upload icon reads a `.table` file back into
+  the open table, replacing its axis bins and values.
+
+Notes:
+
+- `.table` files interoperate with TunerStudio's "Save Table to File" /
+  "Load Table from File".
+- The file's dimensions must match the table's **current** size exactly.
+  Unlike TunerStudio, LibreTune does not resample a mismatched grid onto the
+  table's axes — resize (re-bin) the table first if the sizes differ, so a
+  file can never silently apply at the wrong scale.
+- Importing overwrites the table's axis bins and values; the rest of the tune
+  is untouched. Burn to ECU when you're happy with the result.
+
 ## Undo/Redo
 
 - `Ctrl+Z` - Undo last change

--- a/docs/src/features/tools.md
+++ b/docs/src/features/tools.md
@@ -268,6 +268,74 @@ Action Manager captures:
 
 ---
 
+## AFR Delay Test
+
+Automated measurement of your exhaust's transport delay — how long a fuelling
+change takes to show up at the wideband. AutoTune needs this value (its
+"lambda delay") to compare the AFR it reads against the fuel that was actually
+injected at that moment; guessing it too low is a classic cause of
+recommendations that oscillate.
+
+### Overview
+
+The test:
+
+1. Steps one byte of live tune memory — the warm-plateau warmup-enrichment
+   slot — a configurable amount **richer** for a timed hold.
+2. Records the AFR trace through the step and the recovery.
+3. Reports the time from the step to **half the settled excursion** (the
+   median transit time — the transport delay), not the noisy leading edge.
+4. Repeats, accumulating each measurement into an **rpm × load delay map**.
+
+### Opening the AFR Delay Test
+
+1. Connect to the ECU and open a project
+2. **Go to** Tools → **AFR Delay Test…**
+
+### Settings
+
+| Setting | Range | Meaning |
+|---------|-------|---------|
+| Step size | 3–20 % | How much richer the enrichment step makes the mixture |
+| Hold | 500–5000 ms | How long the step is held before restore |
+| Settle | 500–10000 ms | Recovery window sampled after the restore |
+| Repeats | 1–200 steps | Fixed number of steps (single operating point) |
+| Run until stopped | — | Continuous mode; keep driving and let the map fill |
+
+A single step cannot be timed accurately — the step-to-step scatter is larger
+than the response — so the reading only means something once several traces
+are stacked. The overlay draws every step's trace so you can see the scatter
+yourself.
+
+### The Delay Map
+
+Each successful step lands in a bin of the rpm × load table (mean delay and
+sample count per cell). **Run until stopped** is the most useful mode: start
+it before a drive and every steady operating point you pass through adds a
+measurement, so the map fills where you actually drive.
+
+### Safety
+
+- The step can only make the mixture **richer**, never leaner.
+- Changes are written to **live memory only** — nothing is burned, and
+  cycling the key restores the stored tune.
+- The stepped WUE slot is restored after every step and on Stop.
+- The test never touches the throttle — hold the engine steady yourself.
+
+### Interpreting Results
+
+- **"No measurement"** reasons are surfaced per step: an unstable baseline
+  (you moved the throttle), no response (step too small for the noise), or
+  the response not settling within the hold — the dialog will suggest a
+  longer hold when that's the problem.
+- When the map has enough coverage, take a representative value and enter it
+  as AutoTune's fixed lambda delay (see
+  [Setting Up AutoTune](./autotune/setup.md#lambda-delay-compensation)) — the
+  RPM-based default curve tops out around 200 ms, far short of a real
+  exhaust's dead time, which commonly measures 400–1000 ms.
+
+---
+
 ## Reset to Defaults
 
 Quickly reset tune to factory defaults for a clean start.

--- a/docs/src/getting-started/connecting.md
+++ b/docs/src/getting-started/connecting.md
@@ -104,11 +104,16 @@ The status bar shows your connection state:
 If the ECU signature doesn't match your INI file:
 
 1. A dialog will appear with options:
-   - **Search local repository** for matching INI files
-   - **Search online** for INI files (Speeduino/rusEFI GitHub repos)
+   - **Local matches** — INI files from your local repository whose
+     signature matches the ECU
+   - **Online matches** — searched automatically (Speeduino / rusEFI / FOME
+     GitHub repositories) as soon as the mismatch is reported; shown first
+     when no local match exists
    - **Continue anyway** (advanced users only)
-
 2. Select a matching INI file to update your project
+
+Nothing is downloaded or applied until you explicitly click **Download** —
+only the search itself is automatic.
 
 ## Troubleshooting
 

--- a/docs/src/reference/supported-ecus.md
+++ b/docs/src/reference/supported-ecus.md
@@ -72,10 +72,11 @@ LibreTune includes common INI files:
 Search GitHub repositories:
 1. Speeduino official repo
 2. rusEFI official repo
-3. Auto-download matching INI
+3. FOME official repo
+4. Auto-download matching INI
 
 ### Manual Import
-1. **File → Import ECU Definition**
+1. **Settings → ECU Definitions → Import**
 2. Select your INI file
 3. Added to local repository
 

--- a/docs/src/reference/troubleshooting.md
+++ b/docs/src/reference/troubleshooting.md
@@ -134,6 +134,23 @@ off every animation frame.
 4. Confirm wideband is working
 5. Review filter settings
 
+### Recommendations Never Accumulate
+
+**Symptoms**: AutoTune runs and data flows, but hit counts stay at zero or
+climb far slower than the session length suggests.
+
+**Solutions**:
+1. This was a fixed bug — on real hardware the delayed-sample match window
+   was too tight for the stream's actual cadence and silently dropped a
+   third to a half of all samples. Update to a current nightly.
+2. Samples taken during **overrun fuel cut** (lift-off) and **railed wideband
+   readings** (below ~10 or above ~19.5 AFR — sensor at a stop, unpowered
+   heater, or a cut still washing out) are excluded by design; each rejection
+   is named in the diagnostic log, so check which filter is dropping your
+   samples.
+3. If the wideband reads railed while the engine runs, fix the sensor/heater
+   first — those readings carry no mixture information.
+
 ### Erratic Recommendations
 
 **Symptoms**: Values jumping around

--- a/docs/src/technical/README.md
+++ b/docs/src/technical/README.md
@@ -5,22 +5,20 @@ This section provides in-depth technical documentation for LibreTune's core algo
 ## Contents
 
 ### Algorithms
-- **[AutoTune Algorithm](./autotune-algorithm.md)** - Lambda delay compensation, transient filtering, hit weighting, and recommendation calculation
+- **[AutoTune Algorithm](./autotune-algorithm.md)** - Lambda delay compensation, transient and fuel-cut filtering, hit weighting, and recommendation calculation
 - **[Table Operations](./table-operations.md)** - Interpolation, smoothing, scaling, and re-binning algorithms
-- **[Gauge Rendering](./gauge-rendering.md)** - Canvas-based rendering techniques, color spaces, and visual effects
 
 ### Data Formats
 - **[INI Parser](./ini-parser.md)** - ECU definition file parsing, expression evaluation, and validation
-- **[MSQ File Format](./msq-format.md)** - Tune file structure, XML schema, and serialization
-- **[Dashboard Format](./dashboard-format.md)** - TunerStudio-compatible XML format for gauges and layouts
 
 ### Communication
 - **[ECU Protocol](./ecu-protocol.md)** - Binary and text-based communication protocols, command structure, and error handling
-- **[Realtime Streaming](./realtime-streaming.md)** - Event-based data streaming architecture and performance optimization
 
 ### Core Systems
 - **[Version Control](./version-control.md)** - Git integration, tune fingerprinting, and migration detection
 - **[Lua Scripting](./lua-scripting.md)** - Sandboxed runtime, API reference, and security model
+- **[Plugin System](./plugin-system.md)** - WASM plugin host, permissions, and sandboxing
+- **[Port Editor](./port-editor.md)** - Pin assignment UI and conflict detection rules
 - **[AI Assistant](./ai-assistant.md)** - Bring-your-own-LLM agent loop, provider trait, validation extensions
 
 ## Philosophy
@@ -39,16 +37,20 @@ LibreTune's technical implementation follows these principles:
 crates/
 ├── libretune-core/          # Pure Rust library (no UI dependencies)
 │   ├── src/
-│   │   ├── autotune.rs      # AutoTune algorithm implementation
-│   │   ├── ini/             # INI parser and data structures
-│   │   ├── protocol/        # ECU communication protocols
-│   │   ├── table_ops.rs     # Table manipulation algorithms
-│   │   ├── dash/            # Dashboard format parser/writer
-│   │   ├── project/         # Project and version control
-│   │   └── lua/             # Lua scripting runtime
-│   └── tests/               # Unit and integration tests
+│   │   ├── autotune/         # AutoTune algorithms (incl. delay_measure.rs,
+│   │   │                    # the AFR transport-delay step test)
+│   │   ├── ini/              # INI parser and data structures
+│   │   ├── protocol/         # ECU communication protocols
+│   │   ├── table_ops.rs      # Table manipulation algorithms
+│   │   ├── table_file.rs     # TunerStudio .table single-table IO
+│   │   ├── pin_conflict.rs   # Pin conflict scan & gating rules
+│   │   ├── dash/             # Dashboard format parser/writer
+│   │   ├── project/          # Project and version control
+│   │   └── lua/              # Lua scripting runtime
+│   └── tests/                # Unit and integration tests
 └── libretune-app/           # Tauri desktop application
-    ├── src-tauri/           # Rust backend (Tauri commands)
+    ├── src-tauri/           # Rust backend (Tauri commands, one module per
+    │   │                    # topic under src/commands/)
     └── src/                 # React frontend (TypeScript)
 ```
 

--- a/docs/src/technical/autotune-algorithm.md
+++ b/docs/src/technical/autotune-algorithm.md
@@ -25,17 +25,28 @@ pub struct VEDataPoint {
     pub tps: f64,              // Throttle position (0-100%)
     pub tps_rate: f64,         // TPS change rate (%/sec)
     pub accel_enrich_active: Option<bool>,  // ECU acceleration enrichment flag
+    pub fuel_cut_active: Option<bool>,      // Overrun fuel-cut flag (DFCOOn/dfco channels)
     pub timestamp_ms: u64,     // Timestamp for correlation
 }
 ```
 
-**Data Collection Rate**: 100ms (10 Hz) from realtime stream
+**Data Collection Rate**: follows the realtime stream (10 Hz nominal, but
+111–200 ms is common on real hardware where single-shot reads contend with
+the realtime poll for the connection lock).
 
 ### 2. Lambda Delay Compensation
 
 The AFR sensor reading at time T corresponds to fuel injected at time T-Δ, where Δ is the lambda delay.
 
-**Delay Calculation** (RPM-dependent):
+**Delay resolution order** (first match wins):
+
+1. **Fixed measured delay** — `lambda_delay_ms > 0` in settings. This is
+   where a value from the [AFR Delay Test](../features/tools.md) belongs:
+   real exhausts commonly measure 400–1000 ms, far beyond the RPM curve.
+2. **Per-cell delay table** — `reference_tables.lambda_delay_table`
+   (`[row][col]` matching the VE table layout), when present.
+3. **RPM-based fallback curve** (default when nothing is configured):
+
 ```
 delay_ms = 200 - (150 * (rpm - 800) / (6000 - 800))
 ```
@@ -55,11 +66,36 @@ fn get_lambda_delay_ms(rpm: f64) -> u64 {
 }
 ```
 
+**Flow-scaled delay option**: when `lambda_delay_flow_scaled` is set,
+`lambda_delay_ms` anchors the low-flow (idle/cruise) end of a generated
+per-cell table that scales delay down toward `lambda_delay_floor_ms`
+(high-flow asymptote, default 120 ms) as exhaust flow — approximated by
+rpm·load·VE — rises. Transport delay ≈ exhaust-plumbing volume / flow, so
+this models the physics directly instead of using one flat number.
+
+**Correlation buffer sizing** follows whichever delay is in use: the buffer
+holds at least `configured delay + 500 ms` margin, never shrinking below the
+historical 500 ms, so a long measured delay is never starved of history.
+
 **Data Point Correlation**:
 1. Current AFR reading is buffered
 2. Historical data point is found: `timestamp_now - delay_ms`
-3. Historical RPM/MAP determines which VE cell to update
-4. Current AFR is used for correction calculation
+3. The match window is **0.6× the stream's measured mean sample gap**
+   (floored at the historical 50 ms) — with samples every T ms the nearest
+   one to any target is at most T/2 away, so a fixed 50 ms window used to
+   reject a third to a half of all samples on real hardware
+4. Historical RPM/MAP determines which VE cell to update
+5. Current AFR is used for correction calculation
+
+**Samples that carry no mixture information are rejected outright** (each
+with a named reason in the diagnostic log):
+- **Overrun fuel cut** (`fuel_cut_active == true`): injectors off, wideband
+  pinned lean — each such sample would otherwise demand maximum enrichment
+  in exactly the low-load cells every lift passes through.
+- **Railed wideband** (`afr < 10.0 || afr > 19.5`): no running engine
+  sustains those readings — it's the sensor at a stop, an unpowered heater,
+  or a cut still washing out. Also covers fuel cut on ECUs that expose no
+  DFCO channel.
 
 ### 3. Transient Filtering
 

--- a/docs/src/technical/port-editor.md
+++ b/docs/src/technical/port-editor.md
@@ -59,6 +59,22 @@ Pin colors indicate:
 - Displays number of conflicts (if any)
 - Maximum 3 warnings shown; click to expand
 
+### Conflict Detection Rules
+
+The pre-burn pin conflict scan follows these rules:
+
+- **A switched-off feature does not claim its pin.** Many INI pin fields
+  declare the condition under which they apply (e.g. the knock pin only
+  matters when knock detection is enabled). When that condition evaluates
+  false, the pin is treated as unassigned — it neither raises a conflict nor
+  blocks another function from using the pin. An unparseable condition keeps
+  the pin in the scan, because a missed conflict is worse than a spurious
+  one.
+- **"Board Default" is not a pin.** Selectors left on the board-default
+  value don't participate in conflict checks.
+- **Loading a tune is never blocked by pin lint.** Conflicts warn before a
+  burn; they don't stop you opening someone else's tune.
+
 ## Common Configurations
 
 ### 4-Cylinder Engine (Speeduino)


### PR DESCRIPTION
# Documentation sync — Aug 2026

Aligns all documentation surfaces with the current state of `main` (through #236): the Aug 19–21 merge window had no CHANGELOG entries, several new features were entirely undocumented, and a few docs referenced things that no longer exist.

## CHANGELOG.md

- Adds a `2026-08-20` block covering PRs #218–#236 (23 commits):
  - **Added** — per-table `.table` import/export, auto online INI search on signature mismatch, INI xAxis layout hint, and the previously-unchangelogged AFR Delay Test tool
  - **Fixed** — AutoTune dropping ⅓–½ of samples (fixed 50 ms match window vs. 111–200 ms real stream cadence), overrun fuel-cut / railed-wideband exclusion, AFR delay test half-excursion (median) measurement + concurrency guard, pin-lint gating (switched-off features don't claim pins), the dialog rendering fidelity pass, sidebar highlight, table editor fixes, Tauri drag-drop, HotkeyEditor re-render loop, INI parser fixes
  - **Changed** — CI modernization (lean gated flow, reusable composite actions)

## User manual (`docs/src/` + regenerated `public/manual/`)

- **`features/tools.md`** — new **AFR Delay Test** section (was undocumented): settings table, rpm × load delay map, safety model, interpreting results
- **`features/table-editing.md`** — new "Table File Import/Export (.table)" section (toolbar buttons, exact-dimension requirement)
- **`getting-started/connecting.md`** — signature mismatch dialog now auto-searches online; download remains explicit
- **`technical/autotune-algorithm.md`** — lambda delay section rewritten to match the code: resolution order (fixed measured → per-cell table → RPM curve), flow-scaled option, cadence-based match window, `fuel_cut_active`, AFR rail constants
- **`features/autotune/setup.md`** — points to the AFR Delay Test for measuring lambda delay
- **`technical/port-editor.md`** — new "Conflict Detection Rules" (feature-enable gating, 'Board Default', load not blocked)
- **`technical/README.md`** — removed 4 links to pages that never existed (`gauge-rendering.md`, `msq-format.md`, `dashboard-format.md`, `realtime-streaming.md`); added plugin-system / port-editor listings
- **`reference/supported-ecus.md`** — FOME added to online sources; stale "File → Import ECU Definition" corrected to Settings → ECU Definitions
- **`reference/troubleshooting.md`** — new "Recommendations Never Accumulate" entry (fixed bug + by-design exclusions)
- **`docs/src/changelog.md`** — user-facing Added/Fixed entries for the same window

## Root docs

- **`AGENTS.md`** — stale `autotune.rs` path fixed (now module dir), leftover `/home/pat/...` path removed, nonexistent `npm run lint` removed, "100 ms polling" corrected to event-based streaming, rusEFI console task marked complete, new Recent Changes block
- **`docs/architecture.md`** — module list completed (`agent`, `llm`, `lua`, `pin_conflict`, `table_file`, `tune_view`, `dynamic_table`), command count 72 → ~80, `table_file_io.rs` / `pin_conflicts.rs` noted, datestamp refreshed
- **`README.md`** — `.table` IO, FOME online source, AutoTune exclusions/delay test, command count
- **`CONTRIBUTING.md`** — Node.js 18+ → 20+ (Vite 7 requires ≥20.19)
- **`crates/libretune-app/AGENTS.md`** — Feb 9 stub replaced with an accurate crate-level guide (layout, npm scripts, docs-sync warning, frontend conventions)

Docs-only change; no code touched. `npm run docs:sync` re-run after the `docs/src/` edits so `public/manual/` matches.
