### PR TITLE
fix(tables): refuse an unreadable table rather than serving zeros

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/table_internals.rs
+++ b/crates/libretune-app/src-tauri/src/commands/table_internals.rs
@@ -58,6 +58,78 @@ impl From<&TableSizeInfo> for TableSizeInfoDto {
 }
 
 // Tune health/anomaly/predicted_fills/dyno_overlay extracted to commands/tune_health.rs
+/// Read one constant's values out of the loaded tune.
+///
+/// Every failure returns an error rather than a zero. This used to
+/// substitute `0.0` for an element that would not decode and
+/// `vec![0.0; element_count]` for a missing or short page, then hand the
+/// result to the editor as though it had come from the tune. A table of
+/// zeros is not a recognisable failure - it looks like a table someone
+/// zeroed - and the first edit sends those zeros back down
+/// `update_table_data`, so a display fault becomes a written one. A zero
+/// VE or dwell table is also the shape most likely to hurt if it is
+/// believed. `read_axis_bins` and `read_table_z_values` already refuse the
+/// same conditions.
+///
+/// The `tune.constants` path below is left alone: it returns values that
+/// really are in the tune, so nothing is fabricated there.
+pub(crate) fn read_const_values(
+    constant: &Constant,
+    tune: Option<&TuneFile>,
+    endianness: libretune_core::ini::Endianness,
+) -> Result<Vec<f64>, String> {
+    let element_count = constant.shape.element_count();
+    let element_size = constant.data_type.size_bytes();
+    let tune_file = tune.ok_or_else(|| {
+        format!(
+            "No tune is loaded, so '{}' has no values to show.",
+            constant.name
+        )
+    })?;
+
+    if let Some(tune_value) = tune_file.constants.get(&constant.name) {
+        match tune_value {
+            TuneValue::Array(arr) => return Ok(arr.clone()),
+            TuneValue::Scalar(v) => return Ok(vec![*v]),
+            _ => {}
+        }
+    }
+
+    let page_data = tune_file.pages.get(&constant.page).ok_or_else(|| {
+        format!(
+            "'{}' lives on page {}, which the loaded tune does not contain.",
+            constant.name, constant.page
+        )
+    })?;
+
+    let offset = constant.offset as usize;
+    let total_bytes = element_count * element_size;
+    if offset + total_bytes > page_data.len() {
+        return Err(format!(
+            "'{}' needs {total_bytes} bytes at offset {offset} of page {}, which holds                  only {}. Re-sync the tune and try again.",
+            constant.name,
+            constant.page,
+            page_data.len()
+        ));
+    }
+
+    let mut values = Vec::with_capacity(element_count);
+    for i in 0..element_count {
+        let elem_offset = offset + i * element_size;
+        let raw_val = constant
+            .data_type
+            .read_from_bytes(page_data, elem_offset, endianness)
+            .ok_or_else(|| {
+                format!(
+                    "Element {i} of {element_count} in '{}' could not be decoded from                          page {}. Re-sync the tune and try again.",
+                    constant.name, constant.page
+                )
+            })?;
+        values.push(constant.raw_to_display(raw_val));
+    }
+    Ok(values)
+}
+
 /// Helper function to get table data internally (avoids code duplication)
 pub(crate) async fn get_table_data_internal(
     state: &tauri::State<'_, AppState>,
@@ -116,53 +188,15 @@ pub(crate) async fn get_table_data_internal(
     // Read from tune file (offline mode)
     let tune_guard = state.current_tune.lock().await;
 
-    fn read_const_values(
-        constant: &Constant,
-        tune: Option<&TuneFile>,
-        endianness: libretune_core::ini::Endianness,
-    ) -> Vec<f64> {
-        let element_count = constant.shape.element_count();
-        let element_size = constant.data_type.size_bytes();
-        if let Some(tune_file) = tune {
-            if let Some(tune_value) = tune_file.constants.get(&constant.name) {
-                match tune_value {
-                    TuneValue::Array(arr) => return arr.clone(),
-                    TuneValue::Scalar(v) => return vec![*v],
-                    _ => {}
-                }
-            }
-
-            if let Some(page_data) = tune_file.pages.get(&constant.page) {
-                let offset = constant.offset as usize;
-                let total_bytes = element_count * element_size;
-                if offset + total_bytes <= page_data.len() {
-                    let mut values = Vec::with_capacity(element_count);
-                    for i in 0..element_count {
-                        let elem_offset = offset + i * element_size;
-                        if let Some(raw_val) =
-                            constant
-                                .data_type
-                                .read_from_bytes(page_data, elem_offset, endianness)
-                        {
-                            values.push(constant.raw_to_display(raw_val));
-                        } else {
-                            values.push(0.0);
-                        }
-                    }
-                    return values;
-                }
-            }
-        }
-        vec![0.0; element_count]
-    }
-
-    let x_bins_full = read_const_values(&x_const, tune_guard.as_ref(), endianness);
+    let x_bins_full = read_const_values(&x_const, tune_guard.as_ref(), endianness)?;
     let y_bins_full = if let Some(ref y) = y_const {
-        read_const_values(y, tune_guard.as_ref(), endianness)
+        read_const_values(y, tune_guard.as_ref(), endianness)?
     } else {
+        // A 2D table has no Y axis to read; this placeholder is not a value
+        // standing in for one that could not be read.
         vec![0.0]
     };
-    let z_flat = read_const_values(&z_const, tune_guard.as_ref(), endianness);
+    let z_flat = read_const_values(&z_const, tune_guard.as_ref(), endianness)?;
 
     let size_info = size_snapshot.map(|(mut info, cols_c, rows_c, defaults, max_elements)| {
         info.active_cols = dynamic_table::resolve_axis_count(
@@ -537,4 +571,78 @@ pub(crate) async fn update_constant_array_internal(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod read_const_values_tests {
+    use super::*;
+    use libretune_core::ini::{DataType, Endianness};
+    use libretune_core::tune::TuneFile;
+
+    /// One 4-element U08 constant at offset 2 of page 3.
+    fn constant() -> Constant {
+        Constant {
+            name: "veTable".to_string(),
+            page: 3,
+            offset: 2,
+            data_type: DataType::U08,
+            scale: 1.0,
+            translate: 0.0,
+            shape: libretune_core::ini::Shape::Array1D(4),
+            ..Default::default()
+        }
+    }
+
+    fn tune_with_page(bytes: Vec<u8>) -> TuneFile {
+        let mut t = TuneFile::default();
+        t.pages.insert(3, bytes);
+        t
+    }
+
+    #[test]
+    fn a_complete_page_reads_the_real_values() {
+        let t = tune_with_page(vec![0, 0, 10, 20, 30, 40]);
+        let v = read_const_values(&constant(), Some(&t), Endianness::Big).unwrap();
+        assert_eq!(v, vec![10.0, 20.0, 30.0, 40.0]);
+    }
+
+    /// The bug: a page too short for the constant used to return
+    /// `vec![0.0; element_count]`, which the editor showed as a real table of
+    /// zeros and sent back down update_table_data on the first edit.
+    #[test]
+    fn a_short_page_refuses_rather_than_returning_zeros() {
+        let t = tune_with_page(vec![0, 0, 10, 20]); // 2 of the 4 elements
+        let err = read_const_values(&constant(), Some(&t), Endianness::Big)
+            .expect_err("a page that cannot hold the constant must not answer");
+        assert!(err.contains("veTable") && err.contains("page 3"), "{err}");
+    }
+
+    #[test]
+    fn a_missing_page_refuses() {
+        let mut t = TuneFile::default();
+        t.pages.insert(9, vec![0; 64]); // some other page
+        let err = read_const_values(&constant(), Some(&t), Endianness::Big)
+            .expect_err("a tune without the page must not answer");
+        assert!(err.contains("page 3"), "{err}");
+    }
+
+    #[test]
+    fn no_tune_loaded_refuses() {
+        let err = read_const_values(&constant(), None, Endianness::Big)
+            .expect_err("no tune means no values");
+        assert!(err.contains("veTable"), "{err}");
+    }
+
+    /// Values that really are in the tune are still served from there - that
+    /// path never fabricated anything and is deliberately unchanged.
+    #[test]
+    fn a_stored_constant_is_served_from_the_tune() {
+        let mut t = tune_with_page(vec![0, 0, 10, 20, 30, 40]);
+        t.constants.insert(
+            "veTable".to_string(),
+            TuneValue::Array(vec![1.0, 2.0, 3.0, 4.0]),
+        );
+        let v = read_const_values(&constant(), Some(&t), Endianness::Big).unwrap();
+        assert_eq!(v, vec![1.0, 2.0, 3.0, 4.0], "the stored array wins");
+    }
 }


### PR DESCRIPTION
## What's wrong

Open a table whose page the loaded tune does not contain, or whose page is too short for it, and the editor shows a full grid of zeros. Nothing indicates anything failed.

`read_const_values` — the read behind `get_table_data`, in `crates/libretune-app/src-tauri/src/commands/table_internals.rs` — had three ways to fabricate:

- an element that would not decode became `0.0` (`:149` on main)
- a page present but too short for the constant fell through to the same place
- a missing page, or no tune at all, returned `vec![0.0; element_count]` (`:156`)

All three were handed to the frontend as `TableData`, indistinguishable from values that had actually been read.

## Why it matters

A table of zeros is not a recognisable failure. It looks like a table someone zeroed, which is a thing tuners do deliberately, so there is nothing to react to.

It also does not stay a display fault. The grid the editor is holding is what the toolbar operates on, and the first edit sends the whole array back down `update_table_data` — so a page that could not be *read* becomes a page that has been *written*. A zero VE or dwell table is the shape most likely to hurt if it is believed.

`read_axis_bins` and `read_table_z_values` already refuse these exact conditions. This is their Z-value counterpart, in the same file, and it did not.

## The fix

`read_const_values` returns `Result<Vec<f64>, String>` and errors on every fabrication path, naming the constant and the page. The three call sites propagate with `?`, so `get_table_data` fails instead of answering.

Deliberately unchanged:

- The `tune.constants` path. It returns values that really are in the tune, so nothing is fabricated there.
- The `vec![0.0]` placeholder for a 2D table's absent Y axis. That is a table with no Y axis, not a Y axis that could not be read.

All three frontend callers already handle a failed `get_table_data`: the tab restore at `App.tsx:584` falls through to its other content types, `refreshOpenTabs` (`App.tsx:1263`) keeps the tab's previous data, and `TableEditor2D.tsx:218` clears its size info. None of them needed changing, and none of them previously had a way to know a table was fake.

The function was a nested `fn` inside an async command taking `tauri::State`, so it could not be tested. Lifted to module scope.

## Testing

Five cases in `read_const_values_tests`, all against a 4-element U08 constant at offset 2 of page 3:

1. A complete page returns the real values — catches a guard that starts rejecting valid input.
2. A page holding 2 of the 4 elements errors, naming the constant and page — the short-page bug.
3. A tune carrying some other page errors — the missing-page bug.
4. No tune loaded errors.
5. A constant stored in `tune.constants` is still served from there — pins the path that was deliberately left alone.

## Risk

Medium, and it is a behaviour change rather than a code risk: conditions that previously produced a silent zero grid now produce an error, so a table that used to open showing zeros will not open. That is the intent, but it is the kind of change that surfaces as "a table stopped working" if a tune out there was relying on it.

The reviewer's judgement call is the no-tune-loaded case. Erroring there is consistent with the rest, and all three callers handle it, but it is the one path where "nothing loaded yet" and "something is wrong" are genuinely different situations sharing a return value. Splitting it out is defensible if you would rather.

Found by a completeness pass over PR #258 — the same bug class as the axis fix, in the same file, two hundred lines away.
