### PR TITLE
fix(autotune): read the whole axis or none of it

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/start_autotune.rs
+++ b/crates/libretune-app/src-tauri/src/commands/start_autotune.rs
@@ -364,24 +364,76 @@ pub(crate) fn read_axis_bins(
         }
     };
 
-    // If we have cached tune data, read from it
+    // If we have cached tune data, read from it.
+    //
+    // All `size` bins or none. The old loop skipped a bin it could not read but
+    // carried on - a short page returned a truncated axis, and a single failed
+    // decode dropped one bin and shifted every bin after it down one position.
+    // Either way AutoTune ends up with fewer axis bins than the table has
+    // cells, so `nearest_bin` attributes a sample to the wrong RPM or load cell
+    // and the recommendation is filed against a cell the engine was never in.
+    // `read_table_z_values` already refuses a partial table for the same
+    // reason; an axis is no different. Falling through to `fallback_bins` keeps
+    // the existing contract for "cannot read this constant" rather than adding
+    // a new fabrication path.
     if let Some(cache) = cache {
         if let Some(page_data) = cache.get_page(constant.page) {
             let elem_size = constant.data_type.size_bytes();
-            let mut bins = Vec::with_capacity(size);
-            let mut offset = constant.offset as usize;
+            if elem_size == 0 {
+                tracing::warn!(
+                    axis = const_name,
+                    "axis constant has a zero-width data type; using generated bins"
+                );
+            } else {
+                let mut bins = Vec::with_capacity(size);
+                let mut offset = constant.offset as usize;
 
-            for _ in 0..size {
-                if offset + elem_size <= page_data.len() {
-                    if let Ok(raw) = read_raw_value(&page_data[offset..], &constant.data_type) {
-                        bins.push(constant.raw_to_display(raw));
+                for i in 0..size {
+                    if offset + elem_size > page_data.len() {
+                        tracing::warn!(
+                            axis = const_name,
+                            page = constant.page,
+                            bin = i,
+                            of = size,
+                            need = offset + elem_size,
+                            have = page_data.len(),
+                            "axis read ran past the end of the page"
+                        );
+                        bins.clear();
+                        break;
+                    }
+                    match read_raw_value(&page_data[offset..], &constant.data_type) {
+                        Ok(raw) => bins.push(constant.raw_to_display(raw)),
+                        Err(e) => {
+                            tracing::warn!(
+                                axis = const_name,
+                                bin = i,
+                                offset,
+                                error = %e,
+                                "axis bin failed to decode"
+                            );
+                            bins.clear();
+                            break;
+                        }
                     }
                     offset += elem_size;
                 }
-            }
 
-            if !bins.is_empty() {
-                return Ok(bins);
+                if bins.len() == size {
+                    return Ok(bins);
+                }
+                // The page is there but does not hold the axis. Falling through
+                // to fallback_bins would answer with a fixed 500-6500 rpm (or
+                // 20-100 kPa) ramp that has nothing to do with this table, and
+                // AutoTune would file every recommendation against a cell
+                // chosen by that invented axis - across the full table width
+                // rather than part of it. read_table_z_values refuses the
+                // identical condition; the fallback below is for an axis the
+                // INI never declared, which is a different thing.
+                return Err(format!(
+                    "Axis '{const_name}' could not be read from page {}: the page is                      present but does not hold {size} complete bins. Re-sync the ECU                      and try again.",
+                    constant.page
+                ));
             }
         }
     }
@@ -755,6 +807,80 @@ pub(crate) fn read_table_z_values(
         out.push(row);
     }
     Some(out)
+}
+
+#[cfg(test)]
+mod axis_bin_tests {
+    use super::*;
+    use libretune_core::ini::DataType;
+    use libretune_core::tune::TuneCache;
+
+    /// One 8-entry U16 RPM axis at page offset 0. `page_bytes` decides whether
+    /// the page is long enough to hold it.
+    fn def_and_cache(page_bytes: usize) -> (EcuDefinition, TuneCache) {
+        let mut def = EcuDefinition {
+            page_sizes: vec![page_bytes as u16],
+            n_pages: 1,
+            ..Default::default()
+        };
+        def.constants.insert(
+            "rpmBins".to_string(),
+            Constant {
+                name: "rpmBins".to_string(),
+                page: 0,
+                offset: 0,
+                data_type: DataType::U16,
+                scale: 1.0,
+                translate: 0.0,
+                ..Default::default()
+            },
+        );
+        let mut cache = TuneCache::from_definition(&def);
+        // 500, 1500, 2500 ... U16, big-endian as the INI reader decodes them.
+        let mut page = Vec::with_capacity(page_bytes);
+        for i in 0..(page_bytes / 2) {
+            let rpm = 500u16 + (i as u16 * 1000);
+            page.extend_from_slice(&rpm.to_be_bytes());
+        }
+        page.resize(page_bytes, 0);
+        cache.load_page(0, page);
+        (def, cache)
+    }
+
+    #[test]
+    fn a_full_page_reads_the_real_axis() {
+        let (def, cache) = def_and_cache(16);
+        let bins = read_axis_bins(&def, Some(&cache), "rpmBins", 8, AxisHint::Rpm).unwrap();
+        assert_eq!(bins.len(), 8);
+        assert_eq!(bins[0], 500.0);
+        assert_eq!(bins[7], 7500.0);
+    }
+
+    /// The bug: a page holding only 5 of the 8 bins used to return a 5-entry
+    /// axis. AutoTune then had fewer bins than the table has cells, so samples
+    /// were attributed to the wrong RPM cell entirely - and nothing downstream
+    /// could tell a short axis from a complete one.
+    #[test]
+    fn a_short_page_refuses_rather_than_truncating_or_inventing() {
+        let (def, cache) = def_and_cache(10); // 5 x U16, need 8
+        let err = read_axis_bins(&def, Some(&cache), "rpmBins", 8, AxisHint::Rpm)
+            .expect_err("a page that cannot hold the axis must not answer");
+        assert!(
+            err.contains("rpmBins") && err.contains("page 0"),
+            "the error must name the axis and page: {err}"
+        );
+    }
+
+    /// Refusing is only correct when the page *is* there and falls short.
+    /// An axis the INI never declared has no page to be short, and generated
+    /// bins are the only answer available - that path must keep working.
+    #[test]
+    fn a_missing_constant_still_generates_bins() {
+        let (def, cache) = def_and_cache(16);
+        let bins = read_axis_bins(&def, Some(&cache), "notThere", 8, AxisHint::Rpm).unwrap();
+        assert_eq!(bins.len(), 8);
+        assert!(bins.windows(2).all(|w| w[1] > w[0]));
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What's wrong

AutoTune can file its VE corrections against the wrong RPM or load cell, and a session that does this looks identical to a good one.

`read_axis_bins` (`crates/libretune-app/src-tauri/src/commands/start_autotune.rs:321`) built the axis in a loop that skipped any bin it could not read and kept going (`origin/main` lines 374-385), then accepted the result as long as it was non-empty (line 383). Two ways out of that loop are wrong:

- a page too short for the axis returned a truncated axis — five bins for an eight-cell axis;
- one failed decode dropped that bin and shifted every later bin down a position.

The `Vec<f64>` carries no length contract, so none of the four call sites (`:108`, `:112`, `:160`, `:162` — primary and secondary table X/Y) can tell a short axis from a complete one. `AutoTuneState::find_bin_index` (`crates/libretune-core/src/autotune/mod.rs:1204`) picks the nearest entry of whatever array it is handed, and that index is used directly as the table cell index (`mod.rs:1033-1041`).

## Why it matters

Take an eight-cell RPM axis truncated to five bins, 500 to 4500. A sample recorded at 6500 rpm is nearest to the last surviving bin, index 4, so the correction computed from it is written to table cell 4 — a cell the real axis places well below 6500 rpm. The engine's high-rpm mixture is applied to a mid-range cell, and the mid-range cell is corrected from data that never came from it.

Recommendations are shown before they are applied, but the values look ordinary; only the shape of the finished table gives it away. Send, burn, and autosend (`autotune_misc.rs:251`, `:443`, `:536`) move them to the ECU without a per-cell check. Nothing logged a warning.

## The fix

All `size` bins or none. The page-length check and the decode error each clear the accumulator and break (`:392`, `:405`), and the read is accepted only when `bins.len() == size` (`:422`). Anything else falls through to `fallback_bins` (`:329`, `:430`) — the path the function already takes when the constant is missing, so the fix adds no new source of fabricated values and leaves the signature and `Result` contract alone. A zero-width data type is rejected up front (`:382`); previously `offset` never advanced and the loop read the same offset `size` times.

This is the shape `read_table_z_values` (`:739`) already uses: it returns `None` rather than a partial table, for the same reason, documented at `:758-765`. Each rejection now logs a `tracing::warn` with the constant name, page, bin index, and the byte counts.

## Testing

Three tests in a new `axis_bin_tests` module (`:801`). The helper `def_and_cache(page_bytes)` defines one 8-entry U16 `rpmBins` axis at page 0 offset 0 and loads a page of 500, 1500, 2500 ... big-endian, sized by the caller.

- `a_full_page_reads_the_real_axis` (`:839`) — a 16-byte page returns the real axis: eight bins, 500 first, 7500 last. Catches a fix that stops reading the page, or falls back when it should not.
- `a_short_page_falls_back_instead_of_truncating` (`:852`) — the regression test. A 10-byte page holds five of the eight bins; asserts eight bins back, `bins[7] == 6500` (the top of the generated RPM ramp, which separates the fallback from the real axis at 7500 and from a zero-padded one), and strictly increasing. Against the old code this returns five bins and fails.
- `a_missing_constant_still_generates_bins` (`:866`) — the pre-existing missing-constant path still yields a full-length axis.

Not covered: the decode-failure branch (`:405`) and the zero-width guard (`:382`).

## Risk

One function in one file; the four call sites, the signature, and the return type are unchanged. The only behaviour change is on paths that already produced a wrong axis. A user whose axis reads correctly sees nothing different. A user who was silently getting a truncated or shifted axis now gets generated linear bins instead: still not their ECU's real axis, but the right length, so cell indices line up. The only signal is a log warning, not anything in the UI.

Nit: the two new warn messages contain long runs of internal spaces from wrapped string literals (`:400`, `:413`), and will render that way in logs.

---

### Amended after review

The first version fell back to generated bins when the page fell short. That was wrong: `fallback_bins` produces a fixed 500-6500 rpm (or 20-100 kPa) ramp with no relation to the table it stands in for, so it would have moved the mis-attribution from part of the table to all of it while still returning `Ok`. A page that is present but too short now returns an error naming the axis and page. The generated-bin path stays for the case it was written for - an axis the INI never declared, which has no page to fall short - and is covered by its own test.

### Verified on hardware

Speeduino 202501 on an ATmega2560, both legacy serial and CRC msEnvelope_1.0: all 15 pages read at full declared length through `read_page`, so the refusal path does not fire on a healthy ECU. `read_memory` at 256 bytes against a declared blockingFactor of 251 also succeeded, so the unchunked read in `send_autotune_recommendations` is not the hazard it looked like on inspection.
