### PR TITLE
perf(table): stop live-data render storm freezing open tables (issue #132)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,46 @@ relevant.
 
 ## [Unreleased]
 
+### 2026-08-21 — Fix: open-table render storm with live data (freeze on open)
+
+Opening the fuel table with a live stream froze the window (issue #132): the
+grid re-rendered at up to ~40 Hz and every one of the 256 cells re-derived
+the whole-grid min/max (flattened twice per cell, since `data.min`/`max` are
+never populated) plus regex color parsing per call — enough allocation and
+CPU to saturate the WebView main thread. Merely opening a table also paid an
+unfiltered ~100 ms string-context build server-side.
+
+#### Fixed
+- **Z min/max computed once per data change** (`tuner-ui/TableEditor.tsx`):
+  new `zBounds` memo replaces the per-cell `Math.min(...zValues.flat())` /
+  `Math.max(...)` scans; each cell's color is now derived once instead of
+  twice (background + contrast text both called `getValueColor`).
+- **Live-position identity stabilized.** The raw position memo produced a
+  fresh `{row, col}` object on every realtime tick, so the history-trail
+  effect re-fired per tick and queued a second render even when the cursor
+  stayed in the same cell — the render amplifier behind the storm.
+- **Trail state no longer churns.** The trail-append and cleanup paths return
+  the previous array when nothing changed (the old code always allocated a
+  new filtered array, forcing a re-render every 200 ms tick).
+- **Trail fade driven by a ~5 Hz tick that only runs while trail entries
+  exist**, instead of accidental re-renders.
+- **Per-cell trail lookup is a Map** built once per trail change instead of
+  `Array.find` per cell per render. Behavioral fix included: a re-entered
+  cell (A→B→A) now fades from its *newest* visit — `find()` returned the
+  oldest duplicate entry and showed a freshly re-entered cell as faded.
+- **Same fixes in the dialog-embedded grid** (`tables/TableGrid.tsx`
+  `getCellColor`): `zBounds` memo replaces per-cell whole-grid scans.
+- **`get_table_data` builds a filtered string context.** Only the two
+  axis-label display strings are evaluated, so `build_string_context_filtered`
+  is used with their referenced identifiers instead of the unfiltered
+  ~100 ms build (which also held the definition/tune/project locks), making
+  table-open visibly snappier against a live ECU.
+
+#### Tests
+- New `TableEditor.trail.test.tsx` regression tests, verified failing against
+  the pre-fix code: (1) a re-entered cell fades from its newest visit, and
+  (2) same-cell realtime ticks no longer queue an extra render.
+
 ### 2026-08-18 — Spark generator: combustion chamber & boost (psi)
 
 #### Added

--- a/crates/libretune-app/src-tauri/src/commands/table_internals.rs
+++ b/crates/libretune-app/src-tauri/src/commands/table_internals.rs
@@ -1,6 +1,6 @@
 //! TableData struct and internal table helpers (extracted from lib.rs).
 
-use crate::commands::string_context::{build_string_context, numeric_context_from_tune};
+use crate::commands::string_context::{build_string_context_filtered, numeric_context_from_tune};
 use crate::state::AppState;
 use libretune_core::dynamic_table::{self, TableSizeInfo};
 use libretune_core::ini::expression::evaluate_display_string;
@@ -226,7 +226,19 @@ pub(crate) async fn get_table_data_internal(
         None
     };
 
-    let string_ctx = build_string_context(state).await;
+    // Only the two axis-label display strings are evaluated here. The
+    // unfiltered context clone (~100 ms per call on a real Speeduino INI,
+    // while holding the definition/tune/project locks) made merely opening a
+    // table feel wedged with a live stream running (issue #132). Build only
+    // the entries the labels can reference instead.
+    let label_filter = {
+        let mut names = crate::commands::string_context::referenced_identifiers(&x_label);
+        names.extend(crate::commands::string_context::referenced_identifiers(
+            &y_label,
+        ));
+        names
+    };
+    let string_ctx = build_string_context_filtered(state, Some(&label_filter)).await;
     let numeric = {
         let tune = state.current_tune.lock().await;
         numeric_context_from_tune(tune.as_ref())

--- a/crates/libretune-app/src/components/tables/TableGrid.tsx
+++ b/crates/libretune-app/src/components/tables/TableGrid.tsx
@@ -163,6 +163,22 @@ export default function TableGrid({
     return { x: xPos, y: yPos };
   }, [showLiveCursor, liveCursorX, liveCursorY, x_bins, y_bins]);
 
+  // Min/max of the Z grid, computed once per data change. Scanning the whole
+  // grid inside getCellColor flattened every value on each call (per cell per
+  // render) — the same render storm that froze the tab-based table editor
+  // with a live stream running (issue #132).
+  const zBounds = useMemo(() => {
+    let min = Infinity;
+    let max = -Infinity;
+    for (const row of z_values) {
+      for (const v of row) {
+        if (v < min) min = v;
+        if (v > max) max = v;
+      }
+    }
+    return { min, max };
+  }, [z_values]);
+
   const getCellColor = useCallback((value: number, x: number, y: number) => {
     const cellKey = `${x},${y}`;
     const isLocked = lockedCells?.has(cellKey);
@@ -175,15 +191,12 @@ export default function TableGrid({
       return { background: 'var(--surface)' };
     }
 
-    const minVal = Math.min(...z_values.flat());
-    const maxVal = Math.max(...z_values.flat());
-
-    if (minVal === maxVal) return { background: 'var(--surface)' };
+    if (zBounds.min === zBounds.max) return { background: 'var(--surface)' };
 
     // Use centralized heatmap utility
-    const color = valueToHeatmapColor(value, minVal, maxVal, heatmapScheme);
+    const color = valueToHeatmapColor(value, zBounds.min, zBounds.max, heatmapScheme);
     return { background: color, color: contrastTextColor(color) };
-  }, [lockedCells, showColorShade, z_values, heatmapScheme]);
+  }, [lockedCells, showColorShade, zBounds, heatmapScheme]);
 
   const handleKeyDown = (e: KeyboardEvent, x: number, y: number) => {
     if (e.key === 'Enter' && editingCell) {

--- a/crates/libretune-app/src/components/tuner-ui/TableEditor.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/TableEditor.tsx
@@ -218,55 +218,120 @@ export function TableEditor({
     return { row, col };
   }, [followMode, realtimeData, data.xOutputChannel, data.yOutputChannel, data.xAxis, data.yAxis, findNearestBinIndex]);
 
-  // Merge prop-passed livePosition with calculated one (calculated takes precedence when followMode is on)
-  const effectiveLivePosition = followMode ? calculatedLivePosition : livePosition;
+  // Merge prop-passed livePosition with calculated one (calculated takes
+  // precedence when followMode is on).
+  //
+  // Identity is stabilized against the previous cell: the raw memo produces a
+  // fresh {row, col} object on every realtime tick (~20 Hz), which re-fired
+  // the trail effect below and cascaded a state update + re-render even when
+  // the cursor stayed inside the same cell — a large slice of the
+  // "table open with live data freezes the window" storm (issue #132).
+  const livePosRef = useRef<CellPosition | null>(null);
+  const stableLivePosition = useMemo(() => {
+    const pos = calculatedLivePosition;
+    const last = livePosRef.current;
+    if (pos && last && pos.row === last.row && pos.col === last.col) {
+      return last;
+    }
+    livePosRef.current = pos;
+    return pos;
+  }, [calculatedLivePosition]);
+  const effectiveLivePosition = followMode ? stableLivePosition : livePosition;
 
   // Update history trail when live position changes
   useEffect(() => {
     if (!followMode || !effectiveLivePosition) return;
-    
+
     const now = Date.now();
     const newEntry = { row: effectiveLivePosition.row, col: effectiveLivePosition.col, time: now };
-    
+
     setHistoryTrail((prev) => {
-      // Remove old entries
-      const filtered = prev.filter((entry) => now - entry.time < TRAIL_DURATION_MS);
-      
-      // Only add if position changed from last entry
-      const last = filtered[filtered.length - 1];
+      // Oldest entry first: if it has not expired, nothing has.
+      const nothingExpired =
+        prev.length === 0 || now - prev[0].time < TRAIL_DURATION_MS;
+
+      // Same cell as the last entry: nothing to add. Return the previous
+      // array unchanged when nothing expired, so no re-render is queued.
+      const last = prev[prev.length - 1];
       if (last && last.row === newEntry.row && last.col === newEntry.col) {
-        return filtered;
+        return nothingExpired
+          ? prev
+          : prev.filter((e) => now - e.time < TRAIL_DURATION_MS);
       }
-      
-      return [...filtered, newEntry];
+
+      const base = nothingExpired
+        ? prev
+        : prev.filter((e) => now - e.time < TRAIL_DURATION_MS);
+      return [...base, newEntry];
     });
   }, [followMode, effectiveLivePosition, TRAIL_DURATION_MS]);
 
-  // Periodically clean up old trail entries
+  // Trail cells fade over TRAIL_DURATION_MS, so something must trigger a
+  // periodic re-render while entries exist: this is that tick (~5 Hz) plus
+  // expiry cleanup. It must also return the previous array when nothing
+  // expired, or it would queue a re-render of its own on every firing.
+  const trailActiveRef = useRef(false);
+  trailActiveRef.current = historyTrail.length > 0;
+  const [, setTrailFadeTick] = useState(0);
   useEffect(() => {
     if (!followMode) {
       setHistoryTrail([]);
       return;
     }
-    
+
     const interval = setInterval(() => {
       const now = Date.now();
-      setHistoryTrail((prev) => prev.filter((entry) => now - entry.time < TRAIL_DURATION_MS));
+      setHistoryTrail((prev) => {
+        const filtered = prev.filter((entry) => now - entry.time < TRAIL_DURATION_MS);
+        return filtered.length === prev.length ? prev : filtered;
+      });
+      if (trailActiveRef.current) {
+        setTrailFadeTick((t) => (t + 1) % 1_000_000);
+      }
     }, 200);
-    
+
     return () => clearInterval(interval);
   }, [followMode, TRAIL_DURATION_MS]);
+
+  // Min/max of the Z grid, computed once per data change. `data.min`/`max`
+  // are never populated today, so getValueColor used to flatten the whole
+  // grid (256 elements) on every call — called twice per cell per render at
+  // up to ~40 renders/sec while streaming, which saturated the UI thread
+  // (issue #132).
+  const zBounds = useMemo(() => {
+    if (data.min !== undefined && data.max !== undefined) {
+      return { min: data.min, max: data.max };
+    }
+    let min = Infinity;
+    let max = -Infinity;
+    for (const row of data.zValues) {
+      for (const v of row) {
+        if (v < min) min = v;
+        if (v > max) max = v;
+      }
+    }
+    return { min, max };
+  }, [data.min, data.max, data.zValues]);
+
+  // Trail lookup by cell — one Map build per trail change instead of a
+  // linear find() per cell per render. When a cell was re-entered (A→B→A)
+  // the Map keeps the newest entry, which is also the correct fade (find()
+  // returned the oldest and showed a freshly re-entered cell as faded).
+  const trailMap = useMemo(() => {
+    const m = new Map<string, { row: number; col: number; time: number }>();
+    for (const e of historyTrail) m.set(`${e.row},${e.col}`, e);
+    return m;
+  }, [historyTrail]);
 
   // Calculate color for value based on min/max
   const getValueColor = useCallback((value: number) => {
     if (!heatmapEnabled) return 'var(--table-cell-bg)';
 
-    const min = data.min ?? Math.min(...data.zValues.flat());
-    const max = data.max ?? Math.max(...data.zValues.flat());
+    const { min, max } = zBounds;
     if (min === max) return 'var(--table-cell-bg)';
 
     return getHeatmapColor(value, min, max, 'value');
-  }, [data.min, data.max, data.zValues, heatmapEnabled, getHeatmapColor]);
+  }, [heatmapEnabled, zBounds, getHeatmapColor]);
 
   // Get selected cells as array of positions
   const getSelectedCells = useCallback((): CellPosition[] => {
@@ -999,7 +1064,11 @@ export function TableEditor({
           </thead>
           <tbody>
             {/* Display order only — rowIndex stays in data space */}
-            {(yAxisBottom ? [...data.yAxis.keys()].reverse() : [...data.yAxis.keys()]).map((rowIndex) => (
+            {/* One timestamp per render: the fade refreshes when the trail
+                tick (or any other state change) re-renders the grid. */}
+            {(() => {
+              const renderNow = Date.now();
+              return (yAxisBottom ? [...data.yAxis.keys()].reverse() : [...data.yAxis.keys()]).map((rowIndex) => (
               <tr key={rowIndex}>
                 <th className="table-y-header">{data.yAxis[rowIndex]}</th>
                 {data.xAxis.map((_, colIndex) => {
@@ -1007,20 +1076,23 @@ export function TableEditor({
                   const isSelected = isCellSelected(rowIndex, colIndex);
                   const isEditing = editingCell?.row === rowIndex && editingCell?.col === colIndex;
                   const isLive = effectiveLivePosition?.row === rowIndex && effectiveLivePosition?.col === colIndex;
-                  
+
                   // Check if cell is in trail and calculate opacity
-                  const now = Date.now();
-                  const trailEntry = historyTrail.find((e) => e.row === rowIndex && e.col === colIndex);
-                  const trailOpacity = trailEntry ? Math.max(0, 1 - (now - trailEntry.time) / TRAIL_DURATION_MS) : 0;
+                  const trailEntry = trailMap.get(`${rowIndex},${colIndex}`);
+                  const trailOpacity = trailEntry ? Math.max(0, 1 - (renderNow - trailEntry.time) / TRAIL_DURATION_MS) : 0;
                   const isInTrail = trailOpacity > 0 && !isLive;
+
+                  // One color computation per cell (previously two: the
+                  // background and its contrast text each re-derived it).
+                  const cellColor = getValueColor(value);
 
                   return (
                     <td
                       key={colIndex}
                       className={`table-cell ${isSelected ? 'selected' : ''} ${isLive ? 'live' : ''} ${isInTrail ? 'trail' : ''}`}
                       style={{
-                        backgroundColor: getValueColor(value),
-                        color: contrastTextColor(getValueColor(value)),
+                        backgroundColor: cellColor,
+                        color: contrastTextColor(cellColor),
                         ...(isInTrail && { '--trail-opacity': trailOpacity } as React.CSSProperties)
                       }}
                       onMouseDown={(e) => handleCellMouseDown(rowIndex, colIndex, e)}
@@ -1043,7 +1115,8 @@ export function TableEditor({
                   );
                 })}
               </tr>
-            ))}
+              ));
+            })()}
           </tbody>
         </table>
       </div>

--- a/crates/libretune-app/src/components/tuner-ui/__tests__/TableEditor.trail.test.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/__tests__/TableEditor.trail.test.tsx
@@ -1,0 +1,144 @@
+import { render, act } from '@testing-library/react';
+import { Profiler } from 'react';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { invoke } from '@tauri-apps/api/core';
+import { TableEditor } from '../TableEditor';
+import { useRealtimeStore } from '../../../stores/realtimeStore';
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
+vi.mock('@tauri-apps/plugin-dialog', () => ({ open: vi.fn(), save: vi.fn() }));
+// three.js is heavy and never mounted here (the 3D view stays off).
+vi.mock('../../tables/TableEditor3D', () => ({ default: () => null }));
+
+const invokeMock = vi.mocked(invoke);
+
+const DATA = {
+  name: 'veTable1Tbl',
+  xAxis: [500, 1000, 1500],
+  yAxis: [20, 40, 60],
+  zValues: [
+    [10, 11, 12],
+    [20, 21, 22],
+    [30, 31, 32],
+  ],
+  xOutputChannel: 'RPM',
+  yOutputChannel: 'MAP',
+};
+
+const COLS = 3;
+
+function cellAt(container: HTMLElement, row: number, col: number): HTMLElement {
+  const cells = container.querySelectorAll('td.table-cell');
+  return cells[row * COLS + col] as HTMLElement;
+}
+
+function trailOpacity(cell: HTMLElement): number {
+  return parseFloat(cell.style.getPropertyValue('--trail-opacity'));
+}
+
+/**
+ * Regression tests for the live-data render storm that made an open table
+ * freeze the window with a stream running (issue #132):
+ *
+ * 1. The live position object must keep a stable identity while the cursor
+ *    stays in the same cell — the raw memo produced a fresh `{row, col}` per
+ *    realtime tick, re-firing the trail effect and queuing a second render
+ *    on every tick (~40 renders/sec once combined with the trail interval).
+ * 2. A re-entered cell must fade from its *newest* visit. The per-cell
+ *    `Array.find` returned the oldest duplicate entry, so a freshly
+ *    re-entered cell could render as (nearly) faded.
+ */
+describe('TableEditor live trail', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    invokeMock.mockReset();
+    invokeMock.mockImplementation(() => Promise.resolve({}));
+    useRealtimeStore.getState().clearChannels();
+  });
+
+  afterEach(() => {
+    act(() => {
+      vi.runOnlyPendingTimers();
+    });
+    vi.useRealTimers();
+  });
+
+  it('fades a re-entered cell from its newest visit, not its oldest', async () => {
+    const { container } = render(
+      <TableEditor data={{ ...DATA }} onChange={() => {}} />
+    );
+    // Flush the async get_settings loads (trail fade defaults to 8 s).
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // t=0: live in cell (1,1) — first visit. (MAP 45 is nearest bin 40;
+    // avoid ties: 30 is equidistant between 20 and 40 and picks row 0.)
+    act(() => {
+      useRealtimeStore.getState().updateChannels({ RPM: 1200, MAP: 45 });
+    });
+    expect(cellAt(container, 1, 1).className).toContain('live');
+
+    // t=3s: move to (2,2). Cell (1,1) becomes trail with opacity
+    // 1 - 3000/8000 = 0.625.
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    act(() => {
+      useRealtimeStore.getState().updateChannels({ RPM: 2200, MAP: 55 });
+    });
+
+    const firstVisit = cellAt(container, 1, 1);
+    expect(firstVisit.className).toContain('trail');
+    expect(trailOpacity(firstVisit)).toBeCloseTo(0.625, 1);
+
+    // Re-enter (1,1) and leave again immediately: the trail must reflect the
+    // newest visit (opacity ≈ 1), not the t=0 one (0.625).
+    act(() => {
+      useRealtimeStore.getState().updateChannels({ RPM: 1200, MAP: 45 });
+    });
+    act(() => {
+      useRealtimeStore.getState().updateChannels({ RPM: 2200, MAP: 55 });
+    });
+
+    const reentered = cellAt(container, 1, 1);
+    expect(reentered.className).toContain('trail');
+    expect(trailOpacity(reentered)).toBeGreaterThan(0.9);
+  });
+
+  it('does not queue an extra render when the live cell does not change', async () => {
+    let commits = 0;
+    const onRender = () => {
+      commits += 1;
+    };
+    render(
+      <Profiler id="editor" onRender={onRender}>
+        <TableEditor data={{ ...DATA }} onChange={() => {}} />
+      </Profiler>
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+    // First tick establishes the live position (and its first trail entry —
+    // a legitimate extra commit).
+    act(() => {
+      useRealtimeStore.getState().updateChannels({ RPM: 1200, MAP: 45 });
+    });
+    const before = commits;
+
+    // Two ticks with different values that bin into the SAME cell (1,1)
+    // (RPM under 1250 keeps col 1; MAP 40-50 keeps row 1). Each store change
+    // commits once; the trail effect must not add another (the old code
+    // re-fired it per tick via a fresh position object and a new-array
+    // filter result).
+    act(() => {
+      useRealtimeStore.getState().updateChannels({ RPM: 1150, MAP: 46 });
+    });
+    act(() => {
+      useRealtimeStore.getState().updateChannels({ RPM: 1100, MAP: 44 });
+    });
+
+    expect(commits - before).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the "program freezes when I open the fuel table" symptom from #132: with a live stream running, opening a table saturated the WebView main thread and the window stopped responding until the tab was closed.

Related: #132 (the Alpha-N/ITB feature gaps are addressed separately in #238).

## Root cause

Three multipliers stacked on the same path:

1. **Per-cell whole-grid scans.** `data.min`/`data.max` are never populated, so `getValueColor` flattened all 256 values via `Math.min(...zValues.flat())` / `Math.max(...)` — and each cell called it **twice** (background color + contrast text color), each call also running regex color parsing.
2. **Render amplification.** The live-position memo produced a fresh `{row, col}` object on every realtime tick (~20 Hz), so the history-trail effect re-fired even when the cursor stayed in the same cell — queuing a second state update + render per tick. The trail cleanup interval added another: `prev.filter(...)` always allocated a new array, forcing a re-render every 200 ms regardless of whether anything changed. Net: up to ~40 full-grid renders/sec.
3. **Backend tax on open.** `get_table_data` built the **unfiltered** string context (~100 ms of cloning on a real Speeduino INI, while holding the definition/tune/project locks) — for exactly two axis-label expressions.

## Changes

- `zBounds` `useMemo` — grid min/max once per data change; one color derivation per cell (`tuner-ui/TableEditor.tsx`).
- Stable live-position identity via a ref-backed memo — the trail effect now fires only when the cell actually changes.
- Trail append + cleanup return the previous array when nothing changed (no-op filter no longer forces a re-render).
- Trail fade is driven by a ~5 Hz tick that only runs while trail entries exist (previously it relied on accidental identity churn).
- Trail lookup per cell is a precomputed `Map` instead of `Array.find`. **Behavioral fix included:** a re-entered cell (A→B→A) now fades from its *newest* visit — `find()` returned the oldest duplicate entry, so a freshly re-entered cell rendered as (nearly) faded.
- Same `zBounds` fix in the dialog-embedded grid (`tables/TableGrid.tsx` `getCellColor`).
- `get_table_data` uses `build_string_context_filtered` scoped to the identifiers referenced by the two axis-label expressions.

## Tests

New `TableEditor.trail.test.tsx` regression tests, **verified failing against the pre-fix component** before confirming they pass post-fix:
1. A re-entered cell fades from its newest visit (asserts `--trail-opacity` > 0.9 after re-entry; old code yields 0.625).
2. Same-cell realtime ticks (different values, same nearest bins) commit exactly once per tick instead of twice (React Profiler commit counting).

`tsc --noEmit` clean; vitest 206 passed; `cargo check`/`cargo fmt --check` clean.

## Notes for reviewers

- Rendering semantics are unchanged apart from the re-entered-cell fade fix (arguably a bug fix, noted above).
- `data.min`/`data.max` remain unpopulated by the backend; the memo's scan is O(n) once per edit instead of per cell per render. Populating them server-side later would only shave the initial scan.
