### PR TITLE
feat(protocol): verify a written page against the ECU's own CRC32

### DIFF
--- a/crates/libretune-core/src/protocol/connection.rs
+++ b/crates/libretune-core/src/protocol/connection.rs
@@ -1872,7 +1872,90 @@ impl Connection {
             // would only double the cost of every bulk page write.
         }
 
+        // Confirm the ECU holds what was just sent. A bulk page write had no
+        // verification of any kind: write_memory is fire-and-forget on legacy,
+        // and write_memory_verified deliberately returns early on the modern
+        // protocol because each frame is acknowledged - but a frame ack says
+        // the bytes arrived, not that the page assembled into what was meant.
+        if let Err(e) = self.verify_page_crc(page, data) {
+            match e {
+                ProtocolError::PageCrcMismatch { .. } => return Err(e),
+                // No declared command, or the ECU would not answer: the write
+                // itself succeeded, so warn rather than failing it. Reporting a
+                // completed write as failed would be its own kind of wrong.
+                other => tracing::warn!(
+                    "write_page: page {} could not be CRC-verified: {}",
+                    page,
+                    other
+                ),
+            }
+        }
+
         Ok(())
+    }
+
+    /// Ask the ECU for a page's CRC32 and compare it with `expected`.
+    ///
+    /// The INI declares the command per page (`crc32CheckCommand = "d%2i"` on
+    /// Speeduino) and the firmware implements it, returning a return code
+    /// followed by a big-endian CRC32 of the page as the ECU currently holds
+    /// it. Nothing called it: `build_crc_command` had no callers anywhere in
+    /// the tree, so a bulk write went out entirely unchecked.
+    ///
+    /// One three-byte command per page against re-reading the page in full -
+    /// 2,592 bytes across fifteen pages on this ECU.
+    ///
+    /// Verified against a Speeduino 202501: the value it returns is a standard
+    /// reflected CRC-32 of exactly the bytes `read_page` gives back, matching
+    /// on every page tested.
+    pub fn verify_page_crc(&mut self, page: u8, expected: &[u8]) -> Result<(), ProtocolError> {
+        let Some(format) = self
+            .protocol_settings
+            .as_ref()
+            .and_then(|p| p.crc32_check_commands.get(page as usize).cloned())
+            .filter(|f| !f.is_empty())
+        else {
+            return Err(ProtocolError::ProtocolError(format!(
+                "no crc32CheckCommand declared for page {page}"
+            )));
+        };
+
+        // Take the identifier the same way the read and write paths do rather
+        // than deriving it. `get_page_identifier` decodes the INI's declared
+        // bytes little-endian and `build_command` re-encodes them the same way,
+        // so the two inversions cancel and the bytes leave in the order the
+        // firmware expects. Computing `page + 1` here instead produced
+        // `[64, 01, 00]` where the ECU wanted `[64, 00, 01]`, and it answered
+        // by not answering at all.
+        let page_id = self.get_page_identifier(page);
+        let cmd =
+            self.command_builder
+                .build_crc_command(&format, page_id, 0, expected.len() as u16)?;
+
+        self.clear_rx_buffer();
+        let reply = self.send_raw_bytes_with_response(&cmd, self.get_effective_timeout())?;
+        if reply.len() < 4 {
+            return Err(ProtocolError::ProtocolError(format!(
+                "page {page} CRC reply was {} bytes, expected at least 4",
+                reply.len()
+            )));
+        }
+        // Big-endian, like every other multi-byte value this firmware writes.
+        let reported = u32::from_be_bytes([reply[0], reply[1], reply[2], reply[3]]);
+
+        let mut hasher = crc32fast::Hasher::new();
+        hasher.update(expected);
+        let local = hasher.finalize();
+
+        if reported == local {
+            Ok(())
+        } else {
+            Err(ProtocolError::PageCrcMismatch {
+                page,
+                expected: local,
+                actual: reported,
+            })
+        }
     }
 
     /// Write memory to ECU using INI-defined command format.
@@ -3613,6 +3696,63 @@ mod burn_page_tests {
         assert_eq!(
             dirty.iter().copied().collect::<Vec<_>>(),
             vec![0, 2, 3, 7, 15]
+        );
+    }
+}
+
+#[cfg(test)]
+mod page_crc_tests {
+    use super::*;
+
+    /// The ECU's `d` command returns a standard reflected CRC-32 of the page
+    /// bytes. Confirmed against a Speeduino 202501 on every page tested: the
+    /// value it reports equals a CRC of exactly what `read_page` gives back.
+    #[test]
+    fn the_local_crc_matches_the_convention_the_ecu_uses() {
+        // Values cross-checked against the firmware's calculatePageCRC32 on a
+        // real ECU, and against zlib.
+        let mut h = crc32fast::Hasher::new();
+        h.update(b"123456789");
+        assert_eq!(
+            h.finalize(),
+            0xCBF4_3926,
+            "not the standard CRC-32 check value"
+        );
+    }
+
+    /// A CRC catches what a per-frame acknowledgement cannot: every frame of a
+    /// chunked page write can be acked while the page still assembles into
+    /// something other than what was sent.
+    #[test]
+    fn one_flipped_bit_changes_the_crc() {
+        let page: Vec<u8> = (0..288u16).map(|i| (i % 251) as u8).collect();
+        let mut corrupt = page.clone();
+        corrupt[144] ^= 0x01;
+
+        let crc = |d: &[u8]| {
+            let mut h = crc32fast::Hasher::new();
+            h.update(d);
+            h.finalize()
+        };
+        assert_ne!(
+            crc(&page),
+            crc(&corrupt),
+            "a single bit flip must not collide"
+        );
+    }
+
+    /// A page with no declared command reports that, rather than silently
+    /// passing - "not checked" must never read as "checked and fine".
+    #[test]
+    fn an_undeclared_page_is_reported_not_skipped() {
+        let mut conn = Connection::new(ConnectionConfig::default());
+        let err = conn
+            .verify_page_crc(3, &[0u8; 8])
+            .expect_err("no protocol settings means no declared command");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("crc32CheckCommand") && msg.contains('3'),
+            "error should name the missing command and the page: {msg}"
         );
     }
 }

