### PR TITLE
fix(build): restore the tooth_logger module declaration lost in a merge

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/mod.rs
+++ b/crates/libretune-app/src-tauri/src/commands/mod.rs
@@ -75,6 +75,7 @@ pub mod table_internals;
 pub mod table_ops;
 pub mod table_update;
 pub mod temperature_units;
+pub mod tooth_logger;
 pub mod ts_import;
 pub mod tune_apply;
 pub mod tune_compare;


### PR DESCRIPTION
**`main` does not currently compile.**

```
error[E0433]: cannot find `tooth_logger` in `commands`
   --> crates/libretune-app/src-tauri/src/lib.rs:404:23
```

`lib.rs` registers three tooth-logger commands and
`commands/tooth_logger.rs` is present, but `commands/mod.rs` lost its
`pub mod tooth_logger;` line — so the module is not part of the crate and the
registrations cannot resolve.

The file and its callers both survived; only the one line connecting them did
not. It went missing resolving the conflict between #247, which added it, and
#248, which touched the same file for other modules.

Worth noting: every other module those two PRs added — `file_io`,
`analyze_filters`, `autotune_export`, `autotune_preflight`, `temperature_units`
— kept both its declaration and its registrations. Only this one was dropped,
which is the shape of a hand-resolved conflict rather than anything systematic.

## Testing

One line. **849 Rust tests pass** with it restored, clippy clean. Verified by
checking out `origin/main` in a fresh worktree, reproducing the failure, then
applying the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)