### PR TITLE
feat(alphan): expose Control Algorithm, auto-detect TPS load, rejection indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,49 @@ relevant.
 
 ## [Unreleased]
 
+### 2026-08-21 — Alpha-N / ITB: Control Algorithm field, AutoTune auto-detect, rejection indicator
+
+Closes the remaining gaps from #132 (the PR #162 follow-up): an ITB/Alpha-N
+user could not select the fuel algorithm anywhere, AutoTune could not
+auto-detect a TPS load source on Speeduino, changing the algorithm did not
+re-scale the load axis, and a filter-rejected session was indistinguishable
+from a broken one.
+
+#### Added
+- **Control Algorithm selector in Engine Constants.** The Speeduino `algorithm`
+  constant (MAP / TPS / IMAP-EMAP) is carried by TunerStudio's built-in
+  `std_injection` panel and never declared as an INI dialog field, so it was
+  unreachable in LibreTune's entire UI. `EcuDefinition::std_panel_definition`
+  now synthesizes it first (plus `twoStroke` / `engineType`, which the INI
+  also never declares), rendered as a dropdown; MS2/MS3 (Alpha-N = 1 there
+  too) gain it for free via the existing per-INI candidate skipping.
+- **Changing the fuel algorithm now re-scales load axes immediately.**
+  `update_constant` re-runs the expression-scale resolution when the edited
+  constant feeds a scale/translate expression — directly or through an
+  output-channel helper (`algorithm` → `fuelLoadRes` → the VE load-axis
+  scale, detected by the new `EcuDefinition::constant_feeds_dynamic_scale`).
+  When scales actually change, `tune:loaded` ("scales-resolved") refreshes
+  open tables and dialogs. Previously the axis kept the old factor until the
+  next full sync.
+- **AutoTune auto-detects TPS load on Speeduino.** The VE load-axis channel is
+  named `fuelLoad` regardless of fuel algorithm, so PR #162's channel-name
+  detection could never fire. `start_autotune` (and the AutoTune view's
+  auto-detect) now fall back to the `algorithm` constant: 1 = TPS/Alpha-N
+  selects the throttle load source. A manual choice in the dropdown is never
+  overridden (new `manualLoadSourceRef` guard on both detection effects).
+- **Rejection indicator.** `AutoTuneState` counts rejected samples per filter
+  reason; `get_autotune_status` exposes accepted/rejected tallies and the
+  AutoTune header shows them while running (warning-styled when nothing gets
+  through, hover for the full tally). A session that accepts everything no
+  longer looks identical to one whose filters discard every sample.
+
+#### Changed
+- **`max_tps_rate` default 10 → 50 %/s** (core + AutoTune view). Individual
+  throttle bodies snap far faster than 10 %/s, so the old default rejected
+  nearly every sample on Alpha-N cars and AutoTune looked dead. Genuine accel
+  transients are still caught by `exclude_accel_enrich`. Existing persisted
+  settings keep their stored value.
+
 ### 2026-08-18 — Spark generator: combustion chamber & boost (psi)
 
 #### Added

--- a/crates/libretune-app/public/manual/features/autotune/usage-guide.md
+++ b/crates/libretune-app/public/manual/features/autotune/usage-guide.md
@@ -52,11 +52,14 @@ Target AFR: 14.7 (gasoline stoich)
 Algorithm: Simple (recommended for beginners)
 ```
 
-**Load Source (MAP vs MAF)**
+**Load Source (MAP vs MAF vs TPS)**
 - **MAP (Speed Density)**: Default for VE tables
 - **MAF**: Use for mass-airflow based tables
-- If the table load axis reports MAF, AutoTune auto-switches to **MAF**
+- **TPS (Alpha-N / ITB)**: Use when the VE table's load axis is throttle position — individual-throttle-body (ITB) / Alpha-N setups
+- If the table load axis reports a throttle channel, AutoTune auto-switches to **TPS**; if it reports MAF, to **MAF**
+- On Speeduino the load-axis channel is named `fuelLoad` regardless of fuel algorithm, so AutoTune also reads the **Control Algorithm** constant (Engine Constants → Injection Setup): `TPS` selects the throttle load source automatically. Setting that constant to `MAP`/`TPS` also re-scales the load axis immediately (0–100 % in Alpha-N mode)
 - If no MAF channel is detected, AutoTune falls back to **MAP** and shows a hint
+- Selecting a load source never changes the axis values you see — bins always come from your tune. It only controls which live channel is used to attribute data to cells
 
 **Step 4: Set Authority Limits**
 For your FIRST session ever with this tune:
@@ -73,6 +76,11 @@ Default filters work for most cases. Only adjust if:
 - Your car idles rough: Raise Min RPM to 1200
 - You're tuning a diesel: Adjust temp filters significantly
 - You do a track day: Lower Min TPS to 0 for coast-down testing
+- ITB / Alpha-N setup: The default Max TPS Rate (50 %/s) already accounts for fast individual throttles; genuine accel transients are still excluded separately
+
+**While running — the sample indicator**
+
+While the session runs, a small indicator under the title row shows how many samples passed the filters and, when data is being rejected, which filter is eating it (most frequent reason first; hover for the full tally). **If AutoTune looks like nothing is happening, check this first** — `0 samples accepted` with rejections counting up means the filters (usually Min CLT while warming up, or Max TPS Rate) are discarding everything.
 
 **Step 6: Click Start**
 - AutoTune begins listening to wideband sensor
@@ -294,6 +302,22 @@ Compare before/after values
 4. Loosen filters: Lower Min RPM, Min TPS
 5. Verify ECU is receiving AFR channel
 ```
+
+**Check the sample indicator first.** While running, the indicator under the
+title row (e.g. `132 samples accepted · 400× clt below min_clt · …`, hover for
+the full tally) says exactly which filter is discarding your data:
+
+| Rejection reason | Meaning | Fix |
+|---|---|---|
+| `clt below min_clt` | Engine still warming up | Wait for full operating temp, or lower Min CLT |
+| `tps_rate above max_tps_rate` | Throttle moving too fast | Raise Max TPS Rate (ITBs need 50+ %/s) |
+| `rpm out of range` | Outside Min/Max RPM window | Adjust the RPM filter bounds |
+| `afr at sensor rail` | Wideband railed (< 10.0 or > 19.5) | Fix the sensor / its wiring; a cut or dead sensor reads full lean |
+| `overrun fuel cut` | Deceleration fuel cut active | Normal — keep out of the table on purpose |
+| `accel enrichment active` | Acceleration enrichment engaged | Normal — transient data is not VE data |
+
+If the indicator shows samples accepted but the heat map stays empty, the
+engine has not crossed those cells yet — keep driving.
 
 ### All Cells Show Blue (Very Lean)
 

--- a/crates/libretune-app/src-tauri/src/commands/autotune_misc.rs
+++ b/crates/libretune-app/src-tauri/src/commands/autotune_misc.rs
@@ -81,6 +81,20 @@ pub struct AutotuneStatus {
     pub running: bool,
     pub table_name: Option<String>,
     pub secondary_table_name: Option<String>,
+    /// Samples that passed the filters this session. When this stays at 0
+    /// while the stream runs, the session looks dead — pair it with
+    /// `rejections` to say why (issue #132).
+    pub accepted_samples: u64,
+    /// Filter rejections this session, most frequent reason first.
+    pub rejections: Vec<AutotuneRejectionCount>,
+}
+
+/// One row of the rejection tally exposed by [`AutotuneStatus`].
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AutotuneRejectionCount {
+    pub reason: String,
+    pub count: u64,
 }
 
 #[tauri::command]
