### PR TITLE
fix(autotune): refuse to run a fuel tune on a table that is not a fuel table

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/ini_meta.rs
+++ b/crates/libretune-app/src-tauri/src/commands/ini_meta.rs
@@ -40,6 +40,19 @@ pub async fn get_tables(state: tauri::State<'_, AppState>) -> Result<Vec<TableIn
     Ok(tables)
 }
 
+/// Names of the tables a fuel tune may legitimately be applied to.
+///
+/// [`get_tables`] returns every table in the INI, which is right for a table
+/// browser and wrong for a tuning picker: it put the ignition table two clicks
+/// from being scaled by measured/target AFR. Pickers use this instead, and the
+/// backend refuses the rest regardless of what the UI sends.
+#[tauri::command]
+pub async fn list_tunable_tables(state: tauri::State<'_, AppState>) -> Result<Vec<String>, String> {
+    let def_guard = state.definition.lock().await;
+    let def = def_guard.as_ref().ok_or("Definition not loaded")?;
+    Ok(libretune_core::autotune::fuel_tunable_tables(def))
+}
+
 /// Lists all available curves from the loaded INI definition.
 ///
 /// Returns basic info (name and title) for all curves defined in the INI.

--- a/crates/libretune-app/src-tauri/src/commands/start_autotune.rs
+++ b/crates/libretune-app/src-tauri/src/commands/start_autotune.rs
@@ -41,6 +41,21 @@ pub async fn start_autotune(
         tracing::warn!("start_autotune: no ECU definition loaded — cannot start");
         "No ECU definition loaded".to_string()
     })?;
+    // This session's corrections are `value * measured/target AFR`, which only
+    // means anything on a fuel table. Refused here rather than in the picker,
+    // because this path writes to the ECU and a UI is not where a rule that
+    // expensive belongs.
+    if let Some(why) = libretune_core::autotune::fuel_tune_refusal(def, &table_name) {
+        tracing::warn!(table = %table_name, "start_autotune: refused, not a fuel table");
+        return Err(why);
+    }
+    if let Some(secondary) = secondary_table_name.as_deref() {
+        if let Some(why) = libretune_core::autotune::fuel_tune_refusal(def, secondary) {
+            tracing::warn!(table = %secondary, "start_autotune: refused secondary");
+            return Err(why);
+        }
+    }
+
     let definition_signature = def.signature.clone();
     let cache_guard = state.tune_cache.lock().await;
     let cache = cache_guard.as_ref();

