### PR TITLE
feat(ini): official online INI sources (rusEFI/epicEFI bundles, Speeduino releases, FOME per-board) + listing cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,57 @@ relevant.
 
 ## [Unreleased]
 
+### 2026-08-26 — Online INI sources: official rusEFI/epicEFI bundle servers, Speeduino releases
+
+First slice of #181's coverage gap: the online INI repository now downloads
+from each platform's *official* definition source instead of only GitHub
+directory listings, and the auto-search can actually find matches.
+
+#### Added
+- **epicEFI online INI source** — `content.epicefi.com/firmware/ini/`, a
+  rusEFI white-label publishing the same
+  `{branch}/{year}/{month}/{day}/{board}/{hash}.ini` bundle layout. New
+  `IniSource::EpicEFI`, wired through `download_ini` and the browse dialog.
+- **rusEFI/epicEFI direct signature→URL resolution** — a `rusEFI`-style
+  signature (`rusEFI master.2026.08.26.proteus_f4.1739931529`) encodes the
+  exact bundle path, so `search(Some(sig))` now derives the INI URL directly
+  (new `BundleSignature` parser, same format rusEFI's own console uses) and
+  verifies it with a HEAD probe. Works for *any* published firmware, not just
+  the newest day.
+- **Speeduino release INIs** — the `.ini` asset attached to each tagged
+  firmware release (e.g. `202501.7`) is now listed alongside the
+  master-tracking `reference/speeduino.ini`, so released firmware gets its
+  matching definition.
+- **Apache autoindex browse walk** — signature-less search walks each
+  autoindex server down to the newest day and lists every board's INI
+  (concurrently, semaphore-capped at 8) so the "Search for INI Online"
+  dialog shows real, per-board definitions for rusEFI and epicEFI.
+- Live-network tests (ignored by default) for the bundle-URL derivation and
+  the full-source browse walk.
+
+#### Changed
+- **rusEFI source moved from GitHub fragments to the official bundle server**
+  (`rusefi.com/online/ini/rusefi/`) — the old GitHub `contents/firmware/
+  tunerstudio` listing only exposed fragment INIs (`gauge_declarations.ini`,
+  `top_level_menu.ini`, …) that are not loadable definitions.
+- **FOME source now points at `firmware/tunerstudio/generated/`** — the
+  per-board generated INIs (`fome_proteus_f4.ini`, …) instead of the
+  fragment-only parent directory.
+- **Online signature matching rebuilt** — entries used to carry no signature
+  and required the file *name* to contain the full ECU signature verbatim, so
+  the mismatch auto-search could never match anything real. Entries now carry
+  reconstructed signatures (bundle paths, release tags) and match when every
+  file-name identity token (board, hash, version) appears in the ECU
+  signature's tokens.
+- Unit tests updated for the new endpoint structure; new tests cover
+  `BundleSignature` parsing/URL derivation, autoindex HTML link parsing, URL
+  joining, and token-based entry matching.
+
+#### Not yet covered
+- MegaSquirt MS2/MS3: AMP's firmware page is a Shopify portal with no
+  scrapeable direct-download listing (and MS firmware ships as zips); needs a
+  manual URL inventory or zip extraction support.
+
 ### 2026-08-23 — Dashboard performance & readability (issue #82)
 
 The dashboard redraw path was reworked around the three complaints in issue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,43 @@ relevant.
 
 ## [Unreleased]
 
+### 2026-08-26 — Online INI listing cache: instant dialog, manual refresh, background TTL refresh
+
+Follow-up to the online-sources work above: the multi-source listing scan
+(rusEFI + epicEFI walks are the slow part, ~8–30 s) no longer runs on every
+dialog open.
+
+#### Added
+- **Persisted listing cache** — the full listing is saved to
+  `<app_data>/online_ini_cache.json` after each successful scan and loaded on
+  the next session, so the "Search for INI Online" dialog opens instantly with
+  the previous results.
+- **"Listing last updated" display** — the dialog shows when the cached
+  listing was last refreshed from the network (RFC 3339 timestamp,
+  locale-formatted).
+- **Manual Refresh button** — `refresh_online_inis` command forces a network
+  re-scan bypassing the TTL; the button shows a spinning icon while running
+  and an amber notice ("Refresh failed — showing the cached listing") when
+  the network fails but a cache exists.
+- **Background TTL refresh** — `refresh_online_inis_if_stale` is polled every
+  30 minutes from the app; it is a no-op while the cache is fresh and refreshes
+  automatically once the 24 h TTL expires (`ONLINE_INI_CACHE_TTL_SECS`). Daily
+  matches the fastest upstream (rusEFI/epicEFI publish daily bundles), so new
+  firmware stays discoverable without a manual refresh.
+- Cache tests: save/load roundtrip (incl. corrupt-file and version-guard
+  cases), staleness by age, plus a live refresh→persist→reload test.
+
+#### Changed
+- **Refresh is non-clobbering** — the new listing is built off to the side and
+  only swapped in when at least one source responded; a total network failure
+  keeps the previous cache and timestamp instead of wiping it (offline-safe).
+  A partial failure (e.g. one of four sources down) keeps the other sources'
+  results and logs a warning.
+- **`search_online_inis` response extended** — now returns
+  `{ entries, last_updated, refreshed }` instead of a bare entry array; the
+  signature-mismatch dialog and connect wizard call sites updated.
+- First-load message now reads "Searching online repositories, please wait…".
+
 ### 2026-08-26 — Online INI sources: official rusEFI/epicEFI bundle servers, Speeduino releases
 
 First slice of #181's coverage gap: the online INI repository now downloads

--- a/crates/libretune-app/public/manual/changelog.md
+++ b/crates/libretune-app/public/manual/changelog.md
@@ -45,7 +45,7 @@ All notable changes to LibreTune will be documented in this file.
 - Dashboard tab protection (cannot be accidentally closed; recoverable via View → Dashboard)
 - Configurable status bar channels (Settings → Status Bar Channels, max 8)
 - INI signature mismatch dialog with local and online INI search (the online search now runs automatically when a mismatch is reported; downloading still requires an explicit click)
-- Online INI repository search from Speeduino, rusEFI, and FOME GitHub repos
+- Online INI repository search from official sources: Speeduino (GitHub + Releases), rusEFI and epicEFI (official bundle servers), FOME (generated per-board INIs)
 - Per-table `.table` file import/export (TunerStudio-compatible "Save/Load Table to File" from the table toolbar)
 - AFR Delay Test (Tools → AFR Delay Test…) — automated exhaust transport-delay measurement that steps fuel and reports the delay to enter as AutoTune's lambda delay
 - Resilient ECU sync with partial failure handling and status bar indicator

--- a/crates/libretune-app/public/manual/toc.json
+++ b/crates/libretune-app/public/manual/toc.json
@@ -1,316 +1,280 @@
 [
   {
-    "title": "Getting Started",
+    "title": "Installation",
     "path": "getting-started/installation",
-    "children": [
-      {
-        "title": "Installation",
-        "path": "getting-started/installation",
-        "children": []
-      },
-      {
-        "title": "Creating Your First Project",
-        "path": "getting-started/first-project",
-        "children": []
-      },
-      {
-        "title": "Connecting to Your ECU",
-        "path": "getting-started/connecting",
-        "children": []
-      },
-      {
-        "title": "Settings & Preferences",
-        "path": "getting-started/settings",
-        "children": []
-      }
-    ]
+    "children": []
   },
   {
-    "title": "Core Features",
+    "title": "Creating Your First Project",
+    "path": "getting-started/first-project",
+    "children": []
+  },
+  {
+    "title": "Connecting to Your ECU",
+    "path": "getting-started/connecting",
+    "children": []
+  },
+  {
+    "title": "Settings & Preferences",
+    "path": "getting-started/settings",
+    "children": []
+  },
+  {
+    "title": "Table Editing",
     "path": "features/table-editing",
     "children": [
       {
-        "title": "Table Editing",
-        "path": "features/table-editing",
-        "children": [
-          {
-            "title": "2D Tables",
-            "path": "features/table-editing/2d-tables",
-            "children": []
-          },
-          {
-            "title": "3D Visualization",
-            "path": "features/table-editing/3d-visualization",
-            "children": []
-          },
-          {
-            "title": "Keyboard Shortcuts",
-            "path": "features/table-editing/shortcuts",
-            "children": []
-          }
-        ]
-      },
-      {
-        "title": "AutoTune",
-        "path": "features/autotune",
-        "children": [
-          {
-            "title": "Usage Guide",
-            "path": "features/autotune/usage-guide",
-            "children": []
-          },
-          {
-            "title": "Setting Up AutoTune",
-            "path": "features/autotune/setup",
-            "children": []
-          },
-          {
-            "title": "Understanding Recommendations",
-            "path": "features/autotune/recommendations",
-            "children": []
-          },
-          {
-            "title": "Filters and Authority",
-            "path": "features/autotune/filters",
-            "children": []
-          }
-        ]
-      },
-      {
-        "title": "Dashboards",
-        "path": "features/dashboards",
-        "children": [
-          {
-            "title": "Using Dashboards",
-            "path": "features/dashboards/using",
-            "children": []
-          },
-          {
-            "title": "Customizing Gauges",
-            "path": "features/dashboards/customizing",
-            "children": []
-          },
-          {
-            "title": "Creating Dashboards",
-            "path": "features/dashboards/creating",
-            "children": []
-          },
-          {
-            "title": "Dashboard Validation",
-            "path": "features/dashboards/validation",
-            "children": []
-          }
-        ]
-      },
-      {
-        "title": "Math Channels",
-        "path": "features/math-channels",
+        "title": "2D Tables",
+        "path": "features/table-editing/2d-tables",
         "children": []
       },
       {
-        "title": "Data Logging",
-        "path": "features/datalog",
-        "children": []
-      },
-      {
-        "title": "Smart Recording",
-        "path": "features/smart-recording",
-        "children": []
-      },
-      {
-        "title": "Data Statistics",
-        "path": "features/data-statistics",
-        "children": []
-      },
-      {
-        "title": "Alert Rules",
-        "path": "features/alert-rules",
-        "children": []
-      },
-      {
-        "title": "Lua Scripting",
-        "path": "features/lua-scripting",
-        "children": []
-      },
-      {
-        "title": "Base Map Generator",
-        "path": "features/base-map",
-        "children": []
-      },
-      {
-        "title": "Performance Calculator",
-        "path": "features/performance-calculator",
-        "children": []
-      },
-      {
-        "title": "Diagnostic Loggers",
-        "path": "features/diagnostic-loggers",
-        "children": []
-      },
-      {
-        "title": "Tools",
-        "path": "features/tools",
-        "children": []
-      },
-      {
-        "title": "Pop-out Windows",
-        "path": "features/popout-windows",
-        "children": []
-      },
-      {
-        "title": "ECU Console",
-        "path": "features/ecu-console",
-        "children": []
-      },
-      {
-        "title": "AI Assistant",
-        "path": "features/ai-assistant",
-        "children": []
-      },
-      {
-        "title": "Tune Migration",
-        "path": "features/tune-migration",
-        "children": []
-      },
-      {
-        "title": "Hardware Configuration",
-        "path": "technical/port-editor",
-        "children": []
-      },
-      {
-        "title": "Action Scripting",
-        "path": "reference/action-scripting",
-        "children": []
-      }
-    ]
-  },
-  {
-    "title": "Project Management",
-    "path": "projects/tunes",
-    "children": [
-      {
-        "title": "Managing Tunes",
-        "path": "projects/tunes",
-        "children": []
-      },
-      {
-        "title": "Version Control",
-        "path": "projects/version-control",
-        "children": []
-      },
-      {
-        "title": "Change Annotations",
-        "path": "projects/change-annotations",
-        "children": []
-      },
-      {
-        "title": "Restore Points",
-        "path": "projects/restore-points",
-        "children": []
-      },
-      {
-        "title": "Importing Projects",
-        "path": "projects/importing",
-        "children": []
-      }
-    ]
-  },
-  {
-    "title": "Reference",
-    "path": "reference/supported-ecus",
-    "children": [
-      {
-        "title": "Supported ECUs",
-        "path": "reference/supported-ecus",
-        "children": []
-      },
-      {
-        "title": "INI File Format",
-        "path": "reference/ini-format",
+        "title": "3D Visualization",
+        "path": "features/table-editing/3d-visualization",
         "children": []
       },
       {
         "title": "Keyboard Shortcuts",
-        "path": "reference/shortcuts",
-        "children": []
-      },
-      {
-        "title": "Troubleshooting",
-        "path": "reference/troubleshooting",
-        "children": []
-      },
-      {
-        "title": "Java → WASM Migration",
-        "path": "reference/java-to-wasm-migration",
+        "path": "features/table-editing/shortcuts",
         "children": []
       }
     ]
   },
   {
-    "title": "Technical Reference",
+    "title": "AutoTune",
+    "path": "features/autotune",
+    "children": [
+      {
+        "title": "Usage Guide",
+        "path": "features/autotune/usage-guide",
+        "children": []
+      },
+      {
+        "title": "Setting Up AutoTune",
+        "path": "features/autotune/setup",
+        "children": []
+      },
+      {
+        "title": "Understanding Recommendations",
+        "path": "features/autotune/recommendations",
+        "children": []
+      },
+      {
+        "title": "Filters and Authority",
+        "path": "features/autotune/filters",
+        "children": []
+      }
+    ]
+  },
+  {
+    "title": "Dashboards",
+    "path": "features/dashboards",
+    "children": [
+      {
+        "title": "Using Dashboards",
+        "path": "features/dashboards/using",
+        "children": []
+      },
+      {
+        "title": "Customizing Gauges",
+        "path": "features/dashboards/customizing",
+        "children": []
+      },
+      {
+        "title": "Creating Dashboards",
+        "path": "features/dashboards/creating",
+        "children": []
+      },
+      {
+        "title": "Dashboard Validation",
+        "path": "features/dashboards/validation",
+        "children": []
+      }
+    ]
+  },
+  {
+    "title": "Math Channels",
+    "path": "features/math-channels",
+    "children": []
+  },
+  {
+    "title": "Data Logging",
+    "path": "features/datalog",
+    "children": []
+  },
+  {
+    "title": "Smart Recording",
+    "path": "features/smart-recording",
+    "children": []
+  },
+  {
+    "title": "Data Statistics",
+    "path": "features/data-statistics",
+    "children": []
+  },
+  {
+    "title": "Alert Rules",
+    "path": "features/alert-rules",
+    "children": []
+  },
+  {
+    "title": "Lua Scripting",
+    "path": "features/lua-scripting",
+    "children": []
+  },
+  {
+    "title": "Base Map Generator",
+    "path": "features/base-map",
+    "children": []
+  },
+  {
+    "title": "Performance Calculator",
+    "path": "features/performance-calculator",
+    "children": []
+  },
+  {
+    "title": "Diagnostic Loggers",
+    "path": "features/diagnostic-loggers",
+    "children": []
+  },
+  {
+    "title": "Tools",
+    "path": "features/tools",
+    "children": []
+  },
+  {
+    "title": "Pop-out Windows",
+    "path": "features/popout-windows",
+    "children": []
+  },
+  {
+    "title": "ECU Console",
+    "path": "features/ecu-console",
+    "children": []
+  },
+  {
+    "title": "AI Assistant",
+    "path": "features/ai-assistant",
+    "children": []
+  },
+  {
+    "title": "Tune Migration",
+    "path": "features/tune-migration",
+    "children": []
+  },
+  {
+    "title": "Hardware Configuration",
+    "path": "technical/port-editor",
+    "children": []
+  },
+  {
+    "title": "Action Scripting",
+    "path": "reference/action-scripting",
+    "children": []
+  },
+  {
+    "title": "Managing Tunes",
+    "path": "projects/tunes",
+    "children": []
+  },
+  {
+    "title": "Version Control",
+    "path": "projects/version-control",
+    "children": []
+  },
+  {
+    "title": "Change Annotations",
+    "path": "projects/change-annotations",
+    "children": []
+  },
+  {
+    "title": "Restore Points",
+    "path": "projects/restore-points",
+    "children": []
+  },
+  {
+    "title": "Importing Projects",
+    "path": "projects/importing",
+    "children": []
+  },
+  {
+    "title": "Supported ECUs",
+    "path": "reference/supported-ecus",
+    "children": []
+  },
+  {
+    "title": "INI File Format",
+    "path": "reference/ini-format",
+    "children": []
+  },
+  {
+    "title": "Keyboard Shortcuts",
+    "path": "reference/shortcuts",
+    "children": []
+  },
+  {
+    "title": "Troubleshooting",
+    "path": "reference/troubleshooting",
+    "children": []
+  },
+  {
+    "title": "Java → WASM Migration",
+    "path": "reference/java-to-wasm-migration",
+    "children": []
+  },
+  {
+    "title": "Overview",
     "path": "technical/README",
-    "children": [
-      {
-        "title": "Overview",
-        "path": "technical/README",
-        "children": []
-      },
-      {
-        "title": "AutoTune Algorithm",
-        "path": "technical/autotune-algorithm",
-        "children": []
-      },
-      {
-        "title": "Table Operations",
-        "path": "technical/table-operations",
-        "children": []
-      },
-      {
-        "title": "INI Parser",
-        "path": "technical/ini-parser",
-        "children": []
-      },
-      {
-        "title": "ECU Protocol",
-        "path": "technical/ecu-protocol",
-        "children": []
-      },
-      {
-        "title": "Version Control",
-        "path": "technical/version-control",
-        "children": []
-      },
-      {
-        "title": "Lua Scripting",
-        "path": "technical/lua-scripting",
-        "children": []
-      },
-      {
-        "title": "Plugin System",
-        "path": "technical/plugin-system",
-        "children": []
-      },
-      {
-        "title": "Port Editor",
-        "path": "technical/port-editor",
-        "children": []
-      },
-      {
-        "title": "AI Assistant",
-        "path": "technical/ai-assistant",
-        "children": []
-      }
-    ]
+    "children": []
   },
   {
-    "title": "FAQ",
+    "title": "AutoTune Algorithm",
+    "path": "technical/autotune-algorithm",
+    "children": []
+  },
+  {
+    "title": "Table Operations",
+    "path": "technical/table-operations",
+    "children": []
+  },
+  {
+    "title": "INI Parser",
+    "path": "technical/ini-parser",
+    "children": []
+  },
+  {
+    "title": "ECU Protocol",
+    "path": "technical/ecu-protocol",
+    "children": []
+  },
+  {
+    "title": "Version Control",
+    "path": "technical/version-control",
+    "children": []
+  },
+  {
+    "title": "Lua Scripting",
+    "path": "technical/lua-scripting",
+    "children": []
+  },
+  {
+    "title": "Plugin System",
+    "path": "technical/plugin-system",
+    "children": []
+  },
+  {
+    "title": "Port Editor",
+    "path": "technical/port-editor",
+    "children": []
+  },
+  {
+    "title": "AI Assistant",
+    "path": "technical/ai-assistant",
+    "children": []
+  },
+  {
+    "title": "Frequently Asked Questions",
     "path": "faq",
-    "children": [
-      {
-        "title": "Frequently Asked Questions",
-        "path": "faq",
-        "children": []
-      }
-    ]
+    "children": []
   }
 ]

--- a/crates/libretune-app/src-tauri/src/commands/online_ini.rs
+++ b/crates/libretune-app/src-tauri/src/commands/online_ini.rs
@@ -2,8 +2,9 @@
 
 use libretune_core::project::{IniSource, OnlineIniEntry};
 use serde::Serialize;
+use std::path::PathBuf;
 
-use crate::paths::get_definitions_dir;
+use crate::paths::{get_app_data_dir, get_definitions_dir};
 use crate::state::AppState;
 
 /// Serializable version of OnlineIniEntry for the frontend
@@ -30,6 +31,56 @@ impl From<OnlineIniEntry> for OnlineIniEntryResponse {
     }
 }
 
