### PR TITLE
fix(basemap): write the generated map into tune.constants, not just pages

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/apply_base_map.rs
+++ b/crates/libretune-app/src-tauri/src/commands/apply_base_map.rs
@@ -95,23 +95,17 @@ pub async fn apply_base_map(
                 .write_to_bytes(&mut raw_data, offset, raw_val, endianness);
         }
 
-        cache.write_bytes(constant.page, constant.offset, &raw_data);
-
-        // Also update tune file page data
-        let page_data = tune.pages.entry(constant.page).or_insert_with(|| {
-            vec![
-                0u8;
-                def.page_sizes
-                    .get(constant.page as usize)
-                    .copied()
-                    .unwrap_or(256) as usize
-            ]
-        });
-        let start = constant.offset as usize;
-        let end = start + raw_data.len();
-        if end <= page_data.len() {
-            page_data[start..end].copy_from_slice(&raw_data);
-        }
+        crate::commands::table_internals::sync_constant_into_tune(
+            cache,
+            tune,
+            constant,
+            &raw_data,
+            def.page_sizes
+                .get(constant.page as usize)
+                .copied()
+                .unwrap_or(256) as usize,
+            libretune_core::tune::TuneValue::Array(flat.clone()),
+        );
 
         Ok(table.title.clone())
     }
@@ -144,22 +138,17 @@ pub async fn apply_base_map(
                 .write_to_bytes(&mut raw_data, offset, raw_val, endianness);
         }
 
-        cache.write_bytes(constant.page, constant.offset, &raw_data);
-
-        let page_data = tune.pages.entry(constant.page).or_insert_with(|| {
-            vec![
-                0u8;
-                def.page_sizes
-                    .get(constant.page as usize)
-                    .copied()
-                    .unwrap_or(256) as usize
-            ]
-        });
-        let start = constant.offset as usize;
-        let end = start + raw_data.len();
-        if end <= page_data.len() {
-            page_data[start..end].copy_from_slice(&raw_data);
-        }
+        crate::commands::table_internals::sync_constant_into_tune(
+            cache,
+            tune,
+            constant,
+            &raw_data,
+            def.page_sizes
+                .get(constant.page as usize)
+                .copied()
+                .unwrap_or(256) as usize,
+            libretune_core::tune::TuneValue::Array(final_values.clone()),
+        );
         Ok(())
     }
 
@@ -325,21 +314,17 @@ pub async fn apply_base_map(
                 constant
                     .data_type
                     .write_to_bytes(&mut raw_data, 0, raw_val, endianness);
-                cache.write_bytes(constant.page, constant.offset, &raw_data);
-                let page_data = tune.pages.entry(constant.page).or_insert_with(|| {
-                    vec![
-                        0u8;
-                        def.page_sizes
-                            .get(constant.page as usize)
-                            .copied()
-                            .unwrap_or(256) as usize
-                    ]
-                });
-                let start = constant.offset as usize;
-                let end = start + raw_data.len();
-                if end <= page_data.len() {
-                    page_data[start..end].copy_from_slice(&raw_data);
-                }
+                crate::commands::table_internals::sync_constant_into_tune(
+                    cache,
+                    tune,
+                    constant,
+                    &raw_data,
+                    def.page_sizes
+                        .get(constant.page as usize)
+                        .copied()
+                        .unwrap_or(256) as usize,
+                    libretune_core::tune::TuneValue::Scalar(rf),
+                );
                 applied.push(format!("reqFuel = {:.1} ms", rf));
                 break;
             }
@@ -357,21 +342,17 @@ pub async fn apply_base_map(
                     constant
                         .data_type
                         .write_to_bytes(&mut raw_data, 0, raw_val, endianness);
-                    cache.write_bytes(constant.page, constant.offset, &raw_data);
-                    let page_data = tune.pages.entry(constant.page).or_insert_with(|| {
-                        vec![
-                            0u8;
-                            def.page_sizes
-                                .get(constant.page as usize)
-                                .copied()
-                                .unwrap_or(256) as usize
-                        ]
-                    });
-                    let start = constant.offset as usize;
-                    let end = start + raw_data.len();
-                    if end <= page_data.len() {
-                        page_data[start..end].copy_from_slice(&raw_data);
-                    }
+                    crate::commands::table_internals::sync_constant_into_tune(
+                        cache,
+                        tune,
+                        constant,
+                        &raw_data,
+                        def.page_sizes
+                            .get(constant.page as usize)
+                            .copied()
+                            .unwrap_or(256) as usize,
+                        libretune_core::tune::TuneValue::Scalar(v),
+                    );
                 }
             }
         }