@@ -88,16 +102,32 @@ pub async fn get_autotune_status(
     state: tauri::State<'_, AppState>,
 ) -> Result<AutotuneStatus, String> {
     let config_guard = state.autotune_config.lock().await;
+    // Sample tallies come from the live state, not the config, so the
+    // indicator keeps updating while the session runs.
+    let state_guard = state.autotune_state.lock().await;
+    let rejections = state_guard
+        .rejection_counts()
+        .into_iter()
+        .map(|(reason, count)| AutotuneRejectionCount {
+            reason: reason.to_string(),
+            count,
+        })
+        .collect();
+    let accepted_samples = state_guard.total_samples();
     Ok(match config_guard.as_ref() {
         Some(config) => AutotuneStatus {
             running: true,
             table_name: Some(config.table_name.clone()),
             secondary_table_name: config.secondary_table_name.clone(),
+            accepted_samples,
+            rejections,
         },
         None => AutotuneStatus {
             running: false,
             table_name: None,
             secondary_table_name: None,
+            accepted_samples,
+            rejections,
         },
     })
 }

--- a/crates/libretune-app/src-tauri/src/commands/constant_update.rs
+++ b/crates/libretune-app/src-tauri/src/commands/constant_update.rs
@@ -1,10 +1,60 @@
 //! Update constant value command.
 
 use crate::AppState;
+use tauri::Emitter;
 
 #[tauri::command]
 pub async fn update_constant(
     state: tauri::State<'_, AppState>,
+    app: tauri::AppHandle,
+    name: String,
+    value: f64,
+) -> Result<(), String> {
+    update_constant_internal(&state, name.clone(), value).await?;
+
+    // Re-resolve `{expression}`-valued scale/translate fields when the edited
+    // constant feeds one (Speeduino: `algorithm` → `fuelLoadRes` → the VE
+    // load-axis scale). Runs after the internal write has returned, so none
+    // of its guards are held here.
+    resolve_scales_if_needed(&app, &state, &name).await;
+
+    Ok(())
+}
+
+/// Re-resolve `{expression}`-valued scale/translate fields if the just-edited
+/// constant feeds one, and tell the frontend when scales actually changed.
+///
+/// Speeduino's load axes scale by `{fuelLoadRes}`, which is
+/// `((algorithm == 0) || (algorithm == 2)) ? 2.000 : 0.500`: switching the
+/// fuel algorithm (MAP → TPS for Alpha-N / ITB setups) must re-scale the VE
+/// table's load axis immediately, or tables keep rendering with the old
+/// factor until the next full sync (issue #132).
+///
+/// Must run with no guards held: `resolve_scales_from_tune` locks the
+/// definition and tune state itself.
+async fn resolve_scales_if_needed(app: &tauri::AppHandle, state: &AppState, name: &str) {
+    let feeds_dynamic_scale = {
+        let def_guard = state.definition.lock().await;
+        let Some(def) = def_guard.as_ref() else {
+            return;
+        };
+        def.constant_feeds_dynamic_scale(name)
+    };
+    if !feeds_dynamic_scale {
+        return;
+    }
+
+    let resolved = crate::commands::load_tune::resolve_scales_from_tune(state).await;
+    if resolved > 0 {
+        // Axis scales changed: open tables and dialogs must re-read their
+        // bins. `tune:loaded` is the established refresh signal (consumed by
+        // refreshOpenTabs in App.tsx and PanelComponents' reload tick).
+        let _ = app.emit("tune:loaded", "scales-resolved");
+    }
+}
+
+pub(crate) async fn update_constant_internal(
+    state: &AppState,
     name: String,
     value: f64,
 ) -> Result<(), String> {
@@ -29,7 +79,7 @@ pub async fn update_constant(
 
     // Block assigning a pin that another output already uses (rusEFI Settings Error).
     if constant.data_type == libretune_core::ini::DataType::Bits {
-        crate::commands::pin_conflicts::deny_if_pin_conflict(&state, &name, value).await?;
+        crate::commands::pin_conflicts::deny_if_pin_conflict(state, &name, value).await?;
     }
 
     let mut conn_guard = state.connection.lock().await;

--- a/crates/libretune-app/src-tauri/src/commands/load_tune.rs
+++ b/crates/libretune-app/src-tauri/src/commands/load_tune.rs
@@ -15,21 +15,23 @@ use tauri::Emitter;
 /// `algorithm` constant — unknowable while parsing the INI, so the field falls
 /// back to 1.0 and every load axis renders in raw storage units (8-50 instead
 /// of 16-100 kPa), which also mis-bins anything that looks a cell up by load.
-/// Run after the cache has been populated from the tune.
-pub(crate) async fn resolve_scales_from_tune(state: &AppState) {
+/// Run after the cache has been populated from the tune. Returns the number
+/// of scale/translate fields updated, so callers can refresh open tables only
+/// when something actually changed.
+pub(crate) async fn resolve_scales_from_tune(state: &AppState) -> usize {
     // Read values under an immutable borrow, then re-lock mutably to apply —
     // the definition mutex cannot be held both ways at once.
     let values = {
         let def_guard = state.definition.lock().await;
         let Some(def) = def_guard.as_ref() else {
-            return;
+            return 0;
         };
         if !def
             .constants
             .values()
             .any(|c| c.scale_expr.is_some() || c.translate_expr.is_some())
         {
-            return; // nothing deferred in this INI
+            return 0; // nothing deferred in this INI
         }
         let endianness = def.endianness;
         let cache_guard = state.tune_cache.lock().await;
@@ -59,6 +61,9 @@ pub(crate) async fn resolve_scales_from_tune(state: &AppState) {
                 n
             );
         }
+        n
+    } else {
+        0
     }
 }
 

--- a/crates/libretune-app/src-tauri/src/commands/start_autotune.rs
+++ b/crates/libretune-app/src-tauri/src/commands/start_autotune.rs
@@ -2,8 +2,8 @@
 
 use crate::read_raw_value;
 use crate::state::{
-    is_maf_channel_name, is_tps_channel_name, AppState, AutoTuneConfig, AutoTuneLoadSource,
-    AxisHint,
+    algorithm_selects_tps_load, is_maf_channel_name, is_tps_channel_name, AppState, AutoTuneConfig,
+    AutoTuneLoadSource, AxisHint,
 };
 use libretune_core::autotune::{
     AutoTuneAuthorityLimits, AutoTuneFilters, AutoTuneReferenceTables, AutoTuneSettings,
@@ -62,6 +62,29 @@ pub async fn start_autotune(
                     resolved_load_source = AutoTuneLoadSource::Tps;
                 } else if is_maf_channel_name(channel) {
                     resolved_load_source = AutoTuneLoadSource::Maf;
+                }
+            }
+            // Speeduino names its VE load-axis output channel `fuelLoad`
+            // regardless of the fuel algorithm, so channel-name detection
+            // cannot fire there. Fall back to the `algorithm` constant, which
+            // is authoritative: 1 = TPS / Alpha-N on Speeduino and MS2/MS3
+            // alike (issue #132).
+            if resolved_load_source == AutoTuneLoadSource::Map {
+                if let Some(algorithm) = def.constants.get("algorithm") {
+                    let value = crate::commands::constant_values::read_constant_from_cache_or_tune(
+                        "algorithm",
+                        algorithm,
+                        def.endianness,
+                        state.current_tune.lock().await.as_ref(),
+                        cache,
+                    );
+                    if algorithm_selects_tps_load(value) {
+                        tracing::info!(
+                            value,
+                            "start_autotune: algorithm constant selects TPS load"
+                        );
+                        resolved_load_source = AutoTuneLoadSource::Tps;
+                    }
                 }
             }
         }

--- a/crates/libretune-app/src-tauri/src/commands/table_ops.rs
+++ b/crates/libretune-app/src-tauri/src/commands/table_ops.rs
@@ -151,8 +151,8 @@ pub async fn resize_table_size(
         }
     }
 
