### PR TITLE
fix(ini): find the analysis filter's user-adjustable flag where it really sits

### DIFF
--- a/crates/libretune-core/src/ini/parser.rs
+++ b/crates/libretune-core/src/ini/parser.rs
@@ -3216,11 +3216,22 @@ fn parse_analysis_filter(value: &str) -> Option<AnalysisFilter> {
         let channel = parts[2].trim().to_string();
         let operator = FilterOperator::from_str(parts[3].trim()).unwrap_or(FilterOperator::Equal);
         let default_value = parts[4].trim().parse().unwrap_or(0.0);
-        let user_adjustable = if parts.len() > 5 {
-            parts[5].trim().to_lowercase() == "true"
-        } else {
-            false
-        };
+        // The documented form is six fields, but the real one is seven: a blank
+        // slot sits between the default value and the flag.
+        //
+        //   filter = minCltFilter, "Minimum CLT", coolant, <, 71, , true
+        //
+        // Reading a fixed parts[5] therefore found the blank and every filter
+        // in the shipping INI parsed as not user-adjustable. The test fixture
+        // used the six-field form, so it agreed with the bug. Scan for the
+        // first field that actually has something in it instead, which handles
+        // both shapes.
+        let user_adjustable = parts
+            .get(5..)
+            .unwrap_or(&[])
+            .iter()
+            .find(|s| !s.trim().is_empty())
+            .is_some_and(|s| parse_ini_bool(s));
 
         return Some(AnalysisFilter {
             name,
@@ -4536,5 +4547,49 @@ mod tested_symbol_tests {
         set_default_symbols(Vec::<String>::new());
         assert!(def.tests_symbol("CELSIUS"));
         assert!(def.symbol_is_active("CELSIUS"));
+    }
+}
+
+#[cfg(test)]
+mod analysis_filter_tests {
+    use super::*;
+
+    fn parse(line: &str) -> AnalysisFilter {
+        parse_analysis_filter(line).expect("parses")
+    }
+
+    /// The shape the shipping Speeduino INI actually uses: seven fields, with a
+    /// blank between the default value and the flag. A fixed parts[5] read the
+    /// blank, so every filter came out not user-adjustable.
+    #[test]
+    fn the_real_seven_field_form_finds_the_flag() {
+        let f = parse(r#"minCltFilter, "Minimum CLT", coolant, <, 71, , true"#);
+        assert_eq!(f.name, "minCltFilter");
+        assert_eq!(f.channel, "coolant");
+        assert_eq!(f.default_value, 71.0);
+        assert!(f.user_adjustable, "the flag is at index 6, not 5");
+    }
+
+    /// The six-field form the INI's own comment documents must still work.
+    #[test]
+    fn the_documented_six_field_form_still_works() {
+        let f = parse(r#"minRPMFilter, "Minimum RPM", RPMValue, <, 500, true"#);
+        assert!(f.user_adjustable);
+    }
+
+    /// A filter genuinely declared false stays false either way round.
+    #[test]
+    fn a_false_flag_is_honoured_in_both_shapes() {
+        assert!(!parse(r#"accelFilter, "Accel Flag", engine, &, 16, , false"#).user_adjustable);
+        assert!(!parse(r#"accelFilter, "Accel Flag", engine, &, 16, false"#).user_adjustable);
+    }
+
+    /// parse_ini_bool accepts the other spellings an INI may use, and strips a
+    /// trailing comment.
+    #[test]
+    fn the_other_truthy_spellings_are_accepted() {
+        assert!(parse(r#"f, "F", coolant, <, 1, , 1"#).user_adjustable);
+        assert!(parse(r#"f, "F", coolant, <, 1, , yes"#).user_adjustable);
+        assert!(parse(r#"f, "F", coolant, <, 1, , true ; adjustable"#).user_adjustable);
     }
 }

--- a/crates/libretune-core/tests/ve_analyze.rs
+++ b/crates/libretune-core/tests/ve_analyze.rs
@@ -14,7 +14,7 @@ fn test_ve_analyze_parsing() {
     veAnalyzeMap = veTableTbl, lambdaTableTbl, lambdaValue, egoCorrectionForVeAnalyze, { 1 }
     lambdaTargetTables = lambdaTableTbl, afrTSCustom
     
-    filter = minRPMFilter, "Minimum RPM", RPMValue, <, 500, true
+    filter = minRPMFilter, "Minimum RPM", RPMValue, <, 500, , true
     filter = minCltFilter, "Minimum CLT", coolant, <, 60, true
     filter = deltaTps, "dTPS", deltaTps, >, 50, true
     filter = std_Custom
@@ -147,7 +147,7 @@ fn test_real_corpus_ve_analyze() {
     veAnalyzeMap = veTableTbl, lambdaTableTbl, lambdaValue, egoCorrectionForVeAnalyze, { 1 }
     lambdaTargetTables = lambdaTableTbl, afrTSCustom
 
-    filter = minRPMFilter, "Minimum RPM", RPMValue, <, 500, true
+    filter = minRPMFilter, "Minimum RPM", RPMValue, <, 500, , true
     filter = minCltFilter, "Minimum CLT", coolant, <, 60, true
     filter = deltaTps, "dTPS", deltaTps, >, 50, true
     filter = VBatt, "VBatt", VBatt, <, 12, true


### PR DESCRIPTION
## What's wrong

`parse_analysis_filter` read `user_adjustable` from a fixed `parts[5]`:

```rust
let user_adjustable = if parts.len() > 5 {
    parts[5].trim().to_lowercase() == "true"
```

The form the INI documents in its own comment has six fields. The form it **ships** has seven — a blank slot sits between the default value and the flag (`speeduino-202501.ini:5958`):

```
filter = minCltFilter, "Minimum CLT", coolant,  <  , 71,   , true
```

So `parts[5]` was the blank, and every filter in the shipping Speeduino INI parsed as not user-adjustable.

`split_ini_line` preserves empty fields — correctly — so the blank really does occupy a slot.

## Why the tests didn't catch it

The fixture used the documented six-field form:

```
filter = minRPMFilter, "Minimum RPM", RPMValue, <, 500, true
```

and asserted `user_adjustable` was true — which passed, because with six fields the flag genuinely is at index 5. The fixture and the bug shared an assumption, so the suite stayed green while the feature was dead on every real file.

Updating that fixture to the real seven-field line is the half of this change that stops it coming back.

## Impact

Honest scope: **latent today.** The flag is plumbed from `analyze_filters.rs` through to `AutoTune.tsx`, but grepping the frontend for `userAdjustable` returns only the interface field — the panel gates editability on `sessionValue !== null` instead. So nothing currently behaves differently.

It is still a parse that disagrees with the file it is parsing, on a field the INI declares for a reason, and it is two lines to fix correctly.

## The fix

Scan for the first non-empty field from index 5 rather than trading one fixed index for another. That handles the documented six-field form and the real seven-field one with the same expression.

`parse_ini_bool` — already in this file — replaces the bare comparison. It accepts `true`/`1`/`on`/`yes` case-insensitively and strips a trailing `;` comment, where `parts[5].trim().to_lowercase() == "true"` matched only one spelling and would have been defeated by `true ; adjustable`.

## Testing

Four cases:

1. **`the_real_seven_field_form_finds_the_flag`** — the actual `minCltFilter` line, blank slot and all. This is the bug.
2. **`the_documented_six_field_form_still_works`** — the shape the INI's comment describes, so the fix handles both.
3. **`a_false_flag_is_honoured_in_both_shapes`** — a filter genuinely declared `false` stays false either way round, so this is not a guard that simply returns true.
4. **`the_other_truthy_spellings_are_accepted`** — `1`, `yes`, and `true ; adjustable`.

The `ve_analyze` fixture is updated to the real form at both sites and still passes.

796 core tests pass. Clippy unchanged from the `main` baseline of 32.

## Risk

Low. Filters that were parsing as `false` and should be `true` now come out `true`; nothing reads the flag yet, so the behavioural surface is nil today. The fixture change is the part that carries any risk, and it moves the fixture toward the real file rather than away from it.

## Provenance

Reported in an independent review of an earlier commit. It survived that review's writeup because the fixture masked it, which is worth noting: the finding was correct and the evidence for dismissing it was the test.