--- a/crates/libretune-app/src-tauri/src/commands/autotune_misc.rs
+++ b/crates/libretune-app/src-tauri/src/commands/autotune_misc.rs
@@ -287,7 +287,7 @@ pub async fn send_autotune_recommendations(
     // starves every other command that needs the definition (e.g. load_tune,
     // table views) for the duration of both serial transactions.
     let mut conn_guard = state.connection.lock().await;
-    let (constant, endianness, x_size, y_size, current_signature) = {
+    let (constant, endianness, x_size, y_size, current_signature, default_page_bytes) = {
         let def_guard = state.definition.lock().await;
         let def = def_guard.as_ref().ok_or("Definition not loaded")?;
         let table = def
@@ -298,12 +298,18 @@ pub async fn send_autotune_recommendations(
             .get(&table.map)
             .ok_or_else(|| format!("Constant {} not found for table {}", table.map, table_name))?
             .clone();
+        let default_page_bytes = def
+            .page_sizes
+            .get(constant.page as usize)
+            .copied()
+            .unwrap_or(256) as usize;
         (
             constant,
             def.endianness,
             table.x_size,
             table.y_size,
             def.signature.clone(),
+            default_page_bytes,
         )
     };
     let conn = conn_guard.as_mut().ok_or("Not connected to ECU")?;
@@ -383,15 +389,36 @@ pub async fn send_autotune_recommendations(
         can_id: 0,
         page: constant.page,
         offset: constant.offset,
-        data: raw_out,
+        data: raw_out.clone(),
     };
 
     conn.write_memory(write_params).map_err(|e| e.to_string())?;
+    drop(conn_guard);
+
+    // The ECU is now running these values, so the app has to be showing them.
+    // This used to stop at the write: the engine took the new VE table while
+    // every table view, the AFR-target resolver and the next AutoTune session
+    // all kept serving the pre-apply numbers out of the cache until something
+    // unrelated triggered a re-sync. A tuner comparing screen against engine
+    // had no way to tell which was current - and the doc comment on this
+    // function has always claimed it updated both.
+    let mut cache_guard = state.tune_cache.lock().await;
+    if let Some(cache) = cache_guard.as_mut() {
+        crate::commands::table_internals::mirror_write_into_tune(
+            &state,
+            cache,
+            &constant,
+            &raw_out,
+            default_page_bytes,
+            &values,
+        )
+        .await;
+    }
 
     tracing::info!(
         table = %table_name,
         cells_written = recs.len(),
-        "send_autotune_recommendations: written to ECU RAM (burn separately to persist)"
+        "send_autotune_recommendations: written to ECU RAM and mirrored into the tune (burn separately to persist)"
     );
     Ok(())
 }

--- a/crates/libretune-app/src-tauri/src/commands/table_internals.rs
+++ b/crates/libretune-app/src-tauri/src/commands/table_internals.rs
@@ -8,17 +8,46 @@ use libretune_core::ini::Constant;
 use libretune_core::tune::{TuneFile, TuneValue};
 use serde::Serialize;
 
-/// Mirror a table/axis write into the in-memory tune, so what the screen shows
-/// matches what the ECU was just sent.
+/// Keep the three representations of one constant in step.
 ///
-/// Three things have to move together or the app quietly disagrees with the
-/// engine: the `TuneCache` page bytes, the `TuneFile` page bytes, and
-/// `tune.constants` - offline reads prefer the parsed msq constants over page
-/// data (`read_const_values` checks `tune.constants` first), so leaving those
-/// stale makes an accepted write revert on the next read while the ECU has
-/// already taken it. PR #59 established the invariant for `update_table_data`;
-/// this is the same block the internal helpers and AutoTune's apply each need.
+/// A written value lives in three places and they have to move together: the
+/// `TuneCache` page bytes, the `TuneFile` page bytes, and `tune.constants`.
+/// Offline reads prefer the parsed msq constants over page data
+/// (`read_const_values` checks `tune.constants` first) and `save_msq`
+/// serialises *only* constants - page bytes are never emitted - so leaving the
+/// constants leg out means the value is absent from the file that was just
+/// saved, while the cache and pages both hold it.
 ///
+/// `set_constant_with_page` rather than a bare `constants.insert`: `save_msq`
+/// groups by `constant_pages`, so a constant the tune did not already carry
+/// would otherwise be written out under page 0.
+pub(crate) fn sync_constant_into_tune(
+    cache: &mut libretune_core::tune::TuneCache,
+    tune: &mut TuneFile,
+    constant: &Constant,
+    raw_data: &[u8],
+    default_page_bytes: usize,
+    value: TuneValue,
+) {
+    // TuneCache::write_bytes creates the page if absent and grows it if short,
+    // so it has no failure path to branch on.
+    cache.write_bytes(constant.page, constant.offset, raw_data);
+
+    let page_data = tune
+        .pages
+        .entry(constant.page)
+        .or_insert_with(|| vec![0u8; default_page_bytes]);
+    let start = constant.offset as usize;
+    let end = start + raw_data.len();
+    if end <= page_data.len() {
+        page_data[start..end].copy_from_slice(raw_data);
+    }
+
+    tune.set_constant_with_page(constant.name.clone(), value, constant.page);
+}
+
+/// [`sync_constant_into_tune`] for callers that hold `AppState` rather than the
+/// tune itself, marking the tune modified afterwards.
 pub(crate) async fn mirror_write_into_tune(
     state: &AppState,
     cache: &mut libretune_core::tune::TuneCache,
@@ -27,23 +56,19 @@ pub(crate) async fn mirror_write_into_tune(
     default_page_bytes: usize,
     values: &[f64],
 ) {
-    // TuneCache::write_bytes creates the page if absent and grows it if short,
-    // so it has no failure path to branch on.
-    cache.write_bytes(constant.page, constant.offset, raw_data);
-
     let mut tune_guard = state.current_tune.lock().await;
     if let Some(tune) = tune_guard.as_mut() {
-        let page_data = tune
-            .pages
-            .entry(constant.page)
-            .or_insert_with(|| vec![0u8; default_page_bytes]);
-        let start = constant.offset as usize;
-        let end = start + raw_data.len();
-        if end <= page_data.len() {
-            page_data[start..end].copy_from_slice(raw_data);
-        }
-        tune.constants
-            .insert(constant.name.clone(), TuneValue::Array(values.to_vec()));
+        sync_constant_into_tune(
+            cache,
+            tune,
+            constant,
+            raw_data,
+            default_page_bytes,
+            TuneValue::Array(values.to_vec()),
+        );
+    } else {
+        // No tune open: the cache is still the live view, so keep it current.
+        cache.write_bytes(constant.page, constant.offset, raw_data);
     }
     drop(tune_guard);
 
@@ -544,4 +569,93 @@ pub(crate) async fn update_constant_array_internal(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod sync_constant_into_tune_tests {
+    use super::*;
+    use libretune_core::ini::{DataType, EcuDefinition, Endianness, Shape};
+    use libretune_core::tune::{TuneCache, TuneFile};
+
+    fn def_and_constant() -> (EcuDefinition, Constant) {
+        let mut def = EcuDefinition {
+            page_sizes: vec![0, 0, 0, 64],
+            n_pages: 4,
+            signature: "test".to_string(),
+            ..Default::default()
+        };
+        let c = Constant {
+            name: "veTable".to_string(),
+            page: 3,
+            offset: 2,
+            data_type: DataType::U08,
+            scale: 1.0,
+            translate: 0.0,
+            shape: Shape::Array1D(4),
+            ..Default::default()
+        };
+        def.constants.insert(c.name.clone(), c.clone());
+        (def, c)
+    }
+
+    /// The bug this closes: apply_base_map wrote the cache and tune.pages, then
+    /// saved the msq - and save_msq serialises only `constants`, which nothing
+    /// had written. The generated map was absent from the file it just wrote.
+    #[test]
+    fn a_synced_constant_survives_a_save_and_reload() {
+        let (def, c) = def_and_constant();
+        let mut cache = TuneCache::from_definition(&def);
+        let mut tune = TuneFile::default();
+        tune.signature = "test".to_string();
+
+        sync_constant_into_tune(
+            &mut cache,
+            &mut tune,
+            &c,
+            &[10, 20, 30, 40],
+            64,
+            TuneValue::Array(vec![10.0, 20.0, 30.0, 40.0]),
+        );
+
+        let dir = std::env::temp_dir().join("libretune-sync-test");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("CurrentTune.msq");
+        tune.save(&path).expect("save");
+
+        let reloaded = TuneFile::load(&path).expect("reload");
+        match reloaded.constants.get("veTable") {
+            Some(TuneValue::Array(a)) => assert_eq!(a, &vec![10.0, 20.0, 30.0, 40.0]),
+            other => panic!("veTable did not survive the save: {other:?}"),
+        }
+        assert_eq!(
+            reloaded.constant_pages.get("veTable"),
+            Some(&3),
+            "the page must survive too, or save_msq groups it under page 0"
+        );
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn all_three_representations_move_together() {
+        let (def, c) = def_and_constant();
+        let mut cache = TuneCache::from_definition(&def);
+        let mut tune = TuneFile::default();
+
+        sync_constant_into_tune(
+            &mut cache,
+            &mut tune,
+            &c,
+            &[1, 2, 3, 4],
+            64,
+            TuneValue::Array(vec![1.0, 2.0, 3.0, 4.0]),
+        );
+
+        assert_eq!(
+            cache.read_bytes(3, 2, 4),
+            Some(&[1u8, 2, 3, 4][..]),
+            "cache"
+        );
+        assert_eq!(&tune.pages[&3][2..6], &[1u8, 2, 3, 4], "tune pages");
+        assert!(tune.constants.contains_key("veTable"), "tune constants");
+    }
 }

--- a/crates/libretune-app/src-tauri/src/commands/table_internals.rs
+++ b/crates/libretune-app/src-tauri/src/commands/table_internals.rs
@@ -8,6 +8,48 @@ use libretune_core::ini::Constant;
 use libretune_core::tune::{TuneFile, TuneValue};
 use serde::Serialize;
 
+/// Mirror a table/axis write into the in-memory tune, so what the screen shows
+/// matches what the ECU was just sent.
+///
+/// Three things have to move together or the app quietly disagrees with the
+/// engine: the `TuneCache` page bytes, the `TuneFile` page bytes, and
+/// `tune.constants` - offline reads prefer the parsed msq constants over page
+/// data (`read_const_values` checks `tune.constants` first), so leaving those
+/// stale makes an accepted write revert on the next read while the ECU has
+/// already taken it. PR #59 established the invariant for `update_table_data`;
+/// this is the same block the internal helpers and AutoTune's apply each need.
+///
+pub(crate) async fn mirror_write_into_tune(
+    state: &AppState,
+    cache: &mut libretune_core::tune::TuneCache,
+    constant: &Constant,
+    raw_data: &[u8],
+    default_page_bytes: usize,
+    values: &[f64],
+) {
+    // TuneCache::write_bytes creates the page if absent and grows it if short,
+    // so it has no failure path to branch on.
+    cache.write_bytes(constant.page, constant.offset, raw_data);
+
+    let mut tune_guard = state.current_tune.lock().await;
+    if let Some(tune) = tune_guard.as_mut() {
+        let page_data = tune
+            .pages
+            .entry(constant.page)
+            .or_insert_with(|| vec![0u8; default_page_bytes]);
+        let start = constant.offset as usize;
+        let end = start + raw_data.len();
+        if end <= page_data.len() {
+            page_data[start..end].copy_from_slice(raw_data);
+        }
+        tune.constants
+            .insert(constant.name.clone(), TuneValue::Array(values.to_vec()));
+    }
+    drop(tune_guard);
+
+    *state.tune_modified.lock().await = true;
+}
+
 #[derive(Serialize)]
 pub(crate) struct TableData {
     pub name: String,
@@ -365,33 +407,15 @@ pub(crate) async fn update_table_z_values_internal(
 
     // Write to TuneCache if available
     if let Some(cache) = cache_guard.as_mut() {
-        if cache.write_bytes(constant.page, constant.offset, &raw_data) {
-            // Also update TuneFile in memory
-            let mut tune_guard = state.current_tune.lock().await;
-            if let Some(tune) = tune_guard.as_mut() {
-                let page_data = tune
-                    .pages
-                    .entry(constant.page)
-                    .or_insert_with(|| vec![0u8; default_page_bytes]);
-                let start = constant.offset as usize;
-                let end = start + raw_data.len();
-                if end <= page_data.len() {
-                    page_data[start..end].copy_from_slice(&raw_data);
-                }
-
-                // Offline reads prefer the parsed msq constants over page
-                // data (read_const_values checks tune.constants first), so
-                // keep them in sync or every toolbar op silently reverts on
-                // the next read while a connected ECU has already taken the
-                // write. Same invariant PR #59 established for
-                // update_table_data; these internal helpers were missed.
-                tune.constants.insert(
-                    constant.name.clone(),
-                    libretune_core::tune::TuneValue::Array(flat_values.clone()),
-                );
-            }
-            *state.tune_modified.lock().await = true;
-        }
+        mirror_write_into_tune(
+            state,
+            cache,
+            &constant,
+            &raw_data,
+            default_page_bytes,
+            &flat_values,
+        )
+        .await;
     }
 
     // Write to ECU if connected (optional)
@@ -493,32 +517,15 @@ pub(crate) async fn update_constant_array_internal(
     }
 
     if let Some(cache) = cache_guard.as_mut() {
-        if cache.write_bytes(constant.page, constant.offset, &raw_data) {
-            let mut tune_guard = state.current_tune.lock().await;
-            if let Some(tune) = tune_guard.as_mut() {
-                let page_data = tune
-                    .pages
-                    .entry(constant.page)
-                    .or_insert_with(|| vec![0u8; default_page_bytes]);
-
-                let start = constant.offset as usize;
-                let end = start + raw_data.len();
-                if end <= page_data.len() {
-                    page_data[start..end].copy_from_slice(&raw_data);
-                }
-
-                // Same tune.constants sync as above: without it, rebin_table's
-                // axis write "succeeds", the next get_table_data serves the old
-                // bins from tune.constants, and the new axis is lost — while
-                // the ECU already received it.
-                tune.constants.insert(
-                    constant.name.clone(),
-                    libretune_core::tune::TuneValue::Array(values.clone()),
-                );
-            }
-
-            *state.tune_modified.lock().await = true;
-        }
+        mirror_write_into_tune(
+            state,
+            cache,
+            &constant,
+            &raw_data,
+            default_page_bytes,
+            &values,
+        )
+        .await;
     }
 
     if let Some(conn) = conn_guard.as_mut() {

--- a/crates/libretune-app/src-tauri/src/commands/table_update.rs
+++ b/crates/libretune-app/src-tauri/src/commands/table_update.rs
@@ -65,34 +65,15 @@ pub async fn update_table_data(
 
     // Always write to TuneCache if available (enables offline editing)
     if let Some(cache) = cache_guard.as_mut() {
-        if cache.write_bytes(constant.page, constant.offset, &raw_data) {
-            // Also update TuneFile in memory
-            let mut tune_guard = state.current_tune.lock().await;
-            if let Some(tune) = tune_guard.as_mut() {
-                // Get or create page data
-                let page_data = tune
-                    .pages
-                    .entry(constant.page)
-                    .or_insert_with(|| vec![0u8; default_page_bytes]);
-
-                // Update the page data
-                let start = constant.offset as usize;
-                let end = start + raw_data.len();
-                if end <= page_data.len() {
-                    page_data[start..end].copy_from_slice(&raw_data);
-                }
-
-                // Offline reads prefer the parsed msq constants over page data,
-                // so keep them in sync or edits revert on reload
-                tune.constants.insert(
-                    constant.name.clone(),
-                    libretune_core::tune::TuneValue::Array(flat_values.clone()),
-                );
-            }
-
-            // Mark tune as modified
-            *state.tune_modified.lock().await = true;
-        }
+        crate::commands::table_internals::mirror_write_into_tune(
+            &state,
+            cache,
+            &constant,
+            &raw_data,
+            default_page_bytes,
+            &flat_values,
+        )
+        .await;
     }
 
     // Write to ECU if connected (optional - offline mode works without this)


### PR DESCRIPTION
> **Stacked on #259** for the shared helper. Review that one first; this diff is against its branch.

## What's wrong

Generate a base map, apply it, save, reopen the project — the base map is gone. The table views keep showing the pre-base-map tune the whole time.

`apply_base_map` writes each generated table, axis and scalar into the `TuneCache` and into `tune.pages`, syncs the cache back over `tune.pages` (`apply_base_map.rs:391-394`), then saves `CurrentTune.msq` (`:396`).

But `save_msq` serialises **only** `self.constants` (`crates/libretune-core/src/tune/file.rs:888-908`) — page bytes are never emitted — and `apply_base_map` has no `constants.insert` or `set_constant` anywhere. So the file it just wrote contains none of the map, and `get_table_data`, which prefers `tune.constants`, keeps serving the old values.

Four write sites, all with the same omission: `:98` (table Z), `:147` (axis bins), `:328` (reqFuel), `:360` (other scalars).

## Why it matters

This is the "start a new engine" path, so it is the first thing a tune ever gets and the point where nobody has a prior expectation to check it against. The failure is quiet in both directions: the app shows the old tune, the file holds the old tune, and the only thing that briefly held the new one was the cache.

It is the same invariant `mirror_write_into_tune` was extracted for in #259 — one write, three places that have to move together.

## The fix

`mirror_write_into_tune` locks `AppState`; these are nested helpers already holding `&mut TuneFile`, so the shared part becomes `sync_constant_into_tune(cache, tune, constant, raw_data, default_page_bytes, value)` and `mirror_write_into_tune` is now the `AppState`-locking wrapper around it. All four `apply_base_map` sites call it, which also removes four copies of the same page-entry-or-insert block.

One correctness change comes with the extraction: `set_constant_with_page` rather than a bare `constants.insert`. `save_msq` groups its output by `constant_pages`, so a constant the tune did not already carry would otherwise be written out under page 0. That matters here — a base map can introduce constants a fresh tune has never held — and it tightens #259's path too, where the VE table was only safe because a loaded tune already carried it.

`TuneValue::Scalar` for the two scalar sites rather than a one-element array, so `reqFuel` serialises as a scalar.

## Testing

Two cases in `sync_constant_into_tune_tests`:

1. **`a_synced_constant_survives_a_save_and_reload`** — syncs a constant, saves to a real `.msq`, reloads it, and asserts both the values and `constant_pages` survive. This is the actual bug: without the constants leg the reload returns `None`.
2. **`all_three_representations_move_together`** — asserts the cache bytes, the `tune.pages` bytes and `tune.constants` all carry the write.

Both were confirmed to fail with the `set_constant_with_page` line removed (`veTable did not survive the save: None`) and pass with it, so they bite rather than passing vacuously.

## Risk

Medium. The helper extraction touches #259's path as well as this one, so a mistake reaches both. Against that, the four sites it replaces were verbatim copies, and the behaviour added is strictly additive — nothing that was written before stops being written.

Worth a reviewer's attention: `TuneValue::Scalar` vs `Array` at the two scalar sites. `read_const_values` treats them equivalently, but `save_msq` does not, and I have changed what shape `reqFuel` takes in the file.
