### PR TITLE
fix(app): send tracing to stderr, where everything that captures it looks

### DIFF
--- a/crates/libretune-app/src-tauri/src/lib.rs
+++ b/crates/libretune-app/src-tauri/src/lib.rs
@@ -187,7 +187,18 @@ pub fn run() {
         .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
     tracing_subscriber::fmt()
         .with_env_filter(filter)
-        .with_target(false)
+        // `fmt()` writes to STDOUT by default. Everything that captures this
+        // app's diagnostics redirects stderr, so without this line every
+        // `tracing::` event went to a stream nobody was reading - while the
+        // `eprintln!` calls still being migrated away kept landing in the file,
+        // making the log look healthy. A car session's entire AutoTune trail
+        // was lost that way, including the line naming which AFR target table
+        // had been resolved.
+        .with_writer(std::io::stderr)
+        // Keep the module path: with `RUST_LOG` filtering by target, a line
+        // that does not say where it came from cannot be traced back to the
+        // directive that did or did not select it.
+        .with_target(true)
         .init();
 
     tauri::Builder::default()


### PR DESCRIPTION
`tracing_subscriber::fmt()` writes to **stdout** by default. Every wrapper that
captures this app's diagnostics redirects stderr, so all `tracing::` output went
to a stream nobody was reading.

It looked like logging worked. The crate is mid-migration from `eprintln!` to
`tracing::`, and the remaining `eprintln!` calls do go to stderr — so a capture
file fills with protocol and project-lifecycle lines while whole subsystems that
have finished migrating are silently absent.

Cost during a real session: `start_autotune` is fully migrated, so its entire
trail was missing — including the line naming which AFR target table had been
resolved, at a time when a mis-resolution was retargeting every recommendation
to stoich. There was no forensic record at all.

Also restores `with_target(true)`: with `RUST_LOG` filtering by target, a line
that does not say where it came from cannot be matched back to the directive
that did or did not select it.

## Testing

754 tests pass under a plain `cargo test` (default parallelism). No behaviour
change beyond where bytes go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)