+/// Search / refresh results plus cache metadata for display.
+#[derive(Serialize)]
+pub struct OnlineIniListResponse {
+    pub entries: Vec<OnlineIniEntryResponse>,
+    /// RFC 3339 timestamp of the last successful network refresh.
+    pub last_updated: Option<String>,
+    /// True when this call performed a network refresh (vs. serving cache).
+    pub refreshed: bool,
+}
+
+/// Path of the persisted online-INI listing cache.
+fn online_cache_path(app: &tauri::AppHandle) -> PathBuf {
+    get_app_data_dir(app).join("online_ini_cache.json")
+}
+
+/// Ensure the repository holds a usable listing: load the persisted cache on
+/// first use, then refresh from the network when it is stale (or missing).
+/// A stale cache survives a failed refresh so offline use stays possible.
+/// Returns whether a network refresh happened.
+async fn ensure_repo_cache(
+    repo: &mut libretune_core::project::OnlineIniRepository,
+    app: &tauri::AppHandle,
+) -> Result<bool, String> {
+    if repo.entries().is_empty() {
+        match repo.load_cache(&online_cache_path(app)) {
+            Ok(_) => {}
+            Err(e) => eprintln!("Warning: online INI cache unreadable: {e}"),
+        }
+    }
+    if !repo.is_stale() {
+        return Ok(false);
+    }
+    match repo.refresh().await {
+        Ok(()) => {
+            if let Err(e) = repo.save_cache(&online_cache_path(app)) {
+                eprintln!("Warning: failed to persist online INI cache: {e}");
+            }
+            Ok(true)
+        }
+        Err(e) => {
+            if repo.entries().is_empty() {
+                // Nothing to fall back on — surface the failure.
+                return Err(format!("Failed to refresh online INIs: {e}"));
+            }
+            eprintln!("Warning: online INI refresh failed, serving stale cache: {e}");
+            Ok(false)
+        }
+    }
+}
+
 /// Check if we have internet connectivity
 #[tauri::command]
 pub async fn check_internet_connectivity(
@@ -40,20 +91,93 @@ pub async fn check_internet_connectivity(
 }
 
 /// Search for INI files online matching a signature.
-/// If signature is None, returns all available INIs.
+/// If signature is None, returns all available INIs. Serves the persisted
+/// cache when fresh; refreshes from the network when stale or missing.
 #[tauri::command]
 pub async fn search_online_inis(
+    app: tauri::AppHandle,
     state: tauri::State<'_, AppState>,
     signature: Option<String>,
-) -> Result<Vec<OnlineIniEntryResponse>, String> {
+) -> Result<OnlineIniListResponse, String> {
     let mut repo = state.online_ini_repository.lock().await;
+    let refreshed = ensure_repo_cache(&mut repo, &app).await?;
 
     let results = repo
         .search(signature.as_deref())
         .await
         .map_err(|e| format!("Failed to search online INIs: {}", e))?;
 
-    Ok(results.into_iter().map(|e| e.into()).collect())
+    Ok(OnlineIniListResponse {
+        entries: results.into_iter().map(|e| e.into()).collect(),
+        last_updated: repo.last_updated_rfc3339(),
+        refreshed,
+    })
+}
+
+/// Force a network refresh of the online INI listing, bypassing the cache
+/// TTL (the dialog's manual Refresh button). Falls back to the stale cache
+/// only when the refresh fails and one exists.
+#[tauri::command]
+pub async fn refresh_online_inis(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, AppState>,
+) -> Result<OnlineIniListResponse, String> {
+    let mut repo = state.online_ini_repository.lock().await;
+
+    let refreshed = match repo.refresh().await {
+        Ok(()) => {
+            if let Err(e) = repo.save_cache(&online_cache_path(&app)) {
+                eprintln!("Warning: failed to persist online INI cache: {e}");
+            }
+            true
+        }
+        Err(e) => {
+            if repo.entries().is_empty() {
+                return Err(format!("Failed to refresh online INIs: {e}"));
+            }
+            eprintln!("Warning: online INI refresh failed, keeping cache: {e}");
+            false
+        }
+    };
+
+    let results = repo
+        .search(None)
+        .await
+        .map_err(|e| format!("Failed to list online INIs: {}", e))?;
+
+    Ok(OnlineIniListResponse {
+        entries: results.into_iter().map(|e| e.into()).collect(),
+        last_updated: repo.last_updated_rfc3339(),
+        refreshed,
+    })
+}
+
+/// Refresh the online INI listing only when the cached one has expired past
+/// its TTL. Intended for a periodic background timer: a no-op while fresh.
+#[tauri::command]
+pub async fn refresh_online_inis_if_stale(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, AppState>,
+) -> Result<OnlineIniListResponse, String> {
+    let mut repo = state.online_ini_repository.lock().await;
+    if repo.entries().is_empty() {
+        if let Err(e) = repo.load_cache(&online_cache_path(&app)) {
+            eprintln!("Warning: online INI cache unreadable: {e}");
+        }
+    }
+    if !repo.is_stale() {
+        let results = repo
+            .search(None)
+            .await
+            .map_err(|e| format!("Failed to list online INIs: {}", e))?;
+        return Ok(OnlineIniListResponse {
+            entries: results.into_iter().map(|e| e.into()).collect(),
+            last_updated: repo.last_updated_rfc3339(),
+            refreshed: false,
+        });
+    }
+    drop(repo);
+    refresh_online_inis(app, state).await
 }
 
 /// Download an INI file from online repository

--- a/crates/libretune-app/src-tauri/src/commands/online_ini.rs
+++ b/crates/libretune-app/src-tauri/src/commands/online_ini.rs
@@ -71,6 +71,7 @@ pub async fn download_ini(
         "speeduino" => IniSource::Speeduino,
         "rusefi" => IniSource::RusEFI,
         "fome" => IniSource::Fome,
+        "epicefi" => IniSource::EpicEFI,
         _ => IniSource::Custom,
     };
 

--- a/crates/libretune-app/src-tauri/src/lib.rs
+++ b/crates/libretune-app/src-tauri/src/lib.rs
@@ -125,7 +125,10 @@ use commands::math_channels::{
 };
 use commands::menu::{get_menu_tree, get_searchable_index};
 use commands::metrics::stop_metrics_task;
-use commands::online_ini::{check_internet_connectivity, download_ini, search_online_inis};
+use commands::online_ini::{
+    check_internet_connectivity, download_ini, refresh_online_inis, refresh_online_inis_if_stale,
+    search_online_inis,
+};
 use commands::pin_conflicts::check_pin_conflicts;
 use commands::project_lifecycle::{create_project, open_project};
 use commands::project_listing::{get_projects_path, list_projects};
@@ -458,6 +461,8 @@ pub fn run() {
             // Online INI repository commands
             check_internet_connectivity,
             search_online_inis,
+            refresh_online_inis,
+            refresh_online_inis_if_stale,
             download_ini,
             // AI assistant
             agent_status,

--- a/crates/libretune-app/src/App.css
+++ b/crates/libretune-app/src/App.css
@@ -418,6 +418,16 @@ body {
   animation: demo-pulse 1.5s ease-in-out infinite;
 }
 
+/* Rotating icon utility (e.g. refresh-button spinners) */
+.icon-spinning {
+  animation: icon-spin 1s linear infinite;
+}
+
+@keyframes icon-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
 @keyframes demo-pulse {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.5; }

--- a/crates/libretune-app/src/App.tsx
+++ b/crates/libretune-app/src/App.tsx
@@ -430,6 +430,24 @@ function AppContent() {
     }
   }, [isTauri]);
 
