### PR TITLE
fix(tables): stop the table editor prompts writing NaN into a tune

### DIFF
--- a/crates/libretune-app/src/components/curves/CurveEditor.tsx
+++ b/crates/libretune-app/src/components/curves/CurveEditor.tsx
@@ -11,6 +11,7 @@ import { ArrowLeft, Save, Flame, Undo2, Redo2, AlertTriangle } from 'lucide-reac
 import { GaugeLiveReadout } from '../gauges/GaugeLiveReadout';
 import { TsGaugeConfig } from '../dashboards/dashTypes';
 import { valueToHeatmapColor, textColorForBackground } from '../../utils/heatmapColors';
+import { askNumber } from '../../utils/askNumber';
 import { useChannelValue } from '../../stores/realtimeStore';
 import './CurveEditor.css';
 
@@ -634,45 +635,33 @@ export default function CurveEditor({
   };
 
   const setYAxisMin = () => {
-    const value = prompt('Set Y Axis Minimum:', yAxis.min.toString());
+    const value = askNumber('Set Y Axis Minimum:', yAxis.min);
     if (value !== null) {
-      const num = parseFloat(value);
-      if (!isNaN(num)) {
-        setYAxisOverride(prev => ({ ...prev, min: num, auto: false }));
-      }
+      setYAxisOverride(prev => ({ ...prev, min: value, auto: false }));
     }
     closeContextMenu();
   };
 
   const setYAxisMax = () => {
-    const value = prompt('Set Y Axis Maximum:', yAxis.max.toString());
+    const value = askNumber('Set Y Axis Maximum:', yAxis.max);
     if (value !== null) {
-      const num = parseFloat(value);
-      if (!isNaN(num)) {
-        setYAxisOverride(prev => ({ ...prev, max: num, auto: false }));
-      }
+      setYAxisOverride(prev => ({ ...prev, max: value, auto: false }));
     }
     closeContextMenu();
   };
 
   const setXAxisMin = () => {
-    const value = prompt('Set X Axis Minimum:', xAxis.min.toString());
+    const value = askNumber('Set X Axis Minimum:', xAxis.min);
     if (value !== null) {
-      const num = parseFloat(value);
-      if (!isNaN(num)) {
-        setXAxisOverride(prev => ({ ...prev, min: num, auto: false }));
-      }
+      setXAxisOverride(prev => ({ ...prev, min: value, auto: false }));
     }
     closeContextMenu();
   };
 
   const setXAxisMax = () => {
-    const value = prompt('Set X Axis Maximum:', xAxis.max.toString());
+    const value = askNumber('Set X Axis Maximum:', xAxis.max);
     if (value !== null) {
-      const num = parseFloat(value);
-      if (!isNaN(num)) {
-        setXAxisOverride(prev => ({ ...prev, max: num, auto: false }));
-      }
+      setXAxisOverride(prev => ({ ...prev, max: value, auto: false }));
     }
     closeContextMenu();
   };

--- a/crates/libretune-app/src/components/tuner-ui/TableEditor.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/TableEditor.tsx
@@ -4,6 +4,7 @@ import { open, save } from '@tauri-apps/plugin-dialog';
 import { useChannels } from '../../stores/realtimeStore';
 import { useHeatmapSettings } from '../../utils/useHeatmapSettings';
 import { contrastTextColor } from '../../utils/heatmapColors';
+import { askNumber } from '../../utils/askNumber';
 import { useTableYAxisBottom, useTrailFadeSec } from '../../utils/useTableOrientation';
 import './TableEditor.css';
 import TableEditor3D from '../tables/TableEditor3D';
@@ -941,25 +942,25 @@ export function TableEditor({
           hasClipboard={!!clipboard}
           onResetToOriginal={resetToOriginal}
           onSetValue={() => {
-            const value = prompt('Enter value:');
-            if (value) setEqual(parseFloat(value));
+            const value = askNumber('Enter value:');
+            if (value !== null) setEqual(value);
             closeContextMenu();
           }}
           onStepUp={() => { adjustValues(incrementSettings.stepAmount); closeContextMenu(); }}
           onStepDown={() => { adjustValues(-incrementSettings.stepAmount); closeContextMenu(); }}
           onAddAmount={() => {
-            const amt = prompt('Enter amount to add:');
-            if (amt) adjustValues(parseFloat(amt));
+            const amt = askNumber('Enter amount to add:');
+            if (amt !== null) adjustValues(amt);
             closeContextMenu();
           }}
           onSubtractAmount={() => {
-            const amt = prompt('Enter amount to subtract:');
-            if (amt) adjustValues(-parseFloat(amt));
+            const amt = askNumber('Enter amount to subtract:');
+            if (amt !== null) adjustValues(-amt);
             closeContextMenu();
           }}
           onMultiplyBy={() => {
-            const factor = prompt('Enter multiplier (e.g., 1.02 for +2%):');
-            if (factor) scaleValues(parseFloat(factor));
+            const factor = askNumber('Enter multiplier (e.g., 1.02 for +2%):');
+            if (factor !== null) scaleValues(factor);
             closeContextMenu();
           }}
           onInterpolate={() => { interpolate(); closeContextMenu(); }}
@@ -970,18 +971,18 @@ export function TableEditor({
           onCopy={() => { copySelection(); closeContextMenu(); }}
           onPaste={() => { pasteSelection(); closeContextMenu(); }}
           onSetStepAmount={() => {
-            const amt = prompt('Enter step amount:', String(incrementSettings.stepAmount));
-            if (amt) setIncrementSettings({ ...incrementSettings, stepAmount: parseFloat(amt) });
+            const amt = askNumber('Enter step amount:', incrementSettings.stepAmount);
+            if (amt !== null) setIncrementSettings({ ...incrementSettings, stepAmount: amt });
             closeContextMenu();
           }}
           onSetStepCount={() => {
-            const count = prompt('Enter step multiplier (Ctrl key):', String(incrementSettings.stepCount));
-            if (count) setIncrementSettings({ ...incrementSettings, stepCount: parseInt(count) });
+            const count = askNumber('Enter step multiplier (Ctrl key):', incrementSettings.stepCount);
+            if (count !== null) setIncrementSettings({ ...incrementSettings, stepCount: Math.max(1, Math.round(count)) });
             closeContextMenu();
           }}
           onSetStepPercent={() => {
-            const pct = prompt('Enter step percent (Shift key):', String(incrementSettings.stepPercent));
-            if (pct) setIncrementSettings({ ...incrementSettings, stepPercent: parseFloat(pct) });
+            const pct = askNumber('Enter step percent (Shift key):', incrementSettings.stepPercent);
+            if (pct !== null) setIncrementSettings({ ...incrementSettings, stepPercent: pct });
             closeContextMenu();
           }}
           onToggleHeatmap={() => { setHeatmapEnabled(!heatmapEnabled); closeContextMenu(); }}
@@ -992,16 +993,16 @@ export function TableEditor({
       {/* Toolbar */}
       <TableToolbar
         onSetEqual={() => {
-          const value = prompt('Enter value:');
-          if (value) setEqual(parseFloat(value));
+          const value = askNumber('Enter value:');
+          if (value !== null) setEqual(value);
         }}
         onIncrease={() => adjustValues(0.1)}
         onDecrease={() => adjustValues(-0.1)}
         onIncreaseMore={() => adjustValues(1)}
         onDecreaseMore={() => adjustValues(-1)}
         onScale={() => {
-          const factor = prompt('Enter scale factor (e.g., 1.02 for +2%):');
-          if (factor) scaleValues(parseFloat(factor));
+          const factor = askNumber('Enter scale factor (e.g., 1.02 for +2%):');
+          if (factor !== null) scaleValues(factor);
         }}
         onInterpolate={interpolate}
         onSmooth={smooth}

--- a/crates/libretune-app/src/utils/__tests__/askNumber.test.ts
+++ b/crates/libretune-app/src/utils/__tests__/askNumber.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { askNumber } from '../askNumber';
+
+const answer = (value: string | null) =>
+  vi.spyOn(window, 'prompt').mockReturnValue(value);
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('askNumber', () => {
+  it('returns the number when one is typed', () => {
+    answer(' 12.5 ');
+    expect(askNumber('x')).toBe(12.5);
+  });
+
+  it('returns null for cancel, blank and non-numeric input', () => {
+    for (const input of [null, '', '   ', 'abc', '12abc', 'NaN', '1e', 'Infinity']) {
+      answer(input);
+      expect(askNumber('x')).toBeNull();
+    }
+  });
+
+  it('accepts a comma decimal separator', () => {
+    for (const [input, want] of [['1,5', 1.5], ['12,25', 12.25], ['-3,5', -3.5]] as const) {
+      answer(input);
+      expect(askNumber('x')).toBe(want);
+    }
+  });
+
+  it('still rejects an ambiguous thousands group', () => {
+    // '1,234' could be 1.234 or 1234 depending on locale. Guessing either way
+    // would put a wrong number in a fuel table.
+    for (const input of ['1,234', '1,2,3', '1.2,3', '1,0000']) {
+      answer(input);
+      expect(askNumber('x')).toBeNull();
+    }
+  });
+
+  it('passes the initial value through as the prompt default', () => {
+    const spy = answer('3');
+    askNumber('x', 2.5);
+    expect(spy).toHaveBeenCalledWith('x', '2.5');
+  });
+});

--- a/crates/libretune-app/src/utils/askNumber.ts
+++ b/crates/libretune-app/src/utils/askNumber.ts
@@ -1,0 +1,27 @@
+/**
+ * prompt() for a number, rejecting anything that isn't one.
+ *
+ * Returns null if the user cancelled, left it blank, or typed something that
+ * doesn't parse cleanly - callers must treat null as "do nothing". Uses
+ * Number() rather than parseFloat() on purpose: parseFloat('12abc') is 12,
+ * which silently accepts a typo as a tune value.
+ */
+export function askNumber(label: string, initial?: number): number | null {
+  const raw = window.prompt(label, initial === undefined ? '' : String(initial));
+  if (raw === null) return null;
+  let trimmed = raw.trim();
+  if (trimmed === '') return null;
+  // A comma decimal separator is what most of Europe types, and prompt() gives
+  // no locale hint. Number('1,5') is NaN, so without this the entry is
+  // rejected silently and looks identical to pressing Cancel.
+  //
+  // Accepted only where it cannot be a thousands group: one comma, followed by
+  // one or two digits, to the end. '1,234' stays rejected because 1.234 and
+  // 1234 are both plausible readings of it and picking wrong puts a value out
+  // by a factor of a thousand into a fuel table.
+  if (/^-?\d+,\d{1,2}$/.test(trimmed)) {
+    trimmed = trimmed.replace(',', '.');
+  }
+  const value = Number(trimmed);
+  return Number.isFinite(value) ? value : null;
+}


### PR DESCRIPTION
## What's wrong

Type `abc` into the table editor's "Enter value:" prompt and every selected cell reads `NaN`. Nothing warns you, and the edit goes into undo history like a normal one. Type `12abc` and the cells quietly take 12.

Nine prompts in the tab table editor passed `parseFloat` straight to the mutation helpers, with `if (value)` as the only check — which rejects an empty string and nothing else. On `origin/main`, in `crates/libretune-app/src/components/tuner-ui/TableEditor.tsx`:

- 944, 995 — set value (context menu and toolbar)
- 951, 956, 961, 1003 — add, subtract, multiply, scale
- 973, 978, 983 — step amount, step multiplier, step percent

`setEqual` (:416), `adjustValues` (:428) and `scaleValues` (:440) take the number on trust and write it into every selected cell.

## Why it matters

`adjustValues` and `scaleValues` are relative, so a NaN cell stays NaN through every later step, add or multiply, and interpolating across a span with a NaN endpoint fills the whole span with NaN. One mistyped scale factor over a wide VE selection costs the tuner that selection, mid-session, on a running engine.

The `12abc` case is the quieter one: no NaN, nothing visibly wrong, just a cell reading 12 when the tuner meant 12.5. Other popular tuning software rejects that input rather than truncating it.

For scope, so the severity is not overstated: these edits land in the tab's working copy — the tab editor does not call `update_table_data` for prompt-driven edits — so a NaN from these nine sites does not itself go down the wire. What it corrupts is the tune being built and the grid's claim about what is in it.

## The fix

New `crates/libretune-app/src/utils/askNumber.ts`, 16 lines: prompt, trim, reject blank, `Number()`, return `null` unless `Number.isFinite`. Callers treat `null` as "do nothing".

The guard already existed twice in this codebase, written longhand both times — `finishEdit` (TableEditor.tsx:696) and CurveEditor's four axis prompts. This lifts it into one place and routes all thirteen prompt sites through it: nine in TableEditor.tsx (945–1004) and CurveEditor's four (638–662), where it collapses four eight-line blocks to three lines each.

`Number()` rather than `parseFloat()` on purpose: `parseFloat('12abc')` is 12, `Number('12abc')` is NaN. Rejecting is the point. `Number.isFinite` also drops `Infinity`, which `parseFloat` accepted.

One call site does more than pass the value through: the step multiplier now stores `Math.max(1, Math.round(count))` (TableEditor.tsx:980) where it previously stored `parseInt(count)`.

## Testing

New `crates/libretune-app/src/utils/__tests__/askNumber.test.ts`, three cases, `window.prompt` stubbed with `vi.spyOn`:

1. `' 12.5 '` returns `12.5` — catches losing the trim, or a guard that starts rejecting valid input.
2. `null`, `''`, `'   '`, `'abc'`, `'12abc'`, `'NaN'`, `'1e'` and `'Infinity'` all return `null` — `'12abc'` is the original silent-truncation bug; `'NaN'` and `'Infinity'` are the values that get into the arithmetic and never come out.
3. `askNumber('x', 2.5)` calls `prompt('x', '2.5')` — catches the pre-filled default going missing, which is what makes the step-amount and axis prompts usable.

No test covers the thirteen call sites themselves; the conversions are mechanical and visible in the diff. The existing TableEditor and CurveEditor suites are unchanged.

## Risk

Low. The helper is new and covered; every other change swaps one guard for another at a call site.

Behaviour existing users would notice:

- Rejection is silent. Bad input closes the prompt and nothing happens, indistinguishable from Cancel. That matches how `finishEdit` has always behaved, but it is a change from "something wrong happened" to "nothing happened".
- `Number()` is stricter than `parseFloat()`. `12abc`, `Infinity` and a comma decimal separator (`12,5`) are now no-ops; `parseFloat` gave 12, Infinity and 12. All three were wrong, but the comma case is worth a thought for non-English keyboards.
- Step multiplier rounds instead of truncating and clamps to at least 1: `2.7` was 2 and is now 3, `0` is now 1. `stepCount` is stored and shown as its own prompt default, but is not read anywhere else in the frontend, so the practical effect today is small.

Not closed by this PR: `finishEdit` (TableEditor.tsx:696–699) still uses the longhand `parseFloat`/`isNaN`, so double-clicking a cell and typing `12abc` still yields 12. Same class of bug, different entry point, left for a separate change.

---

### Amended after review

- `askNumber` now accepts a comma decimal separator where it cannot be a thousands group (one comma followed by one or two digits). `1,5` and `12,25` are read as decimals; `1,234` stays rejected because 1.234 and 1234 are both plausible readings and picking wrong is a factor-of-a-thousand error in a fuel table. Silent rejection of `12,5` was the one realistic false negative in the strict `Number()` rule.

### Verified on hardware

Not applicable - this path never reaches the wire. Covered by unit tests only.
