### PR TITLE
docs: Fix stale references in README/CONTRIBUTING and align command examples

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,7 +25,7 @@ Closes #(issue number)
 - [ ] Code compiles without errors
 - [ ] No new clippy warnings (`cargo clippy`)
 - [ ] Code is formatted (`cargo fmt`)
-- [ ] TypeScript compiles without errors (`npx tsc --noEmit`)
+- [ ] TypeScript compiles without errors (`npm run typecheck`)
 - [ ] Documentation updated if needed
 - [ ] Commit messages follow conventional format
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to LibreTune! This document provides
 
 ### Prerequisites
 
-- **Rust 1.75+** - Install via [rustup](https://rustup.rs)
+- **Rust (latest stable)** - Install via [rustup](https://rustup.rs)
 - **Node.js 20+** - For the Tauri frontend
 - **npm** - Comes with Node.js
 
@@ -156,17 +156,17 @@ npm run tauri dev
 npm run build
 
 # Type checking
-npx tsc --noEmit
+npm run typecheck
 ```
 
 ### Testing (Frontend)
 
 We use Vitest + @testing-library/react for unit and integration tests in the frontend.
 
-- Run the full test suite:
+- Run the full test suite (one-shot, as CI does):
 ```bash
 cd crates/libretune-app
-npm test
+npm run test:run
 ```
 
 - Run a single test file (watch-mode):
@@ -175,7 +175,7 @@ npm test -- <path/to/test-file>
 ```
 
 - Test helpers:
-  - The project provides `src/test-utils/setupTauriMocks.ts` to stub Tauri `core.invoke` and `event.listen` during tests. See `src/test-utils/README.md` for details and examples.
+  - The project provides `src/test-utils/tauriMocks.ts` to stub Tauri `core.invoke` and `event.listen` during tests. See `src/test-utils/README.md` for details and examples.
   - Use `setupTauriMocks()` in tests to provide deterministic `invoke` responses and deterministic event emission via `emit()` / `listen()` helpers.
 
 - Test-writing tips:

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Project-based workflow with restore points, Git-based tune versioning, CSV expor
 - **Performance calculator**: Estimated HP/torque curves and acceleration times
 - **Action scripting**: Record and replay tuning actions across tunes, with INI-backed validation
 - **Extensible**: WASM plugin system with sandboxing and permission model
-- **Localization**: i18n scaffold with English and Brazilian Portuguese (`pt-BR`); add new locales under `crates/libretune-app/src/i18n/locales/`
+- **Localization**: i18n scaffold with English, Brazilian Portuguese (`pt-BR`), and Hungarian (`hu-HU`); add new locales under `crates/libretune-app/src/i18n/locales/`
 - **Demo mode**: Run the app without an ECU using the bundled simulator (Settings → Enable Demo Mode)
 
 For full documentation, see the [User Manual](https://rallypat.github.io/LibreTune/) or the [architecture overview](docs/architecture.md).
@@ -202,7 +202,7 @@ cd crates/libretune-app
 npm run typecheck
 ```
 
-The full pre-push pipeline (build + tests + clippy + fmt + frontend build/tests) is wrapped in [scripts/pre-push.sh](scripts/pre-push.sh) and runs automatically as a Git hook.
+The full pre-push pipeline (build + tests + clippy + fmt + frontend build/tests) is wrapped in [scripts/pre-push.sh](scripts/pre-push.sh). Both Git hooks are opt-in: `scripts/setup-git-hooks.ps1` (or `.sh`) enables the pre-commit format check, and `./scripts/pre-push.sh --install-hook` runs the full pipeline before every push.
 
 ## License
 

--- a/crates/libretune-app/public/manual/contributing.md
+++ b/crates/libretune-app/public/manual/contributing.md
@@ -78,7 +78,7 @@ cargo test -p libretune-core
 
 # TypeScript type checking
 cd crates/libretune-app
-npx tsc --noEmit
+npm run typecheck
 ```
 
 ### Documentation

--- a/crates/libretune-app/src/test-utils/README.md
+++ b/crates/libretune-app/src/test-utils/README.md
@@ -31,5 +31,3 @@ if (unlisten) unlisten();
 ## Notes
 - The helper patches `@tauri-apps/api/event.listen` so code that imports `listen` from that module will use the mocked implementation automatically (tests still may use `h.listen` directly).
 - `emit` queues events when listeners are not yet registered; use `getQueued`/`drainQueued` to inspect/deliver queued payloads in complex test flows.
-
-If you'd like, I can add example tests that use `setupTauriMocks` across more test files.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -217,8 +217,8 @@ cd crates/libretune-app
 npm install
 npm run dev          # Vite only
 ./scripts/tauri-dev.sh  # Full Tauri dev (preferred)
-npx tsc --noEmit     # Typecheck
-npm test -- --run    # Vitest
+npm run typecheck    # Typecheck
+npm run test:run     # Vitest
 npm run build        # Production bundle
 ```
 

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -78,7 +78,7 @@ cargo test -p libretune-core
 
 # TypeScript type checking
 cd crates/libretune-app
-npx tsc --noEmit
+npm run typecheck
 ```
 
 ### Documentation


### PR DESCRIPTION
## Summary

Follow-up to a documentation audit: fix stale references and inconsistencies across README, CONTRIBUTING, and related docs.

## Changes

- **README.md**
  - Localization bullet now includes Hungarian (`hu-HU`) — it's fully registered in `languages.ts` and `locales/` but wasn't listed
  - Reworded the Git hook note: both hooks are opt-in (`setup-git-hooks.*` enables the pre-commit fmt check; `pre-push.sh --install-hook` runs the full pipeline)
- **CONTRIBUTING.md**
  - "Rust 1.75+" → "Rust (latest stable)" — no `rust-version` is declared, the dependency set needs newer than 1.75, and CI runs stable
  - Corrected `src/test-utils/setupTauriMocks.ts` → `src/test-utils/tauriMocks.ts` (the function name was right, the filename wasn't)
  - Aligned commands to npm scripts: `npm run typecheck`, `npm run test:run` (one-shot, as CI runs it)
- **`crates/libretune-app/src/test-utils/README.md`** — removed a leftover AI-chat line ("If you'd like, I can add example tests…")
- **`.github/PULL_REQUEST_TEMPLATE.md`**, **`docs/src/contributing.md`**, **`docs/architecture.md`** — same command alignment (`npm run typecheck` / `npm run test:run`)
- **`crates/libretune-app/public/manual/contributing.md`** — regenerated via `npm run docs:sync` (not hand-edited)

## Testing

- [x] Docs-only change (+13/−15) — no code paths touched
- [x] `npm run docs:sync` run to regenerate the synced manual copy
