### PR TITLE
test: stop two suites racing on process-global state

### DIFF
--- a/crates/libretune-core/src/autotune/mod.rs
+++ b/crates/libretune-core/src/autotune/mod.rs
@@ -1767,59 +1767,59 @@ mod tests {
     /// Captures `tracing` event messages into a shared Vec so a test can assert
     /// that a specific diagnostic actually fired (the whole point of D9: these
     /// drop paths used to be silent).
-    #[derive(Clone, Default)]
-    struct LogCapture(std::sync::Arc<std::sync::Mutex<Vec<String>>>);
-    impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for LogCapture {
-        fn on_event(&self, e: &tracing::Event<'_>, _c: tracing_subscriber::layer::Context<'_, S>) {
-            struct V(std::sync::Arc<std::sync::Mutex<Vec<String>>>);
-            impl tracing::field::Visit for V {
-                fn record_debug(&mut self, f: &tracing::field::Field, v: &dyn std::fmt::Debug) {
-                    if f.name() == "message" {
-                        self.0.lock().unwrap().push(format!("{v:?}"));
-                    }
-                }
-            }
-            e.record(&mut V(self.0.clone()));
-        }
-    }
-
+    /// A sample the filters throw out must be visible afterwards, not vanish.
+    ///
+    /// Asserted on `rejection_counts` rather than on the `tracing` event the
+    /// same code emits. That is deliberate: `with_default` installs a
+    /// thread-local subscriber but mutates process-global tracing state to do
+    /// it, so in a parallel test binary the capture came back empty about one
+    /// run in eight - and the failure was never reproducible on its own. Three
+    /// attempts to stabilise it (pinning the level filter, rebuilding the
+    /// callsite interest cache before and then inside the dispatcher scope) all
+    /// looked fixed over twenty runs and still failed over forty-five.
+    ///
+    /// `rejection_counts` is the better assertion regardless: it is the same
+    /// information, it is what `autotune_misc` actually surfaces to the UI's
+    /// rejection indicator, and it is deterministic. The log line remains in
+    /// the code for the human reading a session log.
     #[test]
-    fn filter_rejected_sample_is_logged_not_silent() {
-        use tracing_subscriber::layer::SubscriberExt;
-        let cap = LogCapture::default();
-        let logs = cap.0.clone();
-        let sub = tracing_subscriber::registry().with(cap);
-        tracing::subscriber::with_default(sub, || {
-            let mut st = AutoTuneState::new();
-            st.start();
-            let s = AutoTuneSettings::default();
-            let f = AutoTuneFilters::default(); // min_clt = 160
-            let a = AutoTuneAuthorityLimits::default();
-            // clt=20 is far below min_clt: the sample must be rejected AND
-            // logged (before D9 this path returned silently). The throttle
-            // counts per session, so a fresh state logs its first rejection and
-            // one sample is enough. It used to count per process, which made
-            // this depend on what every other test in the binary had already
-            // rejected.
-            let p = VEDataPoint {
-                rpm: 2000.0,
-                load: 50.0,
-                afr: 14.0,
-                ve: 50.0,
-                clt: 20.0,
-                tps: 5.0,
-                tps_rate: 0.0,
-                timestamp_ms: 1000,
-                ..Default::default()
-            };
-            st.add_data_point(p, &[1000.0, 2000.0], &[40.0, 80.0], &s, &f, &a);
-        });
+    fn filter_rejected_sample_is_counted_not_silent() {
+        let mut st = AutoTuneState::new();
+        st.start();
+        let s = AutoTuneSettings::default();
+        let f = AutoTuneFilters::default(); // min_clt = 160
+        let a = AutoTuneAuthorityLimits::default();
+
         assert!(
-            logs.lock()
-                .unwrap()
-                .iter()
-                .any(|m| m.contains("rejected by filters")),
-            "a filtered-out sample must emit a diagnostic, not drop silently"
+            st.rejection_counts().is_empty(),
+            "a fresh session has rejected nothing"
+        );
+
+        // clt = 20 is far below min_clt, so this must be rejected AND recorded.
+        let p = VEDataPoint {
+            rpm: 2000.0,
+            load: 50.0,
+            afr: 14.0,
+            ve: 50.0,
+            clt: 20.0,
+            tps: 5.0,
+            tps_rate: 0.0,
+            timestamp_ms: 1000,
+            ..Default::default()
+        };
+        st.add_data_point(p, &[1000.0, 2000.0], &[40.0, 80.0], &s, &f, &a);
+
+        let counts = st.rejection_counts();
+        assert_eq!(
+            counts.len(),
+            1,
+            "one rejected sample should record exactly one reason, got {counts:?}"
+        );
+        let (reason, n) = counts[0];
+        assert_eq!(n, 1);
+        assert!(
+            reason.contains("clt"),
+            "the reason must name the filter that fired, got {reason:?}"
         );
     }
 

--- a/crates/libretune-core/src/ini/parser.rs
+++ b/crates/libretune-core/src/ini/parser.rs
@@ -4506,12 +4506,17 @@ ego_max_lambda = scalar, U08, lastOffset, "Lambda", 0.068, 0, 0.5, 1.7, 3
 #[cfg(test)]
 mod tested_symbol_tests {
     use super::*;
+    use serial_test::serial;
 
     /// A definition records which symbols were *asked about*, separately from
     /// which were active. Without that distinction the app cannot tell "this
     /// INI has no temperature choice to make" from "the choice defaulted", and
     /// would prompt on files that never mention units.
+    // Same process-wide DEFAULT_SYMBOLS seed as the two tests already in
+    // this group. Left out of it, this raced with them and flipped the seed
+    // between set_default_symbols and parse_ini.
     #[test]
+    #[serial(default_symbols)]
     fn a_definition_records_the_symbols_it_tested() {
         set_default_symbols(Vec::<String>::new());
         let ini = "\
@@ -4536,7 +4541,11 @@ mod tested_symbol_tests {
         );
     }
 
+    // Same process-wide DEFAULT_SYMBOLS seed as the two tests already in
+    // this group. Left out of it, this raced with them and flipped the seed
+    // between set_default_symbols and parse_ini.
     #[test]
+    #[serial(default_symbols)]
     fn an_ini_that_never_asks_records_nothing() {
         set_default_symbols(Vec::<String>::new());
         let ini = "\
@@ -4555,7 +4564,11 @@ mod tested_symbol_tests {
 
     /// The arm taken must not change what was recorded as tested: the question
     /// was asked either way.
+    // Same process-wide DEFAULT_SYMBOLS seed as the two tests already in
+    // this group. Left out of it, this raced with them and flipped the seed
+    // between set_default_symbols and parse_ini.
     #[test]
+    #[serial(default_symbols)]
     fn the_symbol_is_recorded_even_when_defined() {
         set_default_symbols(vec!["CELSIUS".to_string()]);
         let ini = "\


### PR DESCRIPTION
## What's wrong

Two tests in `libretune-core` fail intermittently. Measured on **unmodified `main`**:

| test | rate |
| --- | --- |
| `filter_rejected_sample_is_logged_not_silent` | 2 in 15, then 3 in 25 (~13%) |
| `celsius_symbol_selects_the_metric_branch` | 1 in 40 |

Both block CI at random. That is how this surfaced: a branch that touched only the protocol layer failed its Windows job on an autotune test.

## The tracing one

The test captured a `tracing` event through `subscriber::with_default`. That installs a *thread-local* subscriber but mutates *process-global* tracing state to do it, so with the suite running in parallel the capture came back empty — instrumenting the assertion showed `captured: []`, the layer receiving nothing at all — and it was never reproducible when the test ran alone.

**Three attempts to stabilise the capture failed**, and are worth recording so nobody repeats them:

1. Pinning `LevelFilter::TRACE` on the registry — still 2 in 12.
2. `rebuild_interest_cache()` before entering the dispatcher — still 3 in 15.
3. `rebuild_interest_cache()` *inside* the dispatcher scope — 20 runs clean, then 3 in 25.

That third one is the instructive failure: twenty consecutive passes looked like a fix and wasn't.

So it now asserts on `rejection_counts()` instead. That is the same information, it is deterministic, and it is what `autotune_misc.rs:109` actually surfaces to the UI's rejection indicator — a better assertion than a log line regardless of the flake. The `tracing` call itself is unchanged; it exists for the human reading a session log, and is no longer what a test hangs off.

Renamed to `filter_rejected_sample_is_counted_not_silent` to match what it now checks.

## The symbols one

`DEFAULT_SYMBOLS` is a process-wide `RwLock`, and `celsius_symbol_selects_the_metric_branch` was already marked `#[serial(default_symbols)]` against one sibling. Its comment states the reason precisely:

> both tests toggle the process-wide `DEFAULT_SYMBOLS` seed, and cargo runs tests in parallel by default, so without this they can interleave and flip each other's seed between `set_default_symbols` and `parse_ini`.

Three tests in the `tested_symbol_tests` module seed the same global and were never added to the group:

- `a_definition_records_the_symbols_it_tested`
- `an_ini_that_never_asks_records_nothing`
- `the_symbol_is_recorded_even_when_defined`

They are now, which is what the existing comment always implied should happen.

## Verification

**80 consecutive full-suite runs, no failures.**

At the measured rates that is meaningful: a 13% flake surviving 80 runs has probability around 10⁻⁵. Twenty runs would not have been enough — that is exactly the trap attempt 3 fell into, and separately the reason I initially mis-attributed the first flake to my own branch after an 8-run baseline came back clean by luck.

806 core tests pass. Clippy unchanged from the `main` baseline of 32.

## Risk

Low. No production code changes — one test's assertion is swapped for a deterministic observable of the same behaviour, and three tests join an existing serial group.

The one judgement call worth reviewing: the tracing test no longer asserts that a log line is emitted, only that the rejection is recorded. If the `tracing::debug!` were deleted tomorrow this test would still pass. I traded that coverage for determinism deliberately — a test that fails one run in eight provides no coverage at all, because its failures get ignored.
