### PR TITLE
feat(dash): configurable refresh rate, EMA smoothing, spike highlight, steady value text (#82)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,45 @@ relevant.
 
 ## [Unreleased]
 
+### 2026-08-23 — Dashboard performance & readability (issue #82)
+
+The dashboard redraw path was reworked around the three complaints in issue
+#82: extreme CPU load on battery, jumping value text when digit count or sign
+changes, and line graphs that look like an audio waveform at high stream
+rates.
+
+#### Added
+- **Configurable gauge refresh rate** — Settings → General → Dashboard →
+  "Gauge refresh rate" (10/15/20/25/30 Hz, default 30). Gauge redraw timers
+  are phase-staggered (16 slots, deterministic per channel) so a dashboard
+  full of gauges no longer piles all canvas work onto the same frame.
+- **Transient spike highlight** — when the raw channel value deviates from
+  the EMA-smoothed display value by more than 15% of the gauge range, digital
+  readouts flash the value in the critical color (~400 ms) and line graphs
+  draw a colored dot at the raw sample position, so short problem pulses stay
+  visible despite smoothing (the issue's "peak detect" ask).
+- **Right-align gauge values setting** (opt-in, default off) — digital/bar
+  gauges anchor value text to a fixed right edge; dial gauges pad values to a
+  fixed monospace width (`steadyValueText`), so number of characters changing
+  no longer shifts glyphs.
+
+#### Changed
+- **Value smoothing is now a time-constant EMA** (`components/gauges/ema.ts`,
+  τ=120 ms) instead of a per-frame lerp factor, so motion converges
+  identically at any refresh rate (the old lerp converged ~6× slower at
+  10 fps than at 60 fps).
+- **LineGraph renders the EMA of the history buffer** rather than raw
+  samples, eliminating the noisy "audio wave" look.
+
+#### Fixed
+- **`pub mod tooth_logger;` restored** in `commands/mod.rs` — the PR #247
+  merge dropped the declaration, leaving `main` not compiling
+  (`commands::tooth_logger::*` references in `lib.rs`).
+
+#### Notes
+- No `.dash` format changes: refresh/smoothing settings are app-global, not
+  per-gauge, so TunerStudio dashboard files round-trip unchanged.
+
 ### 2026-08-21 — Fix: open-table render storm with live data (freeze on open)
 
 Opening the fuel table with a live stream froze the window (issue #132): the

--- a/crates/libretune-app/public/manual/features/dashboards/using.md
+++ b/crates/libretune-app/public/manual/features/dashboards/using.md
@@ -75,6 +75,40 @@ Pop out dashboards to separate monitors:
 
 > **Note**: The main Dashboard tab is protected and cannot be popped out or accidentally closed. To reopen it if missing, go to **View → Dashboard**.
 
+## Performance & Smoothing
+
+Dashboards redraw each gauge on a capped, phase-staggered timer instead of
+redrawing on every incoming sample. This keeps CPU (and laptop battery) use
+predictable even when the ECU streams faster than the display needs.
+
+### Gauge Refresh Rate
+
+**Settings → General → Dashboard → Gauge refresh rate** caps how often each
+gauge redraws:
+
+- **10 Hz (battery saver)** — street tuning on battery power
+- **15–25 Hz** — balanced
+- **30 Hz (default)** — smoothest motion
+
+Redraw timers are staggered so gauges don't all paint in the same frame, and
+needle motion uses a time-based EMA (exponential moving average), so motion
+looks identical at any refresh rate — only the step cadence changes.
+
+### Transient Spike Highlight
+
+Short pulses that would be smoothed away are not lost: when the raw value
+jumps far from the smoothed reading, the value readout briefly flashes in the
+critical color, and line graphs draw a colored dot at the raw position. This
+makes brief excursions (e.g. a lean spike) visible without making the trace
+look like an audio waveform.
+
+### Right-Align Gauge Values
+
+**Settings → General → Dashboard → Right-align gauge values** keeps numeric
+readouts steady when the digit count or sign changes (e.g. timing crossing
+0°). Digital and bar gauges anchor values to a fixed right edge; dial gauges
+pad values to a fixed width so they stay centered but never shift.
+
 ## Tips
 
 ### Reduce Clutter

--- a/crates/libretune-app/public/manual/toc.json
+++ b/crates/libretune-app/public/manual/toc.json
@@ -1,280 +1,316 @@
 [
   {
-    "title": "Installation",
+    "title": "Getting Started",
     "path": "getting-started/installation",
-    "children": []
-  },
-  {
-    "title": "Creating Your First Project",
-    "path": "getting-started/first-project",
-    "children": []
-  },
-  {
-    "title": "Connecting to Your ECU",
-    "path": "getting-started/connecting",
-    "children": []
-  },
-  {
-    "title": "Settings & Preferences",
-    "path": "getting-started/settings",
-    "children": []
-  },
-  {
-    "title": "Table Editing",
-    "path": "features/table-editing",
     "children": [
       {
-        "title": "2D Tables",
-        "path": "features/table-editing/2d-tables",
+        "title": "Installation",
+        "path": "getting-started/installation",
         "children": []
       },
       {
-        "title": "3D Visualization",
-        "path": "features/table-editing/3d-visualization",
+        "title": "Creating Your First Project",
+        "path": "getting-started/first-project",
+        "children": []
+      },
+      {
+        "title": "Connecting to Your ECU",
+        "path": "getting-started/connecting",
+        "children": []
+      },
+      {
+        "title": "Settings & Preferences",
+        "path": "getting-started/settings",
+        "children": []
+      }
+    ]
+  },
+  {
+    "title": "Core Features",
+    "path": "features/table-editing",
+    "children": [
+      {
+        "title": "Table Editing",
+        "path": "features/table-editing",
+        "children": [
+          {
+            "title": "2D Tables",
+            "path": "features/table-editing/2d-tables",
+            "children": []
+          },
+          {
+            "title": "3D Visualization",
+            "path": "features/table-editing/3d-visualization",
+            "children": []
+          },
+          {
+            "title": "Keyboard Shortcuts",
+            "path": "features/table-editing/shortcuts",
+            "children": []
+          }
+        ]
+      },
+      {
+        "title": "AutoTune",
+        "path": "features/autotune",
+        "children": [
+          {
+            "title": "Usage Guide",
+            "path": "features/autotune/usage-guide",
+            "children": []
+          },
+          {
+            "title": "Setting Up AutoTune",
+            "path": "features/autotune/setup",
+            "children": []
+          },
+          {
+            "title": "Understanding Recommendations",
+            "path": "features/autotune/recommendations",
+            "children": []
+          },
+          {
+            "title": "Filters and Authority",
+            "path": "features/autotune/filters",
+            "children": []
+          }
+        ]
+      },
+      {
+        "title": "Dashboards",
+        "path": "features/dashboards",
+        "children": [
+          {
+            "title": "Using Dashboards",
+            "path": "features/dashboards/using",
+            "children": []
+          },
+          {
+            "title": "Customizing Gauges",
+            "path": "features/dashboards/customizing",
+            "children": []
+          },
+          {
+            "title": "Creating Dashboards",
+            "path": "features/dashboards/creating",
+            "children": []
+          },
+          {
+            "title": "Dashboard Validation",
+            "path": "features/dashboards/validation",
+            "children": []
+          }
+        ]
+      },
+      {
+        "title": "Math Channels",
+        "path": "features/math-channels",
+        "children": []
+      },
+      {
+        "title": "Data Logging",
+        "path": "features/datalog",
+        "children": []
+      },
+      {
+        "title": "Smart Recording",
+        "path": "features/smart-recording",
+        "children": []
+      },
+      {
+        "title": "Data Statistics",
+        "path": "features/data-statistics",
+        "children": []
+      },
+      {
+        "title": "Alert Rules",
+        "path": "features/alert-rules",
+        "children": []
+      },
+      {
+        "title": "Lua Scripting",
+        "path": "features/lua-scripting",
+        "children": []
+      },
+      {
+        "title": "Base Map Generator",
+        "path": "features/base-map",
+        "children": []
+      },
+      {
+        "title": "Performance Calculator",
+        "path": "features/performance-calculator",
+        "children": []
+      },
+      {
+        "title": "Diagnostic Loggers",
+        "path": "features/diagnostic-loggers",
+        "children": []
+      },
+      {
+        "title": "Tools",
+        "path": "features/tools",
+        "children": []
+      },
+      {
+        "title": "Pop-out Windows",
+        "path": "features/popout-windows",
+        "children": []
+      },
+      {
+        "title": "ECU Console",
+        "path": "features/ecu-console",
+        "children": []
+      },
+      {
+        "title": "AI Assistant",
+        "path": "features/ai-assistant",
+        "children": []
+      },
+      {
+        "title": "Tune Migration",
+        "path": "features/tune-migration",
+        "children": []
+      },
+      {
+        "title": "Hardware Configuration",
+        "path": "technical/port-editor",
+        "children": []
+      },
+      {
+        "title": "Action Scripting",
+        "path": "reference/action-scripting",
+        "children": []
+      }
+    ]
+  },
+  {
+    "title": "Project Management",
+    "path": "projects/tunes",
+    "children": [
+      {
+        "title": "Managing Tunes",
+        "path": "projects/tunes",
+        "children": []
+      },
+      {
+        "title": "Version Control",
+        "path": "projects/version-control",
+        "children": []
+      },
+      {
+        "title": "Change Annotations",
+        "path": "projects/change-annotations",
+        "children": []
+      },
+      {
+        "title": "Restore Points",
+        "path": "projects/restore-points",
+        "children": []
+      },
+      {
+        "title": "Importing Projects",
+        "path": "projects/importing",
+        "children": []
+      }
+    ]
+  },
+  {
+    "title": "Reference",
+    "path": "reference/supported-ecus",
+    "children": [
+      {
+        "title": "Supported ECUs",
+        "path": "reference/supported-ecus",
+        "children": []
+      },
+      {
+        "title": "INI File Format",
+        "path": "reference/ini-format",
         "children": []
       },
       {
         "title": "Keyboard Shortcuts",
-        "path": "features/table-editing/shortcuts",
+        "path": "reference/shortcuts",
+        "children": []
+      },
+      {
+        "title": "Troubleshooting",
+        "path": "reference/troubleshooting",
+        "children": []
+      },
+      {
+        "title": "Java → WASM Migration",
+        "path": "reference/java-to-wasm-migration",
         "children": []
       }
     ]
   },
   {
-    "title": "AutoTune",
-    "path": "features/autotune",
-    "children": [
-      {
-        "title": "Usage Guide",
-        "path": "features/autotune/usage-guide",
-        "children": []
-      },
-      {
-        "title": "Setting Up AutoTune",
-        "path": "features/autotune/setup",
-        "children": []
-      },
-      {
-        "title": "Understanding Recommendations",
-        "path": "features/autotune/recommendations",
-        "children": []
-      },
-      {
-        "title": "Filters and Authority",
-        "path": "features/autotune/filters",
-        "children": []
-      }
-    ]
-  },
-  {
-    "title": "Dashboards",
-    "path": "features/dashboards",
-    "children": [
-      {
-        "title": "Using Dashboards",
-        "path": "features/dashboards/using",
-        "children": []
-      },
-      {
-        "title": "Customizing Gauges",
-        "path": "features/dashboards/customizing",
-        "children": []
-      },
-      {
-        "title": "Creating Dashboards",
-        "path": "features/dashboards/creating",
-        "children": []
-      },
-      {
-        "title": "Dashboard Validation",
-        "path": "features/dashboards/validation",
-        "children": []
-      }
-    ]
-  },
-  {
-    "title": "Math Channels",
-    "path": "features/math-channels",
-    "children": []
-  },
-  {
-    "title": "Data Logging",
-    "path": "features/datalog",
-    "children": []
-  },
-  {
-    "title": "Smart Recording",
-    "path": "features/smart-recording",
-    "children": []
-  },
-  {
-    "title": "Data Statistics",
-    "path": "features/data-statistics",
-    "children": []
-  },
-  {
-    "title": "Alert Rules",
-    "path": "features/alert-rules",
-    "children": []
-  },
-  {
-    "title": "Lua Scripting",
-    "path": "features/lua-scripting",
-    "children": []
-  },
-  {
-    "title": "Base Map Generator",
-    "path": "features/base-map",
-    "children": []
-  },
-  {
-    "title": "Performance Calculator",
-    "path": "features/performance-calculator",
-    "children": []
-  },
-  {
-    "title": "Diagnostic Loggers",
-    "path": "features/diagnostic-loggers",
-    "children": []
-  },
-  {
-    "title": "Tools",
-    "path": "features/tools",
-    "children": []
-  },
-  {
-    "title": "Pop-out Windows",
-    "path": "features/popout-windows",
-    "children": []
-  },
-  {
-    "title": "ECU Console",
-    "path": "features/ecu-console",
-    "children": []
-  },
-  {
-    "title": "AI Assistant",
-    "path": "features/ai-assistant",
-    "children": []
-  },
-  {
-    "title": "Tune Migration",
-    "path": "features/tune-migration",
-    "children": []
-  },
-  {
-    "title": "Hardware Configuration",
-    "path": "technical/port-editor",
-    "children": []
-  },
-  {
-    "title": "Action Scripting",
-    "path": "reference/action-scripting",
-    "children": []
-  },
-  {
-    "title": "Managing Tunes",
-    "path": "projects/tunes",
-    "children": []
-  },
-  {
-    "title": "Version Control",
-    "path": "projects/version-control",
-    "children": []
-  },
-  {
-    "title": "Change Annotations",
-    "path": "projects/change-annotations",
-    "children": []
-  },
-  {
-    "title": "Restore Points",
-    "path": "projects/restore-points",
-    "children": []
-  },
-  {
-    "title": "Importing Projects",
-    "path": "projects/importing",
-    "children": []
-  },
-  {
-    "title": "Supported ECUs",
-    "path": "reference/supported-ecus",
-    "children": []
-  },
-  {
-    "title": "INI File Format",
-    "path": "reference/ini-format",
-    "children": []
-  },
-  {
-    "title": "Keyboard Shortcuts",
-    "path": "reference/shortcuts",
-    "children": []
-  },
-  {
-    "title": "Troubleshooting",
-    "path": "reference/troubleshooting",
-    "children": []
-  },
-  {
-    "title": "Java → WASM Migration",
-    "path": "reference/java-to-wasm-migration",
-    "children": []
-  },
-  {
-    "title": "Overview",
+    "title": "Technical Reference",
     "path": "technical/README",
-    "children": []
+    "children": [
+      {
+        "title": "Overview",
+        "path": "technical/README",
+        "children": []
+      },
+      {
+        "title": "AutoTune Algorithm",
+        "path": "technical/autotune-algorithm",
+        "children": []
+      },
+      {
+        "title": "Table Operations",
+        "path": "technical/table-operations",
+        "children": []
+      },
+      {
+        "title": "INI Parser",
+        "path": "technical/ini-parser",
+        "children": []
+      },
+      {
+        "title": "ECU Protocol",
+        "path": "technical/ecu-protocol",
+        "children": []
+      },
+      {
+        "title": "Version Control",
+        "path": "technical/version-control",
+        "children": []
+      },
+      {
+        "title": "Lua Scripting",
+        "path": "technical/lua-scripting",
+        "children": []
+      },
+      {
+        "title": "Plugin System",
+        "path": "technical/plugin-system",
+        "children": []
+      },
+      {
+        "title": "Port Editor",
+        "path": "technical/port-editor",
+        "children": []
+      },
+      {
+        "title": "AI Assistant",
+        "path": "technical/ai-assistant",
+        "children": []
+      }
+    ]
   },
   {
-    "title": "AutoTune Algorithm",
-    "path": "technical/autotune-algorithm",
-    "children": []
-  },
-  {
-    "title": "Table Operations",
-    "path": "technical/table-operations",
-    "children": []
-  },
-  {
-    "title": "INI Parser",
-    "path": "technical/ini-parser",
-    "children": []
-  },
-  {
-    "title": "ECU Protocol",
-    "path": "technical/ecu-protocol",
-    "children": []
-  },
-  {
-    "title": "Version Control",
-    "path": "technical/version-control",
-    "children": []
-  },
-  {
-    "title": "Lua Scripting",
-    "path": "technical/lua-scripting",
-    "children": []
-  },
-  {
-    "title": "Plugin System",
-    "path": "technical/plugin-system",
-    "children": []
-  },
-  {
-    "title": "Port Editor",
-    "path": "technical/port-editor",
-    "children": []
-  },
-  {
-    "title": "AI Assistant",
-    "path": "technical/ai-assistant",
-    "children": []
-  },
-  {
-    "title": "Frequently Asked Questions",
+    "title": "FAQ",
     "path": "faq",
-    "children": []
+    "children": [
+      {
+        "title": "Frequently Asked Questions",
+        "path": "faq",
+        "children": []
+      }
+    ]
   }
 ]

--- a/crates/libretune-app/src-tauri/src/commands/app_settings.rs
+++ b/crates/libretune-app/src-tauri/src/commands/app_settings.rs
@@ -23,6 +23,14 @@ pub(crate) struct Settings {
     pub(crate) gauge_lock: bool, // Dashboard gauge lock in place
     #[serde(default = "default_true")]
     pub(crate) auto_sync_gauge_ranges: bool, // Auto-sync gauge ranges from INI
+    /// Dashboard gauge redraw cap in Hz (allowed: 10, 15, 20, 25, 30).
+    /// Lower values cut CPU/battery use on dashboards with many gauges.
+    #[serde(default = "default_dashboard_refresh_hz")]
+    pub(crate) dashboard_refresh_hz: u32,
+    /// Right-align gauge numeric value text in a fixed region so digit-count
+    /// and sign changes don't shift the layout ("jumping text" fix, issue #82).
+    #[serde(default)]
+    pub(crate) gauge_right_align_values: bool,
     #[serde(default)]
     pub(crate) indicator_column_count: String, // "auto" or number like "12"
     #[serde(default)]
@@ -199,6 +207,10 @@ fn default_trail_fade_sec() -> f64 {
     8.0
 }
 
+fn default_dashboard_refresh_hz() -> u32 {
+    30
+}
+
 fn default_true() -> bool {
     true
 }
@@ -329,6 +341,8 @@ fn default_settings() -> Settings {
         gauge_free_move: false,
         gauge_lock: false,
         auto_sync_gauge_ranges: default_true(),
+        dashboard_refresh_hz: default_dashboard_refresh_hz(),
+        gauge_right_align_values: false,
         indicator_column_count: String::new(),
         indicator_fill_empty: false,
         indicator_text_fit: String::new(),

--- a/crates/libretune-app/src-tauri/src/commands/mod.rs
+++ b/crates/libretune-app/src-tauri/src/commands/mod.rs
@@ -72,6 +72,7 @@ pub mod table_internals;
 pub mod table_ops;
 pub mod table_update;
 pub mod temperature_units;
+pub mod tooth_logger;
 pub mod ts_import;
 pub mod tune_apply;
 pub mod tune_compare;

--- a/crates/libretune-app/src-tauri/src/commands/settings.rs
+++ b/crates/libretune-app/src-tauri/src/commands/settings.rs
@@ -28,6 +28,18 @@ fn apply_setting(settings: &mut Settings, key: &str, value: &str) -> Result<(), 
         "auto_sync_gauge_ranges" => {
             settings.auto_sync_gauge_ranges = value.parse().map_err(|_| "Invalid boolean value")?
         }
+        "dashboard_refresh_hz" => {
+            let hz: u32 = value.parse().map_err(|_| "Invalid number value")?;
+            // Whitelist: keeps the renderer's frame budget predictable.
+            match hz {
+                10 | 15 | 20 | 25 | 30 => settings.dashboard_refresh_hz = hz,
+                _ => return Err("dashboard_refresh_hz must be one of 10, 15, 20, 25, 30".into()),
+            }
+        }
+        "gauge_right_align_values" => {
+            settings.gauge_right_align_values =
+                value.parse().map_err(|_| "Invalid boolean value")?
+        }
         "indicator_column_count" => settings.indicator_column_count = value.to_string(),
         "indicator_fill_empty" => {
             settings.indicator_fill_empty = value.parse().map_err(|_| "Invalid boolean value")?

--- a/crates/libretune-app/src/App.tsx
+++ b/crates/libretune-app/src/App.tsx
@@ -33,6 +33,7 @@ import { useTableCurveRefresh } from "./hooks/useTableCurveRefresh";
 import { useGlobalShortcuts } from "./hooks/useGlobalShortcuts";
 import { useEcuEventListeners } from "./hooks/useEcuEventListeners";
 import { useTableAccentColorVars } from "./utils/useTableOrientation";
+import { initRenderSettings } from "./components/gauges/renderSettings";
 import { useAutoConnect, type ConnectOptions } from "./hooks/useAutoConnect";
 import { useReconnectHandler } from "./hooks/useReconnectHandler";
 import { useTuneModified } from "./hooks/useTuneModified";
@@ -174,15 +175,16 @@ function AppContent() {
   const [onlineIniDialogOpen, setOnlineIniDialogOpen] = useState(false);
   const [connectEcuWizardOpen, setConnectEcuWizardOpen] = useState(false);
 
-  // Refresh the repository INI list whenever the New Project dialog opens.
-  // Removing a definition in Settings updates only that dialog's local copy,
-  // so without this the New Project picker would still show deleted INIs.
+  // Refresh the repository INI list whenever the New Project dialog or the
+  // Connect-ECU wizard opens. Removing a definition in Settings updates only
+  // the dialog's local copy, so without this the INI pickers would still show
+  // deleted INIs.
   useEffect(() => {
-    if (!newProjectDialogOpen) return;
+    if (!newProjectDialogOpen && !connectEcuWizardOpen) return;
     invoke<IniEntry[]>("list_repository_inis")
       .then(setRepositoryInis)
       .catch(() => {});
-  }, [newProjectDialogOpen]);
+  }, [newProjectDialogOpen, connectEcuWizardOpen]);
   const [baseMapDialogOpen, setBaseMapDialogOpen] = useState(false);
 
   // Connection state
@@ -763,6 +765,13 @@ function AppContent() {
 
   // User-configured cursor/trail colors → root CSS vars
   useTableAccentColorVars();
+
+  // Dashboard render settings (refresh-rate cap, right-aligned values) —
+  // imperative module read by the gauge rAF loop; keeps itself in sync with
+  // the `settings:changed` event (issue #82).
+  useEffect(() => {
+    void initRenderSettings();
+  }, []);
 
   // App-level event listeners: window title, active-tab persistence,
   // reconnect:request, ini:changed, demo:changed (extracted to hook).

--- a/crates/libretune-app/src/PopOutWindow.tsx
+++ b/crates/libretune-app/src/PopOutWindow.tsx
@@ -18,6 +18,7 @@ import TsDashboard from './components/dashboards/TsDashboard';
 import DialogRenderer, { DialogDefinition as RendererDialogDef } from './components/dialogs/DialogRenderer';
 import { AgentDock } from './components/agent/AgentDock';
 import { useRealtimeStore } from './stores/realtimeStore';
+import { initRenderSettings } from './components/gauges/renderSettings';
 import { ArrowLeftToLine, X } from 'lucide-react';
 import './styles';
 import './PopOutWindow.css';
@@ -67,6 +68,12 @@ export default function PopOutWindow() {
     console.log('[PopOutWindow] Component mounted');
     console.log('[PopOutWindow] hash:', window.location.hash);
     console.log('[PopOutWindow] href:', window.location.href);
+  }, []);
+
+  // Dashboard render settings (refresh-rate cap, right-aligned values) apply
+  // to gauges in pop-out windows too (issue #82).
+  useEffect(() => {
+    void initRenderSettings();
   }, []);
 
   // Track connection status so the popped-out dashboard behaves the same as

--- a/crates/libretune-app/src/components/gauges/TsGauge.tsx
+++ b/crates/libretune-app/src/components/gauges/TsGauge.tsx
@@ -6,7 +6,7 @@
  * Wrapped in React.memo with custom comparator for performance optimization.
  */
 
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useState, useCallback, useRef } from 'react';
 import { TsGaugeConfig, TsColor } from '../dashboards/dashTypes';
 import {
   getEmbeddedImage as getCachedEmbeddedImage,
@@ -14,6 +14,7 @@ import {
   loadEmbeddedAssets,
 } from './assetCache';
 import { useGaugeRenderer } from './useGaugeRenderer';
+import { getRightAlignValues } from './renderSettings';
 import {
   ensurePaintersRegistered,
   painterRegistry,
@@ -39,6 +40,10 @@ interface TsGaugeProps {
 function TsGaugeInner({ config, value, embeddedImages, legacyMode = false, overrideStore = false, isConnected = false }: TsGaugeProps) {
   const [fontsReady, setFontsReady] = useState(false);
   const [imagesReady, setImagesReady] = useState(false);
+  // Transient-spike flash state, written per-frame by useGaugeRenderer and
+  // read per-frame by the paint callback (issue #82). A ref — not state —
+  // because it flips at animation cadence and must not re-render React.
+  const spikeActiveRef = useRef(false);
 
   // Load embedded fonts and images
   useEffect(() => {
@@ -184,6 +189,8 @@ function TsGaugeInner({ config, value, embeddedImages, legacyMode = false, overr
           getFontSpec,
           getFontFamily,
           getEmbeddedImage,
+          rightAlignValues: getRightAlignValues(),
+          spikeActive: spikeActiveRef.current,
         };
         migrated(pctx);
         return;
@@ -204,6 +211,8 @@ function TsGaugeInner({ config, value, embeddedImages, legacyMode = false, overr
         getFontSpec,
         getFontFamily,
         getEmbeddedImage,
+        rightAlignValues: getRightAlignValues(),
+        spikeActive: spikeActiveRef.current,
       });
     },
     // The legacy painter closures close over `config`, helpers, and
@@ -228,6 +237,7 @@ function TsGaugeInner({ config, value, embeddedImages, legacyMode = false, overr
     enabled: fontsReady && imagesReady,
     paint,
     continuousRender,
+    spikeActiveRef,
   });
 
   return (

--- a/crates/libretune-app/src/components/gauges/__tests__/ema.test.ts
+++ b/crates/libretune-app/src/components/gauges/__tests__/ema.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Tests for the time-based EMA, spike detection, stagger slots (issue #82)
+ * and the fixed-width value formatting used by dial-centered painters.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  emaStep,
+  isSpike,
+  staggerSlotForChannel,
+  STAGGER_SLOTS,
+  EMA_TAU_MS,
+  SPIKE_RANGE_FRACTION,
+} from '../ema';
+import { steadyValueText } from '../drawUtils';
+
+describe('emaStep', () => {
+  it('returns prev when no time has elapsed', () => {
+    expect(emaStep(5, 10, 0)).toBe(5);
+    expect(emaStep(5, 10, -16)).toBe(5);
+  });
+
+  it('covers ~63% of a step after one time constant', () => {
+    // dt=100ms stays under the hidden-tab clamp; use a matching tau.
+    const next = emaStep(0, 100, 100, 100);
+    expect(next).toBeCloseTo(100 * (1 - Math.exp(-1)), 5);
+  });
+
+  it('converges identically regardless of frame rate (time-based, not frame-based)', () => {
+    // Same 100 ms of simulated time: 100 fps (10×10ms) vs 10 fps (1×100ms).
+    let fast = 0;
+    for (let i = 0; i < 10; i++) fast = emaStep(fast, 100, 10);
+    const slow = emaStep(0, 100, 100);
+    const expected = 100 * (1 - Math.exp(-100 / EMA_TAU_MS));
+    expect(fast).toBeCloseTo(expected, 5);
+    expect(slow).toBeCloseTo(expected, 5);
+  });
+
+  it('clamps huge deltas (tab was hidden) instead of snapping', () => {
+    // 10 s hidden should behave like a 100 ms step, not a full snap to target.
+    const next = emaStep(0, 100, 10_000);
+    expect(next).toBeCloseTo(emaStep(0, 100, 100), 10);
+    expect(next).toBeLessThan(90);
+  });
+
+  it('honours a custom tau', () => {
+    const fastTau = emaStep(0, 100, 100, 50);
+    const slowTau = emaStep(0, 100, 100, 500);
+    expect(fastTau).toBeGreaterThan(slowTau);
+  });
+});
+
+describe('isSpike', () => {
+  // Range 0..100 → default threshold is 15.
+  it('flags deviations beyond the range fraction', () => {
+    expect(isSpike(120, 100, 0, 100)).toBe(true); // 20 > 15
+    expect(isSpike(80, 100, 0, 100)).toBe(true); // 20 > 15
+    expect(isSpike(110, 100, 0, 100)).toBe(false); // 10 < 15
+  });
+
+  it('boundary: exactly at the threshold is not a spike', () => {
+    const threshold = (100 - 0) * SPIKE_RANGE_FRACTION;
+    expect(isSpike(100 + threshold, 100, 0, 100)).toBe(false);
+  });
+
+  it('never spikes for a zero/negative range', () => {
+    expect(isSpike(100, 0, 50, 50)).toBe(false);
+    expect(isSpike(100, 0, 100, 0)).toBe(false);
+  });
+
+  it('respects a custom fraction', () => {
+    expect(isSpike(105, 100, 0, 100, 0.01)).toBe(true);
+    expect(isSpike(105, 100, 0, 100, 0.5)).toBe(false);
+  });
+});
+
+describe('staggerSlotForChannel', () => {
+  it('is deterministic for the same channel', () => {
+    expect(staggerSlotForChannel('rpm')).toBe(staggerSlotForChannel('rpm'));
+    expect(staggerSlotForChannel('lambda')).toBe(staggerSlotForChannel('lambda'));
+  });
+
+  it('stays within the slot count', () => {
+    for (const ch of ['rpm', 'map', 'tps', 'lambda', 'clt', 'iat', 'afr', 'advance']) {
+      const slot = staggerSlotForChannel(ch);
+      expect(slot).toBeGreaterThanOrEqual(0);
+      expect(slot).toBeLessThan(STAGGER_SLOTS);
+    }
+  });
+
+  it('spreads distinct channels across more than one slot', () => {
+    const slots = new Set(
+      ['rpm', 'map', 'tps', 'lambda', 'clt', 'iat', 'afr', 'advance'].map(staggerSlotForChannel),
+    );
+    expect(slots.size).toBeGreaterThan(1);
+  });
+
+  it('falls back to a rotating counter for channel-less (demo) gauges', () => {
+    const a = staggerSlotForChannel('');
+    const b = staggerSlotForChannel('');
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('steadyValueText', () => {
+  it('pads to the worst-case width of the range', () => {
+    // Range -40..220 with 1 digit: worst is "-40.0" (5 chars).
+    expect(steadyValueText(100, 1, -40, 220)).toBe('100.0');
+    expect(steadyValueText(5, 1, -40, 220)).toBe('  5.0');
+  });
+
+  it('keeps constant width across sign and digit-count changes', () => {
+    const a = steadyValueText(-12.3, 1, -40, 220);
+    const b = steadyValueText(7.8, 1, -40, 220);
+    const c = steadyValueText(220, 1, -40, 220);
+    expect(a.length).toBe(b.length);
+    expect(b.length).toBe(c.length);
+  });
+
+  it('never truncates values wider than the worst case', () => {
+    // Out-of-range values render in full (padStart never truncates).
+    expect(steadyValueText(1234, 1, 0, 100)).toBe('1234.0');
+  });
+});

--- a/crates/libretune-app/src/components/gauges/drawUtils.ts
+++ b/crates/libretune-app/src/components/gauges/drawUtils.ts
@@ -31,6 +31,24 @@ export function roundRect(
   ctx.closePath();
 }
 
+/**
+ * Format a gauge value padded (left, with spaces) to the worst-case width of
+ * the gauge range — the "extend the field but never shrink it" idea from
+ * issue #82. With the monospace font painters already use for values, the
+ * rendered string has constant width, so digit-count and sign changes don't
+ * shift glyphs ("jumping text"). Painters that center the value inside a
+ * dial use this to stay steady while remaining centered.
+ */
+export function steadyValueText(
+  value: number,
+  digits: number,
+  min: number,
+  max: number,
+): string {
+  const worst = Math.max(min.toFixed(digits).length, max.toFixed(digits).length);
+  return value.toFixed(digits).padStart(worst, ' ');
+}
+
 /** Lighten a #rrggbb hex color by `percent` (0-100). */
 export function lightenColor(hex: string, percent: number): string {
   const num = parseInt(hex.replace('#', ''), 16);

--- a/crates/libretune-app/src/components/gauges/ema.ts
+++ b/crates/libretune-app/src/components/gauges/ema.ts
@@ -1,0 +1,85 @@
+/**
+ * `ema` — time-based exponential moving average + transient-spike detection
+ * for gauge rendering (issue #82).
+ *
+ * Replaces the old frame-count lerp (`value += diff * 0.25` per rAF tick),
+ * whose smoothing constant varied with frame rate: at 60 fps it converged in
+ * ~280 ms, at 10 fps it would have taken ~1.7 s. A time-constant EMA
+ * (`alpha = 1 - exp(-dt/tau)`) converges identically at any refresh rate,
+ * which is what makes the configurable 10–30 Hz redraw cap feel smooth.
+ *
+ * Spike detection answers the issue's "peak detect is important to figure out
+ * problems if short pulses can happen": when the raw channel value jumps away
+ * from the smoothed display value by more than a fraction of the gauge range,
+ * the gauge flashes (critical color) briefly so a transient is visible even
+ * though the EMA itself filters it out of the needle position.
+ *
+ * Pure functions, no canvas/timers — same testability pattern as
+ * `peakTracking.ts`.
+ */
+
+/** EMA time constant: ~63% of a step is covered per 120 ms of elapsed time. */
+export const EMA_TAU_MS = 120;
+
+/** Fraction of gauge range that counts as a transient spike. */
+export const SPIKE_RANGE_FRACTION = 0.15;
+
+/** How long the spike flash stays on after the last spiking sample (ms). */
+export const SPIKE_FLASH_MS = 400;
+
+/**
+ * Advance the EMA one step. `dtMs` is the elapsed time since the previous
+ * step; pass the rAF timestamp delta. `dtMs <= 0` returns `prev` unchanged;
+ * very large deltas (tab was hidden) are clamped to 100 ms so a backgrounded
+ * tab doesn't snap the needle on return.
+ */
+export function emaStep(
+  prev: number,
+  target: number,
+  dtMs: number,
+  tauMs: number = EMA_TAU_MS,
+): number {
+  if (dtMs <= 0) return prev;
+  if (dtMs > 100) dtMs = 100;
+  const alpha = 1 - Math.exp(-dtMs / tauMs);
+  return prev + (target - prev) * alpha;
+}
+
+/** True when `raw` deviates from the smoothed value by more than `frac` of range. */
+export function isSpike(
+  raw: number,
+  smoothed: number,
+  min: number,
+  max: number,
+  frac: number = SPIKE_RANGE_FRACTION,
+): boolean {
+  const range = max - min;
+  if (range <= 0) return false;
+  return Math.abs(raw - smoothed) > range * frac;
+}
+
+/** Number of phase slots redraw timers are spread across (issue #82 staggering). */
+export const STAGGER_SLOTS = 16;
+
+let mountCounter = 0;
+
+/**
+ * Deterministic stagger slot for a gauge. Gauges bound to a channel hash to a
+ * stable slot (same dashboard → same phasing every launch); channel-less demo
+ * gauges fall back to a per-mount counter. The render loop multiplies the
+ * slot by `drawInterval / STAGGER_SLOTS` to obtain its phase offset, so 16+
+ * gauges spread their redraws evenly instead of all painting on one frame.
+ */
+export function staggerSlotForChannel(channel: string): number {
+  if (!channel) {
+    const slot = mountCounter % STAGGER_SLOTS;
+    mountCounter += 1;
+    return slot;
+  }
+  // djb2 hash — tiny, stable across runs.
+  let h = 5381;
+  for (let i = 0; i < channel.length; i++) {
+    h = ((h << 5) + h + channel.charCodeAt(i)) | 0;
+  }
+  return Math.abs(h) % STAGGER_SLOTS;
+}

--- a/crates/libretune-app/src/components/gauges/painters/__tests__/lineGraph.test.ts
+++ b/crates/libretune-app/src/components/gauges/painters/__tests__/lineGraph.test.ts
@@ -124,6 +124,8 @@ describe('lineGraphPainter', () => {
       getFontSpec: (size) => `${size}px Arial`,
       getFontFamily: () => 'Arial',
       getEmbeddedImage: () => null,
+      rightAlignValues: false,
+      spikeActive: false,
     });
 
     expect(randomSpy).not.toHaveBeenCalled();
@@ -150,6 +152,8 @@ describe('lineGraphPainter', () => {
       getFontSpec: (size) => `${size}px Arial`,
       getFontFamily: () => 'Arial',
       getEmbeddedImage: () => null,
+      rightAlignValues: false,
+      spikeActive: false,
     });
 
     // With empty history the painter should emit trace points.
@@ -196,9 +200,87 @@ describe('lineGraphPainter', () => {
       getFontSpec: (size) => `${size}px Arial`,
       getFontFamily: () => 'Arial',
       getEmbeddedImage: () => null,
+      rightAlignValues: false,
+      spikeActive: false,
     });
 
     // With history we should get at least as many line points as history entries.
     expect(lineToCalls.length).toBeGreaterThanOrEqual(history.length);
+  });
+
+  it('EMA-smooths the trace instead of plotting raw samples (issue #82)', () => {
+    // 20 steady samples, then one small step (below the spike threshold).
+    for (let i = 0; i < 20; i++) {
+      useRealtimeStore.getState().updateChannels({ lambda: 1.0 });
+    }
+    useRealtimeStore.getState().updateChannels({ lambda: 1.06 });
+
+    const ctx = mockCtx();
+    const lineToCalls: { x: number; y: number }[] = [];
+    (ctx.lineTo as any).mockImplementation((x: number, y: number) => {
+      lineToCalls.push({ x, y });
+    });
+
+    lineGraphPainter({
+      ctx,
+      width: 200,
+      height: 100,
+      value: 1.06,
+      peakValue: 1.06,
+      config: baseConfig,
+      legacyMode: false,
+      bgImage: null,
+      needleImage: null,
+      getValueColor: () => baseConfig.font_color as TsColor,
+      getFontSpec: (size) => `${size}px Arial`,
+      getFontFamily: () => 'Arial',
+      getEmbeddedImage: () => null,
+      rightAlignValues: false,
+      spikeActive: false,
+    });
+
+    // Geometry: padding=8, titleHeight=12, graphY=20, graphHeight=72.
+    // Raw position of 1.06 (pct 0.6 of the 0.7..1.3 range) would be y=48.8.
+    // The smoothed trace must lag the raw step, so the newest trace point
+    // (last lineTo of the stroke path) sits lower (larger y) than raw.
+    const lastY = lineToCalls[lineToCalls.length - 1].y;
+    expect(lastY).toBeGreaterThan(49.5); // raw would be 48.8
+    expect(lastY).toBeLessThan(60); // but it must have moved toward the step
+  });
+
+  it('draws spike dots for transient deviations and none for steady data', () => {
+    const countArcs = (samples: number[]): number => {
+      useRealtimeStore.getState().clearChannels();
+      for (const s of samples) {
+        useRealtimeStore.getState().updateChannels({ lambda: s });
+      }
+      const ctx = mockCtx();
+      lineGraphPainter({
+        ctx,
+        width: 200,
+        height: 100,
+        value: samples[samples.length - 1],
+        peakValue: 1.3,
+        config: baseConfig,
+        legacyMode: false,
+        bgImage: null,
+        needleImage: null,
+        getValueColor: () => baseConfig.font_color as TsColor,
+        getFontSpec: (size) => `${size}px Arial`,
+        getFontFamily: () => 'Arial',
+        getEmbeddedImage: () => null,
+        rightAlignValues: false,
+        spikeActive: false,
+      });
+      return (ctx.arc as any).mock.calls.length;
+    };
+
+    // Steady data: only the current-value dot → exactly 1 arc.
+    const steady = countArcs(new Array(11).fill(1.0));
+    expect(steady).toBe(1);
+
+    // One big jump (0.3 > 15% of the 0.6 range): spike dot(s) + current dot.
+    const spiked = countArcs([...new Array(10).fill(1.0), 1.3]);
+    expect(spiked).toBeGreaterThanOrEqual(2);
   });
 });

--- a/crates/libretune-app/src/components/gauges/painters/analogBarGauge.ts
+++ b/crates/libretune-app/src/components/gauges/painters/analogBarGauge.ts
@@ -1,7 +1,7 @@
 /** AnalogBarGauge — semicircular bar indicator with metallic bezel. */
 
 import { tsColorToHex } from '../../dashboards/dashTypes';
-import { lightenColor, darkenColor, createMetallicGradient } from '../drawUtils';
+import { lightenColor, darkenColor, createMetallicGradient, steadyValueText } from '../drawUtils';
 import type { Painter } from './types';
 
 export const analogBarGaugePainter: Painter = (pctx) => {
@@ -85,7 +85,13 @@ export const analogBarGaugePainter: Painter = (pctx) => {
   ctx.font = getFontSpec(fontSize, { bold: true, monospace: true });
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
-  ctx.fillText(value.toFixed(config.value_digits), centerX, centerY - radius * 0.3);
+  ctx.fillText(
+    pctx.rightAlignValues
+      ? steadyValueText(value, config.value_digits, config.min, config.max)
+      : value.toFixed(config.value_digits),
+    centerX,
+    centerY - radius * 0.3,
+  );
 
   // Units below value
   if (config.units) {

--- a/crates/libretune-app/src/components/gauges/painters/analogMovingBarGauge.ts
+++ b/crates/libretune-app/src/components/gauges/painters/analogMovingBarGauge.ts
@@ -1,7 +1,7 @@
 /** AnalogMovingBarGauge — sweeping needle with bar trail across a 140° arc. */
 
 import { tsColorToHex } from '../../dashboards/dashTypes';
-import { lightenColor, darkenColor, createMetallicGradient } from '../drawUtils';
+import { lightenColor, darkenColor, createMetallicGradient, steadyValueText } from '../drawUtils';
 import type { Painter } from './types';
 
 export const analogMovingBarGaugePainter: Painter = (pctx) => {
@@ -126,7 +126,13 @@ export const analogMovingBarGaugePainter: Painter = (pctx) => {
   ctx.font = getFontSpec(fontSize, { bold: true, monospace: true });
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
-  ctx.fillText(value.toFixed(config.value_digits), centerX, centerY - radius * 0.35);
+  ctx.fillText(
+    pctx.rightAlignValues
+      ? steadyValueText(value, config.value_digits, config.min, config.max)
+      : value.toFixed(config.value_digits),
+    centerX,
+    centerY - radius * 0.35,
+  );
 
   // Units
   if (config.units) {

--- a/crates/libretune-app/src/components/gauges/painters/basicReadout.ts
+++ b/crates/libretune-app/src/components/gauges/painters/basicReadout.ts
@@ -85,12 +85,21 @@ export const basicReadoutPainter: Painter = (pctx) => {
     ctx.shadowBlur = 8;
   }
 
-  ctx.fillStyle = tsColorToRgba(valueColor);
+  // Transient-spike flash (issue #82): tint the value in the critical
+  // color while a spike is active so short pulses stay visible.
+  ctx.fillStyle = tsColorToRgba(pctx.spikeActive ? config.critical_color : valueColor);
   // Use monospace or LCD-style font for values
   ctx.font = getFontSpec(valueFontSize, { bold: true, monospace: true });
-  ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
-  ctx.fillText(valueText, width / 2, height / 2 + titleFontSize * 0.3);
+  if (pctx.rightAlignValues) {
+    // Fixed right edge — text grows leftward, so digit-count and sign
+    // changes don't shift the layout (issue #82 "jumping text").
+    ctx.textAlign = 'right';
+    ctx.fillText(valueText, width - padding - 6, height / 2 + titleFontSize * 0.3);
+  } else {
+    ctx.textAlign = 'center';
+    ctx.fillText(valueText, width / 2, height / 2 + titleFontSize * 0.3);
+  }
   ctx.shadowColor = 'transparent';
 
   // Units at bottom

--- a/crates/libretune-app/src/components/gauges/painters/horizontalDashedBar.ts
+++ b/crates/libretune-app/src/components/gauges/painters/horizontalDashedBar.ts
@@ -88,8 +88,14 @@ export const horizontalDashedBarPainter: Painter = (pctx) => {
   ctx.shadowBlur = 2;
   ctx.fillStyle = tsColorToHex(config.font_color);
   ctx.font = getFontSpec(Math.max(11, valueHeight * 0.6), { bold: true, monospace: true });
-  ctx.textAlign = 'center';
   ctx.textBaseline = 'bottom';
-  ctx.fillText(`${value.toFixed(config.value_digits)}`, width / 2, height - 2);
+  if (pctx.rightAlignValues) {
+    // Fixed right edge — text grows leftward, no layout shift (issue #82).
+    ctx.textAlign = 'right';
+    ctx.fillText(`${value.toFixed(config.value_digits)}`, width - 4, height - 2);
+  } else {
+    ctx.textAlign = 'center';
+    ctx.fillText(`${value.toFixed(config.value_digits)}`, width / 2, height - 2);
+  }
   ctx.shadowColor = 'transparent';
 };

--- a/crates/libretune-app/src/components/gauges/painters/lineGraph.ts
+++ b/crates/libretune-app/src/components/gauges/painters/lineGraph.ts
@@ -3,6 +3,7 @@
 import { tsColorToHex } from '../../dashboards/dashTypes';
 import { roundRect, lightenColor, darkenColor } from '../drawUtils';
 import { getChannelHistoryBuffer } from '../../../stores/realtimeStore';
+import { emaStep, isSpike } from '../ema';
 import type { Painter } from './types';
 
 export const lineGraphPainter: Painter = (pctx) => {
@@ -61,19 +62,36 @@ export const lineGraphPainter: Painter = (pctx) => {
   // Read history imperatively from the non-reactive buffer — no React re-renders needed.
   const history = getChannelHistoryBuffer(config.output_channel);
   const points: { x: number; y: number }[] = [];
-
+  const spikePoints: { x: number; y: number }[] = [];
   if (history && history.length > 0) {
-    // Use actual history data
+    // EMA-smooth the trace (issue #82: raw samples at high stream rates look
+    // like an audio waveform). Samples far from the smoothed value are
+    // transient spikes — highlighted as dots below so short pulses that
+    // indicate problems stay visible (the issue's "peak detect" ask).
     const dataRange = config.max - config.min;
+    const SAMPLE_DT_MS = 100; // matches the default stream cadence
+    const TRACE_TAU_MS = 250; // ~3-sample smoothing horizon
+    const smoothed = new Array<number>(history.length);
+    let ema = history[0];
     for (let i = 0; i < history.length; i++) {
-      const t = i / (history.length - 1);
-      const historicalValue = history[i];
-      const historicalPercent = (historicalValue - config.min) / dataRange;
-      const clampedPercent = Math.max(0, Math.min(1, historicalPercent));
+      ema = i === 0 ? history[0] : emaStep(ema, history[i], SAMPLE_DT_MS, TRACE_TAU_MS);
+      smoothed[i] = ema;
+      if (i > 0 && isSpike(history[i], ema, config.min, config.max)) {
+        const t = i / (history.length - 1);
+        const rawPercent = Math.max(0, Math.min(1, (history[i] - config.min) / dataRange));
+        spikePoints.push({
+          x: padding + t * graphWidth,
+          y: graphY + graphHeight - rawPercent * graphHeight,
+        });
+      }
+    }
+    for (let i = 0; i < smoothed.length; i++) {
+      const t = i / (smoothed.length - 1);
+      const smoothedPercent = Math.max(0, Math.min(1, (smoothed[i] - config.min) / dataRange));
 
       points.push({
         x: padding + t * graphWidth,
-        y: graphY + graphHeight - clampedPercent * graphHeight,
+        y: graphY + graphHeight - smoothedPercent * graphHeight,
       });
     }
   } else {
@@ -123,6 +141,18 @@ export const lineGraphPainter: Painter = (pctx) => {
   ctx.lineCap = 'round';
   ctx.lineJoin = 'round';
   ctx.stroke();
+
+  // Transient-spike dots (issue #82): raw samples that deviated sharply from
+  // the EMA-smoothed trace, drawn in the critical color at the raw position.
+  if (spikePoints.length > 0) {
+    const spikeColor = tsColorToHex(config.critical_color);
+    ctx.fillStyle = spikeColor;
+    for (const sp of spikePoints) {
+      ctx.beginPath();
+      ctx.arc(sp.x, sp.y, 2.5, 0, Math.PI * 2);
+      ctx.fill();
+    }
+  }
 
   // Draw current value dot with glow
   const lastPoint = points[points.length - 1];

--- a/crates/libretune-app/src/components/gauges/painters/roundDashedGauge.ts
+++ b/crates/libretune-app/src/components/gauges/painters/roundDashedGauge.ts
@@ -1,7 +1,7 @@
 /** RoundDashedGauge — circular gauge with segmented arc (~270°). */
 
 import { tsColorToHex, tsColorToRgba } from '../../dashboards/dashTypes';
-import { lightenColor, createMetallicGradient } from '../drawUtils';
+import { lightenColor, createMetallicGradient, steadyValueText } from '../drawUtils';
 import type { Painter } from './types';
 
 export const roundDashedGaugePainter: Painter = (pctx) => {
@@ -80,7 +80,13 @@ export const roundDashedGaugePainter: Painter = (pctx) => {
   ctx.font = getFontSpec(fontSize, { bold: true, monospace: true });
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
-  ctx.fillText(value.toFixed(config.value_digits), centerX, centerY);
+  ctx.fillText(
+    pctx.rightAlignValues
+      ? steadyValueText(value, config.value_digits, config.min, config.max)
+      : value.toFixed(config.value_digits),
+    centerX,
+    centerY,
+  );
 
   // Units
   if (config.units) {

--- a/crates/libretune-app/src/components/gauges/painters/roundGauge.ts
+++ b/crates/libretune-app/src/components/gauges/painters/roundGauge.ts
@@ -1,7 +1,7 @@
 /** RoundGauge — 360° circular gauge with segments. */
 
 import { tsColorToHex, tsColorToRgba } from '../../dashboards/dashTypes';
-import { lightenColor, createMetallicGradient } from '../drawUtils';
+import { lightenColor, createMetallicGradient, steadyValueText } from '../drawUtils';
 import type { Painter } from './types';
 
 export const roundGaugePainter: Painter = (pctx) => {
@@ -68,7 +68,13 @@ export const roundGaugePainter: Painter = (pctx) => {
   ctx.font = getFontSpec(fontSize, { bold: true, monospace: true });
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
-  ctx.fillText(value.toFixed(config.value_digits), centerX, centerY);
+  ctx.fillText(
+    pctx.rightAlignValues
+      ? steadyValueText(value, config.value_digits, config.min, config.max)
+      : value.toFixed(config.value_digits),
+    centerX,
+    centerY,
+  );
 
   // Units below value
   if (config.units) {

--- a/crates/libretune-app/src/components/gauges/painters/sweepGauge.ts
+++ b/crates/libretune-app/src/components/gauges/painters/sweepGauge.ts
@@ -1,7 +1,7 @@
 /** AsymmetricSweepGauge — curved sweep gauge with glowing tip and warning zones. */
 
 import { tsColorToHex } from '../../dashboards/dashTypes';
-import { lightenColor, darkenColor } from '../drawUtils';
+import { lightenColor, darkenColor, steadyValueText } from '../drawUtils';
 import type { Painter } from './types';
 
 export const sweepGaugePainter: Painter = (pctx) => {
@@ -183,7 +183,13 @@ export const sweepGaugePainter: Painter = (pctx) => {
   const sweepValueY = config.display_value_at_180
     ? centerY + radius * 0.25
     : centerY;
-  ctx.fillText(value.toFixed(config.value_digits), centerX, sweepValueY);
+  ctx.fillText(
+    pctx.rightAlignValues
+      ? steadyValueText(value, config.value_digits, config.min, config.max)
+      : value.toFixed(config.value_digits),
+    centerX,
+    sweepValueY,
+  );
   ctx.shadowColor = 'transparent';
 
   // Title below value

--- a/crates/libretune-app/src/components/gauges/painters/tachometer.ts
+++ b/crates/libretune-app/src/components/gauges/painters/tachometer.ts
@@ -1,7 +1,7 @@
 /** Tachometer — specialized RPM gauge with redline zone and chrome bezel. */
 
 import { tsColorToHex } from '../../dashboards/dashTypes';
-import { createMetallicGradient } from '../drawUtils';
+import { createMetallicGradient, steadyValueText } from '../drawUtils';
 import type { Painter } from './types';
 
 export const tachometerPainter: Painter = (pctx) => {
@@ -163,7 +163,13 @@ export const tachometerPainter: Painter = (pctx) => {
   ctx.font = getFontSpec(fontSize, { bold: true, monospace: true });
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
-  ctx.fillText(value.toFixed(0), centerX, centerY + radius * 0.35);
+  ctx.fillText(
+    pctx.rightAlignValues
+      ? steadyValueText(value, 0, config.min, config.max)
+      : value.toFixed(0),
+    centerX,
+    centerY + radius * 0.35,
+  );
 
   // RPM label
   ctx.fillStyle = '#888888';

--- a/crates/libretune-app/src/components/gauges/painters/types.ts
+++ b/crates/libretune-app/src/components/gauges/painters/types.ts
@@ -43,6 +43,18 @@ export interface PainterContext {
   getFontSpec: (size: number, options?: { bold?: boolean; monospace?: boolean }) => string;
   getFontFamily: (preferMonospace?: boolean) => string;
   getEmbeddedImage: (name: string | null | undefined) => HTMLImageElement | null;
+  /**
+   * User setting (issue #82): right-align numeric value text in a fixed
+   * region so digit-count / sign changes don't shift glyphs ("jumping text").
+   * Painters that draw value text honor this; titles/units are unaffected.
+   */
+  rightAlignValues: boolean;
+  /**
+   * True while a transient-spike flash is active (issue #82): the raw
+   * channel value recently jumped far from the EMA-smoothed display value.
+   * Painters opt in by tinting the value readout (critical color).
+   */
+  spikeActive: boolean;
 }
 
 /** A self-contained painter: draws one frame from a `PainterContext`. */

--- a/crates/libretune-app/src/components/gauges/painters/verticalBar.ts
+++ b/crates/libretune-app/src/components/gauges/painters/verticalBar.ts
@@ -92,8 +92,14 @@ export const verticalBarPainter: Painter = (pctx) => {
   ctx.shadowBlur = 3;
   ctx.fillStyle = tsColorToRgba(config.font_color);
   ctx.font = getFontSpec(Math.max(11, labelHeight * 0.9), { bold: true, monospace: true });
-  ctx.textAlign = 'center';
   ctx.textBaseline = 'bottom';
-  ctx.fillText(`${value.toFixed(config.value_digits)}`, width / 2, height - 2);
+  if (pctx.rightAlignValues) {
+    // Fixed right edge — text grows leftward, no layout shift (issue #82).
+    ctx.textAlign = 'right';
+    ctx.fillText(`${value.toFixed(config.value_digits)}`, width - 4, height - 2);
+  } else {
+    ctx.textAlign = 'center';
+    ctx.fillText(`${value.toFixed(config.value_digits)}`, width / 2, height - 2);
+  }
   ctx.shadowColor = 'transparent';
 };

--- a/crates/libretune-app/src/components/gauges/painters/verticalDashedBar.ts
+++ b/crates/libretune-app/src/components/gauges/painters/verticalDashedBar.ts
@@ -85,8 +85,14 @@ export const verticalDashedBarPainter: Painter = (pctx) => {
   ctx.shadowBlur = 2;
   ctx.fillStyle = tsColorToHex(config.font_color);
   ctx.font = getFontSpec(Math.max(11, labelHeight * 0.9), { bold: true, monospace: true });
-  ctx.textAlign = 'center';
   ctx.textBaseline = 'bottom';
-  ctx.fillText(`${value.toFixed(config.value_digits)}`, width / 2, height - 2);
+  if (pctx.rightAlignValues) {
+    // Fixed right edge — text grows leftward, no layout shift (issue #82).
+    ctx.textAlign = 'right';
+    ctx.fillText(`${value.toFixed(config.value_digits)}`, width - 4, height - 2);
+  } else {
+    ctx.textAlign = 'center';
+    ctx.fillText(`${value.toFixed(config.value_digits)}`, width / 2, height - 2);
+  }
   ctx.shadowColor = 'transparent';
 };

--- a/crates/libretune-app/src/components/gauges/renderSettings.ts
+++ b/crates/libretune-app/src/components/gauges/renderSettings.ts
@@ -1,0 +1,104 @@
+/**
+ * `renderSettings` — imperative view of the two dashboard rendering settings
+ * (issue #82):
+ *
+ *  - `dashboard_refresh_hz`  — per-gauge canvas redraw cap (10/15/20/25/30)
+ *  - `gauge_right_align_values` — right-justify numeric value text so that
+ *    digit-count / sign changes don't shift glyphs
+ *
+ * The gauge rAF loop and the pure painter functions are not React — they read
+ * this module directly instead of going through props or state. `init()`
+ * performs the initial `get_settings` fetch and then keeps the values current
+ * via the `settings:changed` event, so changes apply live without an app
+ * restart. When not running under Tauri (unit tests), the defaults apply and
+ * tests can override them with `setForTest()`.
+ */
+
+import { invoke } from '@tauri-apps/api/core';
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+
+export const ALLOWED_REFRESH_HZ = [10, 15, 20, 25, 30] as const;
+export const DEFAULT_REFRESH_HZ = 30;
+
+interface RenderSettings {
+  refreshHz: number;
+  rightAlignValues: boolean;
+}
+
+const state: RenderSettings = {
+  refreshHz: DEFAULT_REFRESH_HZ,
+  rightAlignValues: false,
+};
+
+/** Current per-gauge redraw cap in Hz. */
+export function getRefreshHz(): number {
+  return state.refreshHz;
+}
+
+/** Current per-gauge redraw interval in ms (derived from `getRefreshHz()`). */
+export function getDrawIntervalMs(): number {
+  return 1000 / state.refreshHz;
+}
+
+/** Whether numeric value text should be right-aligned in a fixed region. */
+export function getRightAlignValues(): boolean {
+  return state.rightAlignValues;
+}
+
+function apply(settings: {
+  dashboard_refresh_hz?: number;
+  gauge_right_align_values?: boolean;
+}): void {
+  const hz = settings.dashboard_refresh_hz;
+  if (typeof hz === 'number' && (ALLOWED_REFRESH_HZ as readonly number[]).includes(hz)) {
+    state.refreshHz = hz;
+  }
+  if (settings.gauge_right_align_values !== undefined) {
+    state.rightAlignValues = !!settings.gauge_right_align_values;
+  }
+}
+
+let initPromise: Promise<void> | null = null;
+
+/**
+ * Load current settings and subscribe to `settings:changed`. Idempotent —
+ * safe to call from App startup and again from pop-out windows.
+ */
+export function initRenderSettings(): Promise<void> {
+  if (initPromise) return initPromise;
+  initPromise = (async () => {
+    const load = () =>
+      invoke<{ dashboard_refresh_hz?: number; gauge_right_align_values?: boolean }>(
+        'get_settings',
+      )
+        .then(apply)
+        .catch(() => {
+          // Not running under Tauri, or settings unreadable — keep defaults.
+        });
+    await load();
+    try {
+      const unlisten: UnlistenFn = await listen<string>('settings:changed', (e) => {
+        if (e.payload === 'dashboard_refresh_hz' || e.payload === 'gauge_right_align_values') {
+          void load();
+        }
+      });
+      // Listener lives for the app lifetime; nothing to clean up.
+      void unlisten;
+    } catch {
+      // Not running under Tauri (tests) — defaults stay in effect.
+    }
+  })();
+  return initPromise;
+}
+
+/** Test hook: override values directly (no Tauri). */
+export function setForTest(patch: Partial<RenderSettings>): void {
+  if (patch.refreshHz !== undefined) state.refreshHz = patch.refreshHz;
+  if (patch.rightAlignValues !== undefined) state.rightAlignValues = patch.rightAlignValues;
+}
+
+/** Test hook: restore defaults. */
+export function resetForTest(): void {
+  state.refreshHz = DEFAULT_REFRESH_HZ;
+  state.rightAlignValues = false;
+}

--- a/crates/libretune-app/src/components/gauges/useGaugeRenderer.ts
+++ b/crates/libretune-app/src/components/gauges/useGaugeRenderer.ts
@@ -4,7 +4,7 @@
  * Owns:
  *  - the canvas element ref
  *  - DPR-aware backing-store sizing via `ResizeObserver`
- *  - the requestAnimationFrame loop and its lerp-based smoothing
+ *  - the requestAnimationFrame loop and its time-based EMA smoothing
  *  - the imperative Zustand-store read each frame (no React re-render)
  *  - the 100 ms idle-watchdog that catches new store values once the
  *    rAF loop has converged
@@ -21,19 +21,17 @@ import { useEffect, useRef } from 'react';
 import type { TsGaugeConfig } from '../dashboards/dashTypes';
 import { useRealtimeStore } from '../../stores/realtimeStore';
 import { seedPeak, nextPeakState, type PeakState } from './peakTracking';
-
-/** Lerp factor per animation frame (~280ms to converge at 60fps). */
-const ANIMATION_LERP = 0.25;
+import { emaStep, isSpike, staggerSlotForChannel, STAGGER_SLOTS, SPIKE_FLASH_MS } from './ema';
+import { getDrawIntervalMs } from './renderSettings';
 
 /**
- * Frame limiter: cap drawing to ~30fps per gauge.
- *
- * With 10+ gauges each running at 60fps, the browser can't keep up
- * with 600+ canvas draws per second (each AnalogGauge draw creates
- * gradients, arcs, text = 2-5ms). 30fps per gauge → ~300/sec total,
- * well within budget.
+ * Frame limiter: per-gauge drawing is capped at the user-configured
+ * dashboard refresh rate (10–30 Hz — see `renderSettings`), and the redraw
+ * timers are phase-staggered so 10+ gauges don't all paint on the same frame
+ * (issue #82: extreme CPU load). Value smoothing is a time-constant EMA
+ * (`ema.ts`), so needle motion looks identical at any refresh rate; the old
+ * per-frame lerp converged slower at low frame rates.
  */
-const DRAW_INTERVAL_MS = 33;
 
 /** Function the host calls to draw one frame. */
 export type GaugePaintFn = (
@@ -62,6 +60,13 @@ export interface UseGaugeRendererOptions {
    * tick, but the visual only updates if we keep repainting.
    */
   continuousRender?: boolean;
+  /**
+   * Optional output ref: the loop writes `true` while a transient-spike
+   * flash is active (issue #82 peak detection). TsGauge passes a ref its
+   * paint callback closes over, so painters can tint the value without the
+   * loop ever restarting.
+   */
+  spikeActiveRef?: React.MutableRefObject<boolean>;
 }
 
 export interface UseGaugeRendererResult {
@@ -88,6 +93,10 @@ export interface UseGaugeRendererResult {
 
 export function useGaugeRenderer(opts: UseGaugeRendererOptions): UseGaugeRendererResult {
   const { config, value, overrideStore, enabled, paint, continuousRender } = opts;
+
+  // Spike-flash output: caller-supplied ref wins; internal fallback otherwise.
+  const internalSpikeRef = useRef(false);
+  const spikeRef = opts.spikeActiveRef ?? internalSpikeRef;
 
   const canvasRef = useRef<HTMLCanvasElement>(null);
 
@@ -124,6 +133,14 @@ export function useGaugeRenderer(opts: UseGaugeRendererOptions): UseGaugeRendere
   // Pending rAF ID — `null` when the loop is idle.
   const rafIdRef = useRef<number | null>(null);
   const lastDrawTimeRef = useRef(0);
+  /** Next timestamp at which this gauge may draw (phase-staggered gate). */
+  const nextDrawAtRef = useRef(0);
+  /** rAF timestamp of the previous animate() tick — drives the time-based EMA. */
+  const lastFrameTimeRef = useRef(0);
+  /** Spike-flash expiry timestamp on the rAF clock (0 = inactive). */
+  const spikeUntilRef = useRef(0);
+  /** Phase slot for redraw staggering, claimed once per mount. */
+  const staggerSlotRef = useRef<number | null>(null);
 
   /**
    * Cached canvas dimensions — updated only by ResizeObserver, NOT every
@@ -205,6 +222,12 @@ export function useGaugeRenderer(opts: UseGaugeRendererOptions): UseGaugeRendere
     // Stop animating when within 0.1% of the gauge range of the target.
     const epsilon = Math.max((config.max - config.min) * 0.001, 0.01);
 
+    // Claim a phase slot once so this gauge's redraws stay evenly offset
+    // from the others (issue #82 staggered redraw timers).
+    if (staggerSlotRef.current === null) {
+      staggerSlotRef.current = staggerSlotForChannel(channel);
+    }
+
     /** Look up the channel value in the store (case-insensitive with caching). */
     const readStoreValue = (): number | undefined => {
       const channels = useRealtimeStore.getState().channels;
@@ -268,24 +291,54 @@ export function useGaugeRenderer(opts: UseGaugeRendererOptions): UseGaugeRendere
         config.history_delay,
       );
       peakValueRef.current = peakStateRef.current.peak;
+
+      // Elapsed time since the previous tick — drives the time-based EMA.
+      // First tick assumes one 60fps frame so the EMA starts moving.
+      const dt =
+        lastFrameTimeRef.current === 0 ? 1000 / 60 : timestamp - lastFrameTimeRef.current;
+      lastFrameTimeRef.current = timestamp;
+
+      // Transient spike detection (issue #82): if the raw value jumped far
+      // from the smoothed display value, flash briefly so short pulses stay
+      // visible even though the EMA filters them out of the needle position.
+      if (isSpike(target, displayValueRef.current, config.min, config.max)) {
+        spikeUntilRef.current = timestamp + SPIKE_FLASH_MS;
+      }
+      spikeRef.current = timestamp < spikeUntilRef.current;
+
       const diff = target - displayValueRef.current;
       const keepAlive = continuousRender && !overrideStoreRef.current && channel;
-      if (Math.abs(diff) > epsilon) {
-        displayValueRef.current = displayValueRef.current + diff * ANIMATION_LERP;
-        if (timestamp - lastDrawTimeRef.current >= DRAW_INTERVAL_MS) {
-          drawFrame();
-          lastDrawTimeRef.current = timestamp;
+
+      /**
+       * Phase-staggered draw gate: draws at most once per configured
+       * refresh interval, offset by this gauge's stagger slot so gauges
+       * spread their redraws evenly across the interval.
+       */
+      const drawDue = () => {
+        if (timestamp < nextDrawAtRef.current) return;
+        drawFrame();
+        lastDrawTimeRef.current = timestamp;
+        const interval = getDrawIntervalMs();
+        if (nextDrawAtRef.current === 0) {
+          // First draw: apply the phase offset.
+          nextDrawAtRef.current =
+            timestamp + ((staggerSlotRef.current ?? 0) * interval) / STAGGER_SLOTS;
+        } else {
+          nextDrawAtRef.current = timestamp + interval;
         }
+      };
+
+      if (Math.abs(diff) > epsilon) {
+        // Time-constant EMA: converges identically at any refresh rate.
+        displayValueRef.current = emaStep(displayValueRef.current, target, dt);
+        drawDue();
         rafIdRef.current = requestAnimationFrame(animate);
       } else if (keepAlive) {
         // Time-series painters need continuous redraws so the trace scrolls
         // even when the channel value is constant. Snap to target and throttle
         // drawing to the configured frame interval to avoid burning CPU.
         displayValueRef.current = target;
-        if (timestamp - lastDrawTimeRef.current >= DRAW_INTERVAL_MS) {
-          drawFrame();
-          lastDrawTimeRef.current = timestamp;
-        }
+        drawDue();
         rafIdRef.current = requestAnimationFrame(animate);
       } else {
         // Snap to target and always draw final frame.
@@ -328,6 +381,13 @@ export function useGaugeRenderer(opts: UseGaugeRendererOptions): UseGaugeRendere
           peakValueRef.current = next.peak;
           drawFrame();
         }
+      }
+      // Spike-flash expiry must repaint even while the loop is idle —
+      // performance.now() shares the rAF clock used for spikeUntilRef.
+      const spikeOn = performance.now() < spikeUntilRef.current;
+      if (spikeOn !== spikeRef.current) {
+        spikeRef.current = spikeOn;
+        drawFrame();
       }
       const raw = readStoreValue();
       if (raw !== undefined) {

--- a/crates/libretune-app/src/components/tuner-ui/dialogs/SettingsDialog.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/dialogs/SettingsDialog.tsx
@@ -87,6 +87,8 @@ export function SettingsDialog({ isOpen, onClose, theme, onThemeChange, onSettin
   const [gaugeFreeMove, setGaugeFreeMove] = useState(false);
   const [gaugeLock, setGaugeLock] = useState(false);
   const [autoSyncGaugeRanges, setAutoSyncGaugeRanges] = useState(true);
+  const [dashboardRefreshHz, setDashboardRefreshHz] = useState(30);
+  const [gaugeRightAlignValues, setGaugeRightAlignValues] = useState(false);
   
   // Version control settings
   const [autoCommitOnSave, setAutoCommitOnSave] = useState('never');
@@ -176,6 +178,8 @@ export function SettingsDialog({ isOpen, onClose, theme, onThemeChange, onSettin
         if (settings.gauge_free_move !== undefined) setGaugeFreeMove(!!settings.gauge_free_move);
         if (settings.gauge_lock !== undefined) setGaugeLock(!!settings.gauge_lock);
         if (settings.auto_sync_gauge_ranges !== undefined) setAutoSyncGaugeRanges(!!settings.auto_sync_gauge_ranges);
+        if (settings.dashboard_refresh_hz !== undefined) setDashboardRefreshHz(settings.dashboard_refresh_hz);
+        if (settings.gauge_right_align_values !== undefined) setGaugeRightAlignValues(!!settings.gauge_right_align_values);
         // Version control settings
         if (settings.auto_commit_on_save !== undefined) setAutoCommitOnSave(settings.auto_commit_on_save);
         if (settings.commit_message_format !== undefined) setCommitMessageFormat(settings.commit_message_format);
@@ -474,6 +478,8 @@ export function SettingsDialog({ isOpen, onClose, theme, onThemeChange, onSettin
         ['gauge_free_move', gaugeFreeMove.toString()],
         ['gauge_lock', gaugeLock.toString()],
         ['auto_sync_gauge_ranges', autoSyncGaugeRanges.toString()],
+        ['dashboard_refresh_hz', dashboardRefreshHz.toString()],
+        ['gauge_right_align_values', gaugeRightAlignValues.toString()],
         ['auto_commit_on_save', autoCommitOnSave],
         ['commit_message_format', commitMessageFormat],
         ['runtime_packet_mode', runtimePacketMode],
@@ -538,7 +544,7 @@ export function SettingsDialog({ isOpen, onClose, theme, onThemeChange, onSettin
       }
     }
     return errors;
-  }, [localTheme, localLanguage, localUnits, autoBurnOnClose, statusBarChannels, indicatorColumnCount, indicatorFillEmpty, indicatorTextFit, heatmapValueScheme, heatmapChangeScheme, heatmapCoverageScheme, gaugeSnapToGrid, gaugeFreeMove, gaugeLock, autoSyncGaugeRanges, autoCommitOnSave, commitMessageFormat, runtimePacketMode, aiProvider, aiBaseUrl, aiApiKey, aiModel, aiCapabilityTier, aiRiskAcked, aiEnabled, autoReconnectAfterControllerCommand, autoReconnectAfterFirmware, autoRecordEnabled, keyOnThresholdRpm, keyOffTimeoutSec, alertLargeChangeEnabled, alertLargeChangeAbs, alertLargeChangePercent, hotkeyBindings, autoConnect, currentProject, onThemeChange, onSettingsChange]);
+  }, [localTheme, localLanguage, localUnits, autoBurnOnClose, statusBarChannels, indicatorColumnCount, indicatorFillEmpty, indicatorTextFit, heatmapValueScheme, heatmapChangeScheme, heatmapCoverageScheme, gaugeSnapToGrid, gaugeFreeMove, gaugeLock, autoSyncGaugeRanges, dashboardRefreshHz, gaugeRightAlignValues, autoCommitOnSave, commitMessageFormat, runtimePacketMode, aiProvider, aiBaseUrl, aiApiKey, aiModel, aiCapabilityTier, aiRiskAcked, aiEnabled, autoReconnectAfterControllerCommand, autoReconnectAfterFirmware, autoRecordEnabled, keyOnThresholdRpm, keyOffTimeoutSec, alertLargeChangeEnabled, alertLargeChangeAbs, alertLargeChangePercent, hotkeyBindings, autoConnect, currentProject, onThemeChange, onSettingsChange]);
 
   // Windows-convention buttons:
   //  - Apply: save WITHOUT closing (so the user can verify it worked). The
@@ -943,6 +949,37 @@ export function SettingsDialog({ isOpen, onClose, theme, onThemeChange, onSettin
               Auto-sync gauge ranges from INI
             </label>
             <span className="dialog-form-note">Apply INI gauge min/max/units automatically when a project or INI changes</span>
+          </div>
+
+          <FormField
+            label="Gauge refresh rate"
+            help="Cap how often gauges redraw. Lower rates save CPU and battery (issue #82); 10–15 Hz still feels smooth on the road."
+          >
+            {(id) => (
+              <select
+                id={id}
+                value={dashboardRefreshHz}
+                onChange={(e) => setDashboardRefreshHz(Number(e.target.value))}
+              >
+                <option value={10}>10 Hz (battery saver)</option>
+                <option value={15}>15 Hz</option>
+                <option value={20}>20 Hz</option>
+                <option value={25}>25 Hz</option>
+                <option value={30}>30 Hz (default)</option>
+              </select>
+            )}
+          </FormField>
+
+          <div className="dialog-form-group">
+            <label>
+              <input
+                type="checkbox"
+                checked={gaugeRightAlignValues}
+                onChange={(e) => setGaugeRightAlignValues(e.target.checked)}
+              />
+              Right-align gauge values
+            </label>
+            <span className="dialog-form-note">Keep numeric values steady when digit count or sign changes (no jumping text)</span>
           </div>
 
           <h3 style={{ marginTop: '1.5rem', marginBottom: '0.5rem' }}>Version Control</h3>

--- a/docs/src/features/dashboards/using.md
+++ b/docs/src/features/dashboards/using.md
@@ -75,6 +75,40 @@ Pop out dashboards to separate monitors:
 
 > **Note**: The main Dashboard tab is protected and cannot be popped out or accidentally closed. To reopen it if missing, go to **View → Dashboard**.
 
+## Performance & Smoothing
+
+Dashboards redraw each gauge on a capped, phase-staggered timer instead of
+redrawing on every incoming sample. This keeps CPU (and laptop battery) use
+predictable even when the ECU streams faster than the display needs.
+
+### Gauge Refresh Rate
+
+**Settings → General → Dashboard → Gauge refresh rate** caps how often each
+gauge redraws:
+
+- **10 Hz (battery saver)** — street tuning on battery power
+- **15–25 Hz** — balanced
+- **30 Hz (default)** — smoothest motion
+
+Redraw timers are staggered so gauges don't all paint in the same frame, and
+needle motion uses a time-based EMA (exponential moving average), so motion
+looks identical at any refresh rate — only the step cadence changes.
+
+### Transient Spike Highlight
+
+Short pulses that would be smoothed away are not lost: when the raw value
+jumps far from the smoothed reading, the value readout briefly flashes in the
+critical color, and line graphs draw a colored dot at the raw position. This
+makes brief excursions (e.g. a lean spike) visible without making the trace
+look like an audio waveform.
+
+### Right-Align Gauge Values
+
+**Settings → General → Dashboard → Right-align gauge values** keeps numeric
+readouts steady when the digit count or sign changes (e.g. timing crossing
+0°). Digital and bar gauges anchor values to a fixed right edge; dial gauges
+pad values to a fixed width so they stay centered but never shift.
+
 ## Tips
 
 ### Reduce Clutter


### PR DESCRIPTION
## Summary
Addresses the three complaints in #82: extreme dashboard CPU load, jumping gauge value text, and noisy "audio-waveform" line graphs.

**Note for review:** this branch also restores `pub mod tooth_logger;` in `commands/mod.rs`, dropped by the PR #247 merge — `main` currently does not compile without it (E0433 on `commands::tooth_logger::*` in lib.rs). It's included here so the branch builds; happy to split into a standalone hotfix PR if preferred.

## Changes

### CPU load → configurable, staggered redraw cap
- New global setting **Settings → General → Dashboard → Gauge refresh rate** (10/15/20/25/30 Hz, default 30), backed by `dashboard_refresh_hz` (whitelisted values).
- Gauge redraw timers are **phase-staggered** across 16 deterministic per-channel slots, so a dashboard full of gauges no longer piles all canvas work onto one frame.
- New `renderSettings.ts` feeds settings to the imperative render loop and live-updates on `settings:changed` (no restart); initialized in App and pop-out windows.

### Smoothing → time-based EMA + transient peak detection
- New `gauges/ema.ts`: `emaStep` (τ=120 ms) replaces the frame-count lerp, so needle motion is identical at any refresh rate (the old lerp converged ~6× slower at 10 fps than 60 fps). 100 ms clamp so hidden tabs don't snap needles.
- **Spike detection** (the issue's "peak detect" ask): when the raw value deviates >15% of range from the EMA, digital readouts flash the value in the critical color (~400 ms) and line graphs draw a colored dot at the raw sample position — short problem pulses stay visible despite smoothing.

### Jumping text → opt-in steady values
- **Right-align gauge values** setting (default off): digital/bar gauges anchor to a fixed right edge; dial gauges use `steadyValueText` (fixed-width monospace padding) so they stay centered but never shift when digit count or sign changes.

### Line graphs
- LineGraph renders the **EMA of the history buffer** instead of raw samples, eliminating the noisy trace.

## Testing
- `npm run typecheck` clean; `npm run test:run` → **227/227 pass** (34 files), incl. new `ema.test.ts` and LineGraph smoothing/spike-dot tests.
- `cargo check --workspace` and `cargo test -p libretune-core --test dash_parsing` green — **no `.dash` format changes**, TunerStudio dashboards round-trip unchanged.
- Verified `npm run tauri dev` launches and renders the dashboard.

## Notes / scope decisions
- Global setting only (no per-gauge refresh groups) — keeps `.dash` schema untouched; per-gauge groups could be a follow-up.
- i18n keys not added for the new settings labels (the Dashboard settings section is currently hardcoded English; followed file convention).
- MultiChannelTrend/Histogram left unsmoothed (histogram is a distribution view).

Closes #82