### PR TITLE
feat(ini): ask once which temperature units an INI uses, and remember the answer

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/mod.rs
+++ b/crates/libretune-app/src-tauri/src/commands/mod.rs
@@ -70,6 +70,7 @@ pub mod table_file_io;
 pub mod table_internals;
 pub mod table_ops;
 pub mod table_update;
+pub mod temperature_units;
 pub mod ts_import;
 pub mod tune_apply;
 pub mod tune_compare;

--- a/crates/libretune-app/src-tauri/src/commands/temperature_units.rs
+++ b/crates/libretune-app/src-tauri/src/commands/temperature_units.rs
@@ -1,0 +1,169 @@
+//! Asking which temperature units an INI should use, once, and remembering it.
+//!
+//! An INI selects Celsius through `#if CELSIUS`, and the tuning software that
+//! created the project defines that symbol from its `ecuSettings`. A project carrying no such
+//! declaration silently takes the `#else` arm, so every temperature renders in
+//! Fahrenheit while wearing the INI's generic "TEMP" label — a 15 °C morning
+//! reads 59 and nothing says why.
+//!
+//! It is worse than cosmetic. AutoTune's `min_clt` filter is compared against
+//! that same channel, so a project that quietly decided it was Fahrenheit will
+//! reject or accept entire sessions on a threshold meaning the wrong thing.
+//!
+//! So: ask once, when there is a real question to ask, and write the answer
+//! where both LibreTune and other tuning software will find it.
+
+use crate::commands::app_settings::seed_symbols_from_project;
+use crate::AppState;
+use libretune_core::project::Properties;
+
+/// Whether the user needs to be asked about temperature units, and why not.
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UnitsStatus {
+    /// Show the picker. Only true when the question is real and unanswered.
+    pub needs_choice: bool,
+    /// What the INI is currently parsed as.
+    pub celsius: bool,
+    /// Where that came from: `project`, `preference`, or `default`.
+    pub source: String,
+    /// Does this INI test `CELSIUS` at all? An INI that never asks has no
+    /// answer worth storing.
+    pub ini_uses_celsius: bool,
+}
+
+/// Report whether this project has decided its temperature units.
+#[tauri::command]
+pub async fn get_temperature_units_status(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, AppState>,
+) -> Result<UnitsStatus, String> {
+    let def_guard = state.definition.lock().await;
+    let def = def_guard.as_ref().ok_or("Definition not loaded")?;
+    let ini_uses_celsius = def.tests_symbol("CELSIUS");
+    let celsius = def.symbol_is_active("CELSIUS");
+    drop(def_guard);
+
+    let declared = {
+        let proj_guard = state.current_project.lock().await;
+        proj_guard
+            .as_ref()
+            .map(|p| p.ini_path())
+            .and_then(|ini| ini.parent().map(|d| d.join("project.properties")))
+            .filter(|p| p.exists())
+            .and_then(|p| Properties::load(&p).ok())
+            .and_then(|props| props.get("ecuSettings").cloned())
+            .is_some()
+    };
+
+    // A units preference the user has actually set is an answer, even though
+    // it is not the project's. Prompting over it would be nagging about a
+    // question already decided.
+    let preference_set = !crate::commands::app_settings::load_settings(&app)
+        .units_system
+        .trim()
+        .is_empty();
+
+    let source = if declared {
+        "project"
+    } else if preference_set {
+        "preference"
+    } else {
+        // Nothing declared and no preference: the empty default resolves to
+        // Fahrenheit without ever saying so. This is the case worth asking about.
+        "default"
+    };
+
+    Ok(UnitsStatus {
+        // Only ask when the INI actually branches on it AND nothing has
+        // answered. An INI with no `#if CELSIUS` has no question to put, and a
+        // user who has set a preference has already put theirs.
+        needs_choice: ini_uses_celsius && !declared && !preference_set,
+        celsius,
+        source: source.to_string(),
+        ini_uses_celsius,
+    })
+}
+
+/// Record the choice in the project, where it will outlive this session.
+///
+/// Written to `projectCfg/project.properties` as `ecuSettings`, the same key
+/// and format other popular tuning software uses, so the tools agree rather than
+/// each keeping a private opinion. An existing `ecuSettings` has only its `CELSIUS` token
+/// adjusted — the other tokens belong to whoever wrote them.
+///
+/// Symbols are resolved while the INI is parsed, so this cannot change the
+/// definition already in memory. `reload_required` says so plainly rather than
+/// letting the caller assume it took effect.
+#[tauri::command]
+pub async fn set_temperature_units(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, AppState>,
+    celsius: bool,
+) -> Result<ReloadHint, String> {
+    let proj_guard = state.current_project.lock().await;
+    let project = proj_guard.as_ref().ok_or("No project open")?;
+    let ini = project.ini_path();
+    let dir = ini
+        .parent()
+        .ok_or("Project INI has no parent directory")?
+        .to_path_buf();
+    let props_path = dir.join("project.properties");
+    drop(proj_guard);
+
+    let mut props = if props_path.exists() {
+        Properties::load(&props_path).map_err(|e| format!("read {props_path:?}: {e}"))?
+    } else {
+        Properties::new()
+    };
+
+    // Preserve every other token; only CELSIUS is ours to decide.
+    let mut tokens: Vec<String> = props
+        .get("ecuSettings")
+        .map(|raw| {
+            raw.split('|')
+                .map(str::trim)
+                .filter(|t| !t.is_empty() && !t.eq_ignore_ascii_case("CELSIUS"))
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default();
+    if celsius {
+        tokens.push("CELSIUS".to_string());
+    }
+    // Trailing separator matches the conventional formatting.
+    let value = format!("{}|", tokens.join("|"));
+    props.set("ecuSettings".to_string(), value.clone());
+    props
+        .save(&props_path)
+        .map_err(|e| format!("write {props_path:?}: {e}"))?;
+
+    // Seed the parser for every subsequent parse. The definition currently in
+    // memory keeps whatever it was parsed with.
+    let settings = crate::commands::app_settings::load_settings(&app);
+    seed_symbols_from_project(&ini, &settings);
+
+    tracing::info!(
+        celsius,
+        ecu_settings = %value,
+        path = ?props_path,
+        "temperature units recorded in the project"
+    );
+
+    Ok(ReloadHint {
+        saved_to: props_path.to_string_lossy().to_string(),
+        ecu_settings: value,
+        reload_required: true,
+    })
+}
+
+/// What was written, and the fact that it will not apply until a re-parse.
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReloadHint {
+    pub saved_to: String,
+    pub ecu_settings: String,
+    /// Symbols are resolved during parsing, so the open definition is unchanged
+    /// until the project is reopened.
+    pub reload_required: bool,
+}

--- a/crates/libretune-app/src-tauri/src/lib.rs
+++ b/crates/libretune-app/src-tauri/src/lib.rs
@@ -298,6 +298,8 @@ pub fn run() {
             start_autotune,
             stop_autotune,
             get_autotune_status,
+            commands::temperature_units::get_temperature_units_status,
+            commands::temperature_units::set_temperature_units,
             get_autotune_recommendations,
             get_autotune_heatmap,
             send_autotune_recommendations,

--- a/crates/libretune-app/src/App.css
+++ b/crates/libretune-app/src/App.css
@@ -1209,3 +1209,79 @@ body {
   color: var(--text-dim);
   font-family: 'Consolas', 'Monaco', monospace;
 }
+/* ---- Temperature units, asked once ------------------------------------
+   A project that declares no units silently renders Fahrenheit, and the
+   same channel drives AutoTune's coolant filter — so the wrong answer
+   quietly discards whole sessions. Modal because there is no sensible
+   default to fall back to: guessing is what caused the problem. */
+.units-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.65);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
+}
+
+.units-dialog {
+  background: var(--panel-bg, #1e1e22);
+  color: var(--text, #e8e8ea);
+  border: 1px solid var(--border, #3a3a42);
+  border-radius: 8px;
+  width: min(560px, 92vw);
+  padding: 1.4rem 1.6rem;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.55);
+}
+
+.units-dialog h2 {
+  margin: 0 0 0.75rem;
+  font-size: 1.1rem;
+}
+
+.units-dialog p {
+  margin: 0 0 0.7rem;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.units-why { opacity: 0.85; }
+
+.units-note {
+  font-size: 0.8rem;
+  opacity: 0.7;
+  margin-top: 0.9rem;
+  margin-bottom: 0;
+}
+
+.units-dialog code {
+  background: rgba(255, 255, 255, 0.08);
+  padding: 0.05rem 0.3rem;
+  border-radius: 3px;
+}
+
+.units-actions {
+  display: flex;
+  gap: 0.75rem;
+  margin: 1rem 0 0;
+}
+
+.units-actions button {
+  flex: 1;
+  padding: 0.6rem 1rem;
+  border-radius: 6px;
+  border: 1px solid var(--border, #3a3a42);
+  background: rgba(255, 255, 255, 0.06);
+  color: inherit;
+  font-size: 0.95rem;
+  cursor: pointer;
+}
+
+.units-actions button:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.units-actions button:disabled {
+  opacity: 0.5;
+  cursor: progress;
+}

--- a/crates/libretune-app/src/App.tsx
+++ b/crates/libretune-app/src/App.tsx
@@ -103,6 +103,14 @@ import "./styles";
  * is intentionally registered once at module level (NOT in an effect) to dodge
  * a StrictMode double-invoke race — see the comment near `useRealtimeStream`.
  */
+/** Reported by `get_temperature_units_status`. */
+interface UnitsStatus {
+  needsChoice: boolean;
+  celsius: boolean;
+  source: string;
+  iniUsesCelsius: boolean;
+}
+
 function AppContent() {
   const { theme, setTheme } = useTheme();
   const { t } = useTranslation('menu');
@@ -116,6 +124,49 @@ function AppContent() {
 
   // Project state
   const [currentProject, setCurrentProject] = useState<CurrentProject | null>(null);
+  // Temperature units: an INI picks Celsius through `#if CELSIUS`, and a
+  // project that declares nothing silently takes the Fahrenheit arm. Ask once,
+  // and only when the INI actually branches on it.
+  const [unitsPrompt, setUnitsPrompt] = useState<UnitsStatus | null>(null);
+  const [unitsBusy, setUnitsBusy] = useState(false);
+
+  // Hooked to the project rather than to each open call: there are two places a
+  // project can be opened (restore-on-launch and the picker) and adding a third
+  // should not mean remembering to ask again.
+  useEffect(() => {
+    if (!currentProject) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const status = await invoke<UnitsStatus>('get_temperature_units_status');
+        if (!cancelled && status.needsChoice) setUnitsPrompt(status);
+      } catch {
+        // A project without a parsed definition yet is not an error worth
+        // interrupting anyone over; the question keeps until next open.
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [currentProject]);
+
+  const chooseTemperatureUnits = useCallback(async (celsius: boolean) => {
+    setUnitsBusy(true);
+    try {
+      await invoke('set_temperature_units', { celsius });
+      setUnitsPrompt(null);
+      // Symbols are resolved during parsing, so the definition in memory still
+      // holds the old answer. Reopen to apply it rather than leaving the app
+      // showing one unit and reporting another.
+      const path = currentProject?.path;
+      if (path) {
+        const reopened = await invoke<CurrentProject>('open_project', { path });
+        setCurrentProject(reopened);
+      }
+    } catch (e) {
+      console.error('Failed to save temperature units:', e);
+    } finally {
+      setUnitsBusy(false);
+    }
+  }, [currentProject]);
   const { tuneModified, refreshTuneModified } = useTuneModified(!!currentProject);
   const [availableProjects, setAvailableProjects] = useState<ProjectInfo[]>([]);
   const [repositoryInis, setRepositoryInis] = useState<IniEntry[]>([]);
@@ -1624,6 +1675,35 @@ function AppContent() {
 
   return (
     <>
+      {unitsPrompt && (
+        <div className="units-backdrop" role="dialog" aria-modal="true" aria-label="Temperature units">
+          <div className="units-dialog">
+            <h2>Which temperature units does this ECU use?</h2>
+            <p>
+              This definition selects units with <code>#if CELSIUS</code>, but the project
+              does not say which to use. Until it does, temperatures are read as
+              <strong> Fahrenheit</strong> — so a 15&nbsp;°C morning shows as 59.
+            </p>
+            <p className="units-why">
+              It is not only cosmetic: AutoTune&rsquo;s minimum-coolant filter is compared
+              against this same channel, so the wrong unit silently accepts or rejects
+              whole sessions.
+            </p>
+            <div className="units-actions">
+              <button type="button" disabled={unitsBusy} onClick={() => chooseTemperatureUnits(true)}>
+                Celsius (°C)
+              </button>
+              <button type="button" disabled={unitsBusy} onClick={() => chooseTemperatureUnits(false)}>
+                Fahrenheit (°F)
+              </button>
+            </div>
+            <p className="units-note">
+              Saved to the project&rsquo;s <code>project.properties</code>, the same file and
+              key other tuning software uses, so you are asked once. The project reloads to apply it.
+            </p>
+          </div>
+        </div>
+      )}
       <TunerLayout
         menuItems={menuItems}
         toolbarItems={toolbarItems}

--- a/crates/libretune-core/src/ini/mod.rs
+++ b/crates/libretune-core/src/ini/mod.rs
@@ -107,6 +107,12 @@ pub struct EcuDefinition {
     /// Reading such a global is what let a units change relabel every gauge to
     /// degC while the arithmetic stayed Fahrenheit.
     pub active_symbols: std::collections::HashSet<String>,
+    /// Every symbol the INI tests in an `#if`, regardless of the arm taken.
+    ///
+    /// `active_symbols` says which way a conditional went; this says whether
+    /// the question was ever asked. An INI with no `#if CELSIUS` anywhere has
+    /// no temperature-unit choice to make, and prompting for one would be noise.
+    pub tested_symbols: std::collections::HashSet<String>,
 
     /// Endianness of ECU data
     pub endianness: Endianness,
@@ -221,6 +227,11 @@ impl EcuDefinition {
     /// parsed, e.g. `CELSIUS`. See [`EcuDefinition::active_symbols`].
     pub fn symbol_is_active(&self, symbol: &str) -> bool {
         self.active_symbols.contains(symbol)
+    }
+
+    /// Whether the INI tests `symbol` in an `#if` at all.
+    pub fn tests_symbol(&self, symbol: &str) -> bool {
+        self.tested_symbols.contains(symbol)
     }
 
     /// Parse an ECU definition from an INI file
@@ -700,6 +711,7 @@ impl Default for EcuDefinition {
             ini_spec_version: "3.64".to_string(),
             defines: HashMap::new(),
             active_symbols: std::collections::HashSet::new(),
+            tested_symbols: std::collections::HashSet::new(),
             endianness: Endianness::default(),
             page_sizes: Vec::new(),
             n_pages: 0,

--- a/crates/libretune-core/src/ini/parser.rs
+++ b/crates/libretune-core/src/ini/parser.rs
@@ -46,6 +46,10 @@ struct IncludeContext {
     depth: usize,
     /// Symbols defined via #set directive (shared across includes)
     pub defined_symbols: HashSet<String>,
+    /// Every symbol this INI actually tests in an `#if`, whether or not it was
+    /// defined. Lets a caller ask "does this file care about CELSIUS?" without
+    /// re-reading it - and so avoids prompting for a unit an INI never uses.
+    pub tested_symbols: HashSet<String>,
 }
 
 /// Preprocessor symbols every parse starts with, on top of anything the INI
@@ -83,6 +87,7 @@ impl IncludeContext {
             included_files: HashSet::new(),
             depth: 0,
             defined_symbols: default_symbols(),
+            tested_symbols: HashSet::new(),
         }
     }
 
@@ -107,6 +112,7 @@ pub fn parse_ini(content: &str) -> Result<EcuDefinition, IniError> {
     let mut ctx = IncludeContext::new(None);
     let mut def = parse_ini_internal(content, &mut ctx)?;
     def.active_symbols = ctx.defined_symbols.clone();
+    def.tested_symbols = ctx.tested_symbols.clone();
     Ok(def)
 }
 
@@ -122,6 +128,7 @@ pub fn parse_ini_from_path(path: &Path) -> Result<EcuDefinition, IniError> {
     // `#if` this parse took, including any the INI `#set` itself.
     let mut def = parse_ini_internal(&content, &mut ctx)?;
     def.active_symbols = ctx.defined_symbols.clone();
+    def.tested_symbols = ctx.tested_symbols.clone();
     Ok(def)
 }
 
@@ -201,6 +208,7 @@ fn parse_ini_internal(content: &str, ctx: &mut IncludeContext) -> Result<EcuDefi
         if let Some(stripped) = line.strip_prefix("#if ") {
             let symbol = stripped.trim();
             let is_defined = ctx.defined_symbols.contains(symbol);
+            ctx.tested_symbols.insert(symbol.to_string());
             tracing::debug!("preprocessor: #if {} -> {}", symbol, is_defined);
             condition_stack.push(is_defined);
             i += 1;
@@ -4440,4 +4448,75 @@ ego_max_lambda = scalar, U08, lastOffset, "Lambda", 0.068, 0, 0.5, 1.7, 3
         9,
         "ego_max_lambda must overlay ego_max_afr at offset 9, not chain from the previous overlay"
     );
+}
+
+#[cfg(test)]
+mod tested_symbol_tests {
+    use super::*;
+
+    /// A definition records which symbols were *asked about*, separately from
+    /// which were active. Without that distinction the app cannot tell "this
+    /// INI has no temperature choice to make" from "the choice defaulted", and
+    /// would prompt on files that never mention units.
+    #[test]
+    fn a_definition_records_the_symbols_it_tested() {
+        set_default_symbols(Vec::<String>::new());
+        let ini = "\
+[MegaTune]
+ signature = \"test\"
+
+[OutputChannels]
+#if CELSIUS
+   coolant = { coolantRaw - 40 }
+#else
+   coolant = { (coolantRaw - 40) * 1.8 + 32 }
+#endif
+";
+        let def = parse_ini(ini).expect("parses");
+        assert!(
+            def.tests_symbol("CELSIUS"),
+            "the INI asked about CELSIUS, so there is a question to put to the user"
+        );
+        assert!(
+            !def.symbol_is_active("CELSIUS"),
+            "it was not defined, so the Fahrenheit arm was taken"
+        );
+    }
+
+    #[test]
+    fn an_ini_that_never_asks_records_nothing() {
+        set_default_symbols(Vec::<String>::new());
+        let ini = "\
+[MegaTune]
+ signature = \"test\"
+
+[OutputChannels]
+   coolant = scalar, U08, 0, \"C\", 1.0, 0.0
+";
+        let def = parse_ini(ini).expect("parses");
+        assert!(
+            !def.tests_symbol("CELSIUS"),
+            "nothing to ask about - prompting here would be noise"
+        );
+    }
+
+    /// The arm taken must not change what was recorded as tested: the question
+    /// was asked either way.
+    #[test]
+    fn the_symbol_is_recorded_even_when_defined() {
+        set_default_symbols(vec!["CELSIUS".to_string()]);
+        let ini = "\
+[MegaTune]
+ signature = \"test\"
+
+[OutputChannels]
+#if CELSIUS
+   coolant = { coolantRaw - 40 }
+#endif
+";
+        let def = parse_ini(ini).expect("parses");
+        set_default_symbols(Vec::<String>::new());
+        assert!(def.tests_symbol("CELSIUS"));
+        assert!(def.symbol_is_active("CELSIUS"));
+    }
 }


### PR DESCRIPTION
An INI selects Celsius through `#if CELSIUS`, and the tuning software that
created the project defines that symbol from its `ecuSettings`. A project
carrying no such declaration silently takes the `#else` arm, so every
temperature renders in Fahrenheit while wearing the INI's generic "TEMP" label —
a 15 °C morning reads 59 and nothing says why.

**It is worse than cosmetic.** AutoTune's `min_clt` filter compares against that
same channel, so a project that quietly decided it was Fahrenheit will accept or
reject entire sessions on a threshold meaning the wrong thing. On a real car, a
Celsius project with the 160 default rejected every sample a warm engine could
produce and the session collected nothing.

## Only asks when there is a real question

`EcuDefinition` now records `tested_symbols` alongside `active_symbols`. The
latter says which arm a conditional took; the former says whether the question
was asked at all.

- an INI with no `#if CELSIUS` anywhere has no choice to make — not asked
- a user who has already set a units preference has made theirs — not asked
- a project that declares `ecuSettings` has recorded one — not asked

## Where the answer goes

`projectCfg/project.properties` as `ecuSettings` — the same key and format other
popular tuning software uses, so the tools agree rather than each keeping a
private opinion. Only the `CELSIUS` token is touched; whatever else is in there
belongs to whoever put it there.

Symbols are resolved while the INI is parsed, so the reply carries
`reload_required` rather than letting a caller assume the open definition
changed. The dialog reopens the project to apply it.

## Testing

3 parser tests covering the three cases that matter: a symbol tested but not
defined, an INI that never tests it, and a symbol recorded even when defined.
757 Rust tests pass; `tsc --noEmit` clean.

Verified end to end against a real project: prompted on an undeclared project,
wrote `CELSIUS|`, and stopped asking after reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)