### PR TITLE
fix(ini): clamp writes to the range the INI declares

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/constant_values.rs
+++ b/crates/libretune-app/src-tauri/src/commands/constant_values.rs
@@ -173,6 +173,9 @@ mod tests {
             dynamic_size: None,
             scale_expr: None,
             translate_expr: None,
+            min_expr: None,
+            max_expr: None,
+            range_resolved: true,
         };
 
         // Build a cache with a single page, load raw bytes, write reqFuel=126.
@@ -235,6 +238,9 @@ mod tests {
             dynamic_size: None,
             scale_expr: None,
             translate_expr: None,
+            min_expr: None,
+            max_expr: None,
+            range_resolved: true,
         };
 
         let mut def = EcuDefinition::default();

--- a/crates/libretune-core/src/ini/constants.rs
+++ b/crates/libretune-core/src/ini/constants.rs
@@ -90,6 +90,19 @@ pub struct Constant {
     /// Same as [`Constant::scale_expr`], for the translate field.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub translate_expr: Option<String>,
+    /// Same as [`Constant::scale_expr`], for the min field.
+    pub min_expr: Option<String>,
+    /// Same as [`Constant::scale_expr`], for the max field.
+    pub max_expr: Option<String>,
+    /// Are [`Constant::min`] and [`Constant::max`] the range the INI declares?
+    ///
+    /// False while a `{expression}` bound is unresolved, because the numeric
+    /// fallback is then the raw-byte span rather than the real range.
+    /// `advTable2` declares `{ ign2ValuesMin }` / `{ ign2ValuesMax }` and would
+    /// otherwise fall back to 0..255 - which on a table with `translate = -40`
+    /// refuses every retard value while still waving through an advance far
+    /// past the real maximum. Not clamping is better than clamping to a lie.
+    pub range_resolved: bool,
 }
 
 /// Extract a deferred expression from an INI numeric field.
@@ -132,6 +145,9 @@ impl Constant {
             dynamic_size: None,
             scale_expr: None,
             translate_expr: None,
+            min_expr: None,
+            max_expr: None,
+            range_resolved: true,
         }
     }
 
@@ -154,8 +170,29 @@ impl Constant {
     }
 
     /// Convert a display value to raw value
+    /// Convert a display value to raw storage, clamped to the declared range.
+    ///
+    /// The clamp lives here because this is the one funnel every write path
+    /// already passes through - tables, curves, scalars and bit fields alike.
+    /// Without it `advTable1`, declared `min -40, max 70`, accepted 200 degrees
+    /// of ignition advance: `(200 - -40) / 1.0` is 240, a perfectly legal U08,
+    /// so nothing downstream had cause to object. Confirmed on a bench ECU -
+    /// written and read back as 200 degrees. The only ceiling was the byte
+    /// itself, at 215.
+    ///
+    /// Skipped when the range is not trustworthy; see
+    /// [`Constant::range_resolved`].
     pub fn display_to_raw(&self, display: f64) -> f64 {
-        (display - self.translate) / self.scale
+        let value = if self.range_resolved {
+            // Ordered rather than trusted: f64::clamp panics when lo > hi and a
+            // hand-edited INI can declare them either way round.
+            let lo = self.min.min(self.max);
+            let hi = self.min.max(self.max);
+            display.clamp(lo, hi)
+        } else {
+            display
+        };
+        (value - self.translate) / self.scale
     }
 
     /// Check if a display value is within allowed range
@@ -190,6 +227,9 @@ impl Default for Constant {
             dynamic_size: None,
             scale_expr: None,
             translate_expr: None,
+            min_expr: None,
+            max_expr: None,
+            range_resolved: true,
         }
     }
 }
@@ -293,11 +333,14 @@ pub fn parse_constant_line(
         constant.translate = parts[scale_idx + 1].parse().unwrap_or(0.0);
     }
     if parts.len() > scale_idx + 2 {
+        constant.min_expr = deferred_expr(parts[scale_idx + 2]);
         constant.min = parts[scale_idx + 2].parse().unwrap_or(0.0);
     }
     if parts.len() > scale_idx + 3 {
+        constant.max_expr = deferred_expr(parts[scale_idx + 3]);
         constant.max = parts[scale_idx + 3].parse().unwrap_or(255.0);
     }
+    constant.range_resolved = constant.min_expr.is_none() && constant.max_expr.is_none();
     if parts.len() > scale_idx + 4 {
         constant.digits = parts[scale_idx + 4].parse().unwrap_or(0);
     }
