### PR TITLE
fix(protocol): frame logger reads, and decode records as the wire sends them

### DIFF
--- a/crates/libretune-core/src/ini/diagnostic_logger.rs
+++ b/crates/libretune-core/src/ini/diagnostic_logger.rs
@@ -72,9 +72,8 @@ pub struct DiagnosticLogger {
 impl DiagnosticLogger {
     /// Decode one record into its declared fields.
     ///
-    /// Bit offsets are taken from the start of the record and read
-    /// little-endian, matching how Speeduino packs `refTime` and the composite
-    /// flag bits into the same 5 bytes.
+    /// Bit offsets count from the record's least significant bit, the record
+    /// being a big-endian integer - see [`read_bits`].
     pub fn decode(&self, record: &[u8]) -> Vec<(String, f64)> {
         self.fields
             .iter()
@@ -111,6 +110,24 @@ impl DiagnosticLogger {
 }
 
 /// Read `bit_count` bits starting at `start_bit`, little-endian within the record.
+/// Read `bit_count` bits starting at `start_bit` out of one log record.
+///
+/// The record is a big-endian integer and bit offsets count from its least
+/// significant bit - the last byte on the wire. Both loggers this INI declares
+/// fall out of that one rule, which is how it was arrived at: captures from a
+/// Speeduino 202501 at a known 1427 rpm, 36 teeth, so 1168 us per tooth.
+///
+/// Tooth records are four bytes, `toothTime` at bit 0 for 32 bits:
+///   `[00 00 04 94]` -> 0x494 = 1172 us. Read the other way round it is
+///   2,483,290,112 us, or forty-one minutes between two teeth.
+///
+/// Composite records are five, `priLevel`..`cycle` at bits 0-5 and `refTime` at
+/// bit 8 for 32 bits:
+///   `[00 01 eb e8 10]` -> flags 0x10 from the last byte, refTime 0x0001ebe8 =
+///   125,928 us. The flag bits genuinely are at the low end and the timestamp
+///   above them, which is only true when the record is read big-endian; the
+///   firmware writes that timestamp with `serialWrite(uint32_t)`, which calls
+///   `reverse_bytes` before writing, i.e. big-endian on the wire.
 fn read_bits(record: &[u8], start_bit: u32, bit_count: u32) -> Option<u64> {
     if bit_count == 0 || bit_count > 64 {
         return None;
@@ -122,7 +139,8 @@ fn read_bits(record: &[u8], start_bit: u32, bit_count: u32) -> Option<u64> {
     let mut out: u64 = 0;
     for i in 0..bit_count as u64 {
         let bit = start_bit as u64 + i;
-        let byte = record[(bit / 8) as usize];
+        // Bit 0 is the low bit of the LAST byte, so index back from the end.
+        let byte = record[record.len() - 1 - (bit / 8) as usize];
         if byte >> (bit % 8) & 1 == 1 {
             out |= 1 << i;
         }
@@ -320,14 +338,30 @@ mod tests {
         assert_eq!(l[1].record_count(635), 127);
     }
 
+    /// Bytes captured from a Speeduino 202501 turning a 36-1 wheel at a known
+    /// 1427 rpm, which is 1168 us per tooth. The fixture is real wire data
+    /// rather than a constructed value: the previous one assumed the record was
+    /// little-endian and, being synthetic, agreed with itself.
     #[test]
     fn a_tooth_record_decodes_as_one_32_bit_microsecond_value() {
         let l = parse();
-        // 0x00012345 = 74565 us, little-endian
-        let got = l[0].decode(&[0x45, 0x23, 0x01, 0x00]);
-        assert_eq!(got.len(), 1);
-        assert_eq!(got[0].0, "toothTime");
-        assert!((got[0].1 - 74565.0).abs() < 1e-6, "got {}", got[0].1);
+        for (bytes, want) in [
+            ([0x00, 0x00, 0x04, 0x94], 1172.0),
+            ([0x00, 0x00, 0x04, 0x90], 1168.0),
+            // The gap. A 36-1 wheel reports one double-length tooth per
+            // revolution, and 2336 is exactly twice 1168 - which is what makes
+            // this fixture self-checking.
+            ([0x00, 0x00, 0x09, 0x20], 2336.0),
+        ] {
+            let got = l[0].decode(&bytes);
+            assert_eq!(got.len(), 1);
+            assert_eq!(got[0].0, "toothTime");
+            assert!(
+                (got[0].1 - want).abs() < 1e-6,
+                "{bytes:02x?} decoded to {} us, expected {want}",
+                got[0].1
+            );
+        }
     }
 
     /// The composite record packs flags and a 32-bit time into five bytes; the
@@ -335,19 +369,36 @@ mod tests {
     #[test]
     fn a_composite_record_splits_flags_from_the_timestamp() {
         let l = parse();
-        // byte0 bits: pri=1, sec=0, sync=1  -> 0b0001_0001 = 0x11
-        // bytes 1..5: refTime = 1000 -> 1.000 ms after the 0.001 scale
+        // Captured from the same run as the tooth fixture above: a 32-bit
+        // big-endian timestamp in bytes 0..4 and the flags in the last byte,
+        // which is the low end of the record.
+        //   0x0001ed28 = 126248 us -> 126.248 ms at the declared 0.001 scale
+        //   0x19 = 0b0001_1001 -> priLevel, trigger, sync
         let got: std::collections::HashMap<_, _> = l[1]
-            .decode(&[0x11, 0xE8, 0x03, 0x00, 0x00])
+            .decode(&[0x00, 0x01, 0xED, 0x28, 0x19])
             .into_iter()
             .collect();
         assert_eq!(got["priLevel"], 1.0);
         assert_eq!(got["secLevel"], 0.0);
         assert_eq!(got["sync"], 1.0);
         assert!(
-            (got["refTime"] - 1.0).abs() < 1e-9,
+            (got["refTime"] - 126.248).abs() < 1e-6,
             "got {}",
             got["refTime"]
+        );
+
+        // The next edge, half a tooth later: primary has gone low and the
+        // timestamp has advanced by ~584 us, half of 1168.
+        let next: std::collections::HashMap<_, _> = l[1]
+            .decode(&[0x00, 0x01, 0xEE, 0xF4, 0x10])
+            .into_iter()
+            .collect();
+        assert_eq!(next["priLevel"], 0.0);
+        assert_eq!(next["sync"], 1.0);
+        assert!(
+            (next["refTime"] - 126.708).abs() < 1e-6,
+            "got {}",
+            next["refTime"]
         );
     }
 

--- a/crates/libretune-core/src/protocol/connection.rs
+++ b/crates/libretune-core/src/protocol/connection.rs
@@ -2223,11 +2223,56 @@ impl Connection {
     /// Sends command bytes, waits up to `timeout` for the response, using an
     /// inter-character timeout of 50ms to detect end of transmission.
     /// Returns the raw response bytes.
+    /// Send a raw command and return the reply payload.
+    ///
+    /// Frames the command when the INI declares an envelope
+    /// (`messageEnvelopeFormat`), exactly as [`Self::send_raw_bytes`] already
+    /// does. The two used to disagree, and the consequences were not subtle.
+    ///
+    /// Speeduino locks legacy commands out for the rest of the session the
+    /// first time a CRC-framed command parses (`BIT_STATUS4_ALLOW_LEGACY_COMMS`),
+    /// so on a modern link an unframed `T` was not read as a command at all -
+    /// its `0x54` became the high byte of a two-byte length, and the firmware
+    /// then waited on a payload thousands of bytes long that was never coming.
+    ///
+    /// On a legacy link it reached `legacySerialCommand`, which answers a tooth
+    /// log from `sendToothLog_legacy` - marked `/* Blocking */` in the firmware,
+    /// and measured on the bench at 45 ms of stalled main loop for 508 bytes.
+    /// Ignition schedules are set from that loop, so a capture repeating every
+    /// 250 ms stops spark for 45 ms out of every 250, which is what a misfire
+    /// on a running engine looks like. The framed path yields every four bytes
+    /// (`SERIAL_TRANSMIT_TOOTH_INPROGRESS`) and does not stall it.
+    ///
+    /// Framing also fixes the read length. The envelope carries its own
+    /// two-byte count, so the reply is read to a declared size instead of
+    /// guessed at by the inter-character silence timer below - which ended a
+    /// chunked transfer at the first pause and returned 137 bytes of 508.
+    ///
+    /// The INI's own `dataLength` is deliberately NOT used for this: the
+    /// Speeduino 202501 file declares it as 508 for the tooth logger ("in
+    /// bytes ... (not used)") and 127 for the composite logger ("Number of
+    /// records"), so the same key carries different units on adjacent blocks.
     pub fn send_raw_bytes_with_response(
         &mut self,
         bytes: &[u8],
         timeout: Duration,
     ) -> Result<Vec<u8>, ProtocolError> {
+        if self.use_modern_protocol {
+            let reply = self.send_packet(Packet::new(bytes.to_vec()))?;
+            // A framed reply leads with a return code; the legacy answer to the
+            // same command does not. Strip it here so both paths hand callers
+            // the same thing - otherwise every record is shifted one byte and
+            // the whole log decodes as garbage. `expected_data_len` is unknown
+            // for a raw command, so 0 selects the helper's leading-zero rule.
+            let payload = strip_status_byte(&reply.payload, 0, "raw command");
+            tracing::debug!(
+                "send_raw_bytes_with_response: framed reply, {} payload bytes -> {} after status byte",
+                reply.payload.len(),
+                payload.len()
+            );
+            return Ok(payload);
+        }
+
         let baud_rate = self.config.baud_rate;
         let min_wait = Some(self.get_effective_min_wait());
 


### PR DESCRIPTION
Verified end to end against a Speeduino 202501 on an ATmega2560, driven by a 36-1 trigger simulator at a known 1427 rpm — so 36 teeth per revolution, 1168 µs per tooth. Every number below is measured, not derived.

## What's wrong

The tooth and composite loggers return no usable data from a real ECU, and on a running engine the tooth logger causes misfires. Three defects stack up.

### 1. `send_raw_bytes_with_response` never frames the command

Its sibling `send_raw_bytes` has framed since envelope support landed:

```rust
if self.use_modern_protocol {
    let packet = Packet::new(bytes.to_vec());
    self.send_packet_no_response(packet)
```

`send_raw_bytes_with_response` goes straight to `write_and_wait`, unframed, always — while the INI declares `messageEnvelopeFormat = msEnvelope_1.0`.

The firmware makes that decision irreversible. On the first framed command that parses, `comms.cpp:527`:

```c
BIT_CLEAR(currentStatus.status4, BIT_STATUS4_ALLOW_LEGACY_COMMS); //Lock out legacy commands until next power cycle
```

So on a modern link the unframed `T` is not read as a command at all — its `0x54` becomes the high byte of a two-byte length and the firmware waits on a payload thousands of bytes long that never arrives.

On a legacy link it reaches `sendToothLog_legacy`, which the firmware itself marks `/* Blocking */`, in contrast to `sendCompositeLog_legacy` marked `/* Non-blocking */`. It pushes 508 bytes through a 64-byte TX buffer with no yield.

### 2. The framed return code is decoded as data

A framed reply leads with a return code; the legacy answer to the same command does not. Callers got a payload shifted one byte, so every record after it was misaligned.

### 3. Records are read little-endian; the wire is big-endian

`serialWrite(uint32_t)` calls `reverse_bytes` before writing, so both loggers emit timestamps most-significant byte first. `read_bits` read them the other way round.

## Why it matters

**The misfires are the serious part.** Measured on the bench: the unframed read blocks for **45.1 ms**, at every RPM, because it is transmission-bound (508 bytes × 10 bits ÷ 115200 = 44.1 ms). Ignition schedules are set from the main loop (`speeduino.ino:1073-1169`), and the capture loop repeats every 250 ms. Spark scheduling therefore stops for 45 ms out of every 250, indefinitely, while the view is open. At idle that is two thirds of a crank revolution; at 3000 rpm it is 2.2 revolutions.

Hammering the reads makes it unmistakable — main loop at 2838 rpm:

| | loops/s |
| --- | --- |
| idle polling | 1791 |
| unframed tooth read, continuous | 666 |

The framed path yields every four bytes (`SERIAL_TRANSMIT_TOOTH_INPROGRESS`) and does not stall the loop.

Worth noting the existing 1500 rpm guard is treating a symptom. Sweeping 800 → 6500 rpm, a capture produced **zero sync loss at every step, up to 6061 rpm indicated** (3637 teeth/s) — the decoder ISR keeps up fine. And 45 ms at idle already drops sparks, so the guard does not prevent the problem it exists for.

The data was unusable regardless. Reads returned **137 bytes of 508**, because the reply was sized by an inter-character silence timer that ended the transfer at the firmware's first pause between chunks.

## The fix

Frame the command when the INI declares an envelope, strip the return code through the `strip_status_byte` helper the page reads already use, and read record bits as the wire sends them.

The envelope carries its own two-byte length, so the reply is read to a declared size rather than guessed at — framing fixes the truncation as a side effect.

**The INI's own `dataLength` is deliberately not used.** This file declares `508` for the tooth logger ("in bytes … (not used)") and `127` for the composite logger ("Number of records"): the same key carries different units on adjacent blocks, and one is marked unused. The envelope's self-described length is the reliable source.

One rule covers both record layouts: **the record is a big-endian integer and bit offsets count from its least significant bit.** Tooth records are four bytes with `toothTime` at bit 0; composite records are five with the flags at bits 0-5 and a 32-bit timestamp at bit 8, which is only true when read big-endian.

## Testing

Both decode tests now use captured wire bytes rather than constructed ones. The old fixtures were built from the same little-endian assumption as the code, so they agreed with it and passed while the feature was broken.

The tooth fixture is self-checking: `[00 00 09 20]` is 2336 µs, exactly twice the 1168 µs of its neighbours — the double-length tooth a 36-1 wheel reports once per revolution. If the byte order regresses, that relationship breaks.

The composite fixture uses two consecutive edges, 126.248 ms and 126.708 ms — 460 µs apart, about half a tooth period, which is the edge spacing of a 50 % duty signal.

Results on hardware after the fix:

```
TOOTH      508 bytes, 127 records:  1172, 1168, 2336, 1164, 1168, 1172 us
COMPOSITE  635 bytes, 127 records:  priLevel alternating 1/0, sync=1 throughout,
                                    refTime monotonic at ~584 us intervals
```

785 core tests and 80 app tests pass. Clippy unchanged from baseline.

## Risk

Medium. This changes the wire behaviour of a shared function, so anything else calling `send_raw_bytes_with_response` on a modern link now gets a framed exchange instead of raw bytes. That is the correct behaviour for every caller I can find, and matches what `send_raw_bytes` has always done — but it is the thing to check hardest.

## Not fixed here

The capture loop still reads every 250 ms on a fixed timer and ignores the INI's `dataReadyCondition = { toothLog1Ready == 1 }`. With the blocking transmit gone that is no longer a misfire risk, but polling a declared ready flag would be better than a guess. Separate change.
