### PR TITLE
fix(datalog): read the columns the INI declares, and log what it names

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/data_logging.rs
+++ b/crates/libretune-app/src-tauri/src/commands/data_logging.rs
@@ -101,7 +101,24 @@ pub async fn start_logging(
     let def_guard = state.definition.lock().await;
     let def = def_guard.as_ref().ok_or("Definition not loaded")?;
 
-    let mut channels: Vec<String> = def.output_channels.keys().cloned().collect();
+    // Prefer the channel list the INI declares in [Datalog]: it names the
+    // fields this ECU expects logged, in the order it expects them. The
+    // fallback is every output channel, which came out of a HashMap - so the
+    // column order differed between runs of the same binary, and the columns
+    // themselves were raw channel names rather than the declared labels. Other
+    // log tools key off those names and that order; the INI says so itself
+    // ("programs like MSLVV and MSTweak key off specific column names").
+    let mut channels: Vec<String> = if def.datalog_entries.is_empty() {
+        let mut all: Vec<String> = def.output_channels.keys().cloned().collect();
+        all.sort();
+        all
+    } else {
+        def.datalog_entries
+            .iter()
+            .filter(|e| e.enabled)
+            .map(|e| e.channel.clone())
+            .collect()
+    };
 
     // Also log the canonical alias names (RPM, MAP, TPS, …) that the realtime
     // stream adds via apply_channel_aliases, so recorded logs and saved CSVs

--- a/crates/libretune-core/src/ini/parser.rs
+++ b/crates/libretune-core/src/ini/parser.rs
@@ -1500,25 +1500,49 @@ fn substitute_variables(
     result
 }
 
-/// Parse [Datalog] section entries
+/// Parse a `[Datalog]` entry.
+///
+/// The columns are `Channel, Label, Type, Format[, {condition}]`, as the INI's
+/// own header comment states:
+///
+/// ```text
+/// ;       Channel          Label               Type    Format
+/// entry = rpm,             "RPM",              int,    "%d"
+/// entry = stagingActive,   "Fuel Staging",     int,    "onOff", { stagingEnabled }
+/// ```
+///
+/// This used to read `parts[2]` - the type - as the format, and `parts[3]` -
+/// the format - as an enabled flag, which is never the string "0" and so was
+/// always true. The condition was dropped entirely.
+///
+/// `split_ini_line` rather than `split(',')`: a condition expression can
+/// contain commas, and the naive split shatters it.
 fn parse_datalog_entry(def: &mut EcuDefinition, _key: &str, value: &str) {
-    // Format: entry = channel, "Label", "%.1f", 1
-    let parts: Vec<&str> = value.split(',').map(|s| s.trim()).collect();
-    if !parts.is_empty() {
-        let entry = DatalogEntry {
-            channel: parts[0].trim_matches('"').to_string(),
-            label: parts
-                .get(1)
-                .map(|s| s.trim_matches('"').to_string())
-                .unwrap_or_default(),
-            format: parts
-                .get(2)
-                .map(|s| s.trim_matches('"').to_string())
-                .unwrap_or_else(|| "%.2f".to_string()),
-            enabled: parts.get(3).map(|s| *s != "0").unwrap_or(true),
-        };
-        def.datalog_entries.push(entry);
+    let parts = crate::ini::split_ini_line(value);
+    if parts.is_empty() {
+        return;
     }
+    let field = |i: usize| -> Option<String> {
+        parts
+            .get(i)
+            .map(|s| s.trim().trim_matches('"').to_string())
+            .filter(|s| !s.is_empty())
+    };
+    let entry = DatalogEntry {
+        channel: parts[0].trim().trim_matches('"').to_string(),
+        label: field(1).unwrap_or_default(),
+        data_type: field(2).unwrap_or_else(|| "float".to_string()),
+        format: field(3).unwrap_or_else(|| "%.2f".to_string()),
+        condition: field(4).and_then(|s| {
+            s.strip_prefix('{')
+                .and_then(|s| s.strip_suffix('}'))
+                .map(|s| s.trim().to_string())
+        }),
+        // The INI has no disabled-by-default form; every declared entry is one
+        // the ECU offers. A condition, where present, decides at runtime.
+        enabled: true,
+    };
+    def.datalog_entries.push(entry);
 }
 
 /// Parse [FrontPage] section entries
@@ -4536,5 +4560,68 @@ mod tested_symbol_tests {
         set_default_symbols(Vec::<String>::new());
         assert!(def.tests_symbol("CELSIUS"));
         assert!(def.symbol_is_active("CELSIUS"));
+    }
+}
+
+#[cfg(test)]
+mod datalog_entry_tests {
+    use super::*;
+
+    fn parse(line: &str) -> DatalogEntry {
+        let mut def = EcuDefinition::default();
+        parse_datalog_entry(&mut def, "entry", line);
+        def.datalog_entries.pop().expect("one entry")
+    }
+
+    /// Columns are Channel, Label, Type, Format - per the INI's own header
+    /// comment. The type used to be read as the format, and the format as an
+    /// enabled flag that was never the string "0".
+    #[test]
+    fn the_type_and_format_columns_are_not_swapped() {
+        let e = parse(r#"rpm, "RPM", int, "%d""#);
+        assert_eq!(e.channel, "rpm");
+        assert_eq!(e.label, "RPM");
+        assert_eq!(e.data_type, "int");
+        assert_eq!(e.format, "%d");
+        assert!(e.condition.is_none());
+
+        let e = parse(r#"time, "Time", float, "%.3f""#);
+        assert_eq!(e.data_type, "float");
+        assert_eq!(e.format, "%.3f");
+    }
+
+    /// 62 of the 112 entries in the Speeduino 202501 INI carry a condition.
+    #[test]
+    fn a_declared_condition_is_kept() {
+        let e = parse(r#"stagingActive, "Fuel Staging", int, "onOff", { stagingEnabled }"#);
+        assert_eq!(e.channel, "stagingActive");
+        assert_eq!(e.format, "onOff");
+        assert_eq!(e.condition.as_deref(), Some("stagingEnabled"));
+    }
+
+    /// A condition can contain commas, which is why this uses split_ini_line
+    /// rather than split(','). The naive split shattered the expression and
+    /// left the tail as extra fields.
+    #[test]
+    fn a_condition_containing_commas_survives() {
+        let e = parse(
+            r#"boostDuty, "Boost Duty", int, "%d", { bitStringValue(boostLabels, boostType) }"#,
+        );
+        assert_eq!(e.channel, "boostDuty");
+        assert_eq!(e.format, "%d");
+        assert_eq!(
+            e.condition.as_deref(),
+            Some("bitStringValue(boostLabels, boostType)")
+        );
+    }
+
+    /// A short line must still yield a usable entry rather than a panic.
+    #[test]
+    fn a_two_field_entry_falls_back_sensibly() {
+        let e = parse(r#"afr, "AFR""#);
+        assert_eq!(e.channel, "afr");
+        assert_eq!(e.label, "AFR");
+        assert_eq!(e.data_type, "float");
+        assert_eq!(e.format, "%.2f");
     }
 }

--- a/crates/libretune-core/src/ini/types.rs
+++ b/crates/libretune-core/src/ini/types.rs
@@ -679,8 +679,15 @@ pub struct DatalogEntry {
     pub channel: String,
     /// Display label
     pub label: String,
-    /// Format string
+    /// Declared type - `int`, `float` or a bit-option name like `onOff`.
+    pub data_type: String,
+    /// Printf-style format string, e.g. `%.3f` or `%d`.
     pub format: String,
+    /// Optional `{expression}` gating whether the entry is logged at all.
+    ///
+    /// 62 of the 112 entries in the Speeduino 202501 INI carry one, e.g.
+    /// `entry = knockEventCount, "Current Knock Events", int, "%d", { knock_mode }`.
+    pub condition: Option<String>,
     /// Whether enabled by default
     pub enabled: bool,
 }


### PR DESCRIPTION
## What's wrong

Two defects: one in the parser, one in what consumed the result.

### The columns are read one across

`[Datalog]` declares `Channel, Label, Type, Format` and optionally a condition. The INI states the layout in its own header comment:

```
;       Channel          Label               Type    Format
entry = rpm,             "RPM",              int,    "%d"
entry = stagingActive,   "Fuel Staging",     int,    "onOff", { stagingEnabled }
```

`parse_datalog_entry` read them as:

```rust
format: parts.get(2)...                                  // this is the TYPE
enabled: parts.get(3).map(|s| *s != "0").unwrap_or(true), // this is the FORMAT
```

`"%d"` is never the string `"0"`, so `enabled` was always true. The condition — on **62 of this INI's 112 entries** — was dropped entirely.

It also split on commas directly, and a condition expression can contain them (`{ bitStringValue(boostLabels, boostType) }`), so the naive split shattered the expression and left its tail as extra fields.

### Nothing read the result

Every reference to `datalog_entries` across both languages is the `has_datalog_entries` boolean, used only to decide whether to show a menu item. The recorder built its own list:

```rust
let mut channels: Vec<String> = def.output_channels.keys().cloned().collect();
```

`output_channels` is a `HashMap`, so the column set was *every* channel rather than the declared ones, and the column **order differed between runs of the same binary**.

## Why it matters

The INI comment warns about exactly this: *"programs like MSLVV and MSTweak key off specific column names"*. A log whose columns are in a different order every session, under raw channel names rather than declared labels, does not open in the tools built to read it — and cannot be diffed against another of its own logs.

## The fix

Parse the columns as declared, keep the condition, and use `split_ini_line` — the brace- and quote-aware splitter the constants and gauge parsers already use.

The recorder takes its channels from `datalog_entries` when the INI declares them, in declared order. The fallback for an INI with no `[Datalog]` section is still every output channel, but **sorted**, so it is at least stable run to run.

## Testing

Four cases, using lines from the shipping INI rather than invented ones:

1. **`the_type_and_format_columns_are_not_swapped`** — `rpm, "RPM", int, "%d"` gives `data_type = int`, `format = %d`. This is the bug, pinned.
2. **`a_declared_condition_is_kept`** — the `stagingActive` line's `{ stagingEnabled }` survives.
3. **`a_condition_containing_commas_survives`** — `{ bitStringValue(boostLabels, boostType) }` comes back whole. A naive split fails this.
4. **`a_two_field_entry_falls_back_sensibly`** — a short line yields a usable entry rather than a panic.

**Verified against this car's own data.** Parsing the real 202501 INI gives 112 entries, 62 with conditions, in this order:

```
time  secl  rpm  map  MAPxRPM  tps  afr  lambda  iat  coolant  engine  DFCOOn
Time  SecL  RPM  MAP  MAPxRPM  TPS  AFR  Lambda  IAT  CLT      Engine  DFCO
```

The second row is the parsed labels. The header row of a real log recorded from this car by the reference tool reads:

```
Time	SecL	RPM	MAP	MAPxRPM	TPS	AFR	Lambda	MAT	CLT	Engine	DFCO	...
```

Identical, in order. (`MAT` vs `IAT` is that log's INI version differing from the 202501 release, not a parse difference.)

796 core tests and 94 app tests pass. Clippy unchanged from the `main` baseline of 32.

## Risk

Medium — this changes which columns a recording contains and what order they are in. Any saved LibreTune log from before this will have a different column set to one saved after, so they will not diff against each other. Given the old order was nondeterministic between runs, that was already true; this at least makes it stable going forward.

Worth a reviewer's eye: an INI declaring `[Datalog]` entries for channels that do not exist as output channels would now produce columns of nothing. I did not find such an entry in this INI, but I have not checked others.

## Not addressed here

The export is still comma-separated with raw channel names and a blanket `{:.4}`, where the reference format is tab-separated with a signature preamble, a label row, a units row, and the per-channel precision the INI specifies (`%.3f` / `%d` / `onOff`). Making a LibreTune log actually open in MegaLogViewer needs that too — but it is a file-format change and wants its own review rather than riding along here.