@@ -608,5 +651,64 @@ mod tests {
         assert_eq!(c.bit_options[1], "INVALID");
         assert_eq!(c.bit_options[2], "INVALID");
         assert_eq!(c.bit_options[3], "Advanced");
+    }
+}
+
+#[cfg(test)]
+mod declared_range_tests {
+    use super::*;
+
+    fn spark_table() -> Constant {
+        // advTable1 = array, U08, 0,[16x16], "deg", 1.0, -40, -40, 70.0, 0
+        let mut c = Constant::new("advTable1", 2, 0, DataType::U08);
+        c.scale = 1.0;
+        c.translate = -40.0;
+        c.min = -40.0;
+        c.max = 70.0;
+        c.range_resolved = true;
+        c
+    }
+
+    /// Confirmed on a bench Speeduino before this clamp existed: 90 and 200
+    /// degrees of advance were both written and read back intact, because
+    /// (200 - -40) / 1.0 is 240 and a U08 holds that happily.
+    #[test]
+    fn an_out_of_range_value_cannot_reach_the_ecu() {
+        let c = spark_table();
+        assert_eq!(c.display_to_raw(200.0), c.display_to_raw(70.0));
+        assert_eq!(c.display_to_raw(90.0), c.display_to_raw(70.0));
+        assert_eq!(c.display_to_raw(-500.0), c.display_to_raw(-40.0));
+        // The declared edges themselves must still pass through untouched.
+        assert_eq!(c.display_to_raw(70.0), 110.0);
+        assert_eq!(c.display_to_raw(-40.0), 0.0);
+        assert_eq!(c.display_to_raw(20.0), 60.0);
+    }
+
+    /// `advTable2` declares `{ ign2ValuesMin }` / `{ ign2ValuesMax }`. Until
+    /// those resolve, min/max hold the raw-byte fallback of 0..255 - clamping
+    /// to that would refuse every retard value on a table whose real minimum is
+    /// -40, while still allowing an advance well past the real maximum.
+    #[test]
+    fn an_unresolved_expression_range_does_not_clamp() {
+        let mut c = spark_table();
+        c.min_expr = Some("ign2ValuesMin".into());
+        c.max_expr = Some("ign2ValuesMax".into());
+        c.min = 0.0;
+        c.max = 255.0;
+        c.range_resolved = false;
+
+        // -20 degrees of retard survives rather than being clamped up to 0.
+        assert_eq!(c.display_to_raw(-20.0), 20.0);
+    }
+
+    /// A hand-edited INI can declare the bounds either way round, and
+    /// f64::clamp panics when lo > hi.
+    #[test]
+    fn a_reversed_range_is_ordered_not_trusted() {
+        let mut c = spark_table();
+        c.min = 70.0;
+        c.max = -40.0;
+        assert_eq!(c.display_to_raw(200.0), c.display_to_raw(70.0));
+        assert_eq!(c.display_to_raw(-500.0), c.display_to_raw(-40.0));
     }
 }

--- a/crates/libretune-core/src/ini/mod.rs
+++ b/crates/libretune-core/src/ini/mod.rs
@@ -592,11 +592,23 @@ impl EcuDefinition {
             }
         }
 
