### PR TITLE
fix(realtime): give computed channels the tune and let their chains resolve

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/realtime_stream.rs
+++ b/crates/libretune-app/src-tauri/src/commands/realtime_stream.rs
@@ -526,6 +526,16 @@ pub async fn start_realtime_stream(
         let start_time = std::time::Instant::now();
         let mut string_ctx =
             crate::commands::string_context::build_string_context(&app_state).await;
+        // Computed channels are written against the whole tune, not just the
+        // runtime block: the INI defines `lambda = { afr / stoich }`, and
+        // stoich is a [Constants] value. Without it the expression engine
+        // resolves the identifier to 0.0 by design, so lambda becomes afr/0.
+        // Refreshed on the same cadence as the string context, and for the same
+        // reason - the tune can change mid-session but not per tick.
+        let mut numeric_ctx = {
+            let tune = app_state.current_tune.lock().await;
+            crate::commands::string_context::numeric_context_from_tune(tune.as_ref())
+        };
 
         // Cache output channels + endianness once before the loop.
         // These don't change during a session so there's no need to re-lock every tick.
@@ -608,6 +618,10 @@ pub async fn start_realtime_stream(
             if tick_count.is_multiple_of(20) {
                 string_ctx =
                     crate::commands::string_context::build_string_context(&app_state).await;
+                numeric_ctx = {
+                    let tune = app_state.current_tune.lock().await;
+                    crate::commands::string_context::numeric_context_from_tune(tune.as_ref())
+                };
             }
 
             // Trace: log which phase we're in so we can find deadlocks
@@ -783,9 +797,11 @@ pub async fn start_realtime_stream(
                 // Phase 3: Process data outside of any mutex locks
                 match (&raw_result, def_data) {
                     (Ok(raw), Some((output_channels, endianness))) => {
-                        // Two-pass approach for computed channels:
-                        // Pass 1: Parse all non-computed channels
-                        let mut data: HashMap<String, f64> = HashMap::new();
+                        // Pass 1: the tune's own constants, then the runtime
+                        // block over the top. Runtime wins on a name collision:
+                        // a live channel is the current value, a constant is
+                        // what the tune was configured with.
+                        let mut data: HashMap<String, f64> = numeric_ctx.clone();
                         let mut computed_channels = Vec::new();
 
                         for (name, channel) in output_channels.iter() {
@@ -796,15 +812,32 @@ pub async fn start_realtime_stream(
                             }
                         }
 
-                        // Pass 2: Evaluate computed channels using parsed values as context
-                        for (name, channel) in computed_channels {
-                            if let Some(val) = channel.parse_with_contexts(
-                                raw,
-                                *endianness,
-                                &data,
-                                Some(&string_ctx),
-                            ) {
-                                data.insert(name, val);
+                        // Pass 2: computed channels, repeatedly. They form
+                        // chains - rpm -> revolutionTime -> cycleTime ->
+                        // pulseLimit -> dutyCycle is four deep - and a single
+                        // pass in HashMap order only resolves one if the
+                        // iteration order happens to cooperate. Sorted so a
+                        // given tune behaves the same way every run, and capped
+                        // at three passes the way realtime::Evaluator already
+                        // does: enough for the chains this INI declares, and
+                        // proof against a cycle.
+                        computed_channels.sort_by(|a, b| a.0.cmp(&b.0));
+                        for _ in 0..3 {
+                            let mut changed = false;
+                            for (name, channel) in &computed_channels {
+                                if let Some(val) = channel.parse_with_contexts(
+                                    raw,
+                                    *endianness,
+                                    &data,
+                                    Some(&string_ctx),
+                                ) {
+                                    if data.insert(name.clone(), val) != Some(val) {
+                                        changed = true;
+                                    }
+                                }
+                            }
+                            if !changed {
+                                break;
                             }
                         }
 


### PR DESCRIPTION
## What's wrong

The realtime stream evaluates every computed output channel against a context holding only the runtime block, in a single pass, in `HashMap` order. Two separate defects follow.

### Constants are missing from the context

The INI writes computed channels against the whole tune, not just the runtime data:

```
lambda          = { afr / stoich }
strokeMultipler = { twoStroke == 1 ? 1 : 2 }
```

`stoich` and `twoStroke` are `[Constants]`, not output channels. But the stream's context starts empty and is filled only from output channels:

```rust
let mut data: HashMap<String, f64> = HashMap::new();
```

The expression engine resolves an unknown identifier to zero **by design**:

```rust
// Default to 0 for unknown variables (common in INIs)
Ok(Value::Number(0.0))
```

So `lambda` becomes `afr / 0` — `Infinity` — which the NaN/Inf sanitiser further down flattens to `0.0`. Same for `lambdaTarget`, `bat_correction`, `req_fuel`, `inj_open` and the fuel-load channels.

### Chains do not resolve

The INI declares a four-deep chain:

```
revolutionTime = { rpm ? ( 60000.0 / rpm) : 0 }
cycleTime      = { revolutionTime * strokeMultipler }
pulseLimit     = { cycleTime / nSquirts }
dutyCycle      = { rpm ? ( 100.0*pulseWidth/pulseLimit ) : 0 }
```

A single pass in `HashMap` iteration order only completes that if the order happens to cooperate — and it differs per process, so the same tune behaves differently between runs.

## Why it matters

These are gauge values a tuner reads and acts on. A real log from this car shows `Lambda 1.041` and `Duty_Cycle 2.9` in conditions where LibreTune would show **0 for both** — in the gauge, in the recorded log, and to VE Analyze, which `[VeAnalyze]` names `lambda` as its lambda channel under `#if LAMBDA`.

The stream is the path that feeds the gauges, the datalogger and AutoTune. The one-shot `get_realtime_data` poll already uses `realtime::Evaluator`, which sorts names and does three passes — so the two read paths disagree with each other.

## The fix

Seed the context from `numeric_context_from_tune`, which already builds exactly this map and is already used by `ini_meta` and `pin_conflicts`. The stream simply never asked for it. Built once before the loop and refreshed on the same twenty-tick cadence as the existing string context, so there is no extra per-tick locking on a hot path.

Runtime values overwrite constants on a name collision: a live channel is the current value, a constant is what the tune was configured with.

Then sort the computed channels and repeat up to three passes, stopping early when a pass changes nothing — the same approach `realtime::Evaluator` already takes, which is enough for the chains this INI declares and is proof against a cycle.

## Testing

**Not hardware-verified, and I would rather say so than imply otherwise.** The stream runs inside the Tauri app and cannot be driven from a headless harness the way the protocol paths can, so unlike the other fixes in this batch I could not put it on the bench ECU and watch the number change.

What is verified: the INI's declarations are quoted above from the shipping Speeduino 202501 file; the expression engine's zero-default is quoted from source; and the equivalent single-shot path already resolves these channels correctly using the same three-pass approach.

94 app tests pass. Clippy unchanged from the `main` baseline of 32.

## Risk

Medium, and it is a hot path.

Worth checking hardest: the three-pass loop now runs per tick over the computed channels rather than one pass. It exits early when a pass changes nothing, so the steady-state cost is two passes rather than one — but it is per tick, at up to 80 Hz, and I have not profiled it on a slow machine.

Second: seeding from the tune means a constant and an output channel sharing a name now resolve to the runtime value where previously the constant was simply absent. That is the correct precedence, but it is a behaviour change for any expression that was silently reading zero and happened to want zero.