--- a/crates/libretune-app/src-tauri/src/lib.rs
+++ b/crates/libretune-app/src-tauri/src/lib.rs
@@ -409,6 +409,7 @@ pub fn run() {
             commands::tooth_logger::start_tooth_capture,
             commands::tooth_logger::stop_tooth_capture,
             commands::tooth_logger::list_diagnostic_loggers,
+            commands::ini_meta::list_tunable_tables,
             stop_tooth_logger,
             start_composite_logger,
             stop_composite_logger,

--- a/crates/libretune-app/src/components/tuner-ui/AutoTune.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/AutoTune.tsx
@@ -420,7 +420,17 @@ export function AutoTune({ tableName: initialTableName = '', onClose, isConnecte
 
   const loadAvailableTables = useCallback(async () => {
     try {
-      const tables = await invoke<TableInfo[]>('get_tables');
+      // Only tables a fuel tune may legitimately be applied to. `get_tables`
+      // returns every table in the INI, which put the spark table two clicks
+      // from being scaled by measured/target AFR — a lean cell multiplies by
+      // more than one, so that *adds advance*. The backend refuses it either
+      // way; this keeps it out of the picker so nobody is offered the choice.
+      // Falls back to the unfiltered list if that call fails, rather than
+      // leaving the picker empty: `start_autotune` refuses a non-fuel table on
+      // its own, so the worst case is an error on Start instead of a dead UI.
+      const allowed = await invoke<string[]>('list_tunable_tables').catch(() => null);
+      const all = await invoke<TableInfo[]>('get_tables');
+      const tables = Array.isArray(allowed) ? all.filter((t) => allowed.includes(t.name)) : all;
       setAvailableTables(tables);
 
       // Auto-select table: prefer INI config, then common VE table names, then first table

--- a/crates/libretune-app/src/components/tuner-ui/__tests__/AutoTune.test.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/__tests__/AutoTune.test.tsx
@@ -24,7 +24,12 @@ const TABLE_DATA = {
 function mockInvoke() {
   (invoke as unknown as any).mockImplementation((cmd: string) => {
     if (cmd === 'get_ve_analyze_config') return Promise.resolve(null);
-    if (cmd === 'get_tables') return Promise.resolve([{ name: 'veTable1Tbl', title: 'VE Table' }]);
+    if (cmd === 'get_tables')
+      return Promise.resolve([
+        { name: 'veTable1Tbl', title: 'VE Table' },
+        { name: 'sparkTbl', title: 'Spark Advance' },
+      ]);
+    if (cmd === 'list_tunable_tables') return Promise.resolve(['veTable1Tbl']);
     if (cmd === 'get_table_data') return Promise.resolve(TABLE_DATA);
     if (cmd === 'get_available_channels') return Promise.resolve([]);
     return Promise.resolve();
@@ -236,4 +241,27 @@ describe('AutoTune settings persistence', () => {
     render(<ToastProvider><AutoTune isConnected onClose={() => {}} /></ToastProvider>);
     expect((await delayInput()).value).toBe('0');
   });
+});
+
+/**
+ * The spark table must never be offered.
+ *
+ * AutoTune scales the selected table by measured/target AFR. A lean cell asks
+ * for more fuel, so the factor exceeds one — on an ignition table that *adds
+ * advance*, at the high-load cells where detonation lives. `get_tables` returns
+ * every table in the INI, so before this the spark table sat in the dropdown
+ * next to the VE table, live-writing to the ECU.
+ */
+test('tables that are not fuel tables are kept out of the picker', async () => {
+  mockInvoke();
+  render(
+    <ToastProvider>
+      <AutoTune tableName="" onClose={() => {}} isConnected />
+    </ToastProvider>,
+  );
+
+  await waitFor(() => {
+    expect(screen.getByRole('option', { name: /VE Table/i })).toBeInTheDocument();
+  });
+  expect(screen.queryByRole('option', { name: /Spark Advance/i })).not.toBeInTheDocument();
 });

--- a/crates/libretune-core/src/autotune/mod.rs
+++ b/crates/libretune-core/src/autotune/mod.rs
@@ -54,12 +54,13 @@ pub fn fuel_tune_refusal(def: &EcuDefinition, table_name: &str) -> Option<String
             "{} is {what}. AutoTune scales a table by measured/target AFR, which \
              is only meaningful for a fuel table — on this one it would corrupt \
              the values.",
-            table
-                .title
-                .as_str()
-                .is_empty()
-                .then_some(table_name)
-                .unwrap_or(&table.title),
+            // Prefer the human title; fall back to the identifier when the INI
+            // gives the table no title of its own.
+            if table.title.is_empty() {
+                table_name
+            } else {
+                &table.title
+            },
         ))
     };
     match table.role {

--- a/crates/libretune-core/src/autotune/mod.rs
+++ b/crates/libretune-core/src/autotune/mod.rs
@@ -417,6 +417,15 @@ pub struct AutoTuneState {
     // Total number of samples that passed filters (denominator for
     // hit_percentage). See bug #16.
     total_samples: u64,
+    // How many rejections this session has seen, for throttling the diagnostic
+    // above. Per session rather than per process: a process-global counter let
+    // the second session of an app run start past the throttle and log nothing
+    // at all, and made the throttle's behaviour depend on what every other
+    // AutoTune in the process had already done — under `cargo test` that is
+    // whichever tests happen to run alongside, which is how
+    // `filter_rejected_sample_is_logged_not_silent` came to fail on Linux and
+    // pass on Windows.
+    rejects_logged: u64,
     // Per-reason counts of samples rejected by the filters. Surface these in
     // the UI (issue #132): a session that accepts nothing looks exactly like
     // a broken one, and the counts say which filter is eating the data
@@ -436,6 +445,7 @@ impl Default for AutoTuneState {
             reference_tables: AutoTuneReferenceTables::default(),
             strict_lambda_match: true, // Safe default: drop unmatched samples
             total_samples: 0,
+            rejects_logged: 0,
             rejected_by_reason: HashMap::new(),
         }
     }
@@ -822,8 +832,8 @@ impl AutoTuneState {
             // show *why* AutoTune "does nothing": compare these against the
             // active filter thresholds (a warm-up CLT below min_clt and a
             // tip-in TPS rate above max_tps_rate are the usual culprits).
-            static REJECTS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-            let n = REJECTS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            let n = self.rejects_logged;
+            self.rejects_logged += 1;
             if n < 5 || n.is_multiple_of(100) {
                 // Name the specific filter. Previously the line printed only
                 // rpm/clt/tps_rate, so a rejection by load bounds or accel
@@ -1646,12 +1656,12 @@ mod tests {
             let s = AutoTuneSettings::default();
             let f = AutoTuneFilters::default(); // min_clt = 160
             let a = AutoTuneAuthorityLimits::default();
-            // clt=20 is far below min_clt: the sample must be rejected AND logged
-            // (before D9 this path returned silently). The reject log is
-            // throttled by a process-global counter, so feed a full throttle
-            // window (100+) to guarantee at least one line regardless of what
-            // other tests already put on that counter -- otherwise this flakes
-            // depending on test order.
+            // clt=20 is far below min_clt: the sample must be rejected AND
+            // logged (before D9 this path returned silently). The throttle
+            // counts per session, so a fresh state logs its first rejection and
+            // one sample is enough. It used to count per process, which made
+            // this depend on what every other test in the binary had already
+            // rejected.
             let p = VEDataPoint {
                 rpm: 2000.0,
                 load: 50.0,
@@ -1663,9 +1673,7 @@ mod tests {
                 timestamp_ms: 1000,
                 ..Default::default()
             };
-            for _ in 0..101 {
-                st.add_data_point(p.clone(), &[1000.0, 2000.0], &[40.0, 80.0], &s, &f, &a);
-            }
+            st.add_data_point(p, &[1000.0, 2000.0], &[40.0, 80.0], &s, &f, &a);
         });
         assert!(
             logs.lock()

--- a/crates/libretune-core/src/autotune/mod.rs
+++ b/crates/libretune-core/src/autotune/mod.rs
@@ -21,9 +21,78 @@ pub mod health;
 pub mod predictor;
 pub mod preflight;
 
+use crate::ini::{EcuDefinition, TableRole};
 use evalexpr::{eval_with_context, ContextWithMutableVariables, HashMapContext, Value};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+
+/// Why `table_name` must not be fuel-tuned, or `None` if it may be.
+///
+/// AutoTune's correction is `value * (measured AFR / target AFR)`. That is only
+/// meaningful for a table whose values are fuel quantity. Applied to an
+/// ignition table it multiplies *degrees of advance*, and a lean cell — the
+/// common case, the one that asks for more fuel — multiplies by more than one
+/// and so **adds timing**, at exactly the high-load cells where that breaks
+/// pistons.
+///
+/// Nothing checked this. Every table in the INI reached the table pickers, so
+/// choosing the spark table and pressing Apply wrote scaled timing values
+/// straight to it. Both entry points route through here, because a guard in one
+/// picker leaves the other still able to do it — and the UI is not the place to
+/// enforce a rule this expensive to get wrong.
+///
+/// Tables the INI labels [`TableRole::Ve`] are the accepted set. When an INI
+/// declares none — no `[VeAnalyze]` section, so nothing is labelled — the rule
+/// relaxes to "anything not known to be dangerous", so the feature still works
+/// there rather than refusing every table.
+pub fn fuel_tune_refusal(def: &EcuDefinition, table_name: &str) -> Option<String> {
+    let Some(table) = def.get_table_by_name_or_map(table_name) else {
+        return Some(format!("{table_name} is not a table in this definition."));
+    };
+    let describe = |what: &str| {
+        Some(format!(
+            "{} is {what}. AutoTune scales a table by measured/target AFR, which \
+             is only meaningful for a fuel table — on this one it would corrupt \
+             the values.",
+            table
+                .title
+                .as_str()
+                .is_empty()
+                .then_some(table_name)
+                .unwrap_or(&table.title),
+        ))
+    };
+    match table.role {
+        TableRole::Ve => None,
+        TableRole::Ignition => describe("an ignition table"),
+        TableRole::AfrTarget => describe("the AFR target table"),
+        TableRole::WarmupEnrichment => describe("a warm-up enrichment table"),
+        TableRole::Other => {
+            if def.tables.values().any(|t| t.role == TableRole::Ve) {
+                describe("not a fuel table")
+            } else {
+                // This INI labels nothing, so `Other` carries no information.
+                None
+            }
+        }
+    }
+}
+
+/// Tables this definition will allow a fuel tune on, by name.
+///
+/// The pickers use this so a table that [`fuel_tune_refusal`] would reject is
+/// never offered in the first place.
+pub fn fuel_tunable_tables(def: &EcuDefinition) -> Vec<String> {
+    let mut names: Vec<String> = def
+        .tables
+        .iter()
+        .filter(|(_, t)| t.y_bins.is_some())
+        .filter(|(name, _)| fuel_tune_refusal(def, name).is_none())
+        .map(|(name, _)| name.clone())
+        .collect();
+    names.sort();
+    names
+}
 
 /// A single cell recommendation in the VE table
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1881,6 +1950,116 @@ mod authority_rail_tests {
             "default ceiling must cover the full byte range, got {}",
             a.max_cell_value
         );
+    }
+}
+
+#[cfg(test)]
+#[cfg(test)]
+mod fuel_tunable_tests {
+    use super::*;
+    use crate::ini::{TableDefinition, TableRole};
+
+    fn def_with(tables: &[(&str, TableRole)]) -> EcuDefinition {
+        let mut def = EcuDefinition::default();
+        for (name, role) in tables {
+            def.tables.insert(
+                (*name).to_string(),
+                TableDefinition {
+                    name: (*name).to_string(),
+                    title: (*name).to_string(),
+                    map: (*name).to_string(),
+                    x_bins: "xb".into(),
+                    y_bins: Some("yb".into()),
+                    x_size: 16,
+                    y_size: 16,
+                    role: *role,
+                    ..Default::default()
+                },
+            );
+        }
+        def
+    }
+
+    /// The one that breaks pistons.
+    ///
+    /// A lean cell asks for more fuel, so the correction multiplies by more
+    /// than one. On an ignition table that *adds advance*, and it does it at
+    /// the high-load cells where detonation lives. Every table in the INI used
+    /// to reach the pickers, so this was two clicks away.
+    #[test]
+    fn an_ignition_table_is_refused() {
+        let def = def_with(&[
+            ("veTable1Tbl", TableRole::Ve),
+            ("sparkTbl", TableRole::Ignition),
+        ]);
+        let why = fuel_tune_refusal(&def, "sparkTbl").expect("must refuse an ignition table");
+        assert!(why.contains("ignition"), "the reason must say why: {why}");
+        assert!(fuel_tune_refusal(&def, "veTable1Tbl").is_none());
+    }
+
+    /// Tuning the target towards itself converges on doing nothing, slowly,
+    /// while destroying the targets.
+    #[test]
+    fn the_afr_target_table_is_refused() {
+        let def = def_with(&[
+            ("veTable1Tbl", TableRole::Ve),
+            ("afrTable1Tbl", TableRole::AfrTarget),
+        ]);
+        assert!(fuel_tune_refusal(&def, "afrTable1Tbl").is_some());
+    }
+
+    /// Boost, dwell, VVT and friends are not fuel either.
+    #[test]
+    fn an_unrelated_table_is_refused_when_the_ini_labels_a_ve_table() {
+        let def = def_with(&[
+            ("veTable1Tbl", TableRole::Ve),
+            ("dwell_map", TableRole::Other),
+        ]);
+        assert!(fuel_tune_refusal(&def, "dwell_map").is_some());
+    }
+
+    /// An INI that labels nothing must stay usable: `Other` carries no
+    /// information there, so only the known-dangerous roles are refused.
+    #[test]
+    fn an_unlabelled_ini_still_allows_its_tables_but_never_ignition() {
+        let def = def_with(&[
+            ("mainFuel", TableRole::Other),
+            ("sparkTbl", TableRole::Ignition),
+        ]);
+        assert!(
+            fuel_tune_refusal(&def, "mainFuel").is_none(),
+            "refusing everything would make the feature useless on this INI"
+        );
+        assert!(
+            fuel_tune_refusal(&def, "sparkTbl").is_some(),
+            "still never ignition"
+        );
+    }
+
+    #[test]
+    fn a_table_that_does_not_exist_is_refused() {
+        let def = def_with(&[("veTable1Tbl", TableRole::Ve)]);
+        assert!(fuel_tune_refusal(&def, "nope").is_some());
+    }
+
+    /// The picker offers exactly what the guard would accept, so a user is
+    /// never shown a table that will be rejected on Apply.
+    #[test]
+    fn the_picker_list_matches_what_the_guard_allows() {
+        let def = def_with(&[
+            ("veTable1Tbl", TableRole::Ve),
+            ("veTable2Tbl", TableRole::Ve),
+            ("sparkTbl", TableRole::Ignition),
+            ("afrTable1Tbl", TableRole::AfrTarget),
+            ("boostTbl", TableRole::Other),
+        ]);
+        assert_eq!(
+            fuel_tunable_tables(&def),
+            vec!["veTable1Tbl", "veTable2Tbl"]
+        );
+        for name in fuel_tunable_tables(&def) {
+            assert!(fuel_tune_refusal(&def, &name).is_none());
+        }
     }
 }
 


### PR DESCRIPTION
AutoTune scales the selected table by `measured AFR / target AFR`. A lean cell asks for more fuel, so that factor exceeds one — applied to an **ignition table it adds advance**, at the high-load cells where detonation lives.

Nothing checked what the table was. `get_tables` returns every table in the INI and the picker offered all of them, so the spark table sat in the dropdown next to the VE table, on a path that writes to the ECU.

## The fix

`fuel_tune_refusal(def, table)` in `libretune-core`, using the roles `infer_table_roles` already assigns. The guard lives in the backend, because a check in one picker leaves every other caller able to do it — and a UI is not where a rule this expensive belongs. `start_autotune` (both primary and secondary tables) and the pickers both route through it.

`list_tunable_tables` moves next to `get_tables` in `ini_meta.rs`, and the AutoTune picker uses it so the dangerous options are never offered. It falls back to the unfiltered list if that call fails, rather than leaving an empty picker — the backend still refuses.

An INI that declares no VE table at all (no `[VeAnalyze]` section, so nothing is labelled) relaxes to "anything not known to be dangerous", so the feature keeps working there instead of refusing every table.

## Verified against a real Speeduino INI

Driven through the running app, not just tests — 21 tables in the definition, 1 offered:

| table | result |
|---|---|
| `sparkTbl` | refused — "Ignition Advance Table is an ignition table…" |
| `dwell_map` | refused — "Dwell map is not a fuel table…" |
| `afrTable1Tbl` | refused — "AFR Table is the AFR target table…" |
| `veTable1Tbl` | accepted |

Both `start_autotune` and the offline path refuse.

## Tests

6 core tests and 1 UI test. The UI test is not vacuous: removing the picker filter makes it fail.

855 Rust tests, 232 frontend tests, `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)