### PR TITLE
fix(tables): persist a grid edit when it is made, not when a button is found

### DIFF
--- a/crates/libretune-app/src/components/tables/TableEditor2D.tsx
+++ b/crates/libretune-app/src/components/tables/TableEditor2D.tsx
@@ -151,7 +151,9 @@ export default function TableEditor2D({
   const safeXBins = hasValidData ? x_bins : [0];
   const safeYBins = hasValidData ? y_bins : [0];
   
-  const [localZValues, setLocalZValues] = useState<number[][]>([...safeZValues]);
+  // Renamed: every mutation goes through the `setLocalZValues` wrapper defined
+  // below, which persists as well as sets. Nothing should call this directly.
+  const [localZValues, setLocalZValuesState] = useState<number[][]>([...safeZValues]);
   const [localXBins, setLocalXBins] = useState<number[]>([...safeXBins]);
   const [localYBins, setLocalYBins] = useState<number[]>([...safeYBins]);
   
@@ -279,6 +281,33 @@ export default function TableEditor2D({
       showToast(`${operation} failed: ${message}`, 'error');
     },
     [showToast]
+  );
+
+  /**
+   * Set the grid AND persist it. Every one of the seventeen mutation sites in
+   * this component calls this, so an operation cannot silently forget to save.
+   *
+   * It used to be a plain `useState` setter, and only the toolbar's "s" button
+   * pushed anything to the backend. The result: edits lived in component state
+   * alone, so switching tabs unmounted the grid and discarded them, and
+   * File -> Save As serialised the backend cache and wrote the pre-edit values
+   * with no warning. A real tuning session was lost that way twice - the table
+   * on screen and the table in the file simply disagreed.
+   *
+   * Persisting per edit writes the whole table each time, which is what undo
+   * and redo already did, so the cost is not new. If that ever matters on a
+   * slow link, debounce here rather than moving the call back out to the call
+   * sites, where the next new operation will forget it again.
+   */
+  const setLocalZValues = useCallback(
+    (values: number[][]) => {
+      setLocalZValuesState(values);
+      invoke('update_table_data', { tableName: table_name, zValues: values })
+        // Loudly. The previous `.then(() => {})` had no catch at all, so a
+        // rejected write left the grid showing values the ECU never received.
+        .catch((err) => handleOperationError('Saving table', err));
+    },
+    [table_name, handleOperationError]
   );
 
   useEffect(() => {
@@ -1088,13 +1117,9 @@ export default function TableEditor2D({
       });
 
       if (hasChanges) {
+        // setLocalZValues persists; no second write.
         setLocalZValues(newValues);
         pushHistory(newValues, localXBins, localYBins);
-        // Persist to backend without triggering n*m alerts
-        invoke('update_table_data', {
-          tableName: table_name,
-          zValues: newValues
-        });
         
         // Update selection to cover pasted area
         const endY = Math.min(startY + rows.length - 1, y_bins.length - 1);
@@ -1124,13 +1149,9 @@ export default function TableEditor2D({
       setHistoryIndex(prevIndex);
       onValuesChange?.(snapshot.z);
       
-      // Update backend
-      invoke('update_table_data', {
-        tableName: table_name,
-        zValues: snapshot.z,
-        // Backend update for axis not yet available via simple set command
-        // but local state is reverted
-      });
+      // The z values are persisted by setLocalZValues above. Axis bins are
+      // still local-only: there is no command to write them, so an undo that
+      // crosses a re-bin restores the grid but not the ECU's axes.
     }
   };
 
@@ -1147,10 +1168,6 @@ export default function TableEditor2D({
       setHistoryIndex(nextIndex);
       onValuesChange?.(snapshot.z);
 
-      invoke('update_table_data', {
-        tableName: table_name,
-        zValues: snapshot.z
-      });
     }
   };
 
@@ -1173,12 +1190,16 @@ export default function TableEditor2D({
     }
   };
 
+  /**
+   * Explicit re-send. Edits already persist as they are made, so this is now a
+   * "push it again" for when the ECU was offline at the time - not the only
+   * thing standing between a session's work and losing it, which is what it
+   * used to be.
+   */
   const handleSave = () => {
-    invoke('update_table_data', {
-      tableName: table_name,
-      zValues: localZValues
-    }).then(() => {
-    });
+    invoke('update_table_data', { tableName: table_name, zValues: localZValues })
+      .then(() => showToast('Table sent to the ECU', 'success'))
+      .catch((err) => handleOperationError('Saving table', err));
   };
 
   const handleRightClick = (e: React.MouseEvent, x: number, y: number, cell: HTMLElement) => {

--- a/crates/libretune-app/src/components/tables/__tests__/TableEditor2D.operations.test.tsx
+++ b/crates/libretune-app/src/components/tables/__tests__/TableEditor2D.operations.test.tsx
@@ -146,3 +146,59 @@ describe('TableEditor2D table operations', () => {
     });
   });
 });
+
+/**
+ * A grid edit used to live in component state and nowhere else. Only the
+ * "Save (S)" button pushed anything to the backend, so switching tabs unmounted
+ * the editor and discarded the work, and File -> Save As serialised the backend
+ * cache and wrote the pre-edit values without a word. A real tuning session was
+ * lost that way twice before anyone noticed the table on screen and the table
+ * in the file disagreed.
+ */
+describe('TableEditor2D persistence', () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+    invokeMock.mockResolvedValue({
+      table_name: 'veTable1Tbl',
+      x_bins: X_BINS,
+      y_bins: Y_BINS,
+      z_values: [[99, 11, 12], [20, 21, 22], [30, 31, 32]],
+    });
+  });
+
+  it('persists to the backend as soon as an operation changes the grid', async () => {
+    renderEditor();
+    fireEvent.click(screen.getByTitle('Smooth selected cells (s)'));
+
+    await waitFor(() => {
+      const saved = invokeMock.mock.calls.find(([cmd]) => cmd === 'update_table_data');
+      expect(saved, 'the edit must reach the backend without a separate Save').toBeTruthy();
+    });
+
+    const saved = invokeMock.mock.calls.find(([cmd]) => cmd === 'update_table_data')!;
+    const args = (saved[1] ?? {}) as Record<string, unknown>;
+    expect(args.tableName).toBe('veTable1Tbl');
+    // and it must carry the NEW values, not the ones the grid started with
+    expect(args.zValues).toEqual([[99, 11, 12], [20, 21, 22], [30, 31, 32]]);
+  });
+
+  it('surfaces a failed save instead of swallowing it', async () => {
+    // The operation succeeds, the persist that follows does not.
+    invokeMock.mockImplementation((cmd: string) => {
+      if (cmd === 'update_table_data') return Promise.reject(new Error('ECU said no'));
+      return Promise.resolve({
+        table_name: 'veTable1Tbl',
+        x_bins: X_BINS,
+        y_bins: Y_BINS,
+        z_values: [[99, 11, 12], [20, 21, 22], [30, 31, 32]],
+      });
+    });
+
+    renderEditor();
+    fireEvent.click(screen.getByTitle('Smooth selected cells (s)'));
+
+    // The old code was `.then(() => {})` with no catch at all, so a rejected
+    // write left the grid showing values the ECU never received.
+    await waitFor(() => expect(screen.getByText(/ECU said no/)).toBeInTheDocument());
+  });
+});