+  // Keep the online INI listing cache fresh in the background. The TTL is
+  // enforced backend-side (24h — rusEFI/epicEFI publish daily bundles); this
+  // timer just polls `refresh_online_inis_if_stale`, which is a no-op while
+  // the cache is fresh and only hits the network once it has expired. That
+  // keeps the "Search for INI Online" dialog and the connect-wizard auto-match
+  // instant instead of paying a full multi-source scan on open.
+  useEffect(() => {
+    if (!isTauri) return;
+    const ONLINE_INI_REFRESH_CHECK_MS = 30 * 60 * 1000; // 30 min
+    const tick = () => {
+      invoke("refresh_online_inis_if_stale").catch((e) => {
+        console.warn("Background online-INI refresh failed:", e);
+      });
+    };
+    const interval = setInterval(tick, ONLINE_INI_REFRESH_CHECK_MS);
+    return () => clearInterval(interval);
+  }, [isTauri]);
+
   // Update window title with project name
   // Persist active tab state
   // Listen for reconnect:request, ini:changed, demo:changed events

--- a/crates/libretune-app/src/components/dialogs/ConnectEcuWizard.tsx
+++ b/crates/libretune-app/src/components/dialogs/ConnectEcuWizard.tsx
@@ -227,9 +227,11 @@ export default function ConnectEcuWizard({ isOpen, onClose, inis, onCreateProjec
       }
 
       // 3) Other firmwares: match against the repo listing.
-      const online = await invoke<OnlineIniEntry[]>("search_online_inis", { signature: sig }).catch(
-        () => [],
-      );
+      const online = await invoke<{ entries: OnlineIniEntry[] }>("search_online_inis", {
+        signature: sig,
+      })
+        .then((r) => r.entries)
+        .catch((): OnlineIniEntry[] => []);
       setOnlineResults(online);
     } finally {
       setResolving(false);

--- a/crates/libretune-app/src/components/dialogs/OnlineIniDialog.tsx
+++ b/crates/libretune-app/src/components/dialogs/OnlineIniDialog.tsx
@@ -90,8 +90,9 @@ export default function OnlineIniDialog({ isOpen, onClose }: OnlineIniDialogProp
     <Dialog open={isOpen} onClose={onClose} title="Search for INI Online" size="lg">
       <Dialog.Body>
         <p style={{ marginTop: 0, opacity: 0.8 }}>
-          Browse and download ECU definitions from the online repositories
-          (Speeduino, rusEFI, …). The selected file becomes the project's INI.
+          Browse and download ECU definitions from the official online sources
+          (Speeduino, rusEFI, epicEFI, FOME). The selected file becomes the
+          project's INI.
         </p>
 
         <div style={{ display: "flex", gap: "0.5rem", marginBottom: "0.75rem" }}>

--- a/crates/libretune-app/src/components/dialogs/OnlineIniDialog.tsx
+++ b/crates/libretune-app/src/components/dialogs/OnlineIniDialog.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { RefreshCw } from "lucide-react";
 import { Dialog, Button } from "../common";
 
 interface OnlineIniEntry {
@@ -9,6 +10,12 @@ interface OnlineIniEntry {
   download_url: string;
   repo_path: string;
   size: number | null;
+}
+
+interface OnlineIniListResponse {
+  entries: OnlineIniEntry[];
+  last_updated: string | null;
+  refreshed: boolean;
 }
 
 interface OnlineIniDialogProps {
@@ -22,15 +29,20 @@ interface OnlineIniDialogProps {
  * The signature-mismatch flow already offers online INI search when connecting
  * to an ECU, but only reactively. This exposes the same capability from the
  * menu so a user can browse and download a definition at any time (e.g. before
- * connecting, or in demo mode). It reuses the existing backend commands
- * `search_online_inis` (with no signature → list everything) and
- * `download_ini`, then switches the project to the downloaded file.
+ * connecting, or in demo mode).
+ *
+ * The listing is cached on disk by the backend: opening the dialog serves the
+ * cache instantly (refreshing in the background only when stale), and the
+ * Refresh button forces a network re-scan via `refresh_online_inis`.
  */
 export default function OnlineIniDialog({ isOpen, onClose }: OnlineIniDialogProps) {
   const [results, setResults] = useState<OnlineIniEntry[]>([]);
   const [filter, setFilter] = useState("");
   const [searching, setSearching] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+  const [lastUpdated, setLastUpdated] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
   const [downloading, setDownloading] = useState<string | null>(null);
   const [done, setDone] = useState<string | null>(null);
 
@@ -46,10 +58,13 @@ export default function OnlineIniDialog({ isOpen, onClose }: OnlineIniDialogProp
     setError(null);
     try {
       // No signature → the backend returns every known online definition.
-      const found = await invoke<OnlineIniEntry[]>("search_online_inis", {
+      // Serves the persisted cache when fresh; a full scan only happens when
+      // the cache is missing or older than its TTL.
+      const found = await invoke<OnlineIniListResponse>("search_online_inis", {
         signature: null,
       });
-      setResults(found);
+      setResults(found.entries);
+      setLastUpdated(found.last_updated);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     } finally {
@@ -57,9 +72,28 @@ export default function OnlineIniDialog({ isOpen, onClose }: OnlineIniDialogProp
     }
   }
 
+  async function refresh() {
+    setRefreshing(true);
+    setError(null);
+    setNotice(null);
+    try {
+      const fresh = await invoke<OnlineIniListResponse>("refresh_online_inis");
+      setResults(fresh.entries);
+      setLastUpdated(fresh.last_updated);
+      if (!fresh.refreshed) {
+        setNotice("Refresh failed — showing the cached listing.");
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setRefreshing(false);
+    }
+  }
+
   async function download(entry: OnlineIniEntry) {
     setDownloading(entry.download_url);
     setError(null);
+    setNotice(null);
     setDone(null);
     try {
       const path = await invoke<string>("download_ini", {
@@ -95,7 +129,7 @@ export default function OnlineIniDialog({ isOpen, onClose }: OnlineIniDialogProp
           project's INI.
         </p>
 
-        <div style={{ display: "flex", gap: "0.5rem", marginBottom: "0.75rem" }}>
+        <div style={{ display: "flex", gap: "0.5rem", alignItems: "center", marginBottom: "0.25rem" }}>
           <input
             type="text"
             value={filter}
@@ -103,13 +137,27 @@ export default function OnlineIniDialog({ isOpen, onClose }: OnlineIniDialogProp
             onChange={(e) => setFilter(e.target.value)}
             style={{ flex: 1 }}
           />
-          <Button variant="secondary" onClick={search} disabled={searching}>
-            {searching ? "Searching…" : "Refresh"}
+          <Button
+            variant="secondary"
+            onClick={refresh}
+            disabled={refreshing || searching || downloading !== null}
+            title="Re-scan all online sources now, ignoring the cache"
+          >
+            <RefreshCw size={14} style={{ marginRight: "0.35rem", verticalAlign: "-2px" }} className={refreshing ? "icon-spinning" : undefined} />
+            {refreshing ? "Refreshing…" : "Refresh"}
           </Button>
+        </div>
+        <div style={{ opacity: 0.65, fontSize: "0.85em", marginBottom: "0.75rem" }}>
+          {lastUpdated
+            ? `Listing last updated: ${new Date(lastUpdated).toLocaleString()}`
+            : "Listing not cached yet — first load scans all sources."}
         </div>
 
         {error && (
           <div style={{ color: "var(--color-error, #d33)", marginBottom: "0.5rem" }}>{error}</div>
+        )}
+        {notice && (
+          <div style={{ color: "var(--warning, #b80)", marginBottom: "0.5rem" }}>{notice}</div>
         )}
         {done && (
           <div style={{ color: "var(--color-success, #2a2)", marginBottom: "0.5rem" }}>{done}</div>
@@ -117,7 +165,9 @@ export default function OnlineIniDialog({ isOpen, onClose }: OnlineIniDialogProp
 
         <div style={{ maxHeight: "50vh", overflowY: "auto" }}>
           {searching && shown.length === 0 ? (
-            <div style={{ opacity: 0.7, padding: "1rem" }}>Searching online repositories…</div>
+            <div style={{ opacity: 0.7, padding: "1rem" }}>
+              Searching online repositories, please wait…
+            </div>
           ) : shown.length === 0 ? (
             <div style={{ opacity: 0.7, padding: "1rem" }}>No definitions found.</div>
           ) : (

--- a/crates/libretune-app/src/components/dialogs/SignatureMismatchDialog.tsx
+++ b/crates/libretune-app/src/components/dialogs/SignatureMismatchDialog.tsx
@@ -105,10 +105,10 @@ export default function SignatureMismatchDialog({
     setSearchError(null);
     
     try {
-      const results = await invoke<OnlineIniEntry[]>("search_online_inis", {
+      const response = await invoke<{ entries: OnlineIniEntry[] }>("search_online_inis", {
         signature: mismatchInfo.ecu_signature,
       });
-      setOnlineResults(results);
+      setOnlineResults(response.entries);
     } catch (e) {
       console.error("Failed to search online:", e);
       setSearchError(e instanceof Error ? e.message : String(e));

--- a/crates/libretune-core/src/project/mod.rs
+++ b/crates/libretune-core/src/project/mod.rs
@@ -32,7 +32,7 @@ mod version_control;
 pub use math_channels::{
     load_math_channels, math_channel_evaluation_order, save_math_channels, UserMathChannel,
 };
-pub use online_repository::{IniSource, OnlineIniEntry, OnlineIniRepository};
+pub use online_repository::{BundleSignature, IniSource, OnlineIniEntry, OnlineIniRepository};
 pub use project::{
     ConnectionSettings, Project, ProjectConfig, ProjectInfo, ProjectSettings, RestorePointInfo,
 };

--- a/crates/libretune-core/src/project/online_repository.rs
+++ b/crates/libretune-core/src/project/online_repository.rs
@@ -372,12 +372,36 @@ fn autoindex_entry(
     })
 }
 
+/// How long (seconds) a cached online-INI listing stays fresh before the
+/// next search refreshes it from the network. rusEFI and epicEFI publish new
+/// bundles daily, so a day matches the fastest-moving upstream; longer TTLs
+/// would leave brand-new firmware undiscoverable.
+pub const ONLINE_INI_CACHE_TTL_SECS: u64 = 24 * 60 * 60;
+
+/// On-disk representation of the cached listing (`online_ini_cache.json`).
+#[derive(Debug, Serialize, Deserialize)]
+pub struct OnlineIniCacheFile {
+    /// Bump when the format changes; loaders reject other versions.
+    pub version: u32,
+    /// RFC 3339 timestamp of the last successful network refresh.
+    pub last_updated: String,
+    /// The cached listing entries.
+    pub entries: Vec<OnlineIniEntry>,
+}
+
+impl OnlineIniCacheFile {
+    /// Version of the cache format this build writes and reads.
+    pub const CURRENT_VERSION: u32 = 1;
+}
+
 /// Online INI repository client
 pub struct OnlineIniRepository {
     /// HTTP client for API requests
     client: reqwest::Client,
     /// Cache of known INI entries (signature -> entry)
     cache: Vec<OnlineIniEntry>,
+    /// When the cache was last refreshed from the network (None = never).
+    last_updated: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 impl OnlineIniRepository {
@@ -397,6 +421,7 @@ impl OnlineIniRepository {
         OnlineIniRepository {
             client,
             cache: Vec::new(),
+            last_updated: None,
         }
     }
 
@@ -438,22 +463,131 @@ impl OnlineIniRepository {
         Ok(results)
     }
 
-    /// Refresh the cache by fetching INI lists from all sources
+    /// Refresh the cache by fetching INI lists from all sources.
+    ///
+    /// Builds the new listing off to the side and only swaps it in when at
+    /// least one source answered — a total failure (e.g. offline) keeps the
+    /// previous cache and its timestamp intact instead of wiping it.
     async fn refresh_cache(&mut self) -> Result<(), io::Error> {
-        self.cache.clear();
+        let mut fresh = Vec::new();
+        let mut failures = Vec::new();
 
         for &source in IniSource::online_sources() {
-            let entries = match self.list_source(source).await {
-                Ok(v) => v,
+            match self.list_source(source).await {
+                Ok(entries) => fresh.extend(entries),
                 Err(e) => {
-                    eprintln!("Warning: Failed to fetch INIs from {:?}: {e}", source);
-                    Vec::new()
+                    eprintln!("Warning: Failed to fetch INIs from {source:?}: {e}");
+                    failures.push((source, e));
                 }
-            };
-            self.cache.extend(entries);
+            }
         }
 
+        if fresh.is_empty() {
+            let detail = failures
+                .iter()
+                .map(|(s, e)| format!("{s:?}: {e}"))
+                .collect::<Vec<_>>()
+                .join("; ");
+            return Err(io::Error::other(format!(
+                "No online INI source responded ({detail})"
+            )));
+        }
+        if !failures.is_empty() {
+            eprintln!(
+                "Warning: online INI refresh incomplete, {} of {} sources failed",
+                failures.len(),
+                IniSource::online_sources().len()
+            );
+        }
+
+        self.cache = fresh;
+        self.last_updated = Some(chrono::Utc::now());
         Ok(())
+    }
+
+    /// Force a network refresh of the cached listing (see [`Self::refresh_cache`]).
+    pub async fn refresh(&mut self) -> Result<(), io::Error> {
+        self.refresh_cache().await
+    }
+
+    /// The cached listing entries.
+    pub fn entries(&self) -> &[OnlineIniEntry] {
+        &self.cache
+    }
+
+    /// When the cache was last refreshed (None = never refreshed).
+    pub fn last_updated(&self) -> Option<chrono::DateTime<chrono::Utc>> {
+        self.last_updated
+    }
+
+    /// `last_updated` formatted as RFC 3339, for display in the frontend.
+    pub fn last_updated_rfc3339(&self) -> Option<String> {
+        self.last_updated.map(|t| t.to_rfc3339())
+    }
+
+    /// True when the cache is empty or older than [`ONLINE_INI_CACHE_TTL_SECS`].
+    pub fn is_stale(&self) -> bool {
+        match self.last_updated {
+            None => true,
+            Some(t) => {
+                self.cache.is_empty()
+                    || (chrono::Utc::now() - t).num_seconds() > ONLINE_INI_CACHE_TTL_SECS as i64
+            }
+        }
+    }
+
+    /// Load a previously saved cache file. Returns `Ok(false)` when the file
+    /// does not exist yet (first run); a corrupt or unsupported file is an
+    /// error. Loading a stale-but-present cache is fine — callers decide
+    /// whether to refresh.
+    pub fn load_cache(&mut self, path: &Path) -> io::Result<bool> {
+        let bytes = match std::fs::read(path) {
+            Ok(b) => b,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(false),
+            Err(e) => return Err(e),
+        };
+        let file: OnlineIniCacheFile = serde_json::from_slice(&bytes)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        if file.version != OnlineIniCacheFile::CURRENT_VERSION {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "unsupported cache version {} (expected {})",
+                    file.version,
+                    OnlineIniCacheFile::CURRENT_VERSION
+                ),
+            ));
+        }
+        let parsed = chrono::DateTime::parse_from_rfc3339(&file.last_updated)
+            .map(|t| t.with_timezone(&chrono::Utc))
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        self.cache = file.entries;
+        self.last_updated = Some(parsed);
+        Ok(true)
+    }
+
+    /// Persist the cache so the next session starts without a network scan.
+    pub fn save_cache(&self, path: &Path) -> io::Result<()> {
+        let file = OnlineIniCacheFile {
+            version: OnlineIniCacheFile::CURRENT_VERSION,
+            last_updated: self
+                .last_updated
+                .map(|t| t.to_rfc3339())
+                .unwrap_or_else(|| chrono::Utc::now().to_rfc3339()),
+            entries: self.cache.clone(),
+        };
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let bytes = serde_json::to_vec_pretty(&file)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        std::fs::write(path, bytes)
+    }
+
+    /// Test hook: set the cache timestamp without sleeping.
+    #[cfg(test)]
+    fn set_last_updated_for_test(&mut self, t: chrono::DateTime<chrono::Utc>) {
+        self.last_updated = Some(t);
     }
 
     /// Fetch the current INI list from a single source (no caching). Exposed
@@ -878,6 +1012,64 @@ mod tests {
         assert_eq!(IniSource::Fome.display_name(), "FOME");
     }
 
+    fn sample_entry() -> OnlineIniEntry {
+        OnlineIniEntry {
+            source: IniSource::Speeduino,
+            name: "speeduino.ini".to_string(),
+            signature: None,
+            download_url: "https://example.com/speeduino.ini".to_string(),
+            repo_path: "reference/speeduino.ini".to_string(),
+            size: Some(1234),
+        }
+    }
+
+    #[test]
+    fn test_cache_save_load_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("sub").join("online_ini_cache.json");
+
+        let mut repo = OnlineIniRepository::new();
+        // Missing file: Ok(false), repo stays empty and stale.
+        assert!(!repo.load_cache(&path).unwrap());
+        assert!(repo.is_stale());
+        assert!(repo.entries().is_empty());
+
+        repo.cache = vec![sample_entry()];
+        repo.last_updated = Some(chrono::Utc::now());
+        repo.save_cache(&path).unwrap();
+
+        let mut loaded = OnlineIniRepository::new();
+        assert!(loaded.load_cache(&path).unwrap());
+        assert_eq!(loaded.entries().len(), 1);
+        assert_eq!(loaded.entries()[0].name, "speeduino.ini");
+        assert!(!loaded.is_stale());
+        assert!(loaded.last_updated().is_some());
+
+        // A corrupt file must be an error, not silently ignored.
+        std::fs::write(&path, b"{ not json").unwrap();
+        assert!(loaded.load_cache(&path).is_err());
+    }
+
+    #[test]
+    fn test_cache_staleness_by_age() {
+        let mut repo = OnlineIniRepository::new();
+        repo.cache = vec![sample_entry()];
+
+        // Older than the TTL -> stale.
+        let old =
+            chrono::Utc::now() - chrono::Duration::seconds(ONLINE_INI_CACHE_TTL_SECS as i64 + 60);
+        repo.set_last_updated_for_test(old);
+        assert!(repo.is_stale());
+
+        // Fresh timestamp with non-empty entries -> not stale.
+        repo.set_last_updated_for_test(chrono::Utc::now());
+        assert!(!repo.is_stale());
+
+        // An empty cache is always stale, whatever the timestamp says.
+        repo.cache.clear();
+        assert!(repo.is_stale());
+    }
+
     #[test]
     fn test_bundle_signature_parse_and_url() {
         let sig =
@@ -1023,5 +1215,28 @@ mod tests {
         assert!(results.iter().any(|e| e.source == IniSource::EpicEFI));
         assert!(results.iter().any(|e| e.source == IniSource::Speeduino));
         assert!(results.iter().any(|e| e.source == IniSource::Fome));
+    }
+
+    #[tokio::test]
+    #[ignore = "live network call"]
+    async fn live_refresh_then_cache_roundtrip_serves_next_instance() {
+        // Mirrors the app's ensure-cache flow: refresh from the network,
+        // persist, then a fresh repository instance loads the cache and is
+        // not stale (no second scan needed).
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("online_ini_cache.json");
+
+        let mut first = OnlineIniRepository::new();
+        assert!(first.is_stale());
+        first.refresh().await.unwrap();
+        assert!(!first.is_stale());
+        assert!(!first.entries().is_empty());
+        assert!(first.last_updated().is_some());
+        first.save_cache(&path).unwrap();
+
+        let mut second = OnlineIniRepository::new();
+        assert!(second.load_cache(&path).unwrap());
+        assert!(!second.is_stale());
+        assert_eq!(second.entries().len(), first.entries().len());
     }
 }

--- a/crates/libretune-core/src/project/online_repository.rs
+++ b/crates/libretune-core/src/project/online_repository.rs
@@ -1,20 +1,28 @@
 //! Online INI Repository
 //!
-//! Provides functionality to search for and download INI files from online
-//! repositories like GitHub (Speeduino, rusEFI, etc.).
+//! Provides functionality to search for and download INI files from the
+//! official per-platform definition sources:
 //!
-//! ## Supported Sources
-//!
-//! - Speeduino: https://github.com/noisymime/speeduino/tree/master/reference/tunerstudio
-//! - rusEFI: https://github.com/rusefi/rusefi/tree/master/firmware/tunerstudio
+//! - **Speeduino** — GitHub `reference/` (tracks master) plus the `.ini`
+//!   assets attached to each tagged firmware release on GitHub Releases
+//!   (what released firmware actually matches).
+//! - **rusEFI** — `https://rusefi.com/online/ini/rusefi/`, the same Apache
+//!   directory index the rusEFI console downloads from. Every published
+//!   bundle is addressable as
+//!   `{branch}/{year}/{month}/{day}/{board}/{hash}.ini`, and the firmware
+//!   signature encodes exactly those components.
+//! - **epicEFI** — `https://content.epicefi.com/firmware/ini/`, a rusEFI
+//!   white-label using the identical layout.
+//! - **FOME** — GitHub `firmware/tunerstudio/generated/` (the per-board
+//!   generated definitions; the parent directory only holds fragments).
 //!
 //! ## Usage
 //!
 //! ```ignore
 //! let online = OnlineIniRepository::new();
-//! let results = online.search("speeduino 202305").await?;
+//! let results = online.search(Some("rusEFI master.2026.06.07.proteus_f4.753206531")).await?;
 //! for entry in results {
-//!     println!("{}: {}", entry.name, entry.signature);
+//!     println!("{}: {:?}", entry.name, entry.signature);
 //! }
 //! online.download(&results[0], "./definitions/").await?;
 //! ```
@@ -30,11 +38,13 @@ pub struct OnlineIniEntry {
     pub source: IniSource,
     /// Display name
     pub name: String,
-    /// Firmware signature (if known)
+    /// Firmware signature (if known). For autoindex bundles this is
+    /// reconstructed from the path components; for release assets it is the
+    /// release tag.
     pub signature: Option<String>,
-    /// GitHub raw download URL
+    /// Direct download URL
     pub download_url: String,
-    /// File path within the repository
+    /// Path within the source repository / bundle tree
     pub repo_path: String,
     /// File size in bytes (if known)
     pub size: Option<u64>,
@@ -46,9 +56,14 @@ pub struct OnlineIniEntry {
 pub enum IniSource {
     Speeduino,
     RusEFI,
-    /// FOME — a rusEFI fork; its TunerStudio INIs live under
-    /// `FOME-Tech/fome-fw/firmware/tunerstudio`.
+    /// FOME — a rusEFI fork; its per-board TunerStudio INIs are generated
+    /// under `FOME-Tech/fome-fw/firmware/tunerstudio/generated`.
     Fome,
+    /// epicEFI — a rusEFI white-label for epicECU boards. Publishes its
+    /// TunerStudio INIs on `content.epicefi.com` in the same
+    /// `{branch}/{year}/{month}/{day}/{board}/{hash}.ini` layout as rusEFI,
+    /// with `epicEFI`-branded signatures.
+    EpicEFI,
     Custom,
 }
 
@@ -57,42 +72,60 @@ impl IniSource {
     ///
     /// `Custom` is intentionally excluded — it has no upstream URL and is only
     /// used to tag user-imported files. Add new upstream platforms here (and
-    /// give them URLs below) to widen auto-discovery coverage.
+    /// give them a listing endpoint below) to widen auto-discovery coverage.
     pub fn online_sources() -> &'static [IniSource] {
-        &[IniSource::Speeduino, IniSource::RusEFI, IniSource::Fome]
+        &[
+            IniSource::Speeduino,
+            IniSource::RusEFI,
+            IniSource::EpicEFI,
+            IniSource::Fome,
+        ]
     }
 
-    /// Get the GitHub API URL for searching this source
-    pub fn github_api_url(&self) -> Option<&'static str> {
+    /// Root of the Apache autoindex tree for platforms that publish their
+    /// TunerStudio INIs as
+    /// `{root}/{branch}/{year}/{month}/{day}/{board}/{hash}.ini`.
+    ///
+    /// - rusEFI: the same server the rusEFI console itself downloads from
+    ///   (their `RealIniFileProvider` resolves this exact URL shape).
+    /// - epicEFI: `content.epicefi.com`, identical layout.
+    pub fn autoindex_root(&self) -> Option<&'static str> {
         match self {
-            // The .ini used to live under reference/tunerstudio/, which no longer
-            // exists; the single canonical definition is reference/speeduino.ini.
-            IniSource::Speeduino => {
-                Some("https://api.github.com/repos/noisymime/speeduino/contents/reference")
-            }
-            IniSource::RusEFI => {
-                Some("https://api.github.com/repos/rusefi/rusefi/contents/firmware/tunerstudio")
-            }
-            IniSource::Fome => {
-                Some("https://api.github.com/repos/FOME-Tech/fome-fw/contents/firmware/tunerstudio")
-            }
-            IniSource::Custom => None,
+            IniSource::RusEFI => Some("https://rusefi.com/online/ini/rusefi"),
+            IniSource::EpicEFI => Some("https://content.epicefi.com/firmware/ini"),
+            _ => None,
         }
     }
 
-    /// Get the raw content URL prefix for this source
-    pub fn raw_url_prefix(&self) -> Option<&'static str> {
+    /// GitHub contents-API URL listing a flat directory of `.ini` files.
+    pub fn github_contents_url(&self) -> Option<&'static str> {
+        match self {
+            // The .ini used to live under reference/tunerstudio/, which no
+            // longer exists; the single canonical definition is
+            // reference/speeduino.ini (master-tracking).
+            IniSource::Speeduino => {
+                Some("https://api.github.com/repos/speeduino/speeduino/contents/reference")
+            }
+            // The real per-board definitions are generated into this
+            // subdirectory; the parent only holds fragment INIs (menus,
+            // gauges) that are not loadable definitions.
+            IniSource::Fome => Some(
+                "https://api.github.com/repos/FOME-Tech/fome-fw/contents/firmware/tunerstudio/generated",
+            ),
+            _ => None,
+        }
+    }
+
+    /// GitHub releases API URL for platforms that attach `.ini` assets to
+    /// firmware releases. Speeduino tags every release (e.g. `202501.7`)
+    /// with the matching `speeduino.ini` — that is the definition users
+    /// running released firmware need, since `reference/` tracks master.
+    pub fn github_releases_url(&self) -> Option<&'static str> {
         match self {
             IniSource::Speeduino => {
-                Some("https://raw.githubusercontent.com/noisymime/speeduino/master/reference")
+                Some("https://api.github.com/repos/speeduino/speeduino/releases?per_page=30")
             }
-            IniSource::RusEFI => {
-                Some("https://raw.githubusercontent.com/rusefi/rusefi/master/firmware/tunerstudio")
-            }
-            IniSource::Fome => Some(
-                "https://raw.githubusercontent.com/FOME-Tech/fome-fw/master/firmware/tunerstudio",
-            ),
-            IniSource::Custom => None,
+            _ => None,
         }
     }
 
@@ -101,8 +134,72 @@ impl IniSource {
             IniSource::Speeduino => "Speeduino",
             IniSource::RusEFI => "rusEFI",
             IniSource::Fome => "FOME",
+            IniSource::EpicEFI => "epicEFI",
             IniSource::Custom => "Custom",
         }
+    }
+}
+
+/// A parsed `rusEFI`-style firmware signature:
+/// `{brand} {branch}.{year}.{month}.{day}.{board}.{hash}`.
+///
+/// This is the same format rusEFI's own tooling parses (`SignatureHelper`
+/// and `upload_ini.sh`), and the online-INI URL is derivable directly from
+/// it as `{autoindex_root}/{branch}/{year}/{month}/{day}/{board}/{hash}.ini`.
+/// epicEFI is a white-label rusEFI build and uses the identical layout with
+/// the `epicEFI` brand word.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BundleSignature {
+    pub branch: String,
+    pub year: String,
+    pub month: String,
+    pub day: String,
+    pub board: String,
+    pub hash: String,
+}
+
+impl BundleSignature {
+    /// Parse the dot-separated signature body after the brand word.
+    /// Returns `None` for signatures that don't follow the 6-part format
+    /// (Speeduino, MegaSquirt, ...).
+    pub fn parse(signature: &str) -> Option<Self> {
+        let (_, rest) = signature.split_once(' ')?;
+        let parts: Vec<&str> = rest.trim().split('.').collect();
+        if parts.len() != 6 {
+            return None;
+        }
+        let [branch, year, month, day, board, hash] =
+            [parts[0], parts[1], parts[2], parts[3], parts[4], parts[5]];
+        // Upstream (upload_ini.sh) allows alnum, '-' and '_' in the free-form
+        // components, and zero-padded digits for the date components.
+        let token = |s: &str| {
+            !s.is_empty()
+                && s.bytes()
+                    .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
+        };
+        let numeric = |s: &str, len: usize| s.len() == len && s.bytes().all(|b| b.is_ascii_digit());
+        if !token(branch) || !token(board) || !token(hash) {
+            return None;
+        }
+        if !numeric(year, 4) || !numeric(month, 2) || !numeric(day, 2) {
+            return None;
+        }
+        Some(BundleSignature {
+            branch: branch.to_string(),
+            year: year.to_string(),
+            month: month.to_string(),
+            day: day.to_string(),
+            board: board.to_string(),
+            hash: hash.to_string(),
+        })
+    }
+
+    /// URL of this bundle's INI under an autoindex root.
+    pub fn ini_url(&self, root: &str) -> String {
+        format!(
+            "{}/{}/{}/{}/{}/{}/{}.ini",
+            root, self.branch, self.year, self.month, self.day, self.board, self.hash
+        )
     }
 }
 
@@ -115,6 +212,164 @@ struct GitHubFile {
     download_url: Option<String>,
     #[serde(rename = "type")]
     file_type: String,
+}
+
+/// GitHub API response for a release
+#[derive(Debug, Deserialize)]
+struct GitHubRelease {
+    tag_name: String,
+    #[serde(default)]
+    draft: bool,
+    #[serde(default)]
+    assets: Vec<GitHubAsset>,
+}
+
+/// GitHub API response for a release asset
+#[derive(Debug, Deserialize)]
+struct GitHubAsset {
+    name: String,
+    browser_download_url: String,
+    #[serde(default)]
+    size: Option<u64>,
+}
+
+/// Render a reqwest error together with its full `source()` chain — the
+/// outer Display ("error sending request for url (...)") hides whether the
+/// cause was DNS, connect, TLS or a timeout.
+fn error_chain(e: &reqwest::Error) -> String {
+    use std::fmt::Write;
+    let mut out = String::new();
+    let _ = write!(out, "{e}");
+    let mut cur = std::error::Error::source(e);
+    while let Some(c) = cur {
+        let _ = write!(out, ": {c}");
+        cur = c.source();
+    }
+    out
+}
+
+/// One link extracted from an Apache `mod_autoindex` directory listing.
+#[derive(Debug, Clone)]
+struct AutoindexLink {
+    /// href exactly as it appeared in the HTML (`board/`, `1234567890.ini`)
+    href: String,
+    is_dir: bool,
+}
+
+/// Extract relative directory and `.ini` file links from an Apache
+/// autoindex page. Drops parent links, sort links (`?C=N;O=D`), icons and
+/// off-site URLs.
+fn parse_autoindex_links(html: &str) -> Vec<AutoindexLink> {
+    let marker = "href=\"";
+    let mut out = Vec::new();
+    let mut cursor = 0;
+    while let Some(found) = html[cursor..].find(marker) {
+        let start = cursor + found + marker.len();
+        let Some(end) = html[start..].find('"') else {
+            break;
+        };
+        let href = html[start..start + end].to_string();
+        cursor = start + end;
+        if href.starts_with("..") || href.contains("://") || href.contains('?') {
+            continue;
+        }
+        if let Some(name) = href.strip_suffix('/') {
+            if !name.is_empty() {
+                out.push(AutoindexLink { href, is_dir: true });
+            }
+        } else if href.to_ascii_lowercase().ends_with(".ini") {
+            out.push(AutoindexLink {
+                href,
+                is_dir: false,
+            });
+        }
+    }
+    out
+}
+
+/// The lexicographically-greatest sub-directory link. Autoindex date
+/// directories are zero-padded, so this is the newest date available.
+fn newest_dir(links: &[AutoindexLink]) -> Option<String> {
+    links
+        .iter()
+        .filter(|l| l.is_dir)
+        .map(|l| l.href.clone())
+        .max()
+}
+
+/// Join an autoindex href onto a base URL. Relative hrefs (`board/`,
+/// `123.ini`) append to the base; root-relative hrefs (`/icons/...`)
+/// resolve against the host root.
+fn join_url(base: &str, href: &str) -> String {
+    let base = base.trim_end_matches('/');
+    if href.starts_with('/') {
+        // Root-relative: keep only scheme://host from the base.
+        let root = match (
+            base.find("://"),
+            base[base.find("://").unwrap() + 3..].find('/'),
+        ) {
+            (Some(scheme_end), Some(host_slash)) => &base[..scheme_end + 3 + host_slash],
+            _ => base,
+        };
+        format!("{root}{href}")
+    } else {
+        format!("{base}/{href}")
+    }
+}
+
+/// Lowercased alphanumeric tokens of length >= 2 — the identity vocabulary
+/// used to match online file names against ECU signatures.
+fn identity_tokens(s: &str) -> std::collections::HashSet<String> {
+    s.split(|c: char| !c.is_ascii_alphanumeric())
+        .filter(|t| t.len() >= 2)
+        .map(|t| t.to_ascii_lowercase())
+        .collect()
+}
+
+/// Online listings can't carry the INI's real signature without downloading
+/// every file, so an entry matches when all of its file-name identity tokens
+/// (board, hash, version — e.g. `proteus_f4-1739931529.ini`) appear in the
+/// ECU signature's tokens.
+fn entry_matches_signature(
+    entry: &OnlineIniEntry,
+    sig_tokens: &std::collections::HashSet<String>,
+) -> bool {
+    let stem = entry.name.strip_suffix(".ini").unwrap_or(&entry.name);
+    let stem_tokens = identity_tokens(stem);
+    !stem_tokens.is_empty() && stem_tokens.iter().all(|t| sig_tokens.contains(t))
+}
+
+/// Build an entry for a bundle described by a parsed path / signature. The
+/// file name inside a board directory is the bundle hash.
+fn autoindex_entry(
+    source: IniSource,
+    root: &str,
+    bundle: &BundleSignature,
+) -> Option<OnlineIniEntry> {
+    if bundle.hash.is_empty() {
+        return None;
+    }
+    let repo_path = format!(
+        "{}/{}/{}/{}/{}/{}.ini",
+        bundle.branch, bundle.year, bundle.month, bundle.day, bundle.board, bundle.hash
+    );
+    Some(OnlineIniEntry {
+        source,
+        name: format!("{}-{}.ini", bundle.board, bundle.hash),
+        signature: Some(format!(
+            "{} {}.{}.{}.{}.{}.{}",
+            source.display_name(),
+            bundle.branch,
+            bundle.year,
+            bundle.month,
+            bundle.day,
+            bundle.board,
+            bundle.hash
+        )),
+        download_url: format!("{root}/{repo_path}"),
+        repo_path,
+        size: None,
+    })
 }
 
 /// Online INI repository client
@@ -147,65 +402,98 @@ impl OnlineIniRepository {
 
     /// Search for INI files matching a signature
     ///
-    /// If signature is None, returns all known INIs from all sources.
+    /// If signature is `None`, returns every INI found in the newest
+    /// published bundles of every source. With a signature, returns
+    /// (a) cache entries whose file-name identity tokens (board, hash,
+    /// version) all appear in the signature, plus (b) for `rusEFI`-style
+    /// 6-part signatures, the exact bundle INI derived directly from the
+    /// signature's own path components — older firmware included, no
+    /// directory walk needed.
     pub async fn search(
         &mut self,
         signature: Option<&str>,
     ) -> Result<Vec<OnlineIniEntry>, io::Error> {
-        // Refresh cache if empty
         if self.cache.is_empty() {
             self.refresh_cache().await?;
         }
 
-        match signature {
-            Some(sig) => {
-                let sig_lower = sig.to_lowercase();
-                Ok(self
-                    .cache
-                    .iter()
-                    .filter(|e| {
-                        if let Some(ref entry_sig) = e.signature {
-                            entry_sig.to_lowercase().contains(&sig_lower)
-                                || sig_lower.contains(&entry_sig.to_lowercase())
-                        } else {
-                            // Match by name if no signature
-                            e.name.to_lowercase().contains(&sig_lower)
-                        }
-                    })
-                    .cloned()
-                    .collect())
+        let Some(sig) = signature else {
+            return Ok(self.cache.clone());
+        };
+
+        let sig_tokens = identity_tokens(sig);
+        let mut results: Vec<OnlineIniEntry> = self
+            .cache
+            .iter()
+            .filter(|e| entry_matches_signature(e, &sig_tokens))
+            .cloned()
+            .collect();
+
+        for entry in self.fetch_signature_derived_entries(sig).await {
+            if !results.iter().any(|e| e.download_url == entry.download_url) {
+                results.push(entry);
             }
-            None => Ok(self.cache.clone()),
         }
+
+        Ok(results)
     }
 
     /// Refresh the cache by fetching INI lists from all sources
     async fn refresh_cache(&mut self) -> Result<(), io::Error> {
         self.cache.clear();
 
-        // Fetch from each upstream source
         for &source in IniSource::online_sources() {
-            match self.fetch_source_inis(source).await {
-                Ok(entries) => self.cache.extend(entries),
+            let entries = match self.list_source(source).await {
+                Ok(v) => v,
                 Err(e) => {
-                    eprintln!("Warning: Failed to fetch INIs from {:?}: {}", source, e);
-                    // Continue with other sources
+                    eprintln!("Warning: Failed to fetch INIs from {:?}: {e}", source);
+                    Vec::new()
                 }
-            }
+            };
+            self.cache.extend(entries);
         }
 
         Ok(())
     }
 
-    /// Fetch INI list from a specific source
-    async fn fetch_source_inis(&self, source: IniSource) -> Result<Vec<OnlineIniEntry>, io::Error> {
-        let api_url = source
-            .github_api_url()
-            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "No API URL for source"))?;
+    /// Fetch the current INI list from a single source (no caching). Exposed
+    /// for targeted refresh and diagnostics.
+    pub async fn list_source(&self, source: IniSource) -> io::Result<Vec<OnlineIniEntry>> {
+        match source {
+            IniSource::Speeduino => self.fetch_speeduino().await,
+            IniSource::RusEFI | IniSource::EpicEFI => self.fetch_autoindex_latest(source).await,
+            IniSource::Fome => self.fetch_github_contents(source).await,
+            IniSource::Custom => Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "Custom source has no upstream listing",
+            )),
+        }
+    }
+
+    /// Speeduino lists both the master-tracking `reference/` INI and the INI
+    /// assets attached to tagged firmware releases.
+    async fn fetch_speeduino(&self) -> io::Result<Vec<OnlineIniEntry>> {
+        let mut entries = self.fetch_github_contents(IniSource::Speeduino).await?;
+        entries.extend(
+            self.fetch_github_release_assets(IniSource::Speeduino)
+                .await?,
+        );
+        Ok(entries)
+    }
+
+    /// Fetch the INI list from a GitHub contents-API directory
+    async fn fetch_github_contents(&self, source: IniSource) -> io::Result<Vec<OnlineIniEntry>> {
+        let api_url = source.github_contents_url().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "No GitHub contents URL for source",
+            )
+        })?;
 
         let response = self
             .client
             .get(api_url)
+            .timeout(std::time::Duration::from_secs(15))
             .send()
             .await
             .map_err(|e| io::Error::other(e.to_string()))?;
@@ -220,13 +508,12 @@ impl OnlineIniRepository {
         let files: Vec<GitHubFile> = response
             .json()
             .await
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
 
         let mut entries = Vec::new();
-
         for file in files {
             // Only include .ini files
-            if file.file_type == "file" && file.name.to_lowercase().ends_with(".ini") {
+            if file.file_type == "file" && file.name.to_ascii_lowercase().ends_with(".ini") {
                 if let Some(download_url) = file.download_url {
                     entries.push(OnlineIniEntry {
                         source,
@@ -241,6 +528,241 @@ impl OnlineIniRepository {
         }
 
         Ok(entries)
+    }
+
+    /// Fetch `.ini` assets attached to GitHub releases.
+    async fn fetch_github_release_assets(
+        &self,
+        source: IniSource,
+    ) -> io::Result<Vec<OnlineIniEntry>> {
+        let api_url = source.github_releases_url().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "No GitHub releases URL for source",
+            )
+        })?;
+
+        let response = self
+            .client
+            .get(api_url)
+            .timeout(std::time::Duration::from_secs(15))
+            .send()
+            .await
+            .map_err(|e| io::Error::other(e.to_string()))?;
+
+        if !response.status().is_success() {
+            return Err(io::Error::other(format!(
+                "GitHub API error: {}",
+                response.status()
+            )));
+        }
+
+        let releases: Vec<GitHubRelease> = response
+            .json()
+            .await
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+
+        let mut entries = Vec::new();
+        for release in releases {
+            if release.draft {
+                continue;
+            }
+            for asset in release.assets {
+                if !asset.name.to_ascii_lowercase().ends_with(".ini") {
+                    continue;
+                }
+                entries.push(OnlineIniEntry {
+                    source,
+                    name: format!(
+                        "{}-{}.ini",
+                        source.display_name().to_lowercase(),
+                        release.tag_name
+                    ),
+                    // Release-tagged INIs match firmware of the same tag.
+                    signature: Some(format!("{} {}", source.display_name(), release.tag_name)),
+                    download_url: asset.browser_download_url,
+                    repo_path: format!("releases/{}", release.tag_name),
+                    size: asset.size,
+                });
+            }
+        }
+
+        Ok(entries)
+    }
+
+    /// Fetch the link list of an Apache autoindex page.
+    async fn fetch_autoindex_links(&self, url: &str) -> io::Result<Vec<AutoindexLink>> {
+        // Always fetch directory indexes with a trailing slash: some hosts
+        // answer the slashless form with a 301 whose Location is an
+        // *internal* address (epicEFI's nginx behind Docker redirects to
+        // http://172.18.0.60/...), which the client then follows into an
+        // unroutable black hole until the timeout fires.
+        let url = if url.ends_with('/') {
+            url.to_string()
+        } else {
+            format!("{url}/")
+        };
+        let response = self
+            .client
+            .get(&url)
+            .timeout(std::time::Duration::from_secs(15))
+            .send()
+            .await
+            .map_err(|e| io::Error::other(error_chain(&e)))?;
+        if !response.status().is_success() {
+            return Err(io::Error::other(format!(
+                "Autoindex error: {} for {url}",
+                response.status()
+            )));
+        }
+        let html = response
+            .text()
+            .await
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        Ok(parse_autoindex_links(&html))
+    }
+
+    /// Walk an autoindex tree to its newest day directory and list every
+    /// board's INI: `{root}/{branch}/{year}/{month}/{day}/{board}/{hash}.ini`.
+    /// Directory names are zero-padded dates, so the lexicographically newest
+    /// link is the chronologically newest.
+    async fn fetch_autoindex_latest(&self, source: IniSource) -> io::Result<Vec<OnlineIniEntry>> {
+        let root = source.autoindex_root().ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidInput, "Not an autoindex source")
+        })?;
+
+        let root_links = self.fetch_autoindex_links(root).await?;
+        let branch = root_links
+            .iter()
+            .filter(|l| l.is_dir)
+            .find(|l| l.href == "master/")
+            .map(|l| l.href.clone())
+            .or_else(|| newest_dir(&root_links))
+            .ok_or_else(|| io::Error::other(format!("No branch directory under {root}")))?;
+        let branch_url = join_url(root, &branch);
+
+        let year = newest_dir(&self.fetch_autoindex_links(&branch_url).await?)
+            .ok_or_else(|| io::Error::other(format!("No year directory under {branch_url}")))?;
+        let year_url = join_url(&branch_url, &year);
+
+        let month = newest_dir(&self.fetch_autoindex_links(&year_url).await?)
+            .ok_or_else(|| io::Error::other(format!("No month directory under {year_url}")))?;
+        let month_url = join_url(&year_url, &month);
+
+        let day = newest_dir(&self.fetch_autoindex_links(&month_url).await?)
+            .ok_or_else(|| io::Error::other(format!("No day directory under {month_url}")))?;
+        let day_url = join_url(&month_url, &day);
+
+        let day_links = self.fetch_autoindex_links(&day_url).await?;
+        let boards: Vec<String> = day_links
+            .iter()
+            .filter(|l| l.is_dir)
+            .map(|l| l.href.clone())
+            .collect();
+
+        // One request per board (~40-50 per day); run them concurrently but
+        // capped, to keep the browse dialog fast without hammering the host.
+        let semaphore = std::sync::Arc::new(tokio::sync::Semaphore::new(8));
+        let client = self.client.clone();
+        let mut set = tokio::task::JoinSet::new();
+        for board in boards {
+            let client = client.clone();
+            let semaphore = semaphore.clone();
+            let board_url = join_url(&day_url, &board);
+            let board_name = board.trim_end_matches('/').to_string();
+            let root = root.to_string();
+            let branch = branch.trim_end_matches('/').to_string();
+            let year = year.trim_end_matches('/').to_string();
+            let month = month.trim_end_matches('/').to_string();
+            let day = day.trim_end_matches('/').to_string();
+            set.spawn(async move {
+                let _permit = semaphore.acquire_owned().await;
+                let mut entries = Vec::new();
+                if let Ok(resp) = client
+                    .get(&board_url)
+                    .timeout(std::time::Duration::from_secs(15))
+                    .send()
+                    .await
+                {
+                    if resp.status().is_success() {
+                        if let Ok(html) = resp.text().await {
+                            for link in parse_autoindex_links(&html) {
+                                if link.is_dir {
+                                    continue;
+                                }
+                                let Some(hash) = link.href.strip_suffix(".ini") else {
+                                    continue;
+                                };
+                                let bundle = BundleSignature {
+                                    branch: branch.clone(),
+                                    year: year.clone(),
+                                    month: month.clone(),
+                                    day: day.clone(),
+                                    board: board_name.clone(),
+                                    hash: hash.to_string(),
+                                };
+                                if let Some(entry) = autoindex_entry(source, &root, &bundle) {
+                                    entries.push(entry);
+                                }
+                            }
+                        }
+                    }
+                }
+                entries
+            });
+        }
+
+        let mut out = Vec::new();
+        while let Some(joined) = set.join_next().await {
+            if let Ok(entries) = joined {
+                out.extend(entries);
+            }
+        }
+        out.sort_by(|a, b| a.name.cmp(&b.name));
+        Ok(out)
+    }
+
+    /// Derive download entries directly from a `rusEFI`-style signature.
+    ///
+    /// The signature encodes the exact bundle path, so any firmware — not
+    /// just the newest day the browse walk covers — resolves with a single
+    /// existence probe per platform root.
+    async fn fetch_signature_derived_entries(&self, signature: &str) -> Vec<OnlineIniEntry> {
+        let Some(bundle) = BundleSignature::parse(signature) else {
+            return Vec::new();
+        };
+        // The brand word usually identifies the platform, but the same board
+        // can exist on both, so probe the other root too when the first miss.
+        let lower = signature.to_ascii_lowercase();
+        let ordered = if lower.starts_with("epicefi") {
+            [IniSource::EpicEFI, IniSource::RusEFI]
+        } else {
+            [IniSource::RusEFI, IniSource::EpicEFI]
+        };
+        for source in ordered {
+            let Some(root) = source.autoindex_root() else {
+                continue;
+            };
+            let url = bundle.ini_url(root);
+            if self.url_exists(&url).await {
+                return autoindex_entry(source, root, &bundle).into_iter().collect();
+            }
+        }
+        Vec::new()
+    }
+
+    /// Probe whether a URL exists (HEAD, short timeout).
+    async fn url_exists(&self, url: &str) -> bool {
+        match self
+            .client
+            .head(url)
+            .timeout(std::time::Duration::from_secs(8))
+            .send()
+            .await
+        {
+            Ok(resp) => resp.status().is_success(),
+            Err(_) => false,
+        }
     }
 
     /// Download an INI file to the specified directory
@@ -320,35 +842,186 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_ini_source_urls() {
-        assert!(IniSource::Speeduino.github_api_url().is_some());
-        assert!(IniSource::RusEFI.github_api_url().is_some());
-        assert!(IniSource::Fome.github_api_url().is_some());
-        assert!(IniSource::Custom.github_api_url().is_none());
+    fn test_ini_source_endpoints() {
+        assert!(IniSource::Speeduino.github_contents_url().is_some());
+        assert!(IniSource::Speeduino.github_releases_url().is_some());
+        assert!(IniSource::Fome.github_contents_url().is_some());
+        assert!(IniSource::RusEFI.autoindex_root().is_some());
+        assert!(IniSource::EpicEFI.autoindex_root().is_some());
+        assert!(IniSource::Custom.autoindex_root().is_none());
+        assert!(IniSource::Custom.github_contents_url().is_none());
+        assert!(IniSource::Custom.github_releases_url().is_none());
     }
 
     #[test]
-    fn test_online_sources_all_have_urls() {
-        // Every source the search iterates over must have both a GitHub API URL
-        // and a raw-content prefix, and must not be the Custom (no-upstream) tag.
+    fn test_online_sources_have_a_listing_endpoint() {
+        // Every source the search iterates over must have at least one
+        // listing endpoint and must not be the Custom (no-upstream) tag.
         for &source in IniSource::online_sources() {
             assert_ne!(source, IniSource::Custom);
-            assert!(
-                source.github_api_url().is_some(),
-                "{:?} has no github_api_url",
-                source
-            );
-            assert!(
-                source.raw_url_prefix().is_some(),
-                "{:?} has no raw_url_prefix",
-                source
-            );
+            let endpoints = source.autoindex_root().is_some() as usize
+                + source.github_contents_url().is_some() as usize
+                + source.github_releases_url().is_some() as usize;
+            assert!(endpoints >= 1, "{source:?} has no listing endpoint");
         }
+    }
+
+    #[test]
+    fn test_epicefi_is_an_online_source() {
+        assert!(IniSource::online_sources().contains(&IniSource::EpicEFI));
+        assert_eq!(IniSource::EpicEFI.display_name(), "epicEFI");
     }
 
     #[test]
     fn test_fome_is_an_online_source() {
         assert!(IniSource::online_sources().contains(&IniSource::Fome));
         assert_eq!(IniSource::Fome.display_name(), "FOME");
+    }
+
+    #[test]
+    fn test_bundle_signature_parse_and_url() {
+        let sig =
+            BundleSignature::parse("rusEFI master.2026.06.07.purple-gateway.753206531").unwrap();
+        assert_eq!(sig.branch, "master");
+        assert_eq!(sig.year, "2026");
+        assert_eq!(sig.month, "06");
+        assert_eq!(sig.day, "07");
+        assert_eq!(sig.board, "purple-gateway");
+        assert_eq!(sig.hash, "753206531");
+        assert_eq!(
+            sig.ini_url("https://rusefi.com/online/ini/rusefi"),
+            "https://rusefi.com/online/ini/rusefi/master/2026/06/07/purple-gateway/753206531.ini"
+        );
+
+        // epicEFI white-label signatures use the same layout.
+        let epic = BundleSignature::parse("epicEFI master.2026.08.26.epicECU.4128885531").unwrap();
+        assert_eq!(epic.board, "epicECU");
+        assert_eq!(
+            epic.ini_url("https://content.epicefi.com/firmware/ini"),
+            "https://content.epicefi.com/firmware/ini/master/2026/08/26/epicECU/4128885531.ini"
+        );
+
+        // Non-bundle signatures must not parse.
+        assert!(BundleSignature::parse("Speeduino 202501.7").is_none());
+        assert!(BundleSignature::parse("rusEFI master.2026.06").is_none());
+        assert!(BundleSignature::parse("rusEFI master.202X.06.07.board.123").is_none());
+        assert!(BundleSignature::parse("nospaces").is_none());
+    }
+
+    #[test]
+    fn test_autoindex_link_parsing() {
+        let html = concat!(
+            "<html><body><h1>Index of /firmware/ini/master/2026/08/26</h1>\n",
+            "<pre><img src=\"/icons/blank.gif\" alt=\"[ICO]\">",
+            "<a href=\"../\">Parent Directory</a>",
+            "<a href=\"2025/\">2025/</a>",
+            "<a href=\"2026/\">2026/</a>",
+            "<a href=\"epicECU/\">epicECU/</a>",
+            "<a href=\"4128885531.ini\">4128885531.ini</a>",
+            "<a href=\"/spicons/folder.gif\">icon</a>",
+            "<a href=\"?C=N;O=D\">Name</a>",
+            "<a href=\"readme.md\">readme.md</a></pre></body></html>"
+        );
+        let links = parse_autoindex_links(html);
+        let dirs: Vec<&str> = links
+            .iter()
+            .filter(|l| l.is_dir)
+            .map(|l| l.href.as_str())
+            .collect();
+        assert_eq!(dirs, vec!["2025/", "2026/", "epicECU/"]);
+        let files: Vec<&str> = links
+            .iter()
+            .filter(|l| !l.is_dir)
+            .map(|l| l.href.as_str())
+            .collect();
+        assert_eq!(files, vec!["4128885531.ini"]);
+        // Zero-padded dates: lexicographically newest == chronologically newest.
+        assert_eq!(newest_dir(&links).as_deref(), Some("epicECU/"));
+    }
+
+    #[test]
+    fn test_join_url() {
+        assert_eq!(
+            join_url("https://example.com/ini", "master/"),
+            "https://example.com/ini/master/"
+        );
+        assert_eq!(
+            join_url("https://example.com/ini/", "123.ini"),
+            "https://example.com/ini/123.ini"
+        );
+        assert_eq!(
+            join_url("https://example.com/ini", "/abs/path.ini"),
+            "https://example.com/abs/path.ini"
+        );
+    }
+
+    #[test]
+    fn test_entry_matches_signature_by_name_tokens() {
+        let entry = |name: &str| OnlineIniEntry {
+            source: IniSource::RusEFI,
+            name: name.to_string(),
+            signature: None,
+            download_url: String::new(),
+            repo_path: String::new(),
+            size: None,
+        };
+
+        let proteus_sig = identity_tokens("rusEFI master.2026.08.26.proteus_f4.1739931529");
+        assert!(entry_matches_signature(
+            &entry("proteus_f4-1739931529.ini"),
+            &proteus_sig
+        ));
+        // Wrong board or wrong hash must not match.
+        assert!(!entry_matches_signature(
+            &entry("mre_f4-1739931529.ini"),
+            &proteus_sig
+        ));
+        assert!(!entry_matches_signature(
+            &entry("proteus_f4-999999999.ini"),
+            &proteus_sig
+        ));
+
+        let speeduino_sig = identity_tokens("Speeduino 202501.7");
+        assert!(entry_matches_signature(
+            &entry("speeduino-202501.7.ini"),
+            &speeduino_sig
+        ));
+        // The master-tracking definition matches any Speeduino (dev INI).
+        assert!(entry_matches_signature(
+            &entry("speeduino.ini"),
+            &speeduino_sig
+        ));
+        assert!(!entry_matches_signature(
+            &entry("fome_proteus_f4.ini"),
+            &speeduino_sig
+        ));
+    }
+
+    #[tokio::test]
+    #[ignore = "live network call"]
+    async fn live_search_derives_rusefi_bundle_url() {
+        let mut repo = OnlineIniRepository::new();
+        // Real bundle published on rusefi.com (verified 2026-08-26).
+        let results = repo
+            .search(Some("rusEFI master.2026.08.26.proteus_f4.1739931529"))
+            .await
+            .unwrap();
+        assert!(
+            results.iter().any(|e| e
+                .download_url
+                .ends_with("/master/2026/08/26/proteus_f4/1739931529.ini")),
+            "{results:?}"
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "live network call"]
+    async fn live_browse_lists_all_sources() {
+        let mut repo = OnlineIniRepository::new();
+        let results = repo.search(None).await.unwrap();
+        assert!(results.iter().any(|e| e.source == IniSource::RusEFI));
+        assert!(results.iter().any(|e| e.source == IniSource::EpicEFI));
+        assert!(results.iter().any(|e| e.source == IniSource::Speeduino));
+        assert!(results.iter().any(|e| e.source == IniSource::Fome));
     }
 }

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -45,7 +45,7 @@ All notable changes to LibreTune will be documented in this file.
 - Dashboard tab protection (cannot be accidentally closed; recoverable via View → Dashboard)
 - Configurable status bar channels (Settings → Status Bar Channels, max 8)
 - INI signature mismatch dialog with local and online INI search (the online search now runs automatically when a mismatch is reported; downloading still requires an explicit click)
-- Online INI repository search from Speeduino, rusEFI, and FOME GitHub repos
+- Online INI repository search from official sources: Speeduino (GitHub + Releases), rusEFI and epicEFI (official bundle servers), FOME (generated per-board INIs)
 - Per-table `.table` file import/export (TunerStudio-compatible "Save/Load Table to File" from the table toolbar)
 - AFR Delay Test (Tools → AFR Delay Test…) — automated exhaust transport-delay measurement that steps fuel and reports the delay to enter as AutoTune's lambda delay
 - Resilient ECU sync with partial failure handling and status bar indicator


### PR DESCRIPTION
## Description

Implements the online-INI auto-detection coverage gaps from #181: the online INI repository now downloads from each platform's **official** definition source, the auto-search can actually find matches, and the listing is cached so the browse dialog opens instantly.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Bug fix (the signature matching and wrong-directory bugs below)

## Related Issues

Works toward #181 (remaining gap: MegaSquirt MS2/MS3 — no scrapeable official listing exists; AMP's page is a Shopify portal with firmware zips).

## Changes Made

### Official definition sources

- **rusEFI** moved from the GitHub `firmware/tunerstudio` listing (which only contains *fragment* INIs — `gauge_declarations.ini`, `top_level_menu.ini`, …) to the official bundle server `https://rusefi.com/online/ini/rusefi/` — the same server the rusEFI console itself downloads from.
- **epicEFI** added as a new source: `https://content.epicefi.com/firmware/ini/`, a rusEFI white-label with the identical `{branch}/{YYYY}/{MM}/{DD}/{board}/{hash}.ini` bundle layout (new `IniSource::EpicEFI`, wired through `download_ini` and the dialogs).
- **Speeduino** now also lists the `.ini` asset attached to each tagged firmware release (e.g. `202501.7`) alongside the master-tracking `reference/speeduino.ini`, so released firmware gets its exact matching definition.
- **FOME** listing moved to `firmware/tunerstudio/generated/` — the real per-board definitions instead of the fragment-only parent directory.

### Signature-driven auto-detection

- New `BundleSignature` parser for `rusEFI`-style 6-part signatures (`rusEFI master.2026.08.26.proteus_f4.1739931529`; epicEFI uses the same format with its own brand word — verified against rusEFI's own `SignatureHelper`/`upload_ini.sh`).
- The signature encodes the exact bundle path, so `search(Some(sig))` now **derives the INI URL directly** and verifies it with a HEAD probe — any published firmware version resolves in one request, including older builds, with no directory walk.
- **Fixed the auto-search matcher**: entries previously carried no signature and matching required the *file name* to contain the full ECU signature verbatim, so the connect-time auto-search could never match anything real. Entries now carry reconstructed signatures, and matching is token-based (board + hash/version tokens must appear in the signature).
- Browse walk (`search(None)`) walks each Apache autoindex server down to its newest day and lists every board concurrently (semaphore-capped at 8).

### Listing cache (follow-up)

- Persisted listing cache at `<app_data>/online_ini_cache.json` (versioned, RFC 3339 `last_updated`) — the multi-source scan took 8–30 s and previously ran on every dialog open; the dialog now opens instantly from cache.
- 24 h TTL (`ONLINE_INI_CACHE_TTL_SECS`), matching the fastest upstream (rusEFI/epicEFI publish daily bundles).
- Manual **Refresh** button (forces `refresh_online_inis`), "Listing last updated" display, and an amber notice when a refresh fails but the cache is served.
- Background refresh: the app polls `refresh_online_inis_if_stale` every 30 minutes — a no-op while fresh, a network refresh once the TTL expires.
- **Non-clobbering refresh**: the new listing only swaps in when at least one source responded; going offline keeps the previous cache and timestamp.
- `search_online_inis` now returns `{ entries, last_updated, refreshed }`; all three callers (OnlineIniDialog, SignatureMismatchDialog, ConnectEcuWizard) updated.

## Notable bug found during testing

epicEFI's nginx redirects slashless directory URLs to its **docker-internal IP** (`Location: http://172.18.0.60/firmware/ini/`), which reqwest then follows into an unroutable black hole until timeout. Fixed by always requesting directory indexes with a trailing slash. Also: epicEFI is self-hosted on a residential connection, hence the semaphore cap on concurrent board-directory requests.

## Testing

- [x] I have tested these changes locally
- [x] New and existing tests pass (`cargo test`)
- [x] The UI works correctly with these changes

- 10 offline unit tests: `BundleSignature` parse/URL derivation, autoindex HTML link parsing, URL joining (incl. root-relative), token-based entry matching, cache save/load roundtrip (corrupt-file + version-guard), staleness by age, endpoint coverage for every source.
- 3 live-network tests (ignored by default, run explicitly): bundle-URL derivation against a real published bundle, full 4-source browse walk, and refresh→persist→reload cache roundtrip. Verified live: 43 rusEFI + 50 epicEFI + 8 Speeduino + 29 FOME entries.
- Verified the non-clobbering behavior against a real transient rusefi.com rate-limit (1 of 4 sources failed; the rest of the listing survived with a warning).

## Checklist

- [x] Code compiles without errors
- [x] No new clippy warnings (`cargo clippy`)
- [x] Code is formatted (`cargo fmt`)
- [x] TypeScript compiles without errors (`npx tsc --noEmit`)
- [x] Documentation updated if needed (CHANGELOG + manual changelog)
- [x] Commit messages follow conventional format
