### PR TITLE
fix(autotune): wire Require Steady State to min_steady_ms

### DIFF
--- a/crates/libretune-app/src/components/tuner-ui/AutoTune.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/AutoTune.tsx
@@ -83,9 +83,14 @@ interface AutoTuneFilters {
   min_rpm: number;
   /** Maximum RPM to accept data */
   max_rpm: number;
-  /** Minimum throttle position percentage */
+  /**
+   * Throttle-position bounds, placeholder for a planned TPS window filter.
+   *
+   * No control and no backend field yet - the Rust AutoTuneFilters struct
+   * drops them. Until then, `custom_filter` expresses the same thing
+   * ("tps > 5 && tps < 95"). Keep: the pair is the shape the filter will take.
+   */
   min_tps: number;
-  /** Maximum throttle position percentage */
   max_tps: number;
   /** Minimum coolant temperature (reject cold engine data) */
   min_clt: number;
@@ -95,12 +100,23 @@ interface AutoTuneFilters {
   max_tps_rate: number;
   /** Exclude data when accel enrichment is active */
   exclude_accel_enrich: boolean;
-  /** Require steady-state operation for valid data */
-  require_steady_state: boolean;
-  /** Maximum RPM change for steady-state detection */
+  /**
+   * How long rpm and load must have held steady before a sample counts, in ms.
+   * `0` disables the check, which is the backend default.
+   *
+   * This is the field `AutoTuneFilters` actually reads. The panel used to send
+   * `require_steady_state` / `steady_state_time_ms`, which no longer exist on
+   * the Rust side, so the checkbox has never done anything.
+   */
+  min_steady_ms: number;
+  /**
+   * Placeholder: per-session steadiness tolerance.
+   *
+   * The backend currently judges steadiness against fixed constants
+   * (STEADY_RPM_TOLERANCE 100 rpm, STEADY_LOAD_TOLERANCE 3). Exposing them is
+   * the natural next step; this is the control that would carry the rpm half.
+   */
   steady_state_rpm_delta: number;
-  /** Minimum time at steady-state in milliseconds */
-  steady_state_time_ms: number;
 }
 
 /**
@@ -259,9 +275,24 @@ interface VeAnalyzeConfig {
 /// low-load corrections come back inflated - which is what happened on a
 /// 59-minute drive where the delay had simply never been set.
 ///
-/// Versioned so a future field change discards old state rather than merging a
-/// stale shape into a new one.
-const SETTINGS_KEY = 'libretune.autotune.settings.v1';
+/// Versioned so a field change discards old state rather than merging a stale
+/// shape into a new one.
+
+/**
+ * Steady-state window applied when the box is ticked, in ms.
+ *
+ * Longer than the longest transport delay in use. Across two logged drives
+ * 800 ms lifted the held-out AFR improvement from 34.1% to 39.5% and roughly
+ * halved the largest proposed change, at the cost of covering 52 cells rather
+ * than 131 - a sample has to earn its place.
+ */
+const STEADY_MS_DEFAULT = 800;
+
+/// Bumped to v2 with the steady-state rewiring: a
+/// persisted v1 blob carries require_steady_state / steady_state_time_ms,
+/// which no longer mean anything, and merging it would leave min_steady_ms at
+/// its default while the tuner believes their old setting survived.
+const SETTINGS_KEY = 'libretune.autotune.settings.v2';
 
 function loadPersisted<T>(key: string, fallback: T): T {
   try {
@@ -340,9 +371,12 @@ export function AutoTune({ tableName: initialTableName = '', onClose, isConnecte
     // exclude_accel_enrich.
     max_tps_rate: 50,
     exclude_accel_enrich: true,
-    require_steady_state: true,
-    steady_state_rpm_delta: 50,
-    steady_state_time_ms: 500,
+    // Off, matching the backend default. Turning it on changes which samples
+    // an existing session accepts, and that is the tuner's call - the panel
+    // defaulting it *on* while the backend ignored it is how this came to be
+    // reported as working for so long.
+    min_steady_ms: 0,
+    steady_state_rpm_delta: 100,
   }));
 
   const [authority, setAuthority] = useState<AutoTuneAuthorityLimits>(() =>
@@ -1572,11 +1606,37 @@ export function AutoTune({ tableName: initialTableName = '', onClose, isConnecte
               <label>
                 <input
                   type="checkbox"
-                  checked={filters.require_steady_state}
-                  onChange={(e) => setFilters({ ...filters, require_steady_state: e.target.checked })}
+                  checked={filters.min_steady_ms > 0}
+                  onChange={(e) =>
+                    setFilters({
+                      ...filters,
+                      // 800 ms is the figure that held up across two logged
+                      // drives: held-out AFR improvement 34.1% -> 39.5%, and
+                      // the largest proposed change roughly halved.
+                      min_steady_ms: e.target.checked ? STEADY_MS_DEFAULT : 0,
+                    })
+                  }
                 />
                 Require Steady State
               </label>
+            </div>
+            <div className="setting-row">
+              <label>Steady For (ms):</label>
+              <input
+                type="number"
+                min={0}
+                step={100}
+                disabled={filters.min_steady_ms === 0}
+                value={filters.min_steady_ms}
+                onChange={(e) =>
+                  setFilters({
+                    ...filters,
+                    // u64 on the Rust side - serde rejects a float for it and
+                    // the whole start_autotune call fails, so round here.
+                    min_steady_ms: Math.max(0, Math.round(parseFloat(e.target.value) || 0)),
+                  })
+                }
+              />
             </div>
           </div>
 

--- a/crates/libretune-app/src/components/tuner-ui/__tests__/AutoTune.test.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/__tests__/AutoTune.test.tsx
@@ -227,7 +227,7 @@ describe('AutoTune settings persistence', () => {
     await userEvent.clear(delay);
     await userEvent.type(delay, '470');
     await waitFor(() =>
-      expect(localStorage.getItem('libretune.autotune.settings.v1.settings'))
+      expect(localStorage.getItem('libretune.autotune.settings.v2.settings'))
         .toContain('470'),
     );
 
@@ -237,7 +237,7 @@ describe('AutoTune settings persistence', () => {
   });
 
   it('falls back to defaults when stored state is corrupt', async () => {
-    localStorage.setItem('libretune.autotune.settings.v1.settings', '{not json');
+    localStorage.setItem('libretune.autotune.settings.v2.settings', '{not json');
     render(<ToastProvider><AutoTune isConnected onClose={() => {}} /></ToastProvider>);
     expect((await delayInput()).value).toBe('0');
   });


### PR DESCRIPTION
## What's wrong

The "Require Steady State" checkbox in the AutoTune panel has never changed which samples a session accepts, and it shipped ticked — so the panel has been reporting a transient filter that was not running.

The panel declared `require_steady_state`, `steady_state_rpm_delta` and `steady_state_time_ms` (`crates/libretune-app/src/components/tuner-ui/AutoTune.tsx:99-103` on main), defaulted the first to `true` (`:343`), and the checkbox wrote it (`:1575-1576`). The whole `filters` object goes straight to `start_autotune` (`crates/libretune-app/src-tauri/src/commands/start_autotune.rs:22`), which deserializes into `AutoTuneFilters` (`crates/libretune-core/src/autotune/mod.rs:373`). That struct has never had any of the three fields, and `#[serde(default)]` (`mod.rs:372`) drops unknown keys silently. Nothing errored; nothing filtered.

The steadiness filter does exist — `min_steady_ms` (`mod.rs:397`), enforced by `is_steady` (`mod.rs:835`) and reported by `classify` (`mod.rs:890`) — with no control in the AutoTune panel at all.

## Why it matters

The check exists for load changes the throttle-rate filters cannot see: a gear change, a hill, traffic closing up, all with the pedal still. During those the exhaust gas the wideband reads was burnt in a cell the engine has already left, so the correction lands on the wrong cell. Authority limits still cap each individual change, so this skews cells rather than writing arbitrary values, but the skew accumulates in the cells either side of every transition over a session.

Measured: across two logged drives, an 800 ms window lifted held-out AFR improvement from 34.1% to 39.5% and roughly halved the largest proposed change, covering 52 cells instead of 131.

The tuner had no signal. With `min_steady_ms` at 0, `is_steady` returns true for every sample, so the rejection breakdown never attributed anything to steadiness — a session eating transient data looked identical to one filtering it.

## The fix

- `min_steady_ms` replaces the three phantom fields in the interface (`AutoTune.tsx:111`).
- The checkbox writes it: ticked → `STEADY_MS_DEFAULT` 800 (`:288`, `:1604-1612`), unticked → 0.
- New "Steady For (ms)" number input (`:1618-1632`), disabled while the value is 0, so the window is adjustable rather than fixed at 800.
- Defaults to 0, off (`:373`), matching the backend default (`mod.rs:426`) rather than carrying over the old ticked-by-default. Turning it on changes which samples an existing session accepts, and the panel silently defaulting it on is how this came to be reported as working.

The control shape is copied from the offline log analyser, which already had it: `DatalogViewer.tsx:336` ("Steady for (ms)", step 100, 0 disables) writing `min_steady_ms` at `:202`. This brings the live panel to the same shape.

`steady_state_rpm_delta` stays as a documented placeholder with no control (`:119`), its value moved 50 → 100 to match the backend's fixed `STEADY_RPM_TOLERANCE` (`mod.rs:404`).

## Testing

No test was added or changed — the diff is one file. `crates/libretune-app/src/components/tuner-ui/__tests__/AutoTune.test.tsx` covers connection gating, Alpha-N load-source detection, settings persistence and the table picker; nothing in it inspects `filters`, which is how this survived.

The assertion worth adding is on the payload: render the panel, tick the box, and check the object passed to `invoke('start_autotune')` carries `min_steady_ms: 800` and no `require_steady_state`. That is the only check that catches this class of bug returning, and `invoke` is already mocked in that file (`mockInvoke`, `:24-37`).

Manual check on the bench: with the box ticked, the sample indicator (`AutoTune.tsx:1328-1345`) should start showing an `rpm/load not steady` bucket, the string `classify` returns (`mod.rs:896`). Unticked, that bucket cannot appear.

## Risk

- **Visible change:** the box now reads unticked on first launch after update. `loadPersisted` merges stored settings over the fallback (`AutoTune.tsx:270-272`) and `SETTINGS_KEY` was not versioned up, so a stored `require_steady_state: true` survives in the object but stays inert, and `min_steady_ms` takes the fallback 0. No behaviour changes for those users — it was already off — only the tick mark disappears.
- **Ticking it is a real change:** on the logged drives it covered 52 cells rather than 131. Someone who enables it and does not read the accepted-sample count will read that as AutoTune having stopped working.
- **Float into `u64`:** the input parses with `parseFloat` (`:1629`) but `min_steady_ms` is `u64` (`mod.rs:397`). `min`/`step` keep the stepper on integers; a hand-typed `800.5` is a JSON float that `start_autotune` would refuse to deserialize.
- **Clearing the field:** empty input yields `parseFloat('') || 0` → 0, which unticks the box and disables the input, so the value cannot be cleared and retyped in place.
- `min_tps`/`max_tps` (`:86-95`) and `steady_state_rpm_delta` (`:119`) remain in the interface with no backend field. No control writes them now, so they cannot misreport, but they are the same dead-field shape that produced this bug.
- No Rust changed, so backend behaviour is untouched.

---

### Amended after review

- The "Steady For (ms)" input now rounds. `min_steady_ms` is `u64`, and serde rejects a float for it, so a typed `800.5` would have failed the whole `start_autotune` call rather than just that field.
- `SETTINGS_KEY` bumped to `v2`. The filter shape changed, so a persisted v1 blob carries `require_steady_state` / `steady_state_time_ms`, which no longer mean anything; merging it would leave `min_steady_ms` at its default while the tuner believes their old setting survived.

### Open question for the reviewer

The offline Datalog Viewer defaults the same backend field to 800 (`DatalogViewer.tsx:96`), while this defaults the live panel to 0 to match the backend. `analyse_log.rs` states the two paths exist so they cannot disagree, so one of the two defaults should probably move. Left as-is here because changing the live default changes which samples an existing session accepts, which is a call for this repo rather than for this PR.
