### PR TITLE
fix(autotune): stop inventing missing inputs

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/realtime_stream.rs
+++ b/crates/libretune-app/src-tauri/src/commands/realtime_stream.rs
@@ -228,13 +228,24 @@ pub(crate) async fn feed_autotune_data(
         .copied()
         .unwrap_or(0.0);
 
-    let map = data
+    // A missing MAP is not zero load - it is no load reading. On a speed-density
+    // tune the load axis IS manifold pressure, so a constant 0.0 files every
+    // sample into the lowest load row, and a whole session is spent correcting
+    // the idle corner with wide-open-throttle data. This is the same defect as
+    // the fabricated AFR and the zero VE; MAP was simply missed when those were
+    // fixed. Only fatal when MAP is actually the load axis - a TPS or MAF tune
+    // does not need it, so it is not dropped there.
+    let map_opt = data
         .get("map")
         .or_else(|| data.get("MAP"))
         .or_else(|| data.get("mapValue"))
         .or_else(|| data.get("fuelingLoad"))
-        .copied()
-        .unwrap_or(0.0);
+        .copied();
+    if map_opt.is_none() && config.load_source == AutoTuneLoadSource::Map {
+        missing_channel_warning("MAP");
+        return;
+    }
+    let map = map_opt.unwrap_or(0.0);
 
     let maf_value = data
         .get("maf")
@@ -250,12 +261,25 @@ pub(crate) async fn feed_autotune_data(
     // TPS is read here (before load_value) so a TPS/Alpha-N load source can use
     // it as the load axis. It is also reused below for transient (tps_rate)
     // detection, so this is the single source of truth for the throttle value.
-    let tps = data
+    // A missing TPS is not 0% throttle, it is no throttle reading - and the
+    // difference is the whole transient filter. `tps_rate` is computed from
+    // this, so a constant 0.0 makes the rate constant 0.0 too, and
+    // `max_tps_rate` can never fire: every tip-in and lift-off is then accepted
+    // as steady state, carrying accel enrichment and wall wetting into cells
+    // that never asked for it. Warn once and keep going, because unlike AFR and
+    // VE this does not corrupt the arithmetic - it only widens what gets in.
+    let tps = match data
         .get("tps")
         .or_else(|| data.get("TPS"))
         .or_else(|| data.get("tpsValue"))
         .copied()
-        .unwrap_or(0.0);
+    {
+        Some(v) => v,
+        None => {
+            missing_channel_warning("TPS");
+            0.0
+        }
+    };
 
     // The load value selects which Y-axis (load) cell a sample is attributed
     // to. For MAP (speed-density) it's manifold pressure; for MAF it's mass
@@ -274,24 +298,45 @@ pub(crate) async fn feed_autotune_data(
         AutoTuneLoadSource::Tps => tps,
     };
 
-    let afr = data
+    // No AFR channel means no measurement, and a sample without a measurement
+    // must be dropped rather than invented. The old fallback was 14.7, which is
+    // uniquely bad: it is a *physically valid* mixture, so it sails through the
+    // sensor-rail filter and looks like data. Against a 12.7 wide-open-throttle
+    // target that is a standing request for ~16% more fuel, derived from a
+    // reading that never happened.
+    //
+    // `lambda` is included alongside `lambda1` because `apply_channel_aliases`
+    // publishes the canonical name; looking only for `lambda1` sent a
+    // lambda-only INI to the fabricated default.
+    let Some(afr) = data
         .get("afr")
         .or_else(|| data.get("AFR"))
         .or_else(|| data.get("afr1"))
         .or_else(|| data.get("AFRValue"))
+        .or_else(|| data.get("lambda"))
         .or_else(|| data.get("lambda1"))
         // Shared with the target side (`resolve_target_afr`) so a lambda target
         // table and a lambda sensor reading cannot end up on different scales.
         .map(|v| libretune_core::autotune::normalise_to_afr(*v))
-        .unwrap_or(14.7);
+    else {
+        missing_channel_warning("AFR");
+        return;
+    };
 
-    let ve = data
+    // Same reasoning, sharper consequence: VE 0 proposes a zero-fuel cell, and
+    // the authority limits cannot catch it because a percentage of zero is
+    // zero. `send_autotune_recommendations` already refuses to write a zero for
+    // exactly this reason; the value should never reach it in the first place.
+    let Some(ve) = data
         .get("ve")
         .or_else(|| data.get("VE"))
         .or_else(|| data.get("veValue"))
         .or_else(|| data.get("VEtable"))
         .copied()
-        .unwrap_or(0.0);
+    else {
+        missing_channel_warning("VE");
+        return;
+    };
 
     let clt = data
         .get("clt")
@@ -424,6 +469,8 @@ pub(crate) async fn stop_streaming_on_definition_change(state: &AppState) {
 }
 
 #[tauri::command]
+
+
 pub async fn start_realtime_stream(
     app: tauri::AppHandle,
     state: tauri::State<'_, AppState>,
@@ -1003,5 +1050,26 @@ mod stale_definition_guard_tests {
         // started, or already stopped).
         stop_streaming_on_definition_change(&state).await;
         assert!(state.streaming_task.lock().await.is_none());
+    }
+}
+
+/// Warn once per channel that AutoTune is dropping samples for want of it.
+///
+/// Once, not per sample: this runs at the realtime rate, and a warning that
+/// scrolls past thousands of times is one nobody reads. The condition is
+/// structural anyway - a channel the INI does not publish will not start
+/// appearing later in the session.
+fn missing_channel_warning(channel: &'static str) {
+    use std::sync::{Mutex, OnceLock};
+    static WARNED: OnceLock<Mutex<std::collections::HashSet<&'static str>>> = OnceLock::new();
+    let set = WARNED.get_or_init(|| Mutex::new(std::collections::HashSet::new()));
+    if let Ok(mut g) = set.lock() {
+        if g.insert(channel) {
+            tracing::warn!(
+                channel,
+                "AutoTune has no {} channel and is dropping every sample. Nothing                  will be learned this session - check the INI publishes it under a                  name the resolver knows.",
+                channel
+            );
+        }
     }
 }

--- a/crates/libretune-app/src-tauri/src/commands/realtime_stream.rs
+++ b/crates/libretune-app/src-tauri/src/commands/realtime_stream.rs
@@ -280,7 +280,9 @@ pub(crate) async fn feed_autotune_data(
         .or_else(|| data.get("afr1"))
         .or_else(|| data.get("AFRValue"))
         .or_else(|| data.get("lambda1"))
-        .map(|v| if *v < 2.0 { *v * 14.7 } else { *v }) // Convert lambda to AFR
+        // Shared with the target side (`resolve_target_afr`) so a lambda target
+        // table and a lambda sensor reading cannot end up on different scales.
+        .map(|v| libretune_core::autotune::normalise_to_afr(*v))
         .unwrap_or(14.7);
 
     let ve = data

--- a/crates/libretune-app/src-tauri/src/commands/realtime_stream.rs
+++ b/crates/libretune-app/src-tauri/src/commands/realtime_stream.rs
@@ -470,7 +470,6 @@ pub(crate) async fn stop_streaming_on_definition_change(state: &AppState) {
 
 #[tauri::command]
 
-
 pub async fn start_realtime_stream(
     app: tauri::AppHandle,
     state: tauri::State<'_, AppState>,

--- a/crates/libretune-app/src-tauri/src/commands/start_autotune.rs
+++ b/crates/libretune-app/src-tauri/src/commands/start_autotune.rs
@@ -958,9 +958,14 @@ mod target_afr_resolution_tests {
             },
         );
         // Repeat: a HashMap scan would eventually disagree with itself.
-        let picks: std::collections::HashSet<_> =
-            (0..50).map(|_| ini_declared_afr_target(&def).unwrap().to_string()).collect();
-        assert_eq!(picks.len(), 1, "must pick the same table every time, got {picks:?}");
+        let picks: std::collections::HashSet<_> = (0..50)
+            .map(|_| ini_declared_afr_target(&def).unwrap().to_string())
+            .collect();
+        assert_eq!(
+            picks.len(),
+            1,
+            "must pick the same table every time, got {picks:?}"
+        );
     }
 
     /// When the INI names a primary, that outranks any role scan.

--- a/crates/libretune-app/src-tauri/src/commands/start_autotune.rs
+++ b/crates/libretune-app/src-tauri/src/commands/start_autotune.rs
@@ -168,6 +168,35 @@ pub async fn start_autotune(
     // best-effort auto-discovery from the INI by common table/map names. Any
     // lookup failure falls back to an empty table, which AutoTune handles by
     // reverting to settings.target_afr and the RPM-based delay curve.
+    // `min_clt` compares against the coolant channel, and the INI declares the
+    // right number for its own unit system:
+    //
+    //     #if CELSIUS
+    //          filter = minCltFilter, "Minimum CLT", coolant, <, 71,  , true
+    //     #else
+    //          filter = minCltFilter, "Minimum CLT", coolant, <, 160, , true
+    //
+    // The struct default is a bare 160, sensible in Fahrenheit and above
+    // boiling in Celsius - where it rejects every sample a warm engine can
+    // produce, and a whole session collects nothing. Warning about that after
+    // the fact was treating the symptom; the INI has had the answer all along,
+    // so take it when the caller has not chosen a value of their own.
+    let mut filters = filters;
+    if (filters.min_clt - AutoTuneFilters::default().min_clt).abs() < f64::EPSILON {
+        if let Some(declared) = def
+            .ve_analyze
+            .as_ref()
+            .and_then(|c| c.filters.iter().find(|f| f.name == "minCltFilter"))
+        {
+            tracing::info!(
+                was = filters.min_clt,
+                now = declared.default_value,
+                "min_clt left at its default; taking the value this INI declares"
+            );
+            filters.min_clt = declared.default_value;
+        }
+    }
+
     let (mut reference_tables, target_afr_source) = resolve_reference_tables(
         def,
         cache,
@@ -360,10 +389,41 @@ pub(crate) fn read_axis_bins(
 /// The parser already turns that into [`TableRole::AfrTarget`], so the answer
 /// is sitting in the definition — it was simply never consulted here.
 fn ini_declared_afr_target(def: &EcuDefinition) -> Option<&str> {
-    def.tables
+    // `[VeAnalyze]` names the primary target outright, so take it. Scanning for
+    // the role is a fallback, and a poor primary: `infer_table_roles` stamps
+    // `AfrTarget` on every entry of `lambdaTargetTables` and on the WUE target
+    // too, and `def.tables` is a `HashMap`, whose iteration order is
+    // unspecified and varies between runs of the same binary. On this car that
+    // means `afrTable1Tbl` and `afrTSCustom` both carry the role, so a scan can
+    // silently tune against a custom table one launch and the real one the
+    // next, with nothing on screen to distinguish the two sessions.
+    if let Some(cfg) = def.ve_analyze.as_ref() {
+        let name = cfg.target_table_name.trim();
+        if !name.is_empty() && def.get_table_by_name_or_map(name).is_some() {
+            return Some(name);
+        }
+    }
+
+    // No `[VeAnalyze]`: fall back to the role, but deterministically. Sorting
+    // by name is arbitrary in meaning yet stable in effect, which is the point
+    // - two runs must agree even when neither can be sure it is right.
+    let mut candidates: Vec<&str> = def
+        .tables
         .values()
-        .find(|t| t.role == TableRole::AfrTarget)
+        .filter(|t| t.role == TableRole::AfrTarget)
         .map(|t| t.name.as_str())
+        .collect();
+    candidates.sort_unstable();
+    if candidates.len() > 1 {
+        tracing::warn!(
+            ?candidates,
+            chosen = candidates[0],
+            "several tables claim the AFR-target role and the INI names no \
+             primary; picking the first by name so the choice is at least the \
+             same every run"
+        );
+    }
+    candidates.first().copied()
 }
 
 /// Resolve the per-cell Target AFR and lambda-delay reference tables for an
@@ -393,7 +453,7 @@ fn ini_declared_afr_target(def: &EcuDefinition) -> Option<&str> {
 /// fallback, because a flat target is a documented mode ("blank = use Target
 /// AFR setting"). `target_afr_source` records which of the three applied so the
 /// caller can say so out loud instead of silently substituting stoich.
-fn resolve_reference_tables(
+pub(crate) fn resolve_reference_tables(
     def: &EcuDefinition,
     cache: Option<&TuneCache>,
     ve_table_name: &str,
@@ -559,7 +619,7 @@ fn resolve_named_table(
 
 /// Read the Z (data) values of a table constant and reshape into row-major
 /// `[row][col]`. Returns `None` on any read failure or zero-size table.
-fn read_table_z_values(
+pub(crate) fn read_table_z_values(
     def: &EcuDefinition,
     cache: Option<&TuneCache>,
     map_name: &str,
@@ -877,6 +937,58 @@ mod target_afr_resolution_tests {
         let cache = cache_with_rich_targets(&def);
         let z = read_table_z_values(&def, Some(&cache), "afrTable", 2, 2).expect("full page reads");
         assert_eq!(z, vec![vec![13.0, 13.0], vec![13.0, 13.0]]);
+    }
+
+    /// `infer_table_roles` stamps AfrTarget on several tables, and `def.tables`
+    /// is a HashMap. Without a deterministic rule the session can tune against
+    /// a different table each launch, silently.
+    #[test]
+    fn several_role_claimants_resolve_the_same_way_every_time() {
+        let mut def = def_with_afr_table("afrTable1Tbl", TableRole::AfrTarget);
+        // A second claimant, as a real Speeduino INI produces.
+        def.tables.insert(
+            "afrTSCustom".to_string(),
+            TableDefinition {
+                name: "afrTSCustom".to_string(),
+                map: "afrTable".to_string(),
+                x_size: 2,
+                y_size: 2,
+                role: TableRole::AfrTarget,
+                ..Default::default()
+            },
+        );
+        // Repeat: a HashMap scan would eventually disagree with itself.
+        let picks: std::collections::HashSet<_> =
+            (0..50).map(|_| ini_declared_afr_target(&def).unwrap().to_string()).collect();
+        assert_eq!(picks.len(), 1, "must pick the same table every time, got {picks:?}");
+    }
+
+    /// When the INI names a primary, that outranks any role scan.
+    #[test]
+    fn the_ve_analyze_declaration_outranks_the_role_scan() {
+        use libretune_core::ini::VeAnalyzeConfig;
+        let mut def = def_with_afr_table("afrTSCustom", TableRole::AfrTarget);
+        def.tables.insert(
+            "afrTable1Tbl".to_string(),
+            TableDefinition {
+                name: "afrTable1Tbl".to_string(),
+                map: "afrTable".to_string(),
+                x_size: 2,
+                y_size: 2,
+                role: TableRole::AfrTarget,
+                ..Default::default()
+            },
+        );
+        def.ve_analyze = Some(VeAnalyzeConfig {
+            ve_table_name: "veTable1Tbl".to_string(),
+            target_table_name: "afrTable1Tbl".to_string(),
+            ..Default::default()
+        });
+        assert_eq!(
+            ini_declared_afr_target(&def),
+            Some("afrTable1Tbl"),
+            "the INI's own [VeAnalyze] naming must win"
+        );
     }
 
     #[test]

--- a/crates/libretune-app/src-tauri/src/commands/start_autotune.rs
+++ b/crates/libretune-app/src-tauri/src/commands/start_autotune.rs
@@ -407,7 +407,13 @@ fn resolve_reference_tables(
         def,
         cache,
         requested,
-        &["afrTable", "afr_target", "afrTarget", "targetAfr", "afrTable1"],
+        &[
+            "afrTable",
+            "afr_target",
+            "afrTarget",
+            "targetAfr",
+            "afrTable1",
+        ],
     )
     .unwrap_or_default();
 
@@ -671,7 +677,8 @@ mod target_afr_resolution_tests {
         assert_eq!(ini_declared_afr_target(&def), Some("afrTable1Tbl"));
 
         let cache = cache_with_rich_targets(&def);
-        let (tables, source) = resolve_reference_tables(&def, Some(&cache), "veTable1Tbl", None, None);
+        let (tables, source) =
+            resolve_reference_tables(&def, Some(&cache), "veTable1Tbl", None, None);
 
         assert_eq!(
             source,
@@ -680,7 +687,10 @@ mod target_afr_resolution_tests {
         );
         // The values must actually arrive, not just the name: a resolved-but-empty
         // table falls through to the flat target just as invisibly.
-        assert_eq!(tables.target_afr_table, vec![vec![13.0, 13.0], vec![13.0, 13.0]]);
+        assert_eq!(
+            tables.target_afr_table,
+            vec![vec![13.0, 13.0], vec![13.0, 13.0]]
+        );
     }
 
     #[test]
@@ -690,7 +700,8 @@ mod target_afr_resolution_tests {
         assert_eq!(ini_declared_afr_target(&def), None);
 
         let cache = cache_with_rich_targets(&def);
-        let (tables, source) = resolve_reference_tables(&def, Some(&cache), "veTable1Tbl", None, None);
+        let (tables, source) =
+            resolve_reference_tables(&def, Some(&cache), "veTable1Tbl", None, None);
         assert_eq!(source, TargetAfrSource::NameMatch);
         assert!(!tables.target_afr_table.is_empty());
     }
@@ -701,7 +712,8 @@ mod target_afr_resolution_tests {
         // INI could match a target of ~0.88 against a measured AFR of ~13.
         let def = def_with_afr_table("lambdaTable", TableRole::Other);
         let cache = cache_with_rich_targets(&def);
-        let (tables, source) = resolve_reference_tables(&def, Some(&cache), "veTable1Tbl", None, None);
+        let (tables, source) =
+            resolve_reference_tables(&def, Some(&cache), "veTable1Tbl", None, None);
 
         assert_eq!(source, TargetAfrSource::FlatSetting);
         assert!(
@@ -719,8 +731,12 @@ mod target_afr_resolution_tests {
         // and so would have passed while the units were mismatched.
         let def = def_with_afr_table("lambdaTable1Tbl", TableRole::AfrTarget);
         let cache = cache_with_rich_targets(&def);
-        let (tables, source) = resolve_reference_tables(&def, Some(&cache), "veTable1Tbl", None, None);
-        assert_eq!(source, TargetAfrSource::IniDeclared("lambdaTable1Tbl".to_string()));
+        let (tables, source) =
+            resolve_reference_tables(&def, Some(&cache), "veTable1Tbl", None, None);
+        assert_eq!(
+            source,
+            TargetAfrSource::IniDeclared("lambdaTable1Tbl".to_string())
+        );
         assert!(!tables.target_afr_table.is_empty());
     }
 
@@ -757,9 +773,17 @@ mod target_afr_resolution_tests {
     fn an_explicit_name_outranks_the_ini_declaration() {
         let def = def_with_afr_table("afrTable1Tbl", TableRole::AfrTarget);
         let cache = cache_with_rich_targets(&def);
-        let (_, source) =
-            resolve_reference_tables(&def, Some(&cache), "veTable1Tbl", Some("afrTable1Tbl"), None);
-        assert_eq!(source, TargetAfrSource::Explicit("afrTable1Tbl".to_string()));
+        let (_, source) = resolve_reference_tables(
+            &def,
+            Some(&cache),
+            "veTable1Tbl",
+            Some("afrTable1Tbl"),
+            None,
+        );
+        assert_eq!(
+            source,
+            TargetAfrSource::Explicit("afrTable1Tbl".to_string())
+        );
     }
 
     /// Give the definition a VE table so `resolve_reference_tables` can compare
@@ -801,7 +825,8 @@ mod target_afr_resolution_tests {
         let def = with_ve_table(def, 4, 4); // VE is 4x4, the target is 2x2
         let cache = cache_with_rich_targets(&def);
 
-        let (tables, source) = resolve_reference_tables(&def, Some(&cache), "veTable1Tbl", None, None);
+        let (tables, source) =
+            resolve_reference_tables(&def, Some(&cache), "veTable1Tbl", None, None);
         assert!(
             tables.target_afr_table.is_empty(),
             "a 2x2 target must not be applied to a 4x4 VE table"
@@ -815,9 +840,13 @@ mod target_afr_resolution_tests {
         let def = with_ve_table(def, 2, 2); // same shape as the target
         let cache = cache_with_rich_targets(&def);
 
-        let (tables, source) = resolve_reference_tables(&def, Some(&cache), "veTable1Tbl", None, None);
+        let (tables, source) =
+            resolve_reference_tables(&def, Some(&cache), "veTable1Tbl", None, None);
         assert_eq!(tables.target_afr_table.len(), 2);
-        assert_eq!(source, TargetAfrSource::IniDeclared("afrTable1Tbl".to_string()));
+        assert_eq!(
+            source,
+            TargetAfrSource::IniDeclared("afrTable1Tbl".to_string())
+        );
     }
 
     #[test]
@@ -835,7 +864,8 @@ mod target_afr_resolution_tests {
             "a partial read must fail, not return a zero-padded table: {z:?}"
         );
 
-        let (tables, source) = resolve_reference_tables(&def, Some(&cache), "veTable1Tbl", None, None);
+        let (tables, source) =
+            resolve_reference_tables(&def, Some(&cache), "veTable1Tbl", None, None);
         assert!(tables.target_afr_table.is_empty());
         assert_eq!(source, TargetAfrSource::FlatSetting);
     }

--- a/crates/libretune-app/src-tauri/src/commands/start_autotune.rs
+++ b/crates/libretune-app/src-tauri/src/commands/start_autotune.rs
@@ -8,7 +8,7 @@ use crate::state::{
 use libretune_core::autotune::{
     AutoTuneAuthorityLimits, AutoTuneFilters, AutoTuneReferenceTables, AutoTuneSettings,
 };
-use libretune_core::ini::{Constant, EcuDefinition};
+use libretune_core::ini::{Constant, EcuDefinition, TableRole};
 use libretune_core::tune::TuneCache;
 
 #[tauri::command]
@@ -168,13 +168,30 @@ pub async fn start_autotune(
     // best-effort auto-discovery from the INI by common table/map names. Any
     // lookup failure falls back to an empty table, which AutoTune handles by
     // reverting to settings.target_afr and the RPM-based delay curve.
-    let mut reference_tables = resolve_reference_tables(
+    let (mut reference_tables, target_afr_source) = resolve_reference_tables(
         def,
         cache,
         &table_name,
         target_afr_table_name.as_deref(),
         lambda_delay_table_name.as_deref(),
     );
+
+    // Say which target the corrections are actually chasing. A flat target is a
+    // legitimate mode, but silently substituting one for a table the tuner
+    // believed was auto-discovered is how a session ends up leaning every
+    // full-load cell to stoich.
+    match &target_afr_source {
+        TargetAfrSource::FlatSetting => tracing::warn!(
+            flat_target_afr = settings.target_afr,
+            "{}",
+            target_afr_source.describe(settings.target_afr)
+        ),
+        _ => tracing::info!(
+            table = target_afr_source.table_name().unwrap_or("-"),
+            "{}",
+            target_afr_source.describe(settings.target_afr)
+        ),
+    }
 
     // Flow-scaled lambda-delay table: when requested and no explicit per-cell
     // delay table was found (the Speeduino case — no lambdaDelay in the INI),
@@ -329,37 +346,118 @@ pub(crate) fn read_axis_bins(
     Ok(fallback_bins(axis_hint, size))
 }
 
+/// The AFR/lambda target table the INI itself declares, if any.
+///
+/// Speeduino states the pairing outright rather than leaving it to be guessed:
+///
+/// ```text
+/// #if LAMBDA
+///   veAnalyzeMap = veTable1Tbl, lambdaTable1Tbl, lambda, egoCorrection
+/// #else
+///   veAnalyzeMap = veTable1Tbl, afrTable1Tbl,    afr,    egoCorrection
+/// ```
+///
+/// The parser already turns that into [`TableRole::AfrTarget`], so the answer
+/// is sitting in the definition — it was simply never consulted here.
+fn ini_declared_afr_target(def: &EcuDefinition) -> Option<&str> {
+    def.tables
+        .values()
+        .find(|t| t.role == TableRole::AfrTarget)
+        .map(|t| t.name.as_str())
+}
+
 /// Resolve the per-cell Target AFR and lambda-delay reference tables for an
 /// AutoTune session (bug #14).
 ///
-/// Lookup order for each table:
+/// Lookup order for the AFR target:
 /// 1. The explicit name passed by the caller (UI override).
-/// 2. Best-effort auto-discovery from the INI by common table/map names.
+/// 2. The table the INI declares as [`TableRole::AfrTarget`].
+/// 3. Best-effort name matching, for INIs that declare nothing.
 ///
-/// Any failure returns an empty table for that slot, which AutoTune handles by
-/// falling back to `settings.target_afr` (for AFR) or the RPM-based delay curve
-/// (for lambda delay). This never fails the whole `start_autotune` call.
+/// Step 2 is why this is not merely tidier than guessing. The candidate list
+/// held `afrTable1` while every Speeduino names the table **`afrTable1Tbl`**,
+/// so auto-discovery missed on every Speeduino project and fell through to a
+/// flat `settings.target_afr` of 14.7 — stoich at wide-open throttle, where the
+/// car's own table asked for 12.7. On a real drive that produced 154
+/// recommendations, 117 of them removing fuel, the worst cutting VE 91 -> 78 at
+/// full load. Nothing surfaced the substitution: the UI offers "Auto-discover"
+/// and reports success either way.
+///
+/// The candidate list also spanned both kinds of table (`afrTable` *and*
+/// `lambdaTable`), so on a lambda INI it could match a target of ~0.88 against
+/// a measured AFR of ~13. `lambdaTable` is gone from it: the role lookup picks
+/// the lambda table correctly on a lambda INI, where the measured channel is
+/// lambda too, so the pair stays consistent.
+///
+/// A failure still yields an empty table and the `settings.target_afr`
+/// fallback, because a flat target is a documented mode ("blank = use Target
+/// AFR setting"). `target_afr_source` records which of the three applied so the
+/// caller can say so out loud instead of silently substituting stoich.
 fn resolve_reference_tables(
     def: &EcuDefinition,
     cache: Option<&TuneCache>,
     ve_table_name: &str,
     target_afr_table_name: Option<&str>,
     lambda_delay_table_name: Option<&str>,
-) -> AutoTuneReferenceTables {
+) -> (AutoTuneReferenceTables, TargetAfrSource) {
+    let declared = ini_declared_afr_target(def);
+    let requested = target_afr_table_name.or(declared);
+
     let target_afr_table = resolve_named_table(
         def,
         cache,
-        target_afr_table_name,
-        &[
-            "afrTable",
-            "afr_target",
-            "afrTarget",
-            "targetAfr",
-            "afrTable1",
-            "lambdaTable",
-        ],
+        requested,
+        &["afrTable", "afr_target", "afrTarget", "targetAfr", "afrTable1"],
     )
     .unwrap_or_default();
+
+    // `resolve_target_afr` indexes the target with the VE table's own (x, y),
+    // so the two must be the same shape. Nothing checked that. The AFR target
+    // has independent axes by design — Speeduino gives it `afrRpmBins`/
+    // `afrLoadBins` against the VE table's `veRpmBins`/`veLoadBins` — so a
+    // smaller target simply returns `None` for the rows and columns past its
+    // end, and those cells fall back to the flat target with no symptom. Once
+    // again that is the top-load, high-rpm corner.
+    //
+    // Equal dimensions are necessary but not sufficient: two 16x16 tables on
+    // different bin values line up index-for-index while meaning different
+    // things. Comparing bins would need them plumbed in here; refusing a shape
+    // mismatch removes the case that silently half-applies, which is the one
+    // that produced a wrong answer while looking resolved.
+    let ve_shape = def
+        .get_table_by_name_or_map(ve_table_name)
+        .map(|t| (t.y_size, t.x_size));
+    let target_afr_table = match (&ve_shape, target_afr_table.is_empty()) {
+        (Some((rows, cols)), false) => {
+            let got = (
+                target_afr_table.len(),
+                target_afr_table.first().map(|r| r.len()).unwrap_or(0),
+            );
+            if got == (*rows, *cols) {
+                target_afr_table
+            } else {
+                tracing::warn!(
+                    ve_table = ve_table_name,
+                    expected = ?(*rows, *cols),
+                    got = ?got,
+                    "AFR target table is a different shape to the VE table; \
+                     ignoring it rather than applying it to part of the map"
+                );
+                Vec::new()
+            }
+        }
+        _ => target_afr_table,
+    };
+
+    let target_afr_source = if target_afr_table.is_empty() {
+        TargetAfrSource::FlatSetting
+    } else if target_afr_table_name.is_some() {
+        TargetAfrSource::Explicit(requested.unwrap_or_default().to_string())
+    } else if declared.is_some() {
+        TargetAfrSource::IniDeclared(requested.unwrap_or_default().to_string())
+    } else {
+        TargetAfrSource::NameMatch
+    };
 
     // Lambda-delay tables are uncommon; only attempt when named explicitly or
     // via the most common Speeduino/rusEFI identifier.
@@ -375,9 +473,52 @@ fn resolve_reference_tables(
     // INI cross-referencing (e.g. walking the VE table's own reference field).
     let _ = ve_table_name;
 
-    AutoTuneReferenceTables {
-        lambda_delay_table,
-        target_afr_table,
+    (
+        AutoTuneReferenceTables {
+            lambda_delay_table,
+            target_afr_table,
+        },
+        target_afr_source,
+    )
+}
+
+/// Where a session's per-cell AFR target came from.
+///
+/// Exists so the answer can be shown to the user. The dangerous case is
+/// [`Self::FlatSetting`]: it means every cell is being tuned to one number,
+/// which is only ever right if that is what the tuner intended.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TargetAfrSource {
+    /// Caller named the table explicitly.
+    Explicit(String),
+    /// Taken from the INI's own `TableRole::AfrTarget` declaration.
+    IniDeclared(String),
+    /// Matched by name from the candidate list (INI declared nothing).
+    NameMatch,
+    /// No table resolved — every cell uses the flat `settings.target_afr`.
+    FlatSetting,
+}
+
+impl TargetAfrSource {
+    /// Table name, when a table was actually resolved.
+    pub(crate) fn table_name(&self) -> Option<&str> {
+        match self {
+            Self::Explicit(n) | Self::IniDeclared(n) => Some(n.as_str()),
+            Self::NameMatch | Self::FlatSetting => None,
+        }
+    }
+
+    /// A line fit to show a tuner, naming what the corrections are chasing.
+    pub(crate) fn describe(&self, flat_target: f64) -> String {
+        match self {
+            Self::Explicit(n) => format!("per-cell AFR target from '{n}' (chosen)"),
+            Self::IniDeclared(n) => format!("per-cell AFR target from '{n}' (declared by the INI)"),
+            Self::NameMatch => "per-cell AFR target from a name-matched table".to_string(),
+            Self::FlatSetting => format!(
+                "NO AFR target table resolved - every cell targets a flat {flat_target}. \
+                 Set 'Target AFR Table' if the engine runs richer under load."
+            ),
+        }
     }
 }
 
@@ -431,22 +572,298 @@ fn read_table_z_values(
     }
     let mut offset = constant.offset as usize;
 
+    // A short or undecodable page must fail, not pad. Padding produced a table
+    // that reported as resolved while its tail was zeros — and because
+    // `resolve_target_afr` ignores values <= 0.1, exactly those cells silently
+    // reverted to the flat target. The tail of a row-major table is the
+    // high-load, high-rpm corner, so the cells that got the fabricated target
+    // were the ones where being wrong matters most. `None` costs the caller the
+    // whole table, which is the honest outcome: a partially-read table cannot
+    // be told apart from a fully-read one by anything downstream.
     let mut out = Vec::with_capacity(rows);
     for _ in 0..rows {
         let mut row = Vec::with_capacity(cols);
         for _ in 0..cols {
-            if offset + elem_size <= page_data.len() {
-                if let Ok(raw) = read_raw_value(&page_data[offset..], &constant.data_type) {
-                    row.push(constant.raw_to_display(raw));
-                } else {
-                    row.push(0.0);
-                }
-                offset += elem_size;
-            } else {
-                row.push(0.0);
+            if offset + elem_size > page_data.len() {
+                tracing::warn!(
+                    map = map_name,
+                    page = constant.page,
+                    need = offset + elem_size,
+                    have = page_data.len(),
+                    "table read ran past the end of the page; refusing a partial table"
+                );
+                return None;
             }
+            let raw = match read_raw_value(&page_data[offset..], &constant.data_type) {
+                Ok(raw) => raw,
+                Err(e) => {
+                    tracing::warn!(
+                        map = map_name,
+                        offset,
+                        error = %e,
+                        "table value failed to decode; refusing a partial table"
+                    );
+                    return None;
+                }
+            };
+            row.push(constant.raw_to_display(raw));
+            offset += elem_size;
         }
         out.push(row);
     }
     Some(out)
+}
+
+#[cfg(test)]
+mod target_afr_resolution_tests {
+    use super::*;
+    use libretune_core::ini::{DataType, TableDefinition};
+    use libretune_core::tune::TuneCache;
+
+    /// A definition holding one 2x2 AFR-target table, optionally declaring the
+    /// `AfrTarget` role the way a real Speeduino INI does.
+    fn def_with_afr_table(table_name: &str, role: TableRole) -> EcuDefinition {
+        let mut def = EcuDefinition {
+            page_sizes: vec![16],
+            n_pages: 1,
+            ..Default::default()
+        };
+
+        def.constants.insert(
+            "afrTable".to_string(),
+            Constant {
+                name: "afrTable".to_string(),
+                page: 0,
+                offset: 0,
+                data_type: DataType::U08,
+                scale: 0.1,
+                translate: 0.0,
+                ..Default::default()
+            },
+        );
+        def.tables.insert(
+            table_name.to_string(),
+            TableDefinition {
+                name: table_name.to_string(),
+                map: "afrTable".to_string(),
+                x_size: 2,
+                y_size: 2,
+                role,
+                ..Default::default()
+            },
+        );
+        def
+    }
+
+    /// Page bytes for a 2x2 table of 13.0 AFR at scale 0.1 (raw 130).
+    fn cache_with_rich_targets(def: &EcuDefinition) -> TuneCache {
+        let mut cache = TuneCache::from_definition(def);
+        cache.load_page(0, vec![130u8; 16]);
+        cache
+    }
+
+    #[test]
+    fn ini_declaration_is_consulted_for_the_real_speeduino_table_name() {
+        // `afrTable1Tbl` is what every Speeduino calls it, and it was NOT in the
+        // old candidate list ("afrTable1" was). Before the fix this resolved to
+        // nothing and the session silently targeted a flat 14.7.
+        let def = def_with_afr_table("afrTable1Tbl", TableRole::AfrTarget);
+        assert_eq!(ini_declared_afr_target(&def), Some("afrTable1Tbl"));
+
+        let cache = cache_with_rich_targets(&def);
+        let (tables, source) = resolve_reference_tables(&def, Some(&cache), "veTable1Tbl", None, None);
+
+        assert_eq!(
+            source,
+            TargetAfrSource::IniDeclared("afrTable1Tbl".to_string()),
+            "auto-discovery must take the table the INI declares"
+        );
+        // The values must actually arrive, not just the name: a resolved-but-empty
+        // table falls through to the flat target just as invisibly.
+        assert_eq!(tables.target_afr_table, vec![vec![13.0, 13.0], vec![13.0, 13.0]]);
+    }
+
+    #[test]
+    fn an_undeclared_ini_still_falls_back_to_name_matching() {
+        // `afrTable` is a candidate name, so this resolves even with no role.
+        let def = def_with_afr_table("afrTable", TableRole::Other);
+        assert_eq!(ini_declared_afr_target(&def), None);
+
+        let cache = cache_with_rich_targets(&def);
+        let (tables, source) = resolve_reference_tables(&def, Some(&cache), "veTable1Tbl", None, None);
+        assert_eq!(source, TargetAfrSource::NameMatch);
+        assert!(!tables.target_afr_table.is_empty());
+    }
+
+    #[test]
+    fn a_lambda_table_is_never_name_matched_as_an_afr_target() {
+        // The old candidate list ended in "lambdaTable", so an undeclared lambda
+        // INI could match a target of ~0.88 against a measured AFR of ~13.
+        let def = def_with_afr_table("lambdaTable", TableRole::Other);
+        let cache = cache_with_rich_targets(&def);
+        let (tables, source) = resolve_reference_tables(&def, Some(&cache), "veTable1Tbl", None, None);
+
+        assert_eq!(source, TargetAfrSource::FlatSetting);
+        assert!(
+            tables.target_afr_table.is_empty(),
+            "a lambda table must not be picked up as an AFR target by name"
+        );
+    }
+
+    #[test]
+    fn a_declared_lambda_target_is_still_used_when_the_ini_says_so() {
+        // On a real lambda INI the role points at the lambda table. Resolution
+        // must accept it - but see the unit test below: the VALUES then need
+        // normalising, because the measured side reports AFR either way. An
+        // earlier version of this test asserted only that resolution happened
+        // and so would have passed while the units were mismatched.
+        let def = def_with_afr_table("lambdaTable1Tbl", TableRole::AfrTarget);
+        let cache = cache_with_rich_targets(&def);
+        let (tables, source) = resolve_reference_tables(&def, Some(&cache), "veTable1Tbl", None, None);
+        assert_eq!(source, TargetAfrSource::IniDeclared("lambdaTable1Tbl".to_string()));
+        assert!(!tables.target_afr_table.is_empty());
+    }
+
+    #[test]
+    fn a_lambda_target_is_normalised_before_it_reaches_the_correction() {
+        // The whole point: a lambda table holds ~0.88 while the measured value
+        // arriving at the correction has already been converted to AFR (~13.0).
+        // Divided un-normalised that is a 14.8x correction on every cell, every
+        // pass - the authority ceiling, forever, re-anchored higher each session.
+        use libretune_core::autotune::normalise_to_afr;
+
+        let lambda_target = 0.88_f64;
+        let normalised = normalise_to_afr(lambda_target);
+        assert!(
+            (normalised - 12.936).abs() < 1e-6,
+            "0.88 lambda must become {} AFR, got {normalised}",
+            0.88 * 14.7
+        );
+
+        // An AFR target must pass through untouched.
+        assert_eq!(normalise_to_afr(12.7), 12.7);
+        assert_eq!(normalise_to_afr(14.7), 14.7);
+
+        // And the correction ratio must be sane rather than enormous.
+        let measured = 13.0_f64;
+        let ratio = measured / normalised;
+        assert!(
+            (0.9..1.1).contains(&ratio),
+            "a lambda target of 0.88 against a measured 13.0 AFR should be a              near-unity correction, got {ratio}x"
+        );
+    }
+
+    #[test]
+    fn an_explicit_name_outranks_the_ini_declaration() {
+        let def = def_with_afr_table("afrTable1Tbl", TableRole::AfrTarget);
+        let cache = cache_with_rich_targets(&def);
+        let (_, source) =
+            resolve_reference_tables(&def, Some(&cache), "veTable1Tbl", Some("afrTable1Tbl"), None);
+        assert_eq!(source, TargetAfrSource::Explicit("afrTable1Tbl".to_string()));
+    }
+
+    /// Give the definition a VE table so `resolve_reference_tables` can compare
+    /// shapes. `rows`/`cols` are the VE table's, which the target must match.
+    fn with_ve_table(mut def: EcuDefinition, rows: usize, cols: usize) -> EcuDefinition {
+        def.constants.insert(
+            "veTable".to_string(),
+            Constant {
+                name: "veTable".to_string(),
+                page: 0,
+                offset: 0,
+                data_type: DataType::U08,
+                scale: 1.0,
+                translate: 0.0,
+                ..Default::default()
+            },
+        );
+        def.tables.insert(
+            "veTable1Tbl".to_string(),
+            TableDefinition {
+                name: "veTable1Tbl".to_string(),
+                map: "veTable".to_string(),
+                x_size: cols,
+                y_size: rows,
+                role: TableRole::Ve,
+                ..Default::default()
+            },
+        );
+        def
+    }
+
+    #[test]
+    fn a_target_table_of_a_different_shape_is_refused() {
+        // `resolve_target_afr` indexes the target with the VE table's own
+        // (x, y). A smaller target returns None for the rows and columns past
+        // its end - the high-load, high-rpm corner - and those cells silently
+        // revert to the flat target. Half-applying is worse than not applying.
+        let def = def_with_afr_table("afrTable1Tbl", TableRole::AfrTarget);
+        let def = with_ve_table(def, 4, 4); // VE is 4x4, the target is 2x2
+        let cache = cache_with_rich_targets(&def);
+
+        let (tables, source) = resolve_reference_tables(&def, Some(&cache), "veTable1Tbl", None, None);
+        assert!(
+            tables.target_afr_table.is_empty(),
+            "a 2x2 target must not be applied to a 4x4 VE table"
+        );
+        assert_eq!(source, TargetAfrSource::FlatSetting, "and it must say so");
+    }
+
+    #[test]
+    fn a_matching_shape_is_accepted() {
+        let def = def_with_afr_table("afrTable1Tbl", TableRole::AfrTarget);
+        let def = with_ve_table(def, 2, 2); // same shape as the target
+        let cache = cache_with_rich_targets(&def);
+
+        let (tables, source) = resolve_reference_tables(&def, Some(&cache), "veTable1Tbl", None, None);
+        assert_eq!(tables.target_afr_table.len(), 2);
+        assert_eq!(source, TargetAfrSource::IniDeclared("afrTable1Tbl".to_string()));
+    }
+
+    #[test]
+    fn a_short_page_yields_no_table_rather_than_zeros() {
+        // Padding a short read with 0.0 produced a table that reported as
+        // resolved with a zero tail; `resolve_target_afr` ignores values <= 0.1,
+        // so exactly those cells fell back to the flat target invisibly.
+        let def = def_with_afr_table("afrTable1Tbl", TableRole::AfrTarget);
+        let mut cache = TuneCache::from_definition(&def);
+        cache.load_page(0, vec![130u8; 2]); // 2 bytes for a 2x2 table
+
+        let z = read_table_z_values(&def, Some(&cache), "afrTable", 2, 2);
+        assert!(
+            z.is_none(),
+            "a partial read must fail, not return a zero-padded table: {z:?}"
+        );
+
+        let (tables, source) = resolve_reference_tables(&def, Some(&cache), "veTable1Tbl", None, None);
+        assert!(tables.target_afr_table.is_empty());
+        assert_eq!(source, TargetAfrSource::FlatSetting);
+    }
+
+    #[test]
+    fn a_full_page_still_reads_every_cell() {
+        // The padding fix must not make a healthy read fail.
+        let def = def_with_afr_table("afrTable1Tbl", TableRole::AfrTarget);
+        let cache = cache_with_rich_targets(&def);
+        let z = read_table_z_values(&def, Some(&cache), "afrTable", 2, 2).expect("full page reads");
+        assert_eq!(z, vec![vec![13.0, 13.0], vec![13.0, 13.0]]);
+    }
+
+    #[test]
+    fn an_unresolved_target_says_so_loudly() {
+        // The failure that bit a real car: no table, every cell at 14.7, and
+        // nothing on screen to say so. The message must name the number.
+        let def = EcuDefinition::default();
+        let (tables, source) = resolve_reference_tables(&def, None, "veTable1Tbl", None, None);
+        assert_eq!(source, TargetAfrSource::FlatSetting);
+        assert!(tables.target_afr_table.is_empty());
+
+        let msg = source.describe(14.7);
+        assert!(msg.contains("14.7"), "must name the flat target: {msg}");
+        assert!(
+            msg.contains("NO AFR target table"),
+            "must be unmistakable, got: {msg}"
+        );
+        assert_eq!(source.table_name(), None);
+    }
 }

--- a/crates/libretune-app/src/components/tuner-ui/AutoTune.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/AutoTune.tsx
@@ -101,13 +101,22 @@ interface AutoTuneFilters {
  * Limits on how much AutoTune can modify cell values.
  */
 interface AutoTuneAuthorityLimits {
-  /** Maximum change per update per cell (percentage) */
+  /**
+   * Maximum change per update per cell, in ABSOLUTE table units (VE points).
+   * Not a percentage - the backend clamps the raw delta against this value.
+   * It was labelled "(%)" here and in the panel for as long as it has existed,
+   * so anyone who typed 15 meaning 15% was authorising +/-15 VE.
+   */
   max_change_per_cell: number;
-  /** Maximum total change from original value (percentage) */
+  /** Maximum change per update as a percentage of the cell's session-start value. */
   max_total_change: number;
-  /** Absolute minimum allowed cell value */
+  /**
+   * Absolute floor for any cell value. The two limits above are both measured
+   * from the cell's value at session start, so they reset every session and
+   * cannot bound drift across several; these rails can.
+   */
   min_value: number;
-  /** Absolute maximum allowed cell value */
+  /** Absolute ceiling for any cell value. See `min_value`. */
   max_value: number;
 }
 
@@ -1179,7 +1188,7 @@ export function AutoTune({ tableName: initialTableName = '', onClose, isConnecte
           <div className="autotune-settings-section">
             <h3>Authority Limits</h3>
             <div className="setting-row">
-              <label>Max Change/Cell (%):</label>
+              <label>Max Change/Cell (VE):</label>
               <input
                 type="number"
                 value={authority.max_change_per_cell}
@@ -1187,11 +1196,27 @@ export function AutoTune({ tableName: initialTableName = '', onClose, isConnecte
               />
             </div>
             <div className="setting-row">
-              <label>Max Total Change (%):</label>
+              <label>Max Change/Cell (%):</label>
               <input
                 type="number"
                 value={authority.max_total_change}
                 onChange={(e) => setAuthority({ ...authority, max_total_change: parseFloat(e.target.value) })}
+              />
+            </div>
+            <div className="setting-row">
+              <label>Min Cell Value (VE):</label>
+              <input
+                type="number"
+                value={authority.min_value}
+                onChange={(e) => setAuthority({ ...authority, min_value: parseFloat(e.target.value) })}
+              />
+            </div>
+            <div className="setting-row">
+              <label>Max Cell Value (VE):</label>
+              <input
+                type="number"
+                value={authority.max_value}
+                onChange={(e) => setAuthority({ ...authority, max_value: parseFloat(e.target.value) })}
               />
             </div>
           </div>

--- a/crates/libretune-core/src/agent/orchestrator.rs
+++ b/crates/libretune-core/src/agent/orchestrator.rs
@@ -482,6 +482,7 @@ mod tests {
         AutoTuneAuthorityLimits {
             max_cell_value_change: 5.0,
             max_cell_percentage_change: 10.0,
+            ..Default::default()
         }
     }
 

--- a/crates/libretune-core/src/agent/safety.rs
+++ b/crates/libretune-core/src/agent/safety.rs
@@ -89,6 +89,24 @@ pub fn clamp_table_edit(
         }
     }
 
+    // 3. Absolute rails, last so nothing above can escape them. The two limits
+    // above are both relative to `current_value`, so they bound one edit
+    // against wherever the table already sits and cannot stop a series of
+    // edits from walking a cell anywhere at all.
+    let railed = limits.clamp_to_rails(clamped);
+    if railed != clamped {
+        reason = Some(format!(
+            "value {:.2} outside the allowed range {:.2}..={:.2}",
+            clamped,
+            limits.min_cell_value.min(limits.max_cell_value),
+            limits.min_cell_value.max(limits.max_cell_value)
+        ));
+        if clamped_from.is_none() {
+            clamped_from = Some(new_value);
+        }
+        clamped = railed;
+    }
+
     if clamped_from.is_some() {
         ClampResult {
             action: Action::TableEdit {
@@ -122,6 +140,7 @@ mod tests {
         AutoTuneAuthorityLimits {
             max_cell_value_change: 5.0,
             max_cell_percentage_change: 10.0,
+            ..Default::default()
         }
     }
 
@@ -161,6 +180,7 @@ mod tests {
         let lim = AutoTuneAuthorityLimits {
             max_cell_value_change: 100.0,
             max_cell_percentage_change: 10.0,
+            ..Default::default()
         };
         let r = clamp_table_edit(
             Action::TableEdit {
@@ -191,5 +211,66 @@ mod tests {
         let action = Action::Pause { duration_ms: 100 };
         let r = clamp_table_edit(action, &limits(), None);
         assert!(r.clamped_from.is_none());
+    }
+}
+
+#[cfg(test)]
+mod rail_tests {
+    use super::*;
+    use crate::action_scripting::Action;
+    use crate::autotune::AutoTuneAuthorityLimits;
+
+    fn railed(lo: f64, hi: f64) -> AutoTuneAuthorityLimits {
+        AutoTuneAuthorityLimits {
+            // Wide relative limits so only the rails can bite.
+            max_cell_value_change: 1000.0,
+            max_cell_percentage_change: 1000.0,
+            min_cell_value: lo,
+            max_cell_value: hi,
+        }
+    }
+
+    fn edit(new_value: f64) -> Action {
+        Action::TableEdit {
+            table_name: "veTable1Tbl".to_string(),
+            x_index: 0,
+            y_index: 0,
+            new_value,
+            old_value: None,
+        }
+    }
+
+    fn value_of(a: &Action) -> f64 {
+        match a {
+            Action::TableEdit { new_value, .. } => *new_value,
+            _ => panic!("not a table edit"),
+        }
+    }
+
+    /// The agent path enforces the same authority policy as a live session. If
+    /// the rails only reach one of the two, the other can still write past them.
+    #[test]
+    fn the_agent_path_is_railed_too() {
+        let r = clamp_table_edit(edit(400.0), &railed(0.0, 120.0), Some(100.0));
+        assert_eq!(value_of(&r.action), 120.0, "ceiling must apply to agent edits");
+        assert!(r.clamped_from.is_some(), "clamping must be reported, not silent");
+        assert!(
+            r.reason.as_deref().unwrap_or("").contains("outside the allowed range"),
+            "reason should name the rail, got {:?}",
+            r.reason
+        );
+    }
+
+    #[test]
+    fn the_agent_path_floor_applies() {
+        let r = clamp_table_edit(edit(-50.0), &railed(10.0, 255.0), Some(100.0));
+        assert_eq!(value_of(&r.action), 10.0);
+    }
+
+    #[test]
+    fn an_in_range_edit_is_untouched() {
+        let r = clamp_table_edit(edit(105.0), &railed(0.0, 255.0), Some(100.0));
+        assert_eq!(value_of(&r.action), 105.0);
+        assert!(r.clamped_from.is_none(), "no clamp should be reported");
     }
 }

--- a/crates/libretune-core/src/agent/safety.rs
+++ b/crates/libretune-core/src/agent/safety.rs
@@ -252,10 +252,20 @@ mod rail_tests {
     #[test]
     fn the_agent_path_is_railed_too() {
         let r = clamp_table_edit(edit(400.0), &railed(0.0, 120.0), Some(100.0));
-        assert_eq!(value_of(&r.action), 120.0, "ceiling must apply to agent edits");
-        assert!(r.clamped_from.is_some(), "clamping must be reported, not silent");
+        assert_eq!(
+            value_of(&r.action),
+            120.0,
+            "ceiling must apply to agent edits"
+        );
         assert!(
-            r.reason.as_deref().unwrap_or("").contains("outside the allowed range"),
+            r.clamped_from.is_some(),
+            "clamping must be reported, not silent"
+        );
+        assert!(
+            r.reason
+                .as_deref()
+                .unwrap_or("")
+                .contains("outside the allowed range"),
             "reason should name the rail, got {:?}",
             r.reason
         );

--- a/crates/libretune-core/src/autotune/mod.rs
+++ b/crates/libretune-core/src/autotune/mod.rs
@@ -1600,7 +1600,10 @@ mod authority_rail_tests {
     fn the_ceiling_bounds_a_single_update() {
         // Relative clamps would allow 100 -> 120; the rail stops it at 110.
         let a = limits(50.0, 50.0, 0.0, 110.0);
-        assert_eq!(AutoTuneState::apply_authority_limits(100.0, 120.0, &a), 110.0);
+        assert_eq!(
+            AutoTuneState::apply_authority_limits(100.0, 120.0, &a),
+            110.0
+        );
     }
 
     #[test]

--- a/crates/libretune-core/src/autotune/mod.rs
+++ b/crates/libretune-core/src/autotune/mod.rs
@@ -380,7 +380,15 @@ impl AutoTuneState {
             .lambda_delay_table
             .get(cell_y)
             .and_then(|row| row.get(cell_x))
-            .map(|&v| v.max(0.0) as u64)
+            // A zero cell means "no value here", not "no delay" - the same
+            // reading its AFR sibling `resolve_target_afr` already takes. It
+            // matters more here: a delay of 0 fails the `delay_ms > 0` check
+            // downstream, `historical_point` comes back None, and under strict
+            // matching the sample is dropped. That cell then accumulates
+            // nothing for the whole session, silently. Returning None instead
+            // sends it to the RPM curve, which is at least a number.
+            .filter(|&&v| v > 0.1)
+            .map(|&v| v as u64)
     }
 
     pub fn is_cell_locked(&self, x: usize, y: usize) -> bool {

--- a/crates/libretune-core/src/autotune/mod.rs
+++ b/crates/libretune-core/src/autotune/mod.rs
@@ -89,10 +89,49 @@ impl Default for AutoTuneSettings {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct AutoTuneAuthorityLimits {
+    /// Largest single-update change, in **absolute table units** (not percent).
     #[serde(alias = "max_change_per_cell")]
     pub max_cell_value_change: f64,
+    /// Largest single-update change as a percentage of the cell's value at the
+    /// start of this session.
     #[serde(alias = "max_total_change")]
     pub max_cell_percentage_change: f64,
+    /// Absolute floor for any cell value.
+    ///
+    /// Both clamps above are relative to `beginning_value`, which is re-anchored
+    /// to the live table at the first hit of every session (see
+    /// `add_data_point`). That makes them per-session allowances: three sessions
+    /// of "+20% max" compound to +73%, with nothing to stop the fourth. These
+    /// two are the only limits expressed against the table itself rather than
+    /// against wherever the last session happened to finish, so they are what
+    /// actually bounds a runaway.
+    ///
+    /// The UI has always sent them. Nothing received them: the struct had no
+    /// such fields and `#[serde(default)]` drops unknown keys without a word,
+    /// so a tuner who set "min 0 / max 200" got no clamp at all.
+    #[serde(alias = "min_value")]
+    pub min_cell_value: f64,
+    /// Absolute ceiling for any cell value. See [`Self::min_cell_value`].
+    #[serde(alias = "max_value")]
+    pub max_cell_value: f64,
+}
+
+impl AutoTuneAuthorityLimits {
+    /// Clamp a proposed cell value to the absolute rails.
+    ///
+    /// Shared rather than inlined because the authority policy has two
+    /// implementations — [`AutoTuneState::apply_authority_limits`] for a live
+    /// VE Analyze session and `agent::safety::clamp_table_edit` for agent-driven
+    /// edits. Both enforce the same two relative limits; adding the rails to
+    /// only one would leave the other able to write past them.
+    ///
+    /// A reversed pair (min above max) is ordered rather than trusted, because
+    /// `f64::clamp` panics when `lo > hi` and this runs per accepted sample.
+    pub fn clamp_to_rails(&self, value: f64) -> f64 {
+        let lo = self.min_cell_value.min(self.max_cell_value);
+        let hi = self.min_cell_value.max(self.max_cell_value);
+        value.clamp(lo, hi)
+    }
 }
 
 impl Default for AutoTuneAuthorityLimits {
@@ -100,6 +139,12 @@ impl Default for AutoTuneAuthorityLimits {
         Self {
             max_cell_value_change: 10.0,
             max_cell_percentage_change: 20.0,
+            // The full range a Speeduino VE byte can represent. A default rail
+            // should catch a runaway without ever trimming a legitimate tune —
+            // a big turbo VE can pass 200, so defaulting there would silently
+            // cap real tuning. Operators who want a tighter rail set one.
+            min_cell_value: 0.0,
+            max_cell_value: 255.0,
         }
     }
 }
@@ -194,6 +239,32 @@ impl Default for AutoTuneState {
         }
     }
 }
+
+/// Normalise a mixture reading to AFR, accepting either AFR or lambda.
+///
+/// Lambda runs about 0.7-1.2 and AFR about 10-20, so the two ranges do not
+/// overlap and a threshold of 2.0 separates them safely.
+///
+/// This exists because the measured and target sides used to disagree. The
+/// realtime path normalised what the sensor reported, while `resolve_target_afr`
+/// took the target table's value as-is — so a lambda target table (declared by
+/// the INI on any `#if LAMBDA` project) supplied 0.88 to be divided into a
+/// measured 13.0. That is a correction factor of 14.8 on every cell of every
+/// pass, pinned to whatever the authority ceiling allows and re-anchored higher
+/// next session. Both sides call this now so they cannot drift apart again.
+pub fn normalise_to_afr(value: f64) -> f64 {
+    if value < LAMBDA_AFR_THRESHOLD {
+        value * STOICH_AFR
+    } else {
+        value
+    }
+}
+
+/// Below this a mixture reading is lambda, above it AFR.
+pub const LAMBDA_AFR_THRESHOLD: f64 = 2.0;
+
+/// Stoichiometric AFR for petrol, the lambda -> AFR scale factor.
+pub const STOICH_AFR: f64 = 14.7;
 
 /// Wideband readings outside this range are the sensor at a stop rather than
 /// a mixture: no running engine sustains them, and a railed reading carries no
@@ -294,7 +365,10 @@ impl AutoTuneState {
             .get(cell_y)
             .and_then(|row| row.get(cell_x))
         {
-            Some(&v) if v > 0.1 => v,
+            // Normalised, because the INI may legitimately declare a lambda
+            // table as the target (`#if LAMBDA`) while the measured value
+            // arriving here has already been converted to AFR.
+            Some(&v) if v > 0.1 => normalise_to_afr(v),
             _ => fallback,
         }
     }
@@ -737,7 +811,11 @@ impl AutoTuneState {
         let max_pct_delta = beginning_value * (authority.max_cell_percentage_change / 100.0);
         let final_delta = clamped_delta.clamp(-max_pct_delta, max_pct_delta);
 
-        beginning_value + final_delta
+        // Absolute rails last, so they bound the result no matter what the two
+        // relative clamps allowed. Both of those are measured from
+        // `beginning_value`, which each session re-reads from the live table —
+        // so on their own they permit unlimited drift one session at a time.
+        authority.clamp_to_rails(beginning_value + final_delta)
     }
 
     fn find_bin_index(&self, value: f64, bins: &[f64]) -> Option<usize> {
@@ -1485,5 +1563,97 @@ mod tests {
         assert_eq!(r.cell_x, 2, "rpm 3000 should map to X bin 2");
         assert_eq!(r.cell_y, 3, "75%% throttle should map to Y bin 3");
         assert!(r.hit_count >= 1);
+    }
+}
+
+#[cfg(test)]
+mod authority_rail_tests {
+    use super::*;
+
+    fn limits(max_val: f64, max_pct: f64, lo: f64, hi: f64) -> AutoTuneAuthorityLimits {
+        AutoTuneAuthorityLimits {
+            max_cell_value_change: max_val,
+            max_cell_percentage_change: max_pct,
+            min_cell_value: lo,
+            max_cell_value: hi,
+        }
+    }
+
+    /// The UI has always sent `min_value`/`max_value`. Before these fields
+    /// existed, serde dropped them and the rails did nothing at all.
+    #[test]
+    fn the_ui_payload_field_names_actually_bind() {
+        let json = r#"{
+            "max_change_per_cell": 15.0,
+            "max_total_change": 30.0,
+            "min_value": 40.0,
+            "max_value": 120.0
+        }"#;
+        let a: AutoTuneAuthorityLimits = serde_json::from_str(json).expect("UI payload parses");
+        assert_eq!(a.max_cell_value_change, 15.0);
+        assert_eq!(a.max_cell_percentage_change, 30.0);
+        assert_eq!(a.min_cell_value, 40.0, "min_value must reach the backend");
+        assert_eq!(a.max_cell_value, 120.0, "max_value must reach the backend");
+    }
+
+    #[test]
+    fn the_ceiling_bounds_a_single_update() {
+        // Relative clamps would allow 100 -> 120; the rail stops it at 110.
+        let a = limits(50.0, 50.0, 0.0, 110.0);
+        assert_eq!(AutoTuneState::apply_authority_limits(100.0, 120.0, &a), 110.0);
+    }
+
+    #[test]
+    fn the_floor_bounds_a_single_update() {
+        let a = limits(50.0, 50.0, 80.0, 255.0);
+        assert_eq!(AutoTuneState::apply_authority_limits(100.0, 60.0, &a), 80.0);
+    }
+
+    /// The real failure the rails exist for: each session re-anchors
+    /// `beginning_value` to the live table, so a percentage allowance renews
+    /// itself indefinitely. Without an absolute rail this compounds forever.
+    #[test]
+    fn repeated_sessions_cannot_compound_past_the_rail() {
+        let unrailed = limits(1000.0, 20.0, 0.0, f64::INFINITY);
+        let mut ve = 100.0;
+        for _ in 0..10 {
+            // Each session asks for far more than allowed and is clamped to
+            // +20% of wherever the last one finished.
+            ve = AutoTuneState::apply_authority_limits(ve, ve * 10.0, &unrailed);
+        }
+        assert!(
+            ve > 600.0,
+            "without a rail, ten sessions of +20% compound unbounded; got {ve}"
+        );
+
+        let railed = limits(1000.0, 20.0, 0.0, 130.0);
+        let mut ve = 100.0;
+        for _ in 0..10 {
+            ve = AutoTuneState::apply_authority_limits(ve, ve * 10.0, &railed);
+        }
+        assert_eq!(ve, 130.0, "the rail must stop the compounding");
+    }
+
+    #[test]
+    fn a_reversed_min_max_pair_does_not_panic() {
+        // f64::clamp panics when lo > hi. A misconfigured pair should be inert,
+        // not fatal, in a loop that runs per accepted sample on a live engine.
+        let a = limits(50.0, 50.0, 200.0, 50.0);
+        let out = AutoTuneState::apply_authority_limits(100.0, 120.0, &a);
+        assert!(out.is_finite());
+        assert!((50.0..=200.0).contains(&out));
+    }
+
+    #[test]
+    fn the_default_rail_never_trims_a_legitimate_tune() {
+        // A big-turbo VE can pass 200; a default that clipped there would
+        // silently cap real tuning rather than catch a runaway.
+        let a = AutoTuneAuthorityLimits::default();
+        assert_eq!(a.min_cell_value, 0.0);
+        assert!(
+            a.max_cell_value >= 255.0,
+            "default ceiling must cover the full byte range, got {}",
+            a.max_cell_value
+        );
     }
 }

--- a/crates/libretune-core/tests/afr_target_role.rs
+++ b/crates/libretune-core/tests/afr_target_role.rs
@@ -1,0 +1,91 @@
+//! The AFR-target role, resolved from a real INI rather than a fixture.
+//!
+//! The unit tests around resolution build a synthetic 2x2 definition, which is
+//! exactly the shape that let a units bug pass review: a fixture proves the
+//! plumbing, not that a real INI declares what the code expects. These parse
+//! the shipped `demo.ini` and assert the declaration is actually found, on both
+//! arms of its `#if LAMBDA`.
+
+use libretune_core::ini::{set_default_symbols, EcuDefinition, TableRole};
+use std::path::PathBuf;
+
+fn demo_ini() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../libretune-app/src-tauri/resources/demo.ini")
+}
+
+fn declared_target(def: &EcuDefinition) -> Vec<String> {
+    let mut v: Vec<String> = def
+        .tables
+        .values()
+        .filter(|t| t.role == TableRole::AfrTarget)
+        .map(|t| t.name.clone())
+        .collect();
+    v.sort();
+    v
+}
+
+#[test]
+fn a_real_ini_declares_an_afr_target_table() {
+    let path = demo_ini();
+    if !path.exists() {
+        eprintln!("demo.ini not present; skipping");
+        return;
+    }
+    // The `#else` arm: an AFR-target project.
+    set_default_symbols(Vec::<String>::new());
+    let def = EcuDefinition::from_file(&path).expect("demo.ini parses");
+
+    let targets = declared_target(&def);
+    assert!(
+        !targets.is_empty(),
+        "a real INI must declare an AFR target; auto-discovery has nothing to \
+         consult otherwise and falls back to a flat target"
+    );
+    assert!(
+        targets.iter().any(|n| n.contains("afrTable")),
+        "the non-LAMBDA arm should declare the AFR table, got {targets:?}"
+    );
+}
+
+#[test]
+fn the_lambda_arm_declares_the_lambda_table() {
+    let path = demo_ini();
+    if !path.exists() {
+        return;
+    }
+    set_default_symbols(vec!["LAMBDA".to_string()]);
+    let def = EcuDefinition::from_file(&path).expect("demo.ini parses");
+    let targets = declared_target(&def);
+    set_default_symbols(Vec::<String>::new()); // don't leak into other tests
+
+    assert!(
+        targets.iter().any(|n| n.contains("lambda") || n.contains("Lambda")),
+        "under #if LAMBDA the declared target should be the lambda table, got \
+         {targets:?} - and its values are lambda, which is why the target must \
+         be normalised before it reaches the correction"
+    );
+}
+
+/// The correction is `current_ve * (measured_afr / target_afr)`. Feeding it a
+/// lambda target un-normalised is a ~14.8x demand on every cell. This asserts
+/// the magnitude, not just that a table was found.
+#[test]
+fn a_lambda_target_yields_a_sane_correction_factor() {
+    use libretune_core::autotune::normalise_to_afr;
+
+    let measured_afr = 13.0_f64;
+    let lambda_target = 0.88_f64;
+
+    let naive = measured_afr / lambda_target;
+    assert!(
+        naive > 14.0,
+        "sanity: un-normalised really is enormous ({naive:.1}x)"
+    );
+
+    let corrected = measured_afr / normalise_to_afr(lambda_target);
+    assert!(
+        (0.9..1.1).contains(&corrected),
+        "normalised correction must be near unity, got {corrected:.3}x"
+    );
+}

--- a/crates/libretune-core/tests/afr_target_role.rs
+++ b/crates/libretune-core/tests/afr_target_role.rs
@@ -10,8 +10,7 @@ use libretune_core::ini::{set_default_symbols, EcuDefinition, TableRole};
 use std::path::PathBuf;
 
 fn demo_ini() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../libretune-app/src-tauri/resources/demo.ini")
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../libretune-app/src-tauri/resources/demo.ini")
 }
 
 fn declared_target(def: &EcuDefinition) -> Vec<String> {
@@ -59,7 +58,9 @@ fn demo_ini_declares_the_right_target_on_both_arms() {
     let lambda = declared_target(&EcuDefinition::from_file(&path).expect("demo.ini parses"));
     set_default_symbols(Vec::<String>::new());
     assert!(
-        lambda.iter().any(|n| n.contains("lambda") || n.contains("Lambda")),
+        lambda
+            .iter()
+            .any(|n| n.contains("lambda") || n.contains("Lambda")),
         "under #if LAMBDA the declared target should be the lambda table, got {lambda:?}"
     );
 }

--- a/crates/libretune-core/tests/afr_target_role.rs
+++ b/crates/libretune-core/tests/afr_target_role.rs
@@ -25,45 +25,42 @@ fn declared_target(def: &EcuDefinition) -> Vec<String> {
     v
 }
 
+/// Both arms of `#if LAMBDA`, in ONE test on purpose.
+///
+/// `set_default_symbols` writes process-global state, and integration tests in
+/// a binary run in parallel by default. Two tests each setting it raced: this
+/// file passed under `--test-threads=1` and failed under a plain `cargo test`,
+/// which is what CI runs. One test means the two arms are sequential by
+/// construction rather than by a flag someone has to remember.
 #[test]
-fn a_real_ini_declares_an_afr_target_table() {
+fn demo_ini_declares_the_right_target_on_both_arms() {
     let path = demo_ini();
     if !path.exists() {
         eprintln!("demo.ini not present; skipping");
         return;
     }
+
     // The `#else` arm: an AFR-target project.
     set_default_symbols(Vec::<String>::new());
-    let def = EcuDefinition::from_file(&path).expect("demo.ini parses");
-
-    let targets = declared_target(&def);
+    let afr = declared_target(&EcuDefinition::from_file(&path).expect("demo.ini parses"));
     assert!(
-        !targets.is_empty(),
-        "a real INI must declare an AFR target; auto-discovery has nothing to \
-         consult otherwise and falls back to a flat target"
+        !afr.is_empty(),
+        "a real INI must declare an AFR target; auto-discovery has nothing to          consult otherwise and falls back to a flat target"
     );
     assert!(
-        targets.iter().any(|n| n.contains("afrTable")),
-        "the non-LAMBDA arm should declare the AFR table, got {targets:?}"
+        afr.iter().any(|n| n.contains("afrTable")),
+        "the non-LAMBDA arm should declare the AFR table, got {afr:?}"
     );
-}
 
-#[test]
-fn the_lambda_arm_declares_the_lambda_table() {
-    let path = demo_ini();
-    if !path.exists() {
-        return;
-    }
+    // The `#if LAMBDA` arm: the same declaration names the lambda table, whose
+    // values are lambda - which is why the target must be normalised before it
+    // reaches the correction.
     set_default_symbols(vec!["LAMBDA".to_string()]);
-    let def = EcuDefinition::from_file(&path).expect("demo.ini parses");
-    let targets = declared_target(&def);
-    set_default_symbols(Vec::<String>::new()); // don't leak into other tests
-
+    let lambda = declared_target(&EcuDefinition::from_file(&path).expect("demo.ini parses"));
+    set_default_symbols(Vec::<String>::new());
     assert!(
-        targets.iter().any(|n| n.contains("lambda") || n.contains("Lambda")),
-        "under #if LAMBDA the declared target should be the lambda table, got \
-         {targets:?} - and its values are lambda, which is why the target must \
-         be normalised before it reaches the correction"
+        lambda.iter().any(|n| n.contains("lambda") || n.contains("Lambda")),
+        "under #if LAMBDA the declared target should be the lambda table, got {lambda:?}"
     );
 }
 


### PR DESCRIPTION
> **Depends on #243.** This branch is stacked on it, so the diff below currently
> includes #243's commits. Merge #243 first and this will collapse to its own
> single commit. Reviewing just `fix(autotune): stop inventing missing inputs`
> is the useful read.

One defect class, several instances: something the session needs is absent, and
a plausible number is substituted for it without comment.

**A missing AFR channel fabricated 14.7.** Uniquely bad as a fallback because it
is a *physically valid* mixture — it passes the sensor-rail filter and looks
exactly like data. Against a 12.7 wide-open-throttle target it is a standing
request for ~16% more fuel, derived from a reading that never happened.
`lambda` joins the lookup alongside `lambda1` too, since `apply_channel_aliases`
publishes the canonical name and a lambda-only INI went straight to the
fabricated default.

**A missing VE became 0.0**, proposing a zero-fuel cell the authority limits
cannot catch, since a percentage of zero is zero.

**A missing MAP became zero load.** On a speed-density tune the load axis IS
manifold pressure, so every sample was filed into the lowest load row — a
session spent correcting the idle corner with wide-open-throttle data.

**A zero lambda-delay cell** read as zero delay rather than "no value". A delay
of 0 fails the `delay_ms > 0` check downstream, so under strict matching the
sample is dropped and that cell accumulates nothing all session, silently.

**A missing TPS** made `tps_rate` constantly zero, so `max_tps_rate` could never
fire: every tip-in was accepted as steady state. This one only widens what gets
in rather than corrupting the arithmetic, so it warns and continues.

**The AFR target table came out of a HashMap.** `infer_table_roles` stamps
`AfrTarget` on every `lambdaTargetTables` entry and on the WUE target, so on a
real Speeduino INI both `afrTable1Tbl` and `afrTSCustom` carry it — and iteration
order is unspecified. A session could tune against the custom table one launch
and the real one the next, with nothing on screen to tell them apart. Now takes
`[VeAnalyze]`'s named primary; fifty repeats must agree.

**`min_clt` now comes from the INI**, which declares it with the unit system
already resolved — 71 under `#if CELSIUS`, 160 otherwise. The app used a
constant. On a Celsius project 160 is above boiling: no sample can pass and a
whole session collects nothing.

## Testing

778 tests pass under a plain `cargo test`. Warnings fire once per channel, not
per sample — this runs at the realtime rate, and the condition is structural.

**Note for reviewers:** samples that used to be silently accepted with
fabricated values are now dropped. That is the intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)