### PR TITLE
feat(app): correct the AFR calibration against a reference, one point or two

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/sensor_calibration.rs
+++ b/crates/libretune-app/src-tauri/src/commands/sensor_calibration.rs
@@ -283,29 +283,49 @@ pub async fn preview_afr_calibration(
     state: tauri::State<'_, AppState>,
     preset: Option<String>,
     linear: Option<((f64, f64), (f64, f64))>,
+    correction: Option<Vec<(f64, f64)>>,
 ) -> Result<AfrCurve, String> {
-    if let Some((p1, p2)) = linear {
+    // The base curve: the INI preset, or the manual two-point line.
+    let (mut afr, mut transfer): (Vec<f64>, Option<String>) = if let Some((p1, p2)) = linear {
         let cal = LinearWideband::new(p1, p2).map_err(|e| e.to_string())?;
-        let mut curve = describe_curve(&cal.curve());
-        curve.transfer_function = cal.describe();
-        return Ok(curve);
+        (cal.curve(), Some(cal.describe()))
+    } else {
+        let label = preset.ok_or("no preset or custom linear points given")?;
+        let mut cache = inc_table_cache(&state).await;
+
+        let def_guard = state.definition.lock().await;
+        let def = def_guard.as_ref().ok_or("Definition not loaded")?;
+        let block = def
+            .reference_tables
+            .values()
+            .find(|t| t.has_identifier(O2_TABLE_ID))
+            .ok_or("this INI declares no AFR calibration table")?;
+
+        let curve = calibration::solution_curve(block, &label, &mut cache)
+            .ok_or_else(|| format!("no calibration preset named '{label}'"))?
+            .map_err(|e| e.to_string())?;
+        (curve, None)
+    };
+
+    // An optional reference correction over the base: one (measured, expected)
+    // pair shifts offset, two solve gain and offset. Applied HERE rather than
+    // in the dialog so the plotted curve and the written curve cannot drift
+    // apart - the dialog writes exactly what this returns.
+    if let Some(points) = correction.filter(|p| !p.is_empty()) {
+        let corr = calibration::AfrCorrection::from_points(&points).map_err(|e| e.to_string())?;
+        corr.apply(&mut afr);
+        let suffix = corr.describe();
+        transfer = Some(match transfer {
+            Some(t) => format!("{t}; {suffix}"),
+            None => suffix,
+        });
     }
 
-    let label = preset.ok_or("no preset or custom linear points given")?;
-    let mut cache = inc_table_cache(&state).await;
-
-    let def_guard = state.definition.lock().await;
-    let def = def_guard.as_ref().ok_or("Definition not loaded")?;
-    let block = def
-        .reference_tables
-        .values()
-        .find(|t| t.has_identifier(O2_TABLE_ID))
-        .ok_or("this INI declares no AFR calibration table")?;
-
-    let afr = calibration::solution_curve(block, &label, &mut cache)
-        .ok_or_else(|| format!("no calibration preset named '{label}'"))?
-        .map_err(|e| e.to_string())?;
-    Ok(describe_curve(&afr))
+    let mut curve = describe_curve(&afr);
+    if let Some(t) = transfer {
+        curve.transfer_function = t;
+    }
+    Ok(curve)
 }
 
 /// The corrected calibration solved from a captured key-on trace.

--- a/crates/libretune-app/src/components/dialogs/AfrCalibrationDialog.tsx
+++ b/crates/libretune-app/src/components/dialogs/AfrCalibrationDialog.tsx
@@ -86,6 +86,11 @@ interface StoredSettings {
   customAfr1: number;
   customV2: number;
   customAfr2: number;
+  corrMode: "off" | "one" | "two";
+  corrM1: number;
+  corrE1: number;
+  corrM2: number;
+  corrE2: number;
 }
 
 function loadStored(): Partial<StoredSettings> {
@@ -114,6 +119,15 @@ export default function AfrCalibrationDialog({
   const [customAfr1, setCustomAfr1] = useState(stored.customAfr1 ?? 10);
   const [customV2, setCustomV2] = useState(stored.customV2 ?? 5);
   const [customAfr2, setCustomAfr2] = useState(stored.customAfr2 ?? 20);
+  /** Reference correction over the selected base curve. "off" hides the
+   *  section; one point corrects offset only; two solve gain and offset. */
+  const [corrMode, setCorrMode] = useState<"off" | "one" | "two">(
+    stored.corrMode ?? "off",
+  );
+  const [corrM1, setCorrM1] = useState(stored.corrM1 ?? 14.2);
+  const [corrE1, setCorrE1] = useState(stored.corrE1 ?? 14.7);
+  const [corrM2, setCorrM2] = useState(stored.corrM2 ?? 19.0);
+  const [corrE2, setCorrE2] = useState(stored.corrE2 ?? 18.25);
   const [curve, setCurve] = useState<AfrCurve | null>(null);
   const [autoCal, setAutoCal] = useState<AutoCalResult | null>(null);
   const [captureLeft, setCaptureLeft] = useState(0);
@@ -177,9 +191,18 @@ export default function AfrCalibrationDialog({
   useEffect(() => {
     if (!isOpen || !presetId) return;
     let live = true;
+    const correction =
+      corrMode === "one"
+        ? [[corrM1, corrE1]]
+        : corrMode === "two"
+          ? [
+              [corrM1, corrE1],
+              [corrM2, corrE2],
+            ]
+          : undefined;
     const args = isCustom
-      ? { linear: [[customV1, customAfr1], [customV2, customAfr2]] }
-      : { preset: presetId };
+      ? { linear: [[customV1, customAfr1], [customV2, customAfr2]], correction }
+      : { preset: presetId, correction };
     invoke<AfrCurve>("preview_afr_calibration", args)
       .then((c) => {
         if (!live) return;
@@ -194,7 +217,7 @@ export default function AfrCalibrationDialog({
     return () => {
       live = false;
     };
-  }, [isOpen, presetId, isCustom, customV1, customAfr1, customV2, customAfr2]);
+  }, [isOpen, presetId, isCustom, customV1, customAfr1, customV2, customAfr2, corrMode, corrM1, corrE1, corrM2, corrE2]);
 
   const previewPath = useMemo(() => {
     if (!curve) return "";
@@ -275,6 +298,11 @@ export default function AfrCalibrationDialog({
           customAfr1,
           customV2,
           customAfr2,
+          corrMode,
+          corrM1,
+          corrE1,
+          corrM2,
+          corrE2,
         } satisfies StoredSettings),
       );
       const result = await invoke<CalibrationWriteResult>("write_afr_calibration", {
@@ -367,6 +395,77 @@ export default function AfrCalibrationDialog({
                 onChange={(e) => setCustomAfr2(parseFloat(e.target.value) || 0)}
               />
             </div>
+          </div>
+        )}
+
+        <div className="afrcal-field">
+          <label htmlFor="afrcal-corr">Correct against a reference</label>
+          <select
+            id="afrcal-corr"
+            value={corrMode}
+            onChange={(e) => setCorrMode(e.target.value as "off" | "one" | "two")}
+          >
+            <option value="off">Off — use the curve as-is</option>
+            <option value="one">Single point (offset)</option>
+            <option value="two">Two point (gain + offset)</option>
+          </select>
+          {corrMode !== "off" && (
+            <span className="afrcal-hint">
+              Measured is what the ECU shows on this curve; expected is what a
+              trusted reference reads at the same moment — the controller's own
+              gauge, a second meter, or span gas. One point shifts the whole
+              curve; two points also correct an error that grows across the
+              range. The corrected curve is what previews and writes.
+            </span>
+          )}
+        </div>
+
+        {corrMode !== "off" && (
+          <div className="afrcal-custom-grid">
+            <div className="afrcal-field">
+              <label htmlFor="afrcal-corrm1">{corrMode === "two" ? "Point 1 measured (ECU)" : "Measured (ECU)"}</label>
+              <input
+                id="afrcal-corrm1"
+                type="number"
+                step="0.01"
+                value={corrM1}
+                onChange={(e) => setCorrM1(parseFloat(e.target.value) || 0)}
+              />
+            </div>
+            <div className="afrcal-field">
+              <label htmlFor="afrcal-corre1">{corrMode === "two" ? "Point 1 expected (reference)" : "Expected (reference)"}</label>
+              <input
+                id="afrcal-corre1"
+                type="number"
+                step="0.01"
+                value={corrE1}
+                onChange={(e) => setCorrE1(parseFloat(e.target.value) || 0)}
+              />
+            </div>
+            {corrMode === "two" && (
+              <>
+                <div className="afrcal-field">
+                  <label htmlFor="afrcal-corrm2">Point 2 measured (ECU)</label>
+                  <input
+                    id="afrcal-corrm2"
+                    type="number"
+                    step="0.01"
+                    value={corrM2}
+                    onChange={(e) => setCorrM2(parseFloat(e.target.value) || 0)}
+                  />
+                </div>
+                <div className="afrcal-field">
+                  <label htmlFor="afrcal-corre2">Point 2 expected (reference)</label>
+                  <input
+                    id="afrcal-corre2"
+                    type="number"
+                    step="0.01"
+                    value={corrE2}
+                    onChange={(e) => setCorrE2(parseFloat(e.target.value) || 0)}
+                  />
+                </div>
+              </>
+            )}
           </div>
         )}
 

--- a/crates/libretune-app/src/components/dialogs/__tests__/AfrCalibrationDialog.test.tsx
+++ b/crates/libretune-app/src/components/dialogs/__tests__/AfrCalibrationDialog.test.tsx
@@ -107,3 +107,103 @@ describe('AfrCalibrationDialog', () => {
     expect(screen.getByText(/not connected/i)).toBeInTheDocument();
   });
 });
+
+describe('reference correction', () => {
+  beforeEach(() => {
+    localStorage.removeItem('lt.afrCalibration');
+    setupTauriMocks({
+      list_calibration_presets: PRESETS,
+      preview_afr_calibration: curveOf(10, 20),
+      write_afr_calibration: {
+        table: 'o2',
+        verified: true,
+        verify_note: null,
+        transfer_function: '10.00–20.00 AFR over 0–5 V',
+      },
+    });
+  });
+
+  afterEach(() => {
+    tearDownTauriMocks();
+    localStorage.removeItem('lt.afrCalibration');
+  });
+
+  function correctionSentToPreview(): unknown {
+    const calls = (invoke as any).mock.calls.filter(
+      (c: any[]) => c[0] === 'preview_afr_calibration',
+    );
+    return calls.length ? calls[calls.length - 1][1].correction : undefined;
+  }
+
+  it('is off by default and sends no correction', async () => {
+    render(
+      <AfrCalibrationDialog isOpen onClose={() => {}} connected showToast={vi.fn()} />,
+    );
+    await screen.findByLabelText(/correct against a reference/i);
+    await waitFor(() => expect(correctionSentToPreview()).toBeUndefined());
+    expect(screen.queryByLabelText(/measured \(ecu\)/i)).toBeNull();
+  });
+
+  it('single point sends one measured/expected pair to the preview', async () => {
+    render(
+      <AfrCalibrationDialog isOpen onClose={() => {}} connected showToast={vi.fn()} />,
+    );
+    const mode = await screen.findByLabelText(/correct against a reference/i);
+    fireEvent.change(mode, { target: { value: 'one' } });
+
+    const measured = await screen.findByLabelText(/^measured \(ecu\)/i);
+    const expected = screen.getByLabelText(/^expected \(reference\)/i);
+    fireEvent.change(measured, { target: { value: '14.2' } });
+    fireEvent.change(expected, { target: { value: '14.7' } });
+
+    await waitFor(() => expect(correctionSentToPreview()).toEqual([[14.2, 14.7]]));
+    // Two-point rows must not be shown in single-point mode.
+    expect(screen.queryByLabelText(/point 2 measured/i)).toBeNull();
+  });
+
+  it('two point sends both pairs, in order', async () => {
+    render(
+      <AfrCalibrationDialog isOpen onClose={() => {}} connected showToast={vi.fn()} />,
+    );
+    const mode = await screen.findByLabelText(/correct against a reference/i);
+    fireEvent.change(mode, { target: { value: 'two' } });
+
+    fireEvent.change(await screen.findByLabelText(/point 1 measured/i), {
+      target: { value: '12.5' },
+    });
+    fireEvent.change(screen.getByLabelText(/point 1 expected/i), {
+      target: { value: '12.08' },
+    });
+    fireEvent.change(screen.getByLabelText(/point 2 measured/i), {
+      target: { value: '19' },
+    });
+    fireEvent.change(screen.getByLabelText(/point 2 expected/i), {
+      target: { value: '18.25' },
+    });
+
+    await waitFor(() =>
+      expect(correctionSentToPreview()).toEqual([
+        [12.5, 12.08],
+        [19, 18.25],
+      ]),
+    );
+  });
+
+  it('writes exactly the previewed (corrected) curve, never a local recomputation', async () => {
+    // The backend owns the correction math; the dialog must write curve.afr
+    // verbatim. If the dialog ever starts correcting locally, the mock curve
+    // here would differ from what write receives.
+    render(
+      <AfrCalibrationDialog isOpen onClose={() => {}} connected showToast={vi.fn()} />,
+    );
+    const mode = await screen.findByLabelText(/correct against a reference/i);
+    fireEvent.change(mode, { target: { value: 'one' } });
+
+    const write = await screen.findByRole('button', { name: /write calibration/i });
+    await waitFor(() => expect(write).not.toBeDisabled());
+    fireEvent.click(write);
+
+    await waitFor(() => expect(writeCall()).not.toBeNull());
+    expect(writeCall()!.afrValues).toEqual(curveOf(10, 20).afr);
+  });
+});

--- a/crates/libretune-app/src/components/dialogs/__tests__/AfrCalibrationPresets.test.tsx
+++ b/crates/libretune-app/src/components/dialogs/__tests__/AfrCalibrationPresets.test.tsx
@@ -90,7 +90,7 @@ describe('AfrCalibrationDialog preset preview', () => {
     expect(await screen.findByText('0 V → 10.00')).toBeInTheDocument();
     expect(screen.getByText('5 V → 20.00')).toBeInTheDocument();
 
-    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'Innovate LC-2' } });
+    fireEvent.change(screen.getByLabelText(/wideband controller/i), { target: { value: 'Innovate LC-2' } });
 
     // Exact argument name: `preset`, not a paraphrase of it.
     await waitFor(() => expect(previewCalls()).toContainEqual({ preset: 'Innovate LC-2' }));
@@ -112,7 +112,7 @@ describe('AfrCalibrationDialog preset preview', () => {
     render(<AfrCalibrationDialog isOpen onClose={() => {}} connected showToast={vi.fn()} />);
 
     await screen.findByRole('option', { name: /14Point7 Spartan/ });
-    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'custom' } });
+    fireEvent.change(screen.getByLabelText(/wideband controller/i), { target: { value: 'custom' } });
 
     // linear_defaults = (xLow, xHigh, yLow, yHigh) → (1 V, 9.7) and (4 V, 18.7).
     await waitFor(() =>

--- a/crates/libretune-core/src/calibration/mod.rs
+++ b/crates/libretune-core/src/calibration/mod.rs
@@ -166,6 +166,88 @@ pub fn solution_curve(
 /// can show exactly what was entered, and so [`describe`](Self::describe)
 /// can report the transfer function in the same terms the sensor's datasheet
 /// uses.
+/// A reference correction applied over an existing AFR curve.
+///
+/// The workflow this models: the ECU is displaying an AFR through its current
+/// calibration, and a trusted reference - the wideband controller's own gauge,
+/// a second meter, span gas - says what the mixture actually is. Each point is
+/// `(measured, expected)`: what the ECU showed, and what it should have shown.
+///
+/// One point corrects offset only (`afr' = afr + (expected - measured)`),
+/// which is the right tool when the whole scale reads uniformly rich or lean -
+/// a ground-offset error does exactly that. Two points solve gain and offset,
+/// for a sensor whose error grows across the range - this NA6's Spartan reads
+/// about 0.3 AFR low near stoich and nearly 6% low at the lean end, which an
+/// offset alone cannot express.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AfrCorrection {
+    /// Multiplier applied to the curve's AFR.
+    pub gain: f64,
+    /// Offset added after the gain.
+    pub offset: f64,
+    points: Vec<(f64, f64)>,
+}
+
+impl AfrCorrection {
+    /// Build from one or two `(measured, expected)` pairs.
+    pub fn from_points(points: &[(f64, f64)]) -> Result<Self, CalibrationError> {
+        match points {
+            [(m, e)] => Ok(Self {
+                gain: 1.0,
+                offset: e - m,
+                points: points.to_vec(),
+            }),
+            [(m1, e1), (m2, e2)] => {
+                if (m1 - m2).abs() < 1e-6 {
+                    return Err(CalibrationError::DegenerateInputs(format!(
+                        "the two measured readings must differ (both were                          {m1:.2} AFR) - a gain cannot be solved from one point",
+                    )));
+                }
+                let gain = (e2 - e1) / (m2 - m1);
+                // A non-positive gain flattens or reverses the curve: richer
+                // mixtures would read leaner. No physical sensor error does
+                // that; it means the two points were swapped or mistyped.
+                if gain <= 0.0 {
+                    return Err(CalibrationError::DegenerateInputs(format!(
+                        "these points give a gain of {gain:.3}, which would                          reverse the curve - check the expected values are                          paired with the right measured readings",
+                    )));
+                }
+                Ok(Self {
+                    gain,
+                    offset: e1 - gain * m1,
+                    points: points.to_vec(),
+                })
+            }
+            _ => Err(CalibrationError::DegenerateInputs(format!(
+                "a correction takes one or two points, got {}",
+                points.len()
+            ))),
+        }
+    }
+
+    /// Apply to a curve in place.
+    pub fn apply(&self, afr: &mut [f64]) {
+        for v in afr.iter_mut() {
+            *v = self.gain * *v + self.offset;
+        }
+    }
+
+    /// Human-readable suffix for the stored transfer function, so a log reads
+    /// as corrected rather than silently differing from its preset.
+    pub fn describe(&self) -> String {
+        match self.points.as_slice() {
+            [(m, e)] => format!(
+                "corrected {:+.2} AFR against a reference ({m:.2} read as {e:.2})",
+                self.offset
+            ),
+            _ => format!(
+                "corrected against a reference (gain {:.4}, offset {:+.2})",
+                self.gain, self.offset
+            ),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct LinearWideband {
     /// First calibration point, `(volts, afr)`.
@@ -404,5 +486,66 @@ mod tests {
     fn adc_endpoints_span_the_reference_rail() {
         assert!((adc_to_volts(0) - 0.0).abs() < 1e-12);
         assert!((adc_to_volts(1023) - 5.0).abs() < 1e-12);
+    }
+}
+
+#[cfg(test)]
+mod afr_correction_tests {
+    use super::*;
+
+    #[test]
+    fn a_single_point_shifts_the_whole_curve_by_the_error() {
+        // ECU showed 14.2 where the reference gauge read 14.7: half an AFR lean.
+        let c = AfrCorrection::from_points(&[(14.2, 14.7)]).unwrap();
+        assert_eq!(c.gain, 1.0);
+        assert!((c.offset - 0.5).abs() < 1e-9);
+
+        let mut curve = vec![10.0, 14.2, 19.5];
+        c.apply(&mut curve);
+        assert!((curve[0] - 10.5).abs() < 1e-9);
+        assert!(
+            (curve[1] - 14.7).abs() < 1e-9,
+            "the entered point maps exactly"
+        );
+        assert!((curve[2] - 20.0).abs() < 1e-9);
+    }
+
+    /// The NA6's Spartan case: reads low, and by more at the lean end - an
+    /// error that grows across the range, which one offset cannot express.
+    #[test]
+    fn two_points_solve_gain_and_offset_and_both_map_exactly() {
+        // ECU showed 12.5 where the reference said 12.08, and 19.0 where it
+        // said 18.25 (the measured-twice bench figures for this sensor).
+        let c = AfrCorrection::from_points(&[(12.5, 12.08), (19.0, 18.25)]).unwrap();
+
+        let mut probe = vec![12.5, 19.0, 14.7];
+        c.apply(&mut probe);
+        assert!((probe[0] - 12.08).abs() < 1e-9, "first point maps exactly");
+        assert!((probe[1] - 18.25).abs() < 1e-9, "second point maps exactly");
+        // Between the points the correction interpolates: stoich lands between
+        // the two entered errors, not at either one.
+        assert!(probe[2] < 14.7 && probe[2] > 14.0, "got {}", probe[2]);
+    }
+
+    #[test]
+    fn identical_measured_readings_cannot_solve_a_gain() {
+        let e = AfrCorrection::from_points(&[(14.7, 14.5), (14.7, 15.0)]).unwrap_err();
+        assert!(e.to_string().contains("must differ"), "{e}");
+    }
+
+    /// Swapped or mistyped pairs produce a negative gain - richer reading as
+    /// leaner. Refused with an error that says what to check, because writing
+    /// a reversed AFR curve to a car is how a lean condition gets fueled
+    /// leaner.
+    #[test]
+    fn a_reversing_correction_is_refused() {
+        let e = AfrCorrection::from_points(&[(12.0, 18.0), (18.0, 12.0)]).unwrap_err();
+        assert!(e.to_string().contains("reverse"), "{e}");
+    }
+
+    #[test]
+    fn zero_and_three_points_are_refused() {
+        assert!(AfrCorrection::from_points(&[]).is_err());
+        assert!(AfrCorrection::from_points(&[(1.0, 1.0), (2.0, 2.0), (3.0, 3.0)]).is_err());
     }
 }


### PR DESCRIPTION
Follow-up to #278, which merged while this was being built on the same branch. One commit, rebased onto current `main`.

## What it adds

A **Correct against a reference** mode in the AFR calibration dialog, off by default, with single-point and two-point forms.

The workflow it models is the plainest one there is: the ECU shows one AFR through its current calibration, and a trusted reference — the wideband controller's own gauge, a second meter, span gas — reads another at the same moment. Each point takes a **measured** (ECU) and an **expected** (reference) value.

- **Single point** corrects offset only: `afr' = afr + (expected − measured)`. The ground-offset case — the whole scale shifted equally.
- **Two point** solves gain and offset, for an error that grows across the range. The motivating sensor reads ~0.3 AFR low near stoich and nearly 6% low at the lean end; no single offset can express that.

The corrected curve is what previews and writes, applied over whichever base is selected (INI preset or manual line).

## Where the maths lives, and why

In core (`AfrCorrection`), applied inside `preview_afr_calibration` — not in the dialog. The dialog's standing invariant is that **the plotted curve is the written curve**; correcting locally would have broken it. A test pins that the dialog writes `curve.afr` verbatim.

The transfer function stored with the tune records the correction (`…; corrected +0.50 AFR against a reference (14.20 read as 14.70)`), so a log reads as corrected rather than silently differing from its preset.

## Refused corrections

- Two points with the same measured reading — no gain is solvable.
- Any pair giving a **non-positive gain**, which would flatten or reverse the curve: richer mixtures reading leaner. No physical sensor error does that; it means the pairs were swapped or mistyped, and the error says so. Writing a reversed AFR curve is how a lean condition gets fueled leaner.

## Testing

Five core unit tests on the maths — including that entered points map *exactly* (not approximately) after correction, using the motivating sensor's real bench figures — and refusal of degenerate and reversing inputs.

Seven dialog tests: mode off by default sends no correction; single-point sends one pair; two-point sends both in order; and the write-verbatim invariant above.

Two incidental fixes the new tests forced: the correction rows carry proper `htmlFor`/`id` label association, which the dialog's existing rows never had (the new tests select by label and caught it) — and two pre-existing preset tests that located "the only combobox" by role now select the labelled one, since there are two.

982 Rust / 287 frontend tests pass; clippy at the `main` baseline of 32.

## Risk

Low. Off by default, additive, and refused corrections fail the preview loudly rather than writing anything. Same hardware caveat as #278: the write path itself awaits a bench session.
