### PR TITLE
Fix issue #132 follow-ups: second VE table in AutoTune pickers, trace line in table views

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -308,6 +308,27 @@ Based on analysis of common ECU tuning software patterns:
 Detailed session-by-session history has moved to [CHANGELOG.md](CHANGELOG.md).
 What follows is a high-level pointer to the most recent cleanup pass.
 
+### AutoTune second-table picker & table trace line (Aug 2026)
+
+- **Numbered-sibling role inference** — `EcuDefinition::infer_table_roles`
+  extends Ve/AfrTarget roles to digit-siblings of the `[VeAnalyze]`-labelled
+  table (`veTable1Tbl` → `veTable2Tbl`), so dual-fuel Speeduino tunes can pick
+  the second VE table in AutoTune again. The fuel-tune guard
+  (`fuel_tune_refusal`) is unchanged and stays authoritative for both the
+  picker list and `start_autotune`. See `is_digit_sibling` in
+  `crates/libretune-core/src/ini/mod.rs` (issue #132 follow-up).
+- **Trace line in the tab-view table editor** — `tuner-ui/TableEditor.tsx` now
+  draws the SVG trail overlay (measured grid geometry, `yAxisBottom`-aware,
+  layered under sticky headers) that the dialog-embedded `TableGrid` always
+  had; the dialog trail was bumped to 3 px stroke / 4 px dots with a
+  current-position halo.
+- **AutoTune current-cell highlight wired** — derived live from the table's
+  axis channels via `useChannels` (was dead state); tab-view tables fall back
+  to `rpm`/`map` when the INI declares no axis channels; the secondary-table
+  selector shows a "No other fuel tables" placeholder instead of echoing the
+  primary.
+- See the `2026-08-28` CHANGELOG block for details.
+
 ### AI Assistant enhancement pass (Aug 2026)
 
 Four phases; see the `2026-08-26` "AI Assistant" CHANGELOG block for the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,55 @@ relevant.
 
 ## [Unreleased]
 
+### 2026-08-28 — AutoTune second-table picker & table trace line (issue #132 follow-ups)
+
+Two reports from the issue #132 thread after the Aug 20 fixes: a
+dual-table user could no longer select the second VE table in AutoTune,
+and the live trace line was missing (tab-view tables) or too faint
+(dialog-view tables) to locate the active cell.
+
+#### Fixed
+- **Second VE table back in the AutoTune pickers** — `infer_table_roles`
+  now extends a role to numbered siblings of the `[VeAnalyze]`-labelled
+  table (`veTable1Tbl` → `veTable2Tbl`, likewise for AFR targets).
+  `[VeAnalyze]` names exactly one table because the analyzer runs one at
+  a time, so `veTable2Tbl` fell through to `Other`, the fuel-tune guard
+  refused it, and both table pickers (which list only guard-approved
+  tables) stopped offering it — an empty dropdown reads exactly like a
+  broken one. The sibling rule is prefix + digits + suffix with the
+  digits differing, so `veTableMafTbl` (no number) and cross-family
+  names stay unlabelled. The guard itself is unchanged and remains
+  authoritative for both the picker list and `start_autotune`.
+- **Secondary table selector empty state** — with a single tunable
+  table the secondary select echoed the primary (`|| tables[0]`
+  fallback) and looked dead; it now shows a disabled "No other fuel
+  tables" placeholder.
+
+#### Added
+- **Trace line in the tab-view table editor** — `tuner-ui/TableEditor`
+  (spark tables, the 3D-map menu entries) previously had no line at
+  all, only per-cell fills: "no indication of the current position"
+  (issue #132). It now draws the same SVG trail the dialog-embedded
+  editor has — 3 px stroke, 4 px dots, age-faded per segment, halo +
+  solid dot on the current cell — positioned over measured grid
+  geometry (ResizeObserver), layered under the sticky axis headers, and
+  orientation-aware for `yAxisBottom`.
+- **Current-cell highlight in AutoTune** — the `current` cell pulse
+  existed in CSS but `currentCell` was dead state (setter never
+  called). It is now derived from the table's own axis channels via the
+  realtime store (`useChannels`, nearest-bin).
+- **rpm/map channel fallback in the tab view** — an INI that declares
+  no axis output channels previously showed no cursor at all (silent
+  bail-out); the tab view now falls back to the canonical `rpm`/`map`
+  channels exactly like the dialog editor, and Follow Mode is no
+  longer disabled in that case.
+
+#### Changed
+- **Trail visibility in the dialog-embedded editor** — `TableGrid`'s
+  trail bumped from 2 px stroke / 3 px dots to 3 px / 4 px with round
+  joins and caps, plus a halo + solid dot on the newest point ("the
+  line is too small to identify which cell is active", issue #132).
+
 ### 2026-08-26 — AI Assistant: the apply path made real, analyst tools, trust & traceability, UX
 
 Four-phase enhancement of the bring-your-own-LLM assistant. The headline

--- a/crates/libretune-app/public/manual/features/autotune/usage-guide.md
+++ b/crates/libretune-app/public/manual/features/autotune/usage-guide.md
@@ -41,8 +41,9 @@ Or keyboard: Ctrl+Shift+A
 
 **Step 2: Select Table**
 - Default: VE Table 1 (most common)
-- Alternative: Choose different table if your ECU uses different tables
-- Secondary: Enable if you want to tune multiple tables simultaneously
+- Only fuel (VE) tables are offered: AutoTune scales fuel quantity, so ignition, AFR-target and other table types are deliberately not selectable
+- On dual-fuel setups (e.g. Speeduino's second fuel algorithm), **VE Table 2** is listed alongside VE Table 1
+- Secondary: Tick the checkbox to tune a second VE table simultaneously; if the tune has only one fuel table, the selector shows "No other fuel tables"
 
 **Step 3: Configure Basic Settings**
 ```
@@ -232,16 +233,21 @@ Click: Start again (with same or adjusted authority limits)
 
 ### Multi-Table Tuning
 
-Tune fuel and ignition tables together for best results:
+On dual-fuel setups, tune both VE tables in one session:
 
 ```
-1. Enable "Secondary Table"
-2. Select AFR Target table
-3. Primary: VE Table 1
-4. Secondary: AFR Table 1
+1. Tick "Secondary:"
+2. Primary: VE Table 1
+3. Secondary: VE Table 2
 
-Drive normally - both tables get tuned simultaneously
+Drive normally - both tables collect hits and recommendations independently
 ```
+
+The AFR target table is **not** tuned here — it is the reference AutoTune
+measures against, chosen during the preflight check. Ignition timing is a
+separate, manual workflow: scaling degrees of advance by AFR error would add
+timing in exactly the lean, high-load cells where detonation lives, so
+AutoTune refuses ignition tables entirely.
 
 ### Cell Locking
 

--- a/crates/libretune-app/public/manual/features/table-editing.md
+++ b/crates/libretune-app/public/manual/features/table-editing.md
@@ -123,6 +123,18 @@ Enable **Follow Mode** to automatically highlight the cell corresponding to curr
 2. Click the crosshair icon in the toolbar
 3. The current operating cell is highlighted
 
+On top of the highlight, a **trace line** is drawn through the cells visited
+recently, ending in a bright dot on the current cell — an at-a-glance answer
+to "where is the engine operating right now?". It is drawn in both the
+standalone table view and tables embedded in dialogs.
+
+- Older segments fade out over time; the fade duration follows the
+  *Trail fade* setting (`table_trail_fade_sec`, 0 = never fade)
+- The position comes from the table's own axis channels; if the INI declares
+  none, the standard `rpm` / `map` channels are used
+- Toggle with `F`; trail and cursor colors follow the *Cursor color* /
+  *Trail color* settings
+
 ## Editing Curves
 
 1D curves (for example, warmup enrichment or fan PWM vs. temperature) open in

--- a/crates/libretune-app/public/manual/features/table-editing/2d-tables.md
+++ b/crates/libretune-app/public/manual/features/table-editing/2d-tables.md
@@ -70,9 +70,14 @@ The color scale is based on the table's min/max range.
 ## Follow Mode
 
 When connected to ECU:
-1. Click the crosshair icon
+1. Click the crosshair icon (or press `F`)
 2. Current operating cell is highlighted
 3. Values update in real-time
+
+A **trace line** through the recently visited cells is drawn over the grid,
+ending in a bright dot on the current cell. Older segments fade according to
+the *Trail fade* setting; if the table's INI declares no axis channels, the
+standard `rpm` / `map` channels drive the cursor.
 
 ## Tips
 

--- a/crates/libretune-app/src/components/tables/TableGrid.tsx
+++ b/crates/libretune-app/src/components/tables/TableGrid.tsx
@@ -368,18 +368,33 @@ export default function TableGrid({
 
     if (centers.length === 0) return null;
 
+    // `centers` runs oldest → newest, so the live end of the trail is the
+    // last entry. Issue #132 asked for a clearly visible current position:
+    // at 2 px stroke / 3 px dots the line was hard to place on the active
+    // cell. The newest point gets a halo + solid dot so it reads as "you
+    // are here" even over a busy heatmap.
+    const newest = centers[centers.length - 1];
+
     return (
       <svg className="history-trail-svg">
         <polyline
           points={centers.map((c) => `${c.cx},${c.cy}`).join(' ')}
           fill="none"
           style={{ stroke: 'var(--cursor-trail, #4A90E2)' }}
-          strokeWidth="2"
-          strokeOpacity="0.7"
+          strokeWidth="3"
+          strokeOpacity="0.75"
+          strokeLinejoin="round"
+          strokeLinecap="round"
         />
         {centers.map((c, i) => (
-          <circle key={i} cx={c.cx} cy={c.cy} r="3" style={{ fill: 'var(--cursor-trail, #4A90E2)' }} fillOpacity="0.8" />
+          <circle key={i} cx={c.cx} cy={c.cy} r="4" style={{ fill: 'var(--cursor-trail, #4A90E2)' }} fillOpacity="0.85" />
         ))}
+        {newest && (
+          <>
+            <circle cx={newest.cx} cy={newest.cy} r="9" style={{ fill: 'var(--cursor-trail, #4A90E2)' }} fillOpacity="0.3" />
+            <circle cx={newest.cx} cy={newest.cy} r="6" style={{ fill: 'var(--cursor-trail, #4A90E2)' }} fillOpacity="1" />
+          </>
+        )}
       </svg>
     );
   };

--- a/crates/libretune-app/src/components/tuner-ui/AutoTune.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/AutoTune.tsx
@@ -35,6 +35,7 @@ import { open, save } from '@tauri-apps/plugin-dialog';
 import { valueToHeatmapColor } from '../../utils/heatmapColors';
 import { TuneHealthCard } from './TuneHealth';
 import { useToast } from '../../contexts/ToastContext';
+import { useChannels } from '../../stores/realtimeStore';
 import './AutoTune.css';
 
 // =============================================================================
@@ -314,6 +315,27 @@ function persist(key: string, value: unknown) {
   }
 }
 
+/** Stable empty list so the axis-channel subscription below can skip
+ * subscribing entirely when the table declares no channels. */
+const NO_CHANNELS: string[] = [];
+
+/**
+ * Index of the bin nearest to `value` — the cell a live reading falls into.
+ * Matches the nearest-bin logic the table editors use for their cursors.
+ */
+function nearestBinIndex(value: number, bins: number[]): number {
+  let best = 0;
+  let diff = Infinity;
+  bins.forEach((bin, i) => {
+    const d = Math.abs(bin - value);
+    if (d < diff) {
+      diff = d;
+      best = i;
+    }
+  });
+  return best;
+}
+
 export function AutoTune({ tableName: initialTableName = '', onClose, isConnected }: AutoTuneProps) {
   const { showToast } = useToast();
 
@@ -331,7 +353,6 @@ export function AutoTune({ tableName: initialTableName = '', onClose, isConnecte
   const [veAnalyzeConfig, setVeAnalyzeConfig] = useState<VeAnalyzeConfig | null>(null);
   const [lockedCells, setLockedCells] = useState<Set<string>>(new Set());
   const [selectedCells, _setSelectedCells] = useState<Set<string>>(new Set());
-  const [currentCell, _setCurrentCell] = useState<{ x: number; y: number } | null>(null);
   const [showHeatmap, setShowHeatmap] = useState<'weighting' | 'change' | 'none'>('weighting');
   const [error, setError] = useState<string | null>(null);
   const [loadSource, setLoadSource] = useState<AutoTuneLoadSource>('map');
@@ -342,6 +363,34 @@ export function AutoTune({ tableName: initialTableName = '', onClose, isConnecte
   // lets async detection re-fire after e.g. the MAF-verify demotion and flip
   // the dropdown back (issue #132).
   const manualLoadSourceRef = useRef(false);
+
+  // Current operating cell for the grid's "current" highlight, derived from
+  // the table's own axis channels (issue #132: "no indication of the current
+  // position"). A `currentCell` state used to sit here but its setter was
+  // never called, so the highlight never fired. x indexes columns (x_bins),
+  // y indexes rows (y_bins) — matching how the grid iterates them. A missing
+  // Y channel (1-D curves) pins the row at 0, same as the table editors.
+  const currentXChannel = tableData?.x_output_channel ?? undefined;
+  const currentYChannel = tableData?.y_output_channel ?? undefined;
+  const liveAxisValues = useChannels(
+    currentXChannel
+      ? currentYChannel
+        ? [currentXChannel, currentYChannel]
+        : [currentXChannel]
+      : NO_CHANNELS
+  );
+  const currentCell = useMemo<{ x: number; y: number } | null>(() => {
+    if (!tableData || !currentXChannel) return null;
+    const xv = liveAxisValues[currentXChannel];
+    if (xv === undefined) return null;
+    const x = nearestBinIndex(xv, tableData.x_bins);
+    if (!currentYChannel || tableData.y_bins.length <= 1) {
+      return { x, y: 0 };
+    }
+    const yv = liveAxisValues[currentYChannel];
+    if (yv === undefined) return { x, y: 0 };
+    return { x, y: nearestBinIndex(yv, tableData.y_bins) };
+  }, [tableData, currentXChannel, currentYChannel, liveAxisValues]);
 
   // Settings state
   const [settings, setSettings] = useState<AutoTuneSettings>(() =>
@@ -487,12 +536,16 @@ export function AutoTune({ tableName: initialTableName = '', onClose, isConnecte
         }
       }
 
-      if (!secondaryTable && tables.length > 1) {
+      // Only a *different* fuel table is a valid secondary pick. The old
+      // `|| tables[0]` fallback made the secondary selector echo the primary
+      // when only one table is tunable — and an empty picker looks exactly
+      // like a broken one (issue #132). '' selects the placeholder below.
+      if (!secondaryTable) {
         const preferredSecondary = veAnalyzeConfig?.lambda_target_tables
           ?.map((name) => tables.find((t) => t.name === name))
           .find((t) => t && t.name !== selectedTable);
-        const fallbackSecondary = preferredSecondary || tables.find((t) => t.name !== selectedTable) || tables[0];
-        setSecondaryTable(fallbackSecondary.name);
+        const fallbackSecondary = preferredSecondary || tables.find((t) => t.name !== selectedTable);
+        setSecondaryTable(fallbackSecondary ? fallbackSecondary.name : '');
       }
     } catch (e) {
       console.error('Failed to load available tables:', e);
@@ -1297,9 +1350,15 @@ export function AutoTune({ tableName: initialTableName = '', onClose, isConnecte
                 onChange={(e) => setSecondaryTable(e.target.value)}
                 disabled={!secondaryTableEnabled || isRunning}
               >
-                {secondaryOptions.map((t) => (
-                  <option key={t.name} value={t.name}>{t.title || t.name}</option>
-                ))}
+                {secondaryOptions.length === 0 ? (
+                  <option value="" disabled>
+                    No other fuel tables
+                  </option>
+                ) : (
+                  secondaryOptions.map((t) => (
+                    <option key={t.name} value={t.name}>{t.title || t.name}</option>
+                  ))
+                )}
               </select>
             </div>
             <div className="autotune-table-group">

--- a/crates/libretune-app/src/components/tuner-ui/TableEditor.css
+++ b/crates/libretune-app/src/components/tuner-ui/TableEditor.css
@@ -80,6 +80,9 @@
   flex: 1;
   overflow: auto;
   padding: var(--space-2);
+  /* Containing block for the trail overlay, which is sized and positioned
+     in the container's content space so it scrolls with the grid. */
+  position: relative;
 }
 
 /* Grid */
@@ -180,6 +183,17 @@
   opacity: calc(var(--trail-opacity, 0.3) * 0.4);
   pointer-events: none;
   border-radius: 2px;
+}
+
+/* Trail line overlay (issue #132): the tab view showed only per-cell fills,
+   with no line to follow the current position. Sits above plain cells and
+   z-1 fills (later in DOM wins ties) but below the live-cell tint and the
+   sticky axis headers (z-2/3), so the line scrolls under them. */
+.table-trail-overlay {
+  position: absolute;
+  pointer-events: none;
+  z-index: 1;
+  overflow: visible;
 }
 
 /* Follow mode button */

--- a/crates/libretune-app/src/components/tuner-ui/TableEditor.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/TableEditor.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef, useEffect, KeyboardEvent, useMemo } from 'react';
+import { useState, useCallback, useRef, useEffect, useLayoutEffect, KeyboardEvent, useMemo } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { open, save } from '@tauri-apps/plugin-dialog';
 import { useChannels } from '../../stores/realtimeStore';
@@ -37,6 +37,27 @@ export interface TableData {
 export interface CellPosition {
   row: number;
   col: number;
+}
+
+/** Measured on-screen geometry of the grid, for the trail overlay. */
+interface GridGeometry {
+  /** Table origin within the scroll container's content space. */
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+  /** Column header rects, table-relative. */
+  cols: Array<{ left: number; width: number }>;
+  /** Row header rects, table-relative, in DOM (display) order. */
+  rows: Array<{ top: number; height: number }>;
+}
+
+/**
+ * Display row for a data-space row. `yAxisBottom` renders rows reversed;
+ * geometry arrays follow the DOM, so the overlay must flip back.
+ */
+export function trailDisplayRow(row: number, rowCount: number, yAxisBottom: boolean): number {
+  return yAxisBottom ? rowCount - 1 - row : row;
 }
 
 interface TableEditorProps {
@@ -80,9 +101,11 @@ export function TableEditor({
   const outputChannels = useMemo(() => {
     const channels: string[] = [];
     if (data.xOutputChannel) channels.push(data.xOutputChannel);
+    else channels.push('rpm'); // canonical fallback, matches the cursor below
     if (data.yOutputChannel) channels.push(data.yOutputChannel);
+    else if (data.yAxis.length > 1) channels.push('map');
     return channels;
-  }, [data.xOutputChannel, data.yOutputChannel]);
+  }, [data.xOutputChannel, data.yOutputChannel, data.yAxis.length]);
   const realtimeData = useChannels(outputChannels);
 
   const [selection, setSelection] = useState<Selection | null>(null);
@@ -197,11 +220,12 @@ export function TableEditor({
   const calculatedLivePosition = useMemo((): CellPosition | null => {
     if (!followMode) return null;
     
-    const xChannel = data.xOutputChannel;
-    const yChannel = data.yOutputChannel;
-    
-    if (!xChannel) return null;
-    
+    // Parity with the dialog-embedded editor (TableEditor2D): an INI that
+    // declares no output channels still gets a cursor from the canonical
+    // rpm/map channels instead of silently showing nothing (issue #132).
+    const xChannel = data.xOutputChannel ?? 'rpm';
+    const yChannel = data.yOutputChannel ?? 'map';
+
     const xValue = realtimeData[xChannel];
     if (xValue === undefined) return null;
     
@@ -323,6 +347,147 @@ export function TableEditor({
     for (const e of historyTrail) m.set(`${e.row},${e.col}`, e);
     return m;
   }, [historyTrail]);
+
+  // ── Trail line overlay (issue #132) ──
+  // The tab view showed only per-cell fills — a 2 px live outline and a
+  // ≤0.4-opacity tint — so there was "no indication of the current
+  // position": no line at all on the spark table, nothing to follow on
+  // the fuel one. The dialog-embedded editor (TableGrid) has always drawn
+  // one; this gives the tab view the same SVG trail, sized to stay readable
+  // (3 px stroke, 4 px dots, halo + solid dot on the current cell).
+  const tableElRef = useRef<HTMLTableElement | null>(null);
+  const scrollHostRef = useRef<HTMLDivElement | null>(null);
+  const [gridGeometry, setGridGeometry] = useState<GridGeometry | null>(null);
+
+  useLayoutEffect(() => {
+    const table = tableElRef.current;
+    const host = scrollHostRef.current;
+    if (!table || !host) return;
+
+    const measure = () => {
+      const tRect = table.getBoundingClientRect();
+      const hRect = host.getBoundingClientRect();
+      // Content-space origin: rects are viewport-based, so undo the current
+      // scroll to get coordinates that stay correct as the user scrolls.
+      const left = tRect.left - hRect.left + host.scrollLeft;
+      const top = tRect.top - hRect.top + host.scrollTop;
+      const cols = Array.from(table.querySelectorAll<HTMLTableCellElement>('thead th'))
+        .slice(1) // the corner cell is not a column
+        .map((th) => {
+          const r = th.getBoundingClientRect();
+          return { left: r.left - tRect.left, width: r.width };
+        });
+      const rows = Array.from(
+        table.querySelectorAll<HTMLTableCellElement>('tbody tr > th:first-child')
+      ).map((th) => {
+        const r = th.getBoundingClientRect();
+        return { top: r.top - tRect.top, height: r.height };
+      });
+      setGridGeometry((prev) => {
+        const close = (a: number, b: number) => Math.abs(a - b) < 0.5;
+        const same =
+          prev !== null &&
+          close(prev.left, left) &&
+          close(prev.top, top) &&
+          close(prev.width, tRect.width) &&
+          close(prev.height, tRect.height) &&
+          prev.cols.length === cols.length &&
+          prev.rows.length === rows.length &&
+          prev.cols.every((c, i) => close(c.left, cols[i].left) && close(c.width, cols[i].width)) &&
+          prev.rows.every((r, i) => close(r.top, rows[i].top) && close(r.height, rows[i].height));
+        return same
+          ? prev
+          : { left, top, width: tRect.width, height: tRect.height, cols, rows };
+      });
+    };
+
+    measure();
+    if (typeof ResizeObserver === 'undefined') return; // jsdom
+    const ro = new ResizeObserver(() => measure());
+    ro.observe(table);
+    ro.observe(host);
+    return () => ro.disconnect();
+    // Bin-count changes, the orientation flip, and 2D/3D remounts all
+    // require a fresh measurement.
+  }, [data.xAxis.length, data.yAxis.length, yAxisBottom, show3D]);
+
+  const cellCenter = useCallback(
+    (row: number, col: number): { cx: number; cy: number } | null => {
+      if (!gridGeometry) return null;
+      const c = gridGeometry.cols[col];
+      const r = gridGeometry.rows[trailDisplayRow(row, data.yAxis.length, yAxisBottom)];
+      if (!c || !r) return null;
+      return { cx: c.left + c.width / 2, cy: r.top + r.height / 2 };
+    },
+    [gridGeometry, data.yAxis.length, yAxisBottom]
+  );
+
+  const renderTrailOverlay = () => {
+    if (!followMode || !gridGeometry) return null;
+    const now = Date.now();
+    const fade = (t: number) =>
+      TRAIL_DURATION_MS === Infinity ? 1 : Math.max(0, 1 - (now - t) / TRAIL_DURATION_MS);
+
+    const points = historyTrail
+      .map((e) => {
+        const c = cellCenter(e.row, e.col);
+        return c ? { cx: c.cx, cy: c.cy, fade: fade(e.time) } : null;
+      })
+      .filter((p): p is { cx: number; cy: number; fade: number } => p !== null);
+
+    const current = effectiveLivePosition
+      ? cellCenter(effectiveLivePosition.row, effectiveLivePosition.col)
+      : null;
+    if (points.length === 0 && !current) return null;
+
+    const segments = points.slice(1).map((p, i) => {
+      const a = points[i];
+      return { x1: a.cx, y1: a.cy, x2: p.cx, y2: p.cy, opacity: 0.75 * p.fade };
+    });
+    const head = current ?? points[points.length - 1];
+
+    return (
+      <svg
+        className="table-trail-overlay"
+        style={{
+          left: gridGeometry.left,
+          top: gridGeometry.top,
+          width: gridGeometry.width,
+          height: gridGeometry.height,
+        }}
+      >
+        {segments.map((s, i) => (
+          <line
+            key={i}
+            x1={s.x1}
+            y1={s.y1}
+            x2={s.x2}
+            y2={s.y2}
+            style={{ stroke: 'var(--cursor-trail, #4A90E2)' }}
+            strokeWidth="3"
+            strokeOpacity={s.opacity}
+            strokeLinecap="round"
+          />
+        ))}
+        {points.map((p, i) => (
+          <circle
+            key={i}
+            cx={p.cx}
+            cy={p.cy}
+            r="4"
+            style={{ fill: 'var(--cursor-trail, #4A90E2)' }}
+            fillOpacity={0.85 * p.fade}
+          />
+        ))}
+        {head && (
+          <>
+            <circle cx={head.cx} cy={head.cy} r="9" style={{ fill: 'var(--cursor-trail, #4A90E2)' }} fillOpacity={0.3} />
+            <circle cx={head.cx} cy={head.cy} r="6" style={{ fill: 'var(--cursor-trail, #4A90E2)' }} fillOpacity={1} />
+          </>
+        )}
+      </svg>
+    );
+  };
 
   // Calculate color for value based on min/max
   const getValueColor = useCallback((value: number) => {
@@ -1017,7 +1182,9 @@ export function TableEditor({
         canRedo={historyIndex < history.length - 1}
         followMode={followMode}
         onToggleFollowMode={() => setFollowMode(!followMode)}
-        hasOutputChannels={!!data.xOutputChannel}
+        // The rpm/map fallback (see calculatedLivePosition) makes follow mode
+        // usable even when the INI declares no axis channels.
+        hasOutputChannels={true}
         show3D={show3D}
         onToggle3D={() => setShow3D(!show3D)}
         onGenerate={generatableKind ? () => setShowGenerateDialog(true) : undefined}
@@ -1049,8 +1216,8 @@ export function TableEditor({
 
       {/* Table */}
       {!show3D && (
-      <div className="table-grid-container">
-        <table className="table-grid">
+      <div className="table-grid-container" ref={scrollHostRef}>
+        <table className="table-grid" ref={tableElRef}>
           <thead>
             <tr>
               <th className="table-corner">
@@ -1120,6 +1287,7 @@ export function TableEditor({
             })()}
           </tbody>
         </table>
+        {renderTrailOverlay()}
       </div>
       )}
 

--- a/crates/libretune-app/src/components/tuner-ui/__tests__/TableEditor.trail.test.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/__tests__/TableEditor.trail.test.tsx
@@ -2,7 +2,7 @@ import { render, act } from '@testing-library/react';
 import { Profiler } from 'react';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { invoke } from '@tauri-apps/api/core';
-import { TableEditor } from '../TableEditor';
+import { TableEditor, trailDisplayRow } from '../TableEditor';
 import { useRealtimeStore } from '../../../stores/realtimeStore';
 
 vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
@@ -140,5 +140,87 @@ describe('TableEditor live trail', () => {
     });
 
     expect(commits - before).toBe(2);
+  });
+});
+
+describe('trail overlay', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    invokeMock.mockReset();
+    invokeMock.mockImplementation(() => Promise.resolve({}));
+    useRealtimeStore.getState().clearChannels();
+  });
+
+  afterEach(() => {
+    act(() => {
+      vi.runOnlyPendingTimers();
+    });
+    vi.useRealTimers();
+  });
+
+  it('draws a trail line and current-position dot over the grid', async () => {
+    const { container } = render(
+      <TableEditor data={{ ...DATA }} onChange={() => {}} />
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // No live data yet: no trail to draw.
+    expect(container.querySelector('svg.table-trail-overlay')).toBeNull();
+
+    // Move between two cells: the overlay appears with a segment joining
+    // them and a solid current dot. (jsdom reports zero rects, so the
+    // geometry is degenerate — presence and structure are what's testable
+    // here; the mapping itself is covered by trailDisplayRow below.)
+    act(() => {
+      useRealtimeStore.getState().updateChannels({ RPM: 1200, MAP: 45 });
+    });
+    act(() => {
+      useRealtimeStore.getState().updateChannels({ RPM: 2200, MAP: 55 });
+    });
+
+    const svg = container.querySelector('svg.table-trail-overlay');
+    expect(svg).not.toBeNull();
+    const lines = svg ? Array.from(svg.querySelectorAll('line')) : [];
+    expect(lines.length).toBeGreaterThanOrEqual(1);
+    // Halo (r=9) + solid dot (r=6) mark the current position.
+    const radii = (svg ? Array.from(svg.querySelectorAll('circle')) : []).map((c) =>
+      c.getAttribute('r')
+    );
+    expect(radii).toContain('6');
+    expect(radii).toContain('9');
+  });
+
+  it('falls back to rpm/map channels when the INI declares none', async () => {
+    const { container } = render(
+      <TableEditor
+        data={{ ...DATA, xOutputChannel: undefined, yOutputChannel: undefined }}
+        onChange={() => {}}
+      />
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Canonical channel names drive the cursor even with no declared ones
+    // (issue #132: silently showing nothing read as a missing trace).
+    act(() => {
+      useRealtimeStore.getState().updateChannels({ rpm: 1200, map: 45 });
+    });
+    expect(cellAt(container, 1, 1).className).toContain('live');
+  });
+});
+
+describe('trailDisplayRow', () => {
+  it('maps data rows through the yAxisBottom display flip', () => {
+    // Normal orientation: display order equals data order.
+    expect(trailDisplayRow(0, 4, false)).toBe(0);
+    expect(trailDisplayRow(3, 4, false)).toBe(3);
+    // Y-axis at bottom renders rows reversed.
+    expect(trailDisplayRow(0, 4, true)).toBe(3);
+    expect(trailDisplayRow(2, 4, true)).toBe(1);
+    expect(trailDisplayRow(3, 4, true)).toBe(0);
   });
 });

--- a/crates/libretune-core/src/autotune/mod.rs
+++ b/crates/libretune-core/src/autotune/mod.rs
@@ -2214,6 +2214,43 @@ mod fuel_tunable_tests {
             assert!(fuel_tune_refusal(&def, &name).is_none());
         }
     }
+
+    /// The hand-stamped test above cannot catch an inference gap: it never
+    /// asks how the roles got there. This one parses a dual-table INI, so the
+    /// whole chain — parser, `[VeAnalyze]` config, `infer_table_roles`,
+    /// guard — runs as it does in the app. Before sibling inference, the
+    /// second VE table came out `Other` and vanished from the pickers
+    /// (issue #132: "the drop-down for selecting the second table isn't
+    /// opening" — an empty dropdown looks exactly like a broken one).
+    #[test]
+    fn a_parsed_dual_table_ini_offers_both_ve_tables() {
+        let ini = "[TableEditor]
+table = veTable1Tbl, veTable1, \"VE Table 1\", 2
+    xBins = rpmBins1, rpm
+    yBins = fuelLoadBins1, fuelLoad
+    zBins = veTable1
+table = veTable2Tbl, veTable2, \"VE Table 2\", 2
+    xBins = rpmBins2, rpm
+    yBins = fuelLoadBins2, fuelLoad
+    zBins = veTable2
+table = afrTable1Tbl, afrTable1, \"AFR Table 1\", 2
+    xBins = rpmBins1, rpm
+    yBins = fuelLoadBins1, fuelLoad
+    zBins = afrTable1
+table = sparkTbl, spark, \"Spark Table\", 2
+    xBins = rpmBins1, rpm
+    yBins = ignLoadBins, ignLoad
+    zBins = spark
+[VeAnalyze]
+veAnalyzeMap = veTable1Tbl, afrTable1Tbl, afr, egoCorrection
+";
+        let def = EcuDefinition::from_str(ini).expect("parses");
+        assert_eq!(
+            fuel_tunable_tables(&def),
+            vec!["veTable1Tbl", "veTable2Tbl"],
+            "both VE tables must be offered; spark and AFR tables must not"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/libretune-core/src/ini/mod.rs
+++ b/crates/libretune-core/src/ini/mod.rs
@@ -318,7 +318,9 @@ impl EcuDefinition {
     /// is fully parsed (both `[TableEditor]` and the analyze sections). Safe
     /// to call more than once. Tables not referenced by any analyze config
     /// are left as [`TableRole::Other`] (their default), with a name-based
-    /// heuristic for ignition tables as a fallback.
+    /// heuristic for ignition tables as a fallback. A numbered sibling of a
+    /// referenced table (`veTable2Tbl` of `veTable1Tbl`) inherits its role —
+    /// see [`is_digit_sibling`].
     pub fn infer_table_roles(&mut self) {
         let mut ve_names: Vec<String> = Vec::new();
         let mut afr_target_names: Vec<String> = Vec::new();
@@ -343,11 +345,16 @@ impl EcuDefinition {
             let map_name = table.map_name.as_deref();
 
             // A table matches a candidate name if either its canonical name
-            // or its map_name equals the candidate.
+            // or its map_name equals the candidate — or if it is a numbered
+            // sibling of the candidate, so `veTable2Tbl` rides along with a
+            // config that names only `veTable1Tbl`.
             let matches_any = |names: &[String]| {
-                names
-                    .iter()
-                    .any(|n| n == canonical_name || map_name == Some(n.as_str()))
+                names.iter().any(|n| {
+                    n == canonical_name
+                        || map_name == Some(n.as_str())
+                        || is_digit_sibling(n, canonical_name)
+                        || map_name.is_some_and(|m| is_digit_sibling(n, m))
+                })
             };
 
             if matches_any(&ve_names) {
@@ -809,6 +816,39 @@ impl Default for EcuDefinition {
             requires_power_cycle: Vec::new(),
         }
     }
+}
+
+/// Split a table name around its last digit run: `veTable1Tbl` becomes
+/// (`veTable`, `1`, `Tbl`). Returns `None` when the name contains no digits.
+fn split_digit_run(name: &str) -> Option<(String, String, String)> {
+    let digits_end = name.rfind(|c: char| c.is_ascii_digit())? + 1;
+    let digits_start = name[..digits_end]
+        .rfind(|c: char| !c.is_ascii_digit())
+        .map_or(0, |i| i + 1);
+    Some((
+        name[..digits_start].to_string(),
+        name[digits_start..digits_end].to_string(),
+        name[digits_end..].to_string(),
+    ))
+}
+
+/// True when two table names differ only in their digit run — `veTable1Tbl`
+/// and `veTable2Tbl` are siblings; `veTable1Tbl` and `afrTable1Tbl` are not
+/// (different prefixes), nor is `veTableMafTbl` (no number to vary).
+///
+/// `[VeAnalyze]` names exactly one VE table because the analyzer runs one
+/// at a time, but dual-table INIs (Speeduino's second fuel algorithm, MS3
+/// table sets) define a whole numbered family. Without this, every sibling
+/// fell through to [`TableRole::Other`], the fuel-tune guard refused it, and
+/// the AutoTune pickers — which offer only guard-approved tables — stopped
+/// listing the second VE table at all (issue #132).
+fn is_digit_sibling(labeled: &str, candidate: &str) -> bool {
+    let (Some((lp, ld, ls)), Some((cp, cd, cs))) =
+        (split_digit_run(labeled), split_digit_run(candidate))
+    else {
+        return false;
+    };
+    lp == cp && ls == cs && ld != cd
 }
 
 #[cfg(test)]

--- a/crates/libretune-core/src/ini/parser.rs
+++ b/crates/libretune-core/src/ini/parser.rs
@@ -3725,6 +3725,47 @@ veAnalyzeMap = veTable1Tbl, afrTable1Tbl, afr, egoCorrection
         assert_eq!(role("sparkTbl"), crate::ini::TableRole::Ignition);
     }
 
+    /// Dual-table INIs define a numbered family (`veTable1Tbl`,
+    /// `veTable2Tbl`, …) but `[VeAnalyze]` names only the first, since the
+    /// analyzer runs one table at a time. The siblings used to fall through
+    /// to `Other`, so the fuel-tune guard refused them and the AutoTune
+    /// pickers no longer offered the second VE table (issue #132).
+    #[test]
+    fn numbered_siblings_inherit_the_labeled_role() {
+        let ini = "[TableEditor]
+table = veTable1Tbl, veTable1, \"VE Table 1\", 2
+table = veTable2Tbl, veTable2, \"VE Table 2\", 2
+table = afrTable1Tbl, afrTable1, \"AFR Table 1\", 2
+table = afrTable2Tbl, afrTable2, \"AFR Table 2\", 2
+table = veTableMafTbl, veTableMaf, \"MAF trim\", 2
+table = sparkTbl, spark, \"Spark Table\", 2
+[VeAnalyze]
+veAnalyzeMap = veTable1Tbl, afrTable1Tbl, afr, egoCorrection
+";
+        let def = parse_ini(ini).expect("parses");
+        let role = |n: &str| {
+            def.tables
+                .values()
+                .find(|t| t.name == n)
+                .map(|t| t.role)
+                .unwrap_or(crate::ini::TableRole::Other)
+        };
+        assert_eq!(role("veTable1Tbl"), crate::ini::TableRole::Ve);
+        assert_eq!(
+            role("veTable2Tbl"),
+            crate::ini::TableRole::Ve,
+            "numbered sibling of the labeled VE table"
+        );
+        assert_eq!(role("afrTable1Tbl"), crate::ini::TableRole::AfrTarget);
+        assert_eq!(role("afrTable2Tbl"), crate::ini::TableRole::AfrTarget);
+        assert_eq!(
+            role("veTableMafTbl"),
+            crate::ini::TableRole::Other,
+            "no number to vary, and the INI does not label it"
+        );
+        assert_eq!(role("sparkTbl"), crate::ini::TableRole::Ignition);
+    }
+
     /// Speeduino declares these in `[Constants]`, where the section parser had
     /// no arm for either — `delayAfterPortOpen` stayed 0 (handshake raced the
     /// port open) and `tsWriteBlocks` was never matched at all because only the

--- a/docs/src/features/autotune/usage-guide.md
+++ b/docs/src/features/autotune/usage-guide.md
@@ -41,8 +41,9 @@ Or keyboard: Ctrl+Shift+A
 
 **Step 2: Select Table**
 - Default: VE Table 1 (most common)
-- Alternative: Choose different table if your ECU uses different tables
-- Secondary: Enable if you want to tune multiple tables simultaneously
+- Only fuel (VE) tables are offered: AutoTune scales fuel quantity, so ignition, AFR-target and other table types are deliberately not selectable
+- On dual-fuel setups (e.g. Speeduino's second fuel algorithm), **VE Table 2** is listed alongside VE Table 1
+- Secondary: Tick the checkbox to tune a second VE table simultaneously; if the tune has only one fuel table, the selector shows "No other fuel tables"
 
 **Step 3: Configure Basic Settings**
 ```
@@ -232,16 +233,21 @@ Click: Start again (with same or adjusted authority limits)
 
 ### Multi-Table Tuning
 
-Tune fuel and ignition tables together for best results:
+On dual-fuel setups, tune both VE tables in one session:
 
 ```
-1. Enable "Secondary Table"
-2. Select AFR Target table
-3. Primary: VE Table 1
-4. Secondary: AFR Table 1
+1. Tick "Secondary:"
+2. Primary: VE Table 1
+3. Secondary: VE Table 2
 
-Drive normally - both tables get tuned simultaneously
+Drive normally - both tables collect hits and recommendations independently
 ```
+
+The AFR target table is **not** tuned here — it is the reference AutoTune
+measures against, chosen during the preflight check. Ignition timing is a
+separate, manual workflow: scaling degrees of advance by AFR error would add
+timing in exactly the lean, high-load cells where detonation lives, so
+AutoTune refuses ignition tables entirely.
 
 ### Cell Locking
 

--- a/docs/src/features/table-editing.md
+++ b/docs/src/features/table-editing.md
@@ -123,6 +123,18 @@ Enable **Follow Mode** to automatically highlight the cell corresponding to curr
 2. Click the crosshair icon in the toolbar
 3. The current operating cell is highlighted
 
+On top of the highlight, a **trace line** is drawn through the cells visited
+recently, ending in a bright dot on the current cell — an at-a-glance answer
+to "where is the engine operating right now?". It is drawn in both the
+standalone table view and tables embedded in dialogs.
+
+- Older segments fade out over time; the fade duration follows the
+  *Trail fade* setting (`table_trail_fade_sec`, 0 = never fade)
+- The position comes from the table's own axis channels; if the INI declares
+  none, the standard `rpm` / `map` channels are used
+- Toggle with `F`; trail and cursor colors follow the *Cursor color* /
+  *Trail color* settings
+
 ## Editing Curves
 
 1D curves (for example, warmup enrichment or fan PWM vs. temperature) open in

--- a/docs/src/features/table-editing/2d-tables.md
+++ b/docs/src/features/table-editing/2d-tables.md
@@ -70,9 +70,14 @@ The color scale is based on the table's min/max range.
 ## Follow Mode
 
 When connected to ECU:
-1. Click the crosshair icon
+1. Click the crosshair icon (or press `F`)
 2. Current operating cell is highlighted
 3. Values update in real-time
+
+A **trace line** through the recently visited cells is drawn over the grid,
+ending in a bright dot on the current cell. Older segments fade according to
+the *Trail fade* setting; if the table's INI declares no axis channels, the
+standard `rpm` / `map` channels drive the cursor.
 
 ## Tips
 


### PR DESCRIPTION
## Summary

Follow-ups from the [issue #132 thread](https://github.com/RallyPat/LibreTune/issues/132#issuecomment-5425467892) (2026-08-26): the main issues were resolved, and the reporter called out two remaining problems on real hardware —

> The drop-down menu for selecting the second table isn't opening; this is essential since I use two tables, and previous versions allowed me to select the second one.
>
> It is really important to display the trace line within the cells; right now, I can see changes occurring in the cells, but there is no indication of the current position. The trace line is missing from the spark table, and in the fuel tables, the line is too small, making it difficult to identify exactly which cell is active.

Both are fixed, plus one dead feature found along the way (the AutoTune current-cell highlight was wired to nothing).

## Root causes

**Second table missing from the pickers.** The AutoTune table pickers list only tables the fuel-tune guard accepts (`fuel_tunable_tables` → `TableRole::Ve`). `infer_table_roles` labeled exactly one VE table — the single one `[VeAnalyze]` names — because the analyzer runs one table at a time. Dual-fuel INIs (Speeduino's second fuel algorithm) define a numbered family (`veTable1Tbl`, `veTable2Tbl`), so `veTable2Tbl` fell through to `Other`, was refused, and vanished from both dropdowns. With only one remaining entry the secondary selector also echoed the primary, and an empty dropdown reads exactly like a broken one.

**No trace line.** Two different 2D editors: the dialog-embedded `TableGrid` (fuel tables via `veTableDialog`) draws a 2 px SVG polyline — "too small to identify the active cell" — while the tab view `tuner-ui/TableEditor` (spark table, 3D-map menu entries) had **no line at all**, only per-cell fills. Additionally, `AutoTune.tsx`'s `currentCell` state was dead code: the setter was never called and the component never subscribed to realtime data.

## Changes

### Fixed
- **Numbered-sibling role inference** (`libretune-core/src/ini/mod.rs`): a table whose name differs from an `[VeAnalyze]`-labelled table only in its digit run (`veTable1Tbl` → `veTable2Tbl`, likewise for AFR targets) now inherits that role. The rule is prefix + digits + suffix with the digits differing, so `veTableMafTbl` (no number) and cross-family names stay unlabelled. The guard itself is unchanged and remains authoritative for both the picker list and `start_autotune`.
- **Secondary selector empty state** (`AutoTune.tsx`): with a single tunable table it shows a disabled "No other fuel tables" placeholder instead of echoing the primary.

### Added
- **Trace line in the tab-view editor** (`tuner-ui/TableEditor.tsx`): the same SVG trail the dialog editor has — 3 px stroke, 4 px dots, age-faded per segment, halo + solid dot on the current cell — positioned over measured grid geometry (ResizeObserver, scroll-compensated), layered under the sticky axis headers, and orientation-aware for `yAxisBottom`.
- **Current-cell highlight in AutoTune** (`AutoTune.tsx`): `currentCell` is now derived live from the table's own axis channels (`useChannels`, nearest-bin) — no new state, no render storm.
- **rpm/map channel fallback** in the tab view: an INI that declares no axis output channels previously showed no cursor at all (silent bail-out); it now falls back to the canonical `rpm`/`map` channels exactly like the dialog editor, and Follow Mode is no longer disabled in that case.

### Changed
- **Dialog-view trail visibility** (`TableGrid.tsx`): 2 → 3 px stroke, 3 → 4 px dots, round joins/caps, highlighted newest point.

### Docs
- `docs/src` + `public/manual` (synced): AutoTune table-selection and multi-table guidance (the old "Secondary: AFR Table 1" advice predates the fuel-table guard and would have had the user tune the reference against itself), Follow Mode & trace line sections in both table-editing pages.
- `AGENTS.md` recent-changes pointer; `CHANGELOG.md` entry under `[Unreleased]` dated 2026-08-28.

## Tests

- `numbered_siblings_inherit_the_labeled_role` (parser) — siblings inherit Ve/AfrTarget; `veTableMafTbl` stays `Other`; ignition heuristic untouched.
- `a_parsed_dual_table_ini_offers_both_ve_tables` (core) — real parse → inference → `fuel_tunable_tables` chain, replacing the hand-stamped-role blind spot in the existing picker test.
- `TableEditor.trail.test.tsx` — trail overlay presence/structure, rpm/map fallback, and `trailDisplayRow` orientation mapping.

## Verification

- `cargo test -p libretune-core` — 571 lib tests, 0 failures (rebased on current `main`)
- `cargo clippy -p libretune-core` clean; `cargo fmt --all -- --check` clean
- `tsc` clean; `vitest` 283/283

## Manual test checklist (dual-table Speeduino)

- [ ] AutoTune picker lists **VE Table 1 and VE Table 2**; secondary select works after ticking the checkbox; a session on VE Table 2 passes preflight (its AFR table appears among the target candidates)
- [ ] Spark table (tab view) with a live stream shows the trail polyline + current dot
- [ ] Fuel table (dialog view) trail is clearly visible; current position readable at a glance
- [ ] AutoTune grid pulses the current cell while driving
- [ ] Single-fuel-table tune shows the "No other fuel tables" placeholder

Closes nothing (issue #132 remains open for the reporter's continued testing).