+        /// Which deferred field an expression resolves into.
+        enum Field {
+            Scale,
+            Translate,
+            Min,
+            Max,
+        }
+
         let mut updated = 0;
         for constant in self.constants.values_mut() {
+            let mut min_done = constant.min_expr.is_none();
+            let mut max_done = constant.max_expr.is_none();
             for (source, target) in [
-                (constant.scale_expr.clone(), true),
-                (constant.translate_expr.clone(), false),
+                (constant.scale_expr.clone(), Field::Scale),
+                (constant.translate_expr.clone(), Field::Translate),
+                (constant.min_expr.clone(), Field::Min),
+                (constant.max_expr.clone(), Field::Max),
             ] {
                 let Some(src) = source else { continue };
                 let mut parser = expression::Parser::new(&src);
@@ -608,18 +620,41 @@ impl EcuDefinition {
                 if !v.is_finite() {
                     continue;
                 }
-                if target {
-                    // A zero scale would render every value as 0; treat it as
-                    // an unresolved expression rather than trusting it.
-                    if v != 0.0 && constant.scale != v {
-                        constant.scale = v;
-                        updated += 1;
+                match target {
+                    Field::Scale => {
+                        // A zero scale would render every value as 0; treat it
+                        // as an unresolved expression rather than trusting it.
+                        if v != 0.0 && constant.scale != v {
+                            constant.scale = v;
+                            updated += 1;
+                        }
                     }
-                } else if constant.translate != v {
-                    constant.translate = v;
-                    updated += 1;
+                    Field::Translate => {
+                        if constant.translate != v {
+                            constant.translate = v;
+                            updated += 1;
+                        }
+                    }
+                    Field::Min => {
+                        if constant.min != v {
+                            constant.min = v;
+                            updated += 1;
+                        }
+                        min_done = true;
+                    }
+                    Field::Max => {
+                        if constant.max != v {
+                            constant.max = v;
+                            updated += 1;
+                        }
+                        max_done = true;
+                    }
                 }
             }
+            // Only trust the range for clamping once every declared bound has
+            // actually produced a number. A half-resolved range is the raw-byte
+            // fallback wearing the INI's clothes.
+            constant.range_resolved = min_done && max_done;
         }
         updated
     }


### PR DESCRIPTION
Confirmed on a bench Speeduino 202501 before and after the change.

## What's wrong

Typing `200` into an ignition table cell writes **200 degrees of advance to the ECU**.

`advTable1` is declared at `speeduino-202501.ini:499`:

```
advTable1 = array, U08, 0,[16x16], "deg", 1.0, -40, -40, 70.0, 0
```

scale 1.0, translate −40, **min −40, max 70**. But `display_to_raw` is:

```rust
pub fn display_to_raw(&self, display: f64) -> f64 {
    (display - self.translate) / self.scale
}
```

`(200 - -40) / 1.0` is 240 — a perfectly legal U08, so nothing downstream had cause to question it. Measured on hardware before this change:

```
asked  90 deg -> ECU holds  90 deg   LANDED
asked 200 deg -> ECU holds 200 deg   LANDED
```

The only ceiling was the storage type itself, at raw 255 = **215 degrees**.

`Constant::is_in_range` encodes the contract exactly:

```rust
pub fn is_in_range(&self, display_value: f64) -> bool {
    display_value >= self.min && display_value <= self.max
}
```

A repo-wide grep across `.rs`, `.ts` and `.tsx` returns the definition and nothing else. It has never had a caller.

## Why it matters

Every write path converts through `display_to_raw` and none of them range-check: `table_update.rs`, `constant_update.rs`, `curve_ops.rs`, and both helpers in `table_internals.rs`. Cell edits, spreadsheet paste and every toolbar operation all route through them.

The reference tuning software refuses the entry at 70. Here it is accepted, written, and read back as a legitimate value — so nothing on screen afterwards suggests anything is wrong.

## The fix

The clamp goes in `display_to_raw` rather than at the call sites, because that is the one funnel all five already pass through. Bounds are ordered rather than trusted — `f64::clamp` panics when `lo > hi`, and a hand-edited INI can declare them either way round.

**The prerequisite half.** Clamping needed the declared bounds to actually be the declared bounds. `min` and `max` were parsed as:

```rust
constant.min = parts[scale_idx + 2].parse().unwrap_or(0.0);
constant.max = parts[scale_idx + 3].parse().unwrap_or(255.0);
```

while `scale` and `translate` immediately above them got `deferred_expr`. So any `{expression}` bound silently became the raw-byte span. `advTable2` (`ini:1495`) declares `{ ign2ValuesMin }` / `{ ign2ValuesMax }`, and clamping *that* to 0..255 would have refused every retard value on a table whose real minimum is −40, while still allowing an advance far past its real maximum — a regression worse than the bug.

So `min_expr` / `max_expr` now resolve alongside scale and translate in the existing `resolve_dynamic_scales` loop, and `range_resolved` records whether every declared bound actually produced a number. **An unresolved range does not clamp at all** — no clamp beats clamping to a fallback.

23 constants in this INI carry expression bounds, including `fuelLoadBins`, `boostTable`, the eight `fuelTrimNloadBins` and `advTable2`.

## Testing

Three cases in `declared_range_tests`:

1. **`an_out_of_range_value_cannot_reach_the_ecu`** — 200 and 90 both clamp to the declared 70; −500 clamps to −40; and the declared edges themselves (70, −40, 20) still convert exactly, so the clamp cannot be satisfied by a guard that simply rejects everything.
2. **`an_unresolved_expression_range_does_not_clamp`** — with `min_expr`/`max_expr` unresolved, −20 degrees of retard survives rather than being clamped to 0. This is the `advTable2` regression, pinned.
3. **`a_reversed_range_is_ordered_not_trusted`** — min and max the wrong way round still clamps correctly rather than panicking.

Hardware, after the change:

```
asked     200 deg -> ECU holds      70 deg   clamped
asked      90 deg -> ECU holds      70 deg   clamped
asked      65 deg -> ECU holds      65 deg   accepted (in range)
asked     -35 deg -> ECU holds     -35 deg   accepted (in range)
```

795 core tests and 94 app tests pass. Clippy unchanged from the current `main` baseline of 32.

## Risk

Medium, and worth reviewing carefully — this changes the value written for any entry outside a declared range, on every write path at once.

Two judgement calls to check hardest:

**Silent clamping.** A tuner typing 90 now gets 70 with no message. That is a large improvement on getting 90, but it is still silent, and this codebase has a habit of silent behaviour that I would rather not add to. A visible rejection at the UI layer is the natural follow-up; I kept this change to the safety floor that cannot be bypassed.

**Bad INI bounds.** If an INI declares a range narrower than reality, this will now clamp legitimate values that previously got through. The `range_resolved` guard covers the unresolved-expression case, but not a bound that resolves to something wrong.