-    update_constant(state.clone(), cols_const, new_cols as f64).await?;
-    update_constant(state.clone(), rows_const, new_rows as f64).await?;
+    update_constant(state.clone(), app.clone(), cols_const, new_cols as f64).await?;
+    update_constant(state.clone(), app.clone(), rows_const, new_rows as f64).await?;
 
     let connected = state.connection.lock().await.is_some();
     if connected {

--- a/crates/libretune-app/src-tauri/src/commands/wasm_plugin.rs
+++ b/crates/libretune-app/src-tauri/src/commands/wasm_plugin.rs
@@ -246,6 +246,7 @@ async fn build_plugin_data_snapshot(state: &tauri::State<'_, AppState>) -> Plugi
 #[tauri::command]
 pub async fn execute_wasm_plugin(
     name: String,
+    app: tauri::AppHandle,
     state: tauri::State<'_, AppState>,
 ) -> Result<WasmPluginExecutionResult, String> {
     let snapshot = build_plugin_data_snapshot(&state).await;
@@ -266,6 +267,7 @@ pub async fn execute_wasm_plugin(
             } => {
                 match crate::commands::constant_update::update_constant(
                     state.clone(),
+                    app.clone(),
                     const_name.clone(),
                     value,
                 )

--- a/crates/libretune-app/src-tauri/src/state.rs
+++ b/crates/libretune-app/src-tauri/src/state.rs
@@ -161,6 +161,16 @@ pub fn is_tps_channel_name(name: &str) -> bool {
         || lower.contains("throttle")
 }
 
+/// Whether a decoded `algorithm` constant value selects a throttle-position
+/// (Alpha-N) fuel load. Speeduino names its VE load-axis output channel
+/// `fuelLoad` no matter which fuel algorithm is active, so channel-name
+/// detection cannot distinguish a MAP tune from an Alpha-N / ITB one. The
+/// `algorithm` bits constant is authoritative instead: bit 1 is TPS on
+/// Speeduino (`$loadSourceNames`) and Alpha-N on MS2/MS3. See issue #132.
+pub fn algorithm_selects_tps_load(algorithm_value: f64) -> bool {
+    algorithm_value == 1.0
+}
+
 /// AutoTune configuration stored when tuning session starts
 #[derive(Clone)]
 pub struct AutoTuneConfig {
@@ -238,7 +248,7 @@ pub struct AppState {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_maf_channel_name, is_tps_channel_name};
+    use super::{algorithm_selects_tps_load, is_maf_channel_name, is_tps_channel_name};
 
     #[test]
     fn detects_tps_load_channels() {
@@ -272,6 +282,19 @@ mod tests {
         // and vice-versa, so auto-detection picks the right load source.
         assert!(is_maf_channel_name("maf") && !is_tps_channel_name("maf"));
         assert!(is_tps_channel_name("tps") && !is_maf_channel_name("tps"));
+    }
+
+    #[test]
+    fn algorithm_value_selects_tps_only_on_alpha_n() {
+        // Speeduino $loadSourceNames: 0 = MAP, 1 = TPS, 2 = IMAP/EMAP (then
+        // INVALID fillers). MS2/MS3: 0 = Speed Density, 1 = Alpha-N, 2 = MAF.
+        // Only 1 means a throttle-position load in both.
+        assert!(!algorithm_selects_tps_load(0.0), "0 = MAP / speed density");
+        assert!(algorithm_selects_tps_load(1.0), "1 = TPS / Alpha-N");
+        assert!(
+            !algorithm_selects_tps_load(2.0),
+            "2 = IMAP-EMAP / MAF, not TPS"
+        );
     }
 }
 

--- a/crates/libretune-app/src/components/tuner-ui/AutoTune.css
+++ b/crates/libretune-app/src/components/tuner-ui/AutoTune.css
@@ -74,6 +74,37 @@
   font-weight: bold;
 }
 
+/* Sample/rejection indicator (issue #132): says why a session is not
+   accumulating data instead of looking dead. Neutral when data flows;
+   warning-tinted when every sample is filtered out. */
+.autotune-sample-stats {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 4px 10px;
+  border-radius: 4px;
+  border: 1px solid var(--border-default);
+  background: var(--bg-primary);
+  font-size: 12px;
+  color: var(--text-secondary);
+  cursor: default;
+  margin-top: 6px;
+  width: fit-content;
+}
+
+.autotune-sample-stats-warning {
+  border-color: var(--error);
+  color: var(--text-primary);
+}
+
+.autotune-sample-accepted {
+  font-weight: 600;
+}
+
+.autotune-sample-rejected {
+  color: var(--text-secondary);
+}
+
 .autotune-table-selector {
   padding: 6px 12px;
   border: 1px solid var(--border-default);

--- a/crates/libretune-app/src/components/tuner-ui/AutoTune.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/AutoTune.tsx
@@ -28,7 +28,7 @@
  * @see {@link AutoTuneAuthorityLimits} for correction limits
  */
 
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { FolderOpen, Save, Square, Play, Upload, X, Lock, LockOpen } from 'lucide-react';
 import { invoke } from '@tauri-apps/api/core';
 import { open, save } from '@tauri-apps/plugin-dialog';
@@ -152,6 +152,18 @@ interface ChannelInfo {
 }
 
 /**
+ * Live sample tallies for the rejection indicator (issue #132).
+ *
+ * A session that accepts nothing looks exactly like a broken one — the
+ * indicator surfaces how many samples passed the filters and, when data is
+ * being rejected, which filter is eating it (most frequent reason first).
+ */
+interface AutotuneSampleStats {
+  accepted: number;
+  rejections: { reason: string; count: number }[];
+}
+
+/**
  * Minimal table info for selection dropdown.
  */
 interface TableInfo {
@@ -231,6 +243,7 @@ export function AutoTune({ tableName: initialTableName = '', onClose, isConnecte
   const [tableData, setTableData] = useState<TableData | null>(null);
   const [_referenceData, setReferenceData] = useState<TableData | null>(null);
   const [heatmapData, setHeatmapData] = useState<HeatmapEntry[]>([]);
+  const [sampleStats, setSampleStats] = useState<AutotuneSampleStats | null>(null);
   const [veAnalyzeConfig, setVeAnalyzeConfig] = useState<VeAnalyzeConfig | null>(null);
   const [lockedCells, setLockedCells] = useState<Set<string>>(new Set());
   const [selectedCells, _setSelectedCells] = useState<Set<string>>(new Set());
@@ -239,6 +252,12 @@ export function AutoTune({ tableName: initialTableName = '', onClose, isConnecte
   const [error, setError] = useState<string | null>(null);
   const [loadSource, setLoadSource] = useState<AutoTuneLoadSource>('map');
   const [loadSourceHint, setLoadSourceHint] = useState<string | null>(null);
+  // Set the moment the user picks a load source themselves. Auto-detection
+  // (by Y-axis channel name or by the `algorithm` constant) must never fight
+  // an explicit choice — without this, a stale-closure check on `loadSource`
+  // lets async detection re-fire after e.g. the MAF-verify demotion and flip
+  // the dropdown back (issue #132).
+  const manualLoadSourceRef = useRef(false);
 
   // Settings state
   const [settings, setSettings] = useState<AutoTuneSettings>(() =>
@@ -259,7 +278,11 @@ export function AutoTune({ tableName: initialTableName = '', onClose, isConnecte
     max_tps: 100,
     min_clt: 60,
     custom_filter: '',
-    max_tps_rate: 10,
+    // 50 %/s — ITB/Alpha-N throttles move far faster than the old 10 %/s
+    // default allowed, which made AutoTune reject nearly every sample and
+    // look dead (issue #132). Accel transients are still filtered by
+    // exclude_accel_enrich.
+    max_tps_rate: 50,
     exclude_accel_enrich: true,
     require_steady_state: true,
     steady_state_rpm_delta: 50,
@@ -437,7 +460,7 @@ export function AutoTune({ tableName: initialTableName = '', onClose, isConnecte
   }, [activeTable]);
 
   useEffect(() => {
-    if (!tableData || isRunning) return;
+    if (!tableData || isRunning || manualLoadSourceRef.current) return;
     // Auto-detect the load source from the selected table's Y-axis output
     // channel when the user hasn't already picked one. TPS (Alpha-N / ITB) is
     // checked first because a TPS channel name like "tps" would not otherwise
@@ -449,6 +472,36 @@ export function AutoTune({ tableName: initialTableName = '', onClose, isConnecte
     } else if (isMafChannelName(yChan) && loadSource !== 'maf') {
       setLoadSource('maf');
     }
+  }, [isMafChannelName, isTpsChannelName, isRunning, loadSource, tableData]);
+
+  // Speeduino names its VE load-axis output channel `fuelLoad` regardless of
+  // the fuel algorithm, so channel-name detection (above) cannot fire there.
+  // The `algorithm` constant is authoritative instead: 1 = TPS / Alpha-N on
+  // Speeduino and MS2/MS3 alike. Only corrects the untouched MAP default so a
+  // deliberate manual choice is respected (issue #132).
+  useEffect(() => {
+    if (!tableData || isRunning || loadSource !== 'map' || manualLoadSourceRef.current) {
+      return;
+    }
+    const yChan = tableData.y_output_channel;
+    if (isTpsChannelName(yChan) || isMafChannelName(yChan)) {
+      return; // channel-name detection already decided
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const v = await invoke<number>('get_constant_value', { name: 'algorithm' });
+        if (!cancelled && v === 1 && loadSource === 'map') {
+          setLoadSource('tps');
+          setLoadSourceHint('Fuel algorithm is TPS (Alpha-N) — throttle load selected.');
+        }
+      } catch {
+        // No `algorithm` constant in this INI — nothing to detect.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
   }, [isMafChannelName, isTpsChannelName, isRunning, loadSource, tableData]);
 
   useEffect(() => {
@@ -503,6 +556,20 @@ export function AutoTune({ tableName: initialTableName = '', onClose, isConnecte
         setHeatmapData(data);
       } catch (e) {
         console.error('Failed to fetch heatmap:', e);
+      }
+      // Sample tallies ride the same poll: the rejection indicator must say
+      // *why* nothing accumulates while the user watches (issue #132).
+      try {
+        const status = await invoke<{
+          acceptedSamples: number;
+          rejections: { reason: string; count: number }[];
+        }>('get_autotune_status');
+        setSampleStats({
+          accepted: status.acceptedSamples ?? 0,
+          rejections: status.rejections ?? [],
+        });
+      } catch {
+        // Status is diagnostic; keep the last known tallies.
       }
     }, 500);
 
@@ -811,6 +878,40 @@ export function AutoTune({ tableName: initialTableName = '', onClose, isConnecte
             </div>
           </div>
         </div>
+        {/* Rejection indicator (issue #132): a session that accepts nothing
+            looks exactly like a broken one. Show what the filters are doing
+            while the session runs; highlight when nothing gets through. */}
+        {isRunning && sampleStats && (
+          <div
+            className={`autotune-sample-stats${
+              sampleStats.accepted === 0 && sampleStats.rejections.length > 0
+                ? ' autotune-sample-stats-warning'
+                : ''
+            }`}
+            title={
+              sampleStats.rejections.length > 0
+                ? `Rejected samples by reason:\n${sampleStats.rejections
+                    .map((r) => `${r.reason}: ${r.count}`)
+                    .join('\n')}`
+                : 'All samples passed the filters.'
+            }
+          >
+            <span className="autotune-sample-accepted">
+              {sampleStats.accepted} sample{sampleStats.accepted === 1 ? '' : 's'} accepted
+            </span>
+            {sampleStats.rejections.length > 0 && (
+              <span className="autotune-sample-rejected">
+                {sampleStats.rejections
+                  .slice(0, 2)
+                  .map((r) => `${r.count}× ${r.reason}`)
+                  .join(' · ')}
+                {sampleStats.rejections.length > 2
+                  ? ` · +${sampleStats.rejections.length - 2} more`
+                  : ''}
+              </span>
+            )}
+          </div>
+        )}
         <div className="autotune-controls">
           <button onClick={loadReferenceTable} title="Load reference table from CSV">
             <FolderOpen size={14} /> Load Ref
@@ -996,6 +1097,7 @@ export function AutoTune({ tableName: initialTableName = '', onClose, isConnecte
               <select
                 value={loadSource}
                 onChange={(e) => {
+                  manualLoadSourceRef.current = true;
                   setLoadSource(e.target.value as AutoTuneLoadSource);
                   setLoadSourceHint(null);
                 }}

--- a/crates/libretune-app/src/components/tuner-ui/__tests__/AutoTune.test.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/__tests__/AutoTune.test.tsx
@@ -79,6 +79,110 @@ describe('AutoTune connection awareness', () => {
   });
 });
 
+// Speeduino names its VE load-axis output channel `fuelLoad` regardless of
+// the fuel algorithm, so channel-name detection can never fire on a real
+// Speeduino tune. The `algorithm` constant must fill the gap: 1 = TPS /
+// Alpha-N (issue #132 — an ITB user's tune silently stayed on the MAP load
+// source and AutoTune attributed samples to the wrong cells).
+describe('AutoTune Alpha-N detection via fuel algorithm', () => {
+  const loadSourceSelect = async () => {
+    const label = await screen.findByText('Load Source:');
+    const select = label.parentElement?.querySelector('select');
+    if (!select) throw new Error('load source select not found next to its label');
+    return select as HTMLSelectElement;
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    (invoke as unknown as any).mockImplementation((cmd: string, args: any) => {
+      if (cmd === 'get_ve_analyze_config') return Promise.resolve(null);
+      if (cmd === 'get_tables')
+        return Promise.resolve([{ name: 'veTable1Tbl', title: 'VE Table' }]);
+      if (cmd === 'get_table_data')
+        return Promise.resolve({ ...TABLE_DATA, y_output_channel: 'fuelLoad' });
+      if (cmd === 'get_available_channels') return Promise.resolve([]);
+      if (cmd === 'get_constant_value' && args?.name === 'algorithm')
+        return Promise.resolve(1);
+      return Promise.resolve();
+    });
+  });
+
+  it('selects the TPS load source when the algorithm constant is Alpha-N', async () => {
+    render(
+      <ToastProvider>
+        <AutoTune tableName="veTable1Tbl" isConnected />
+      </ToastProvider>
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText(/Fuel algorithm is TPS/)).toBeInTheDocument()
+    );
+    expect((await loadSourceSelect()).value).toBe('tps');
+  });
+
+  it('stays on MAP when the algorithm constant is speed density', async () => {
+    (invoke as unknown as any).mockImplementation((cmd: string, args: any) => {
+      if (cmd === 'get_ve_analyze_config') return Promise.resolve(null);
+      if (cmd === 'get_tables')
+        return Promise.resolve([{ name: 'veTable1Tbl', title: 'VE Table' }]);
+      if (cmd === 'get_table_data')
+        return Promise.resolve({ ...TABLE_DATA, y_output_channel: 'fuelLoad' });
+      if (cmd === 'get_available_channels') return Promise.resolve([]);
+      if (cmd === 'get_constant_value' && args?.name === 'algorithm')
+        return Promise.resolve(0);
+      return Promise.resolve();
+    });
+
+    render(
+      <ToastProvider>
+        <AutoTune tableName="veTable1Tbl" isConnected />
+      </ToastProvider>
+    );
+
+    // Give the async detection a chance to (wrongly) fire, then confirm it
+    // did not.
+    await waitFor(() =>
+      expect((invoke as unknown as any).mock.calls).toContainEqual(
+        ['get_constant_value', { name: 'algorithm' }],
+      ),
+    );
+    expect((await loadSourceSelect()).value).toBe('map');
+  });
+
+  it('does not override a manual load source choice', async () => {
+    // A MAF channel must exist, or the (pre-existing) MAF-verify effect would
+    // demote the manual choice to MAP — a different behavior than the one
+    // under test here.
+    (invoke as unknown as any).mockImplementation((cmd: string, args: any) => {
+      if (cmd === 'get_ve_analyze_config') return Promise.resolve(null);
+      if (cmd === 'get_tables')
+        return Promise.resolve([{ name: 'veTable1Tbl', title: 'VE Table' }]);
+      if (cmd === 'get_table_data')
+        return Promise.resolve({ ...TABLE_DATA, y_output_channel: 'fuelLoad' });
+      if (cmd === 'get_available_channels')
+        return Promise.resolve([{ name: 'maf', label: 'Mass Air Flow' }]);
+      if (cmd === 'get_constant_value' && args?.name === 'algorithm')
+        return Promise.resolve(1);
+      return Promise.resolve();
+    });
+
+    render(
+      <ToastProvider>
+        <AutoTune tableName="veTable1Tbl" isConnected />
+      </ToastProvider>
+    );
+
+    const select = await loadSourceSelect();
+    // Manually pick MAF; algorithm-based detection must respect that.
+    await userEvent.selectOptions(select, 'maf');
+    expect(select.value).toBe('maf');
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(select.value).toBe('maf');
+    expect(screen.queryByText(/Fuel algorithm is TPS/)).not.toBeInTheDocument();
+  });
+});
+
 // The lambda delay is a measured per-engine fact (about 470 ms at idle on the
 // reference NA6), not view state. It used to reset on every launch, and the
 // default of 0 does not mean "no delay" - it means "fall back to the built-in

--- a/crates/libretune-core/src/autotune/mod.rs
+++ b/crates/libretune-core/src/autotune/mod.rs
@@ -128,7 +128,12 @@ impl Default for AutoTuneFilters {
             max_y_axis: None,
             min_clt: 160.0,
             custom_filter: None,
-            max_tps_rate: 10.0,         // 10%/sec threshold
+            // 50 %/s: brisk-but-deliberate throttle use. The old 10 %/s
+            // default rejected nearly everything on individual-throttle-body
+            // (Alpha-N) engines, whose throttles snap far faster than a
+            // single-plenum setup — AutoTune looked dead (issue #132). Genuine
+            // accel transients are still caught by `exclude_accel_enrich`.
+            max_tps_rate: 50.0,
             exclude_accel_enrich: true, // Exclude accel enrichment by default
         }
     }
@@ -166,6 +171,12 @@ pub struct AutoTuneState {
     // Total number of samples that passed filters (denominator for
     // hit_percentage). See bug #16.
     total_samples: u64,
+    // Per-reason counts of samples rejected by the filters. Surface these in
+    // the UI (issue #132): a session that accepts nothing looks exactly like
+    // a broken one, and the counts say which filter is eating the data
+    // (a warm-up CLT below min_clt and a tip-in TPS rate above max_tps_rate
+    // are the usual culprits).
+    rejected_by_reason: HashMap<&'static str, u64>,
 }
 
 impl Default for AutoTuneState {
@@ -179,6 +190,7 @@ impl Default for AutoTuneState {
             reference_tables: AutoTuneReferenceTables::default(),
             strict_lambda_match: true, // Safe default: drop unmatched samples
             total_samples: 0,
+            rejected_by_reason: HashMap::new(),
         }
     }
 }
@@ -247,6 +259,7 @@ impl AutoTuneState {
         self.recommendations.clear();
         self.data_buffer.clear();
         self.total_samples = 0;
+        self.rejected_by_reason.clear();
     }
 
     pub fn stop(&mut self) {
@@ -447,6 +460,20 @@ impl AutoTuneState {
         self.total_samples
     }
 
+    /// Per-reason counts of filter-rejected samples this session, most
+    /// frequent first. Empty when nothing has been rejected. Lets the UI say
+    /// *why* a session is not accumulating data instead of looking dead
+    /// (issue #132).
+    pub fn rejection_counts(&self) -> Vec<(&'static str, u64)> {
+        let mut counts: Vec<(&'static str, u64)> = self
+            .rejected_by_reason
+            .iter()
+            .map(|(k, v)| (*k, *v))
+            .collect();
+        counts.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(b.0)));
+        counts
+    }
+
     /// Which filter rejected a sample, for the diagnostic log. Mirrors the
     /// order of the checks in `passes_filters`.
     fn rejection_reason(point: &VEDataPoint, filters: &AutoTuneFilters) -> &'static str {
@@ -504,6 +531,10 @@ impl AutoTuneState {
         self.prune_data_buffer(point.timestamp_ms);
 
         if !self.passes_filters(&point, filters) {
+            // Count per reason for the UI's rejection indicator (issue #132):
+            // a session that accepts nothing looks exactly like a broken one.
+            let reason = Self::rejection_reason(&point, filters);
+            *self.rejected_by_reason.entry(reason).or_insert(0) += 1;
             // Throttled so a full drive doesn't flood the log, but enough to
             // show *why* AutoTune "does nothing": compare these against the
             // active filter thresholds (a warm-up CLT below min_clt and a
@@ -516,7 +547,7 @@ impl AutoTuneState {
                 // enrichment showed every printed value passing while samples
                 // still vanished — an hour of misdiagnosis on real hardware.
                 tracing::debug!(
-                    reason = Self::rejection_reason(&point, filters),
+                    reason = reason,
                     rpm = point.rpm,
                     clt = point.clt,
                     load = point.load,
@@ -944,11 +975,6 @@ mod tests {
     use super::*;
 
     /// The accel-enrich filter must only reject when the flag is known-true.
-    /// An unknown flag (None — e.g. an ECU that publishes no boolean AE
-    /// channel) must not reject: treating unknown as active silently discarded
-    /// 100% of samples on Speeduino, whose `accelEnrich` channel is a
-    /// percentage (100 = no enrichment) and was misread as a boolean.
-    #[test]
     /// During overrun the injectors are off: the wideband reads full lean
     /// while rpm, load, CLT and a steady closed throttle all pass. Left in,
     /// each such sample asks for the authority-limit maximum enrichment in
@@ -1061,6 +1087,15 @@ mod tests {
         );
     }
 
+    /// The accel-enrich filter must only reject when the flag is known-true.
+    /// An unknown flag (None — e.g. an ECU that publishes no boolean AE
+    /// channel) must not reject: treating unknown as active silently discarded
+    /// 100% of samples on Speeduino, whose `accelEnrich` channel is a
+    /// percentage (100 = no enrichment) and was misread as a boolean.
+    /// (The `#[test]` for this function was previously stranded on the wrong
+    /// doc comment above `fuel_cut_samples_are_rejected`, so this test never
+    /// ran.)
+    #[test]
     fn accel_filter_rejects_only_known_active() {
         let state = AutoTuneState::default();
         let filters = AutoTuneFilters {
@@ -1115,11 +1150,99 @@ mod tests {
         );
 
         point.clt = 180.0;
-        point.tps_rate = 50.0;
+        point.tps_rate = 80.0;
         assert_eq!(
             AutoTuneState::rejection_reason(&point, &filters),
             "tps_rate above max_tps_rate"
         );
+    }
+
+    /// The default transient threshold must stay ITB-friendly: the old
+    /// 10 %/s rejected nearly every sample on individual-throttle-body
+    /// (Alpha-N) engines, whose throttles snap far faster than a
+    /// single-plenum setup — AutoTune looked dead (issue #132). A point at
+    /// 50 %/s (deliberate-but-brisk throttle use) must pass by default.
+    #[test]
+    fn default_tps_rate_is_itb_friendly() {
+        assert_eq!(AutoTuneFilters::default().max_tps_rate, 50.0);
+
+        let mut point = VEDataPoint::default();
+        point.rpm = 2000.0;
+        point.clt = 180.0;
+        point.tps_rate = 50.0;
+        assert!(
+            AutoTuneState::default().passes_filters(&point, &AutoTuneFilters::default()),
+            "50 %/s throttle movement must not be rejected by default"
+        );
+    }
+
+    /// Rejected samples must be counted per reason so the UI can say *why* a
+    /// session is not accumulating data instead of looking dead (issue #132).
+    #[test]
+    fn rejected_samples_are_counted_per_reason() {
+        let mut state = AutoTuneState::default();
+        state.start();
+
+        let filters = AutoTuneFilters {
+            min_rpm: 1000.0,
+            min_clt: 160.0,
+            max_tps_rate: 50.0,
+            ..Default::default()
+        };
+
+        let mut cold = VEDataPoint::default();
+        cold.rpm = 2000.0;
+        cold.clt = 100.0; // below min_clt
+
+        let mut fast_throttle = VEDataPoint::default();
+        fast_throttle.rpm = 2000.0;
+        fast_throttle.clt = 180.0;
+        fast_throttle.tps_rate = 80.0; // above max_tps_rate
+
+        let mut good = VEDataPoint::default();
+        good.rpm = 2000.0;
+        good.clt = 180.0;
+        good.afr = 14.7;
+        good.ve = 50.0;
+
+        // Bins for a 1-cell table; attribution is not what's under test.
+        let bins_x = [1000.0];
+        let bins_y = [50.0];
+        let settings = AutoTuneSettings::default();
+        let authority = AutoTuneAuthorityLimits::default();
+
+        state.add_data_point(
+            cold.clone(),
+            &bins_x,
+            &bins_y,
+            &settings,
+            &filters,
+            &authority,
+        );
+        state.add_data_point(cold, &bins_x, &bins_y, &settings, &filters, &authority);
+        state.add_data_point(
+            fast_throttle,
+            &bins_x,
+            &bins_y,
+            &settings,
+            &filters,
+            &authority,
+        );
+        state.add_data_point(good, &bins_x, &bins_y, &settings, &filters, &authority);
+
+        let counts = state.rejection_counts();
+        assert_eq!(
+            counts[0],
+            ("clt below min_clt", 2),
+            "sorted most frequent first"
+        );
+        assert_eq!(counts[1], ("tps_rate above max_tps_rate", 1));
+        assert_eq!(state.total_samples(), 1, "accepted sample is counted too");
+
+        // Restarting the session clears the tallies.
+        state.start();
+        assert!(state.rejection_counts().is_empty());
+        assert_eq!(state.total_samples(), 0);
     }
 
     /// Captures `tracing` event messages into a shared Vec so a test can assert

--- a/crates/libretune-core/src/ini/expression.rs
+++ b/crates/libretune-core/src/ini/expression.rs
@@ -1159,6 +1159,33 @@ pub fn evaluate_simple(expr: &Expr, context: &HashMap<String, f64>) -> Result<Va
     evaluate(expr, context, None)
 }
 
+/// Identifiers an expression mentions.
+///
+/// A deliberately over-inclusive word scan: every bare word is returned,
+/// including function names and keywords, because a spurious extra name
+/// usually costs one map lookup while a missing one would silently change a
+/// dependency decision. Numeric literals (words starting with a digit) are
+/// dropped; a name cannot start with one.
+pub fn identifiers(expression: &str) -> std::collections::HashSet<String> {
+    let mut out = std::collections::HashSet::new();
+    let mut word = String::new();
+    let keep = |w: &str| w.starts_with(|c: char| c.is_alphabetic() || c == '_');
+    for ch in expression.chars() {
+        if ch.is_alphanumeric() || ch == '_' {
+            word.push(ch);
+        } else if !word.is_empty() {
+            let w = std::mem::take(&mut word);
+            if keep(&w) {
+                out.insert(w);
+            }
+        }
+    }
+    if !word.is_empty() && keep(&word) {
+        out.insert(word);
+    }
+    out
+}
+
 /// Resolve a display string that may be a braced INI expression.
 ///
 /// If `raw` trims to `{ ... }`, the inner expression is evaluated and stringified.

--- a/crates/libretune-core/src/ini/mod.rs
+++ b/crates/libretune-core/src/ini/mod.rs
@@ -352,11 +352,23 @@ impl EcuDefinition {
         // (constant name, human label). Ordered to match the layout a user
         // expects in the corresponding TunerStudio standard panel.
         let (title, candidates): (&str, &[(&str, &str)]) = match name {
+            // TunerStudio's native panel also carries the fuel `algorithm`
+            // selector ("Control Algorithm": MAP / TPS / IMAP-EMAP). The
+            // Speeduino INI never declares it as a dialog field — it is only
+            // reachable through this panel — so omitting it left Alpha-N (ITB)
+            // users with no way to see or change the fuel algorithm, and kept
+            // the VE table's load-axis scale (fuelLoadRes) stuck on its MAP
+            // resolution (issue #132). twoStroke / engineType ride along for
+            // the same reason: TS lists them in Engine Constants but the INI
+            // defines no field for them either.
             "std_injection" => (
                 "Injection Setup",
                 &[
+                    ("algorithm", "Control Algorithm"),
                     ("reqFuel", "Required Fuel"),
                     ("nCylinders", "Number of Cylinders"),
+                    ("twoStroke", "Engine Stroke"),
+                    ("engineType", "Engine Type"),
                     ("injType", "Injector Type"),
                     ("divider", "Injector Divider"),
                     ("alternate", "Injection Timing"),
@@ -463,6 +475,58 @@ impl EcuDefinition {
         }
 
         format!("{:016x}", hasher.finish())
+    }
+
+    /// Whether the constant `name` feeds any `{expression}`-valued scale or
+    /// translate field, either directly or through an output-channel helper.
+    ///
+    /// Speeduino's load axes scale by `{fuelLoadRes}`, whose value is the
+    /// output-channel expression `((algorithm == 0) || (algorithm == 2)) ?
+    /// 2.000 : 0.500` — so the `algorithm` constant feeds every load axis
+    /// even though no scale expression mentions it by name. Used to decide
+    /// whether an edit must re-run [`Self::resolve_dynamic_scales`]:
+    /// switching the fuel algorithm (e.g. MAP → TPS for Alpha-N/ITB setups)
+    /// has to re-scale the VE table's load axis immediately (issue #132).
+    pub fn constant_feeds_dynamic_scale(&self, name: &str) -> bool {
+        // Identifiers reachable from any scale/translate expression.
+        let mut frontier: Vec<String> = self
+            .constants
+            .values()
+            .filter_map(|c| c.scale_expr.as_ref().or(c.translate_expr.as_ref()))
+            .flat_map(|e| expression::identifiers(e).into_iter())
+            .collect();
+        if frontier.iter().any(|i| i == name) {
+            return true; // direct mention
+        }
+
+        // Follow output-channel helper expressions (fuelLoadRes → algorithm).
+        // Bounded depth: these chains are short in practice, and
+        // resolve_dynamic_scales itself only unfolds two helper passes.
+        let mut seen: std::collections::HashSet<String> = frontier.iter().cloned().collect();
+        for _ in 0..3 {
+            let mut next: Vec<String> = Vec::new();
+            for ident in &frontier {
+                let Some(channel) = self.output_channels.get(ident) else {
+                    continue;
+                };
+                let Some(expr) = channel.expression.as_ref() else {
+                    continue;
+                };
+                for id in expression::identifiers(expr) {
+                    if id == name {
+                        return true;
+                    }
+                    if seen.insert(id.clone()) {
+                        next.push(id);
+                    }
+                }
+            }
+            if next.is_empty() {
+                break;
+            }
+            frontier = next;
+        }
+        false
     }
 
     /// Resolve `scale`/`translate` fields that the INI expresses as
@@ -730,6 +794,59 @@ mod tests {
         assert_eq!(constants::deferred_expr("{}"), None);
     }
 
+    /// The real Speeduino dependency chain: the VE load-axis scale expression
+    /// names the `fuelLoadRes` output-channel helper, and only that helper's
+    /// expression mentions `algorithm`. Detection must follow the chain or
+    /// editing `algorithm` would not re-resolve the axis scale (issue #132).
+    #[test]
+    fn constant_feeds_dynamic_scale_follows_helper_chain() {
+        let mut def = EcuDefinition::default();
+
+        let mut bins = Constant::new("fuelLoadBins", 1, 272, DataType::U08);
+        bins.scale_expr = Some("fuelLoadRes".to_string());
+        def.constants.insert(bins.name.clone(), bins);
+
+        def.output_channels.insert(
+            "fuelLoadRes".to_string(),
+            OutputChannel {
+                name: "fuelLoadRes".to_string(),
+                expression: Some(
+                    "((algorithm == 0) || (algorithm == 2)) ? 2.000 : 0.500".to_string(),
+                ),
+                ..Default::default()
+            },
+        );
+
+        assert!(def.constant_feeds_dynamic_scale("algorithm"));
+        assert!(!def.constant_feeds_dynamic_scale("rpm"));
+        // `fuelLoadRes` is named directly by the scale expression.
+        assert!(def.constant_feeds_dynamic_scale("fuelLoadRes"));
+    }
+
+    /// A constant named directly inside a scale/translate expression is the
+    /// simple (no-helper) case.
+    #[test]
+    fn constant_feeds_dynamic_scale_direct_mention() {
+        let mut def = EcuDefinition::default();
+        let mut bins = Constant::new("someBins", 1, 0, DataType::U08);
+        bins.translate_expr = Some("mapOffset * 2".to_string());
+        def.constants.insert(bins.name.clone(), bins);
+
+        assert!(def.constant_feeds_dynamic_scale("mapOffset"));
+        assert!(!def.constant_feeds_dynamic_scale("algorithm"));
+    }
+
+    /// INIs with no expression-valued scales must answer false for anything
+    /// without touching output channels.
+    #[test]
+    fn constant_feeds_dynamic_scale_without_dynamic_scales() {
+        let mut def = EcuDefinition::default();
+        def.constants
+            .insert("plain".to_string(), scalar_const("plain"));
+        assert!(!def.constant_feeds_dynamic_scale("plain"));
+        assert!(!def.constant_feeds_dynamic_scale("algorithm"));
+    }
+
     #[test]
     fn test_default_definition() {
         let def = EcuDefinition::default();
@@ -749,6 +866,7 @@ mod tests {
         // names exists, the rest (nInjectors) is absent.
         let mut def = EcuDefinition::default();
         for n in [
+            "algorithm",
             "reqFuel",
             "divider",
             "alternate",
@@ -765,7 +883,8 @@ mod tests {
 
         assert_eq!(d.name, "std_injection");
         // nInjectors was not in constants, so it must be dropped. Every other
-        // candidate should be present in declaration order.
+        // candidate should be present in declaration order — algorithm first,
+        // matching TunerStudio's native panel layout.
         let field_names: Vec<String> = d
             .components
             .iter()
@@ -777,6 +896,7 @@ mod tests {
         assert_eq!(
             field_names,
             vec![
+                "algorithm".to_string(),
                 "reqFuel".to_string(),
                 "nCylinders".to_string(),
                 "injType".to_string(),
@@ -785,6 +905,73 @@ mod tests {
                 "injOpen".to_string(),
             ]
         );
+    }
+
+    /// The fuel `algorithm` constant is a `bits` field whose options come from
+    /// a `#define` ($loadSourceNames). Options are resolved at parse time, so
+    /// the synthesized panel only needs to emit the field; the dialog renderer
+    /// turns it into a dropdown. This test pins the contract the renderer
+    /// relies on: the field is present and named `algorithm`.
+    #[test]
+    fn std_panel_injection_includes_algorithm_when_present() {
+        let mut def = EcuDefinition::default();
+        let mut algorithm = scalar_const("algorithm");
+        algorithm.data_type = DataType::Bits;
+        algorithm.bit_options = vec![
+            "MAP".to_string(),
+            "TPS".to_string(),
+            "IMAP/EMAP".to_string(),
+            "INVALID".to_string(),
+        ];
+        def.constants.insert("algorithm".to_string(), algorithm);
+
+        let d = def
+            .std_panel_definition("std_injection")
+            .expect("std_injection should synthesize");
+
+        let field = d
+            .components
+            .iter()
+            .find_map(|c| match c {
+                DialogComponent::Field { name, .. } if name == "algorithm" => Some(c),
+                _ => None,
+            })
+            .expect("algorithm field must be synthesized when the constant exists");
+        match field {
+            DialogComponent::Field { label, .. } => {
+                assert_eq!(label, "Control Algorithm");
+            }
+            _ => panic!("expected a Field component"),
+        }
+        // The bit options live on the constant itself (resolved from
+        // $loadSourceNames at parse time); the renderer reads them from there.
+        assert_eq!(
+            def.constants["algorithm"].bit_options,
+            vec![
+                "MAP".to_string(),
+                "TPS".to_string(),
+                "IMAP/EMAP".to_string(),
+                "INVALID".to_string()
+            ]
+        );
+    }
+
+    /// A definition without an `algorithm` constant (e.g. an INI that predates
+    /// it) must still synthesize the panel from the remaining candidates.
+    #[test]
+    fn std_panel_injection_without_algorithm_still_synthesizes() {
+        let mut def = EcuDefinition::default();
+        def.constants
+            .insert("reqFuel".to_string(), scalar_const("reqFuel"));
+
+        let d = def
+            .std_panel_definition("std_injection")
+            .expect("std_injection should synthesize from reqFuel alone");
+        assert!(!d.components.is_empty());
+        assert!(d.components.iter().all(|c| match c {
+            DialogComponent::Field { name, .. } => name != "algorithm",
+            _ => true,
+        }));
     }
 
     #[test]

--- a/docs/src/features/autotune/usage-guide.md
+++ b/docs/src/features/autotune/usage-guide.md
@@ -52,11 +52,14 @@ Target AFR: 14.7 (gasoline stoich)
 Algorithm: Simple (recommended for beginners)
 ```
 
-**Load Source (MAP vs MAF)**
+**Load Source (MAP vs MAF vs TPS)**
 - **MAP (Speed Density)**: Default for VE tables
 - **MAF**: Use for mass-airflow based tables
-- If the table load axis reports MAF, AutoTune auto-switches to **MAF**
+- **TPS (Alpha-N / ITB)**: Use when the VE table's load axis is throttle position — individual-throttle-body (ITB) / Alpha-N setups
+- If the table load axis reports a throttle channel, AutoTune auto-switches to **TPS**; if it reports MAF, to **MAF**
+- On Speeduino the load-axis channel is named `fuelLoad` regardless of fuel algorithm, so AutoTune also reads the **Control Algorithm** constant (Engine Constants → Injection Setup): `TPS` selects the throttle load source automatically. Setting that constant to `MAP`/`TPS` also re-scales the load axis immediately (0–100 % in Alpha-N mode)
 - If no MAF channel is detected, AutoTune falls back to **MAP** and shows a hint
+- Selecting a load source never changes the axis values you see — bins always come from your tune. It only controls which live channel is used to attribute data to cells
 
 **Step 4: Set Authority Limits**
 For your FIRST session ever with this tune:
@@ -73,6 +76,11 @@ Default filters work for most cases. Only adjust if:
 - Your car idles rough: Raise Min RPM to 1200
 - You're tuning a diesel: Adjust temp filters significantly
 - You do a track day: Lower Min TPS to 0 for coast-down testing
+- ITB / Alpha-N setup: The default Max TPS Rate (50 %/s) already accounts for fast individual throttles; genuine accel transients are still excluded separately
+
+**While running — the sample indicator**
+
+While the session runs, a small indicator under the title row shows how many samples passed the filters and, when data is being rejected, which filter is eating it (most frequent reason first; hover for the full tally). **If AutoTune looks like nothing is happening, check this first** — `0 samples accepted` with rejections counting up means the filters (usually Min CLT while warming up, or Max TPS Rate) are discarding everything.
 
 **Step 6: Click Start**
 - AutoTune begins listening to wideband sensor
@@ -294,6 +302,22 @@ Compare before/after values
 4. Loosen filters: Lower Min RPM, Min TPS
 5. Verify ECU is receiving AFR channel
 ```
+
+**Check the sample indicator first.** While running, the indicator under the
+title row (e.g. `132 samples accepted · 400× clt below min_clt · …`, hover for
+the full tally) says exactly which filter is discarding your data:
+
+| Rejection reason | Meaning | Fix |
+|---|---|---|
+| `clt below min_clt` | Engine still warming up | Wait for full operating temp, or lower Min CLT |
+| `tps_rate above max_tps_rate` | Throttle moving too fast | Raise Max TPS Rate (ITBs need 50+ %/s) |
+| `rpm out of range` | Outside Min/Max RPM window | Adjust the RPM filter bounds |
+| `afr at sensor rail` | Wideband railed (< 10.0 or > 19.5) | Fix the sensor / its wiring; a cut or dead sensor reads full lean |
+| `overrun fuel cut` | Deceleration fuel cut active | Normal — keep out of the table on purpose |
+| `accel enrichment active` | Acceleration enrichment engaged | Normal — transient data is not VE data |
+
+If the indicator shows samples accepted but the heat map stays empty, the
+engine has not crossed those cells yet — keep driving.
 
 ### All Cells Show Blue (Very Lean)
 


### PR DESCRIPTION
## Summary

Follow-up to #132 / PR #162 for Alpha-N / ITB users. Three gaps remained after the TPS load source was added: the fuel **algorithm** constant was unreachable in the UI, AutoTune couldn't auto-detect a TPS load source on Speeduino, and a filter-rejected session looked identical to a broken one.

Partially addresses #132 (the freeze-on-open symptom is a separate rendering-perf fix to follow).

## Changes

### Control Algorithm selector (Engine Constants → Injection Setup)
- The Speeduino `algorithm` constant (bits: MAP / TPS / IMAP-EMAP via `$loadSourceNames`) is carried by TunerStudio's built-in `std_injection` panel and is **never declared as an INI dialog field** — so no LibreTune dialog ever rendered it. `EcuDefinition::std_panel_definition` now synthesizes it first, plus `twoStroke` / `engineType` (same situation). Existing per-INI candidate skipping means MS2/MS3 (Alpha-N = 1 there too) gain the dropdown automatically.

### Changing the algorithm re-scales load axes immediately
- `update_constant` now re-runs expression-scale resolution when the edited constant feeds a scale/translate expression — directly **or through an output-channel helper** (`algorithm` → `fuelLoadRes` → the VE load-axis scale; detected by the new `EcuDefinition::constant_feeds_dynamic_scale`, which follows helper chains).
- `resolve_scales_from_tune` returns the number of fields updated; when > 0 the backend emits `tune:loaded` (`"scales-resolved"`), and the existing listeners (App.tsx `refreshOpenTabs`, PanelComponents reload) refresh open tables and dialogs. Previously the axis kept the old factor until the next full sync.
- Lock discipline: the hook runs after `update_constant_internal` returns, so no connection/tune-cache guards are held while re-resolving.

### AutoTune TPS auto-detection on Speeduino
- The VE load-axis channel is named `fuelLoad` regardless of fuel algorithm, so PR #162's channel-name detection can never fire on a real Speeduino. `start_autotune` (backend) and the AutoTune view (frontend) now fall back to the decoded `algorithm` constant: `1` selects the TPS load source (`algorithm_selects_tps_load`).
- A manual choice in the Load Source dropdown is never overridden — new `manualLoadSourceRef` guards both detection effects (this also fixes a latent race where async detection could re-fire after the MAF-verify demotion and flip the dropdown back).

### Rejection indicator
- `AutoTuneState` counts rejected samples per filter reason (`rejection_counts()`, most-frequent-first); `get_autotune_status` exposes accepted/rejected tallies; the AutoTune header shows them while running — warning-styled when nothing is being accepted, hover for the full tally. A session whose filters discard everything no longer looks like a dead app.

### Transient filter default
- `max_tps_rate` default **10 → 50 %/s** (core + AutoTune view; persisted user settings are untouched). ITB throttles snap far faster than 10 %/s, so the old default rejected nearly every sample on Alpha-N cars and AutoTune "did nothing". Genuine accel transients are still caught by `exclude_accel_enrich`.

### Drive-by
- Restored a stranded `#[test]` on `accel_filter_rejects_only_known_active` — the attribute had landed on the wrong doc comment, so that test silently never ran. It passes.

## Tests
- Core: std-panel synthesis with/without `algorithm`; `constant_feeds_dynamic_scale` (helper-chain, direct, none); `algorithm_selects_tps_load` bit values; per-reason rejection tallies + reset on restart; ITB-friendly default threshold.
- Frontend: Alpha-N detection via the algorithm constant (selects TPS, stays on MAP for speed density, respects a manual choice).
- `cargo test -p libretune-core --lib` 425 passed; `cargo clippy` clean for touched code; `cargo fmt --check` clean; `tsc --noEmit` clean; vitest 207 passed.

## Notes for reviewers
- The reporter's video was recorded on an Aug-17 build; the 0–200 axis and dropped-samples symptoms were already fixed Aug 20 (expression-scale resolution + lambda-delay match window). This PR covers the genuinely-missing pieces on top.
- The freeze-when-opening-the-fuel-table symptom is a rendering-performance problem (full-grid re-render at stream cadence with per-cell min/max recomputation) — separate PR to keep this one reviewable.