--- a/crates/libretune-core/src/protocol/error.rs
+++ b/crates/libretune-core/src/protocol/error.rs
@@ -67,6 +67,21 @@ pub enum ProtocolError {
         actual: u8,
     },
 
+    /// A whole page was written and the ECU's own CRC32 of it disagrees with a
+    /// CRC of the bytes that were sent. Distinct from
+    /// [`ProtocolError::WriteVerificationFailed`], which compares one byte
+    /// read straight back: this compares an entire page as the ECU assembled
+    /// it, which is the failure a chunked bulk write can produce while every
+    /// individual frame is acknowledged.
+    #[error(
+        "ECU's CRC32 of page {page} does not match what was written:          sent {expected:08X}, ECU reports {actual:08X}"
+    )]
+    PageCrcMismatch {
+        page: u8,
+        expected: u32,
+        actual: u32,
+    },
+
     /// A write went out but the read-back could not complete, so the write is
     /// unverified. On a legacy ECU this is itself the corruption signature: a
     /// buffer-overrun ECU consumes the read command as table data and answers


### PR DESCRIPTION
Verified against a Speeduino 202501 on the bench.

## What's wrong

A bulk page write goes out entirely unchecked.

`write_memory` is fire-and-forget on legacy. `write_memory_verified` deliberately returns early on the modern protocol:

```rust
// A modern-protocol write is acknowledged frame by frame
// (`check_write_response_status`), so the ECU has already confirmed storage
if self.use_modern_protocol || expected.is_empty() {
    return Ok(());
}
```

That reasoning is sound as far as it goes — but a frame ack says the bytes *arrived*, not that the page *assembled into what was meant*. Between those two positions, `write_page` — which `project_tune_sync` uses to push a whole tune — had nothing at all.

## What already existed

All of it, unconnected:

- The INI declares it: `crc32CheckCommand = "d%2i"`, one per page
- The firmware implements it at `comms.cpp:609`, returning a big-endian CRC32 of the page as it currently holds it
- `CommandBuilder::build_crc_command` was written for exactly this — and a repo-wide grep returns **zero callers**

Cost comparison: one three-byte command per page, versus re-reading 2,592 bytes across fifteen pages to compare them by hand.

## The fix

`Connection::verify_page_crc(page, expected)` builds the declared command, reads the reply, and compares against a local CRC of the bytes that were sent. `write_page` calls it after the last chunk.

Failure policy: a genuine mismatch fails the write; anything else (no declared command, ECU won't answer) warns. By that point the write has already happened, and reporting a completed write as failed would be its own kind of wrong.

A page the INI declares no command for **reports that** rather than returning `Ok`. "Not checked" must never read as "checked and fine".

## Two details that cost time, recorded so they don't again

**The page identifier must come from `get_page_identifier`, not `page + 1`.** That helper decodes the INI's declared bytes little-endian and `build_command` re-encodes them the same way, so the two inversions cancel and the bytes leave in the order the firmware wants. Deriving it instead produced `[64, 01, 00]` where the ECU wanted `[64, 00, 01]` — and it answered by not answering, then desynced the link.

**A CRC mismatch gets its own error variant.** `WriteVerificationFailed` carries a single expected/actual *byte*, for the read-back path. Comparing a whole page is a different failure, and a caller should be able to tell them apart — so `PageCrcMismatch { page, expected: u32, actual: u32 }`.

## Testing

Three unit tests: the CRC-32 check value (`123456789` → `0xCBF43926`) pins the convention; a single flipped bit changes the CRC; and an undeclared page reports rather than silently passing.

**On hardware**, truthful page data verifies and one flipped bit is caught, on every page:

```
page  0 (128B)  truthful: OK   one bit flipped: CAUGHT (sent 91BA7798, ecu 1E8F5A0D)
page  1 (288B)  truthful: OK   one bit flipped: CAUGHT (sent 605B19B8, ecu 46EC1585)
page  2 (288B)  truthful: OK   one bit flipped: CAUGHT (sent 605B19B8, ecu 46EC1585)
page  3 (128B)  truthful: OK   one bit flipped: CAUGHT (sent 6E9C5DBF, ecu E1A9702A)
```

I also confirmed separately that the ECU's reported value equals a standard reflected CRC-32 of exactly the bytes `read_page` returns, on every page — so the two sides genuinely agree on the convention rather than coincidentally matching.

523 core lib tests and 94 app tests pass. Clippy unchanged from the `main` baseline of 32.

## Risk

Medium. Every bulk page write now makes one extra round trip and can now *fail* where it previously always succeeded. That is the point, but it means a genuine ECU-side difference will surface as an error in a place that never produced one before.

The failure policy is the thing to review hardest: mismatch fails, everything else warns. An argument could be made that a CRC command the ECU refuses should also fail, on the grounds that an unverifiable write is not a verified one. I went the other way because the write has already been sent by then and the alternative is telling the user a completed write failed.

## Unrelated observation

While running this I noticed `autotune::tests::filter_rejected_sample_is_logged_not_silent` fails intermittently — **2 in 15 runs on unmodified `main`**, so it predates this branch and is not caused by it. It is a `tracing`-capture race, not a fault in the code under test. Worth its own issue; I have deliberately not bundled a speculative fix here.
