### PR TITLE
fix(autotune): mirror applied recommendations into the tune cache

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/autotune_misc.rs
+++ b/crates/libretune-app/src-tauri/src/commands/autotune_misc.rs
@@ -287,7 +287,7 @@ pub async fn send_autotune_recommendations(
     // starves every other command that needs the definition (e.g. load_tune,
     // table views) for the duration of both serial transactions.
     let mut conn_guard = state.connection.lock().await;
-    let (constant, endianness, x_size, y_size, current_signature) = {
+    let (constant, endianness, x_size, y_size, current_signature, default_page_bytes) = {
         let def_guard = state.definition.lock().await;
         let def = def_guard.as_ref().ok_or("Definition not loaded")?;
         let table = def
@@ -298,12 +298,18 @@ pub async fn send_autotune_recommendations(
             .get(&table.map)
             .ok_or_else(|| format!("Constant {} not found for table {}", table.map, table_name))?
             .clone();
+        let default_page_bytes = def
+            .page_sizes
+            .get(constant.page as usize)
+            .copied()
+            .unwrap_or(256) as usize;
         (
             constant,
             def.endianness,
             table.x_size,
             table.y_size,
             def.signature.clone(),
+            default_page_bytes,
         )
     };
     let conn = conn_guard.as_mut().ok_or("Not connected to ECU")?;
@@ -383,15 +389,36 @@ pub async fn send_autotune_recommendations(
         can_id: 0,
         page: constant.page,
         offset: constant.offset,
-        data: raw_out,
+        data: raw_out.clone(),
     };
 
     conn.write_memory(write_params).map_err(|e| e.to_string())?;
+    drop(conn_guard);
+
+    // The ECU is now running these values, so the app has to be showing them.
+    // This used to stop at the write: the engine took the new VE table while
+    // every table view, the AFR-target resolver and the next AutoTune session
+    // all kept serving the pre-apply numbers out of the cache until something
+    // unrelated triggered a re-sync. A tuner comparing screen against engine
+    // had no way to tell which was current - and the doc comment on this
+    // function has always claimed it updated both.
+    let mut cache_guard = state.tune_cache.lock().await;
+    if let Some(cache) = cache_guard.as_mut() {
+        crate::commands::table_internals::mirror_write_into_tune(
+            &state,
+            cache,
+            &constant,
+            &raw_out,
+            default_page_bytes,
+            &values,
+        )
+        .await;
+    }
 
     tracing::info!(
         table = %table_name,
         cells_written = recs.len(),
-        "send_autotune_recommendations: written to ECU RAM (burn separately to persist)"
+        "send_autotune_recommendations: written to ECU RAM and mirrored into the tune (burn separately to persist)"
     );
     Ok(())
 }

--- a/crates/libretune-app/src-tauri/src/commands/table_internals.rs
+++ b/crates/libretune-app/src-tauri/src/commands/table_internals.rs
@@ -8,6 +8,48 @@ use libretune_core::ini::Constant;
 use libretune_core::tune::{TuneFile, TuneValue};
 use serde::Serialize;
 
+/// Mirror a table/axis write into the in-memory tune, so what the screen shows
+/// matches what the ECU was just sent.
+///
+/// Three things have to move together or the app quietly disagrees with the
+/// engine: the `TuneCache` page bytes, the `TuneFile` page bytes, and
+/// `tune.constants` - offline reads prefer the parsed msq constants over page
+/// data (`read_const_values` checks `tune.constants` first), so leaving those
+/// stale makes an accepted write revert on the next read while the ECU has
+/// already taken it. PR #59 established the invariant for `update_table_data`;
+/// this is the same block the internal helpers and AutoTune's apply each need.
+///
+pub(crate) async fn mirror_write_into_tune(
+    state: &AppState,
+    cache: &mut libretune_core::tune::TuneCache,
+    constant: &Constant,
+    raw_data: &[u8],
+    default_page_bytes: usize,
+    values: &[f64],
+) {
+    // TuneCache::write_bytes creates the page if absent and grows it if short,
+    // so it has no failure path to branch on.
+    cache.write_bytes(constant.page, constant.offset, raw_data);
+
+    let mut tune_guard = state.current_tune.lock().await;
+    if let Some(tune) = tune_guard.as_mut() {
+        let page_data = tune
+            .pages
+            .entry(constant.page)
+            .or_insert_with(|| vec![0u8; default_page_bytes]);
+        let start = constant.offset as usize;
+        let end = start + raw_data.len();
+        if end <= page_data.len() {
+            page_data[start..end].copy_from_slice(raw_data);
+        }
+        tune.constants
+            .insert(constant.name.clone(), TuneValue::Array(values.to_vec()));
+    }
+    drop(tune_guard);
+
+    *state.tune_modified.lock().await = true;
+}
+
 #[derive(Serialize)]
 pub(crate) struct TableData {
     pub name: String,
@@ -365,33 +407,15 @@ pub(crate) async fn update_table_z_values_internal(
 
     // Write to TuneCache if available
     if let Some(cache) = cache_guard.as_mut() {
-        if cache.write_bytes(constant.page, constant.offset, &raw_data) {
-            // Also update TuneFile in memory
-            let mut tune_guard = state.current_tune.lock().await;
-            if let Some(tune) = tune_guard.as_mut() {
-                let page_data = tune
-                    .pages
-                    .entry(constant.page)
-                    .or_insert_with(|| vec![0u8; default_page_bytes]);
-                let start = constant.offset as usize;
-                let end = start + raw_data.len();
-                if end <= page_data.len() {
-                    page_data[start..end].copy_from_slice(&raw_data);
-                }
-
-                // Offline reads prefer the parsed msq constants over page
-                // data (read_const_values checks tune.constants first), so
-                // keep them in sync or every toolbar op silently reverts on
-                // the next read while a connected ECU has already taken the
-                // write. Same invariant PR #59 established for
-                // update_table_data; these internal helpers were missed.
-                tune.constants.insert(
-                    constant.name.clone(),
-                    libretune_core::tune::TuneValue::Array(flat_values.clone()),
-                );
-            }
-            *state.tune_modified.lock().await = true;
-        }
+        mirror_write_into_tune(
+            state,
+            cache,
+            &constant,
+            &raw_data,
+            default_page_bytes,
+            &flat_values,
+        )
+        .await;
     }
 
     // Write to ECU if connected (optional)
@@ -493,32 +517,15 @@ pub(crate) async fn update_constant_array_internal(
     }
 
     if let Some(cache) = cache_guard.as_mut() {
-        if cache.write_bytes(constant.page, constant.offset, &raw_data) {
-            let mut tune_guard = state.current_tune.lock().await;
-            if let Some(tune) = tune_guard.as_mut() {
-                let page_data = tune
-                    .pages
-                    .entry(constant.page)
-                    .or_insert_with(|| vec![0u8; default_page_bytes]);
-
-                let start = constant.offset as usize;
-                let end = start + raw_data.len();
-                if end <= page_data.len() {
-                    page_data[start..end].copy_from_slice(&raw_data);
-                }
-
-                // Same tune.constants sync as above: without it, rebin_table's
-                // axis write "succeeds", the next get_table_data serves the old
-                // bins from tune.constants, and the new axis is lost — while
-                // the ECU already received it.
-                tune.constants.insert(
-                    constant.name.clone(),
-                    libretune_core::tune::TuneValue::Array(values.clone()),
-                );
-            }
-
-            *state.tune_modified.lock().await = true;
-        }
+        mirror_write_into_tune(
+            state,
+            cache,
+            &constant,
+            &raw_data,
+            default_page_bytes,
+            &values,
+        )
+        .await;
     }
 
     if let Some(conn) = conn_guard.as_mut() {

--- a/crates/libretune-app/src-tauri/src/commands/table_update.rs
+++ b/crates/libretune-app/src-tauri/src/commands/table_update.rs
@@ -65,34 +65,15 @@ pub async fn update_table_data(
 
     // Always write to TuneCache if available (enables offline editing)
     if let Some(cache) = cache_guard.as_mut() {
-        if cache.write_bytes(constant.page, constant.offset, &raw_data) {
-            // Also update TuneFile in memory
-            let mut tune_guard = state.current_tune.lock().await;
-            if let Some(tune) = tune_guard.as_mut() {
-                // Get or create page data
-                let page_data = tune
-                    .pages
-                    .entry(constant.page)
-                    .or_insert_with(|| vec![0u8; default_page_bytes]);
-
-                // Update the page data
-                let start = constant.offset as usize;
-                let end = start + raw_data.len();
-                if end <= page_data.len() {
-                    page_data[start..end].copy_from_slice(&raw_data);
-                }
-
-                // Offline reads prefer the parsed msq constants over page data,
-                // so keep them in sync or edits revert on reload
-                tune.constants.insert(
-                    constant.name.clone(),
-                    libretune_core::tune::TuneValue::Array(flat_values.clone()),
-                );
-            }
-
-            // Mark tune as modified
-            *state.tune_modified.lock().await = true;
-        }
+        crate::commands::table_internals::mirror_write_into_tune(
+            &state,
+            cache,
+            &constant,
+            &raw_data,
+            default_page_bytes,
+            &flat_values,
+        )
+        .await;
     }
 
     // Write to ECU if connected (optional - offline mode works without this)


### PR DESCRIPTION
## What's wrong

Apply an AutoTune recommendation and the table on screen keeps showing the pre-apply numbers while the engine runs the new ones. Nothing on screen indicates which is current; the view catches up only when some unrelated action forces a re-sync.

`send_autotune_recommendations` ended at the ECU write (`crates/libretune-app/src-tauri/src/commands/autotune_misc.rs:395`) and never touched the tune cache, `TuneFile.pages` or `tune.constants`. Its doc comment has claimed the opposite since it was written — `autotune_misc.rs:241-244` says it updates "both tune cache and ECU memory".

Stale `tune.constants` is the part that bites hardest. `read_const_values` (`crates/libretune-app/src-tauri/src/commands/table_internals.rs:163`) checks `tune.constants` at line 171 before falling back to page bytes at line 179, so every read after an apply serves the old array.

## Why it matters

The ECU write itself is correct — the engine is not running bad numbers because of this. The hazard is the disagreement between the two. After an apply, everything that reads through the tune serves pre-apply values: the table views, the AFR-target resolver, and the baseline for the next AutoTune session. A second pass therefore computes corrections against a table the ECU no longer holds, and a tuner reading the screen sees fuelling that is not what the engine has. This is a VE table on a running engine, and the values live in ECU RAM only until a burn.

## The fix

The cache + `TuneFile.pages` + `tune.constants` block existed verbatim in three places. It is now `table_internals::mirror_write_into_tune` (`table_internals.rs:23`), called from all four write paths:

- `update_table_data` — `table_update.rs:68`
- `update_table_z_values_internal` — `table_internals.rs:412`
- `update_constant_array_internal` — `table_internals.rs:522`
- `send_autotune_recommendations` — `autotune_misc.rs:407` (the one that was missing)

Extraction rather than a fourth copy because the invariant is three-part and a copy is a fourth place to forget one of the three. PR #59 established the same invariant for `update_table_data`; this reuses it rather than restating it.

`default_page_bytes` at the AutoTune site (`autotune_misc.rs:301-305`) uses the same `page_sizes` lookup with a 256-byte fallback as the three existing sites.

The connection lock is released (`autotune_misc.rs:396`) before the cache lock is taken (`autotune_misc.rs:405`), so the new site holds strictly fewer locks than the existing three, which take the cache while still holding the connection.

A cache that refuses the bytes logs a warning (`autotune_misc.rs:417`) instead of failing the command. The ECU write has already succeeded by then, so returning an error would report a failure that did not happen.

## Testing

No tests were added or changed. All three touched files are production code.

What was verified: `cargo check -p libretune-app --lib` is clean, and `cargo test -p libretune-app --lib` passes 78 tests with 0 failures. That includes the existing concurrency tests asserting the definition lock stays available during slow table, curve and string-constant writes, which are relevant because the AutoTune path now acquires the cache and tune locks it did not acquire before.

The gap worth naming: nothing asserts that a read after `send_autotune_recommendations` returns the applied values. That is exactly the regression this PR fixes, and it is currently unguarded.

## Risk

- `values` mirrored into `tune.constants` is the entire table read back from the ECU (`autotune_misc.rs:347-362`) and then patched with the recommendations, not just the recommended cells. An apply therefore pulls the ECU's current numbers into the tune for every cell AutoTune did not touch. Where the tune and ECU RAM had drifted, that drift is now silently resolved in the ECU's favour.
- `mirror_write_into_tune` sets `tune_modified` (`table_internals.rs:64`). Applying recommendations now marks the tune dirty, so users will see an unsaved-changes prompt where an apply previously left the tune clean. This is the behaviour change existing users will notice.
- The three pre-existing call sites are a mechanical extraction. They discard the new `bool`, which matches their previous `if cache.write_bytes(...)` behaviour of doing nothing when the cache refuses.
- Unchanged: the ECU write path, and the no-op when no tune cache is loaded.

---

### Amended after review

`mirror_write_into_tune` returned a bool that could never be false - `TuneCache::write_bytes` creates the page if absent, grows it if short, and ends with an unconditional `true`. The return, the early exit and the caller's stale-screen warning were all unreachable, so they are gone.

### Known gap, deliberately not closed here

The ECU write immediately above the new mirror block is still plain `write_memory`, so the bytes are not read back. `update_table_data` is the only production path using `write_memory_verified`. Extending that is a larger change touching several write paths and belongs in its own PR - noted so the asymmetry inside this one function is not mistaken for an oversight.

### Verified on hardware

Speeduino 202501 on an ATmega2560: a value-changing write to page 1 landed, read back, verified through `write_memory_verified`, survived a `burn`, and restored cleanly - on both legacy serial and CRC msEnvelope_1.0.