### PR DESCRIPTION
Table edits lived in component state and nowhere else. Only the toolbar's
"Save (S)" button pushed anything to the backend, and it sits unlabelled among
the arithmetic operators next to "Smooth (s)".

Three consequences, all silent:

- switching tabs unmounted the editor, and `useState([...safeZValues])` re-read
  the prop on remount — so the work was simply gone, with no prompt;
- **`File → Save As` serialises the backend cache**, so it wrote the PRE-edit
  values while the grid showed the new ones. Two saves of a real tuning session
  produced byte-identical files that did not contain the tuning;
- `handleSave` was `.then(() => {})` with no `.catch()`, so a rejected write left
  the grid showing values the ECU had never received.

## The fix

At the setter rather than the seventeen call sites that use it:
`setLocalZValues` now sets state **and** persists. A new operation cannot forget
to save, because forgetting would mean not changing the grid at all.

The explicit Save button remains as a re-send for when the ECU was offline, and
now reports success and failure instead of neither.

## Testing

2 new tests — one asserting an edit reaches the backend without a separate Save,
one asserting a failed save surfaces instead of being swallowed. 211 frontend
tests and 754 Rust tests pass; `tsc --noEmit` clean.

**Note for reviewers:** this writes the whole table per edit — which undo, redo
and paste already did, so the traffic is not new. Debounce inside the wrapper if
it ever matters, rather than moving the call back out to the call sites where
the next operation will forget it again.

Axis bins remain local-only: there is no command to write them, so an undo
across a re-bin restores the grid but not the ECU's axes. Called out in a
comment rather than silently left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)