### PR TITLE
feat(datalog): read TunerStudio .mlg logs

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/data_logging.rs
+++ b/crates/libretune-app/src-tauri/src/commands/data_logging.rs
@@ -335,7 +335,7 @@ pub(crate) struct DatalogListing {
     pub modified: String,
 }
 
-/// List the CSVs in the current project's `datalogs/` folder, newest first.
+/// List the readable logs in the project's `datalogs/` folder, newest first.
 /// Returns an empty list when no project is open or the folder doesn't
 /// exist yet.
 pub(crate) async fn list_datalog_files(state: &AppState) -> Vec<DatalogListing> {
@@ -353,9 +353,8 @@ pub(crate) async fn list_datalog_files(state: &AppState) -> Vec<DatalogListing> 
         .flatten()
         .filter_map(|e| {
             let path = e.path();
-            if path.extension().and_then(|x| x.to_str())? != "csv" {
-                return None;
-            }
+            // Only formats the loader can read back are worth listing.
+            libretune_core::datalog::LogFormat::from_extension(&path)?;
             let meta = e.metadata().ok()?;
             let modified = meta
                 .modified()
@@ -403,7 +402,7 @@ pub(crate) async fn load_datalog_file(state: &AppState, name: &str) -> Result<Da
             .ok_or_else(|| "No project loaded".to_string())?
     };
     let path = dir.join(name);
-    let (channels, entries) = libretune_core::datalog::format::read_csv(&path)
+    let (channels, entries) = libretune_core::datalog::format::read_log(&path)
         .map_err(|e| format!("could not read log '{name}': {e}"))?;
     Ok(DatalogData {
         channels,

--- a/crates/libretune-core/src/datalog/format.rs
+++ b/crates/libretune-core/src/datalog/format.rs
@@ -251,10 +251,18 @@ mod tests {
     #[test]
     fn read_log_rejects_an_extension_it_has_no_reader_for() {
         let dir = tempfile::tempdir().unwrap();
+        // Readable CSV under a .msl name: read_csv would happily parse it, so
+        // the rejection can only come from the extension, not the content.
         let path = dir.path().join("log.msl");
-        std::fs::write(&path, "Time\n0.0\n").unwrap();
+        std::fs::write(&path, "Time,rpm\n0.0,900\n").unwrap();
 
-        assert!(read_log(&path).is_err());
+        let error = read_log(&path).unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+        assert!(
+            error.to_string().contains("not a log format"),
+            "expected the extension to be named as the reason, got: {error}"
+        );
     }
     #[test]
     fn read_log_sends_mlg_files_to_the_mlg_reader() {

--- a/crates/libretune-core/src/datalog/format.rs
+++ b/crates/libretune-core/src/datalog/format.rs
@@ -36,6 +36,19 @@ impl LogFormat {
     }
 }
 
+/// Read a saved log, choosing the reader from the file extension.
+pub fn read_log<P: AsRef<Path>>(path: P) -> io::Result<(Vec<String>, Vec<LogEntry>)> {
+    let path = path.as_ref();
+    match LogFormat::from_extension(path) {
+        Some(LogFormat::Csv) => read_csv(path),
+        Some(LogFormat::Mlg) => super::mlg::read_mlg(path),
+        None => Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("{} is not a log format LibreTune reads", path.display()),
+        )),
+    }
+}
+
 /// Write log entries to a CSV file
 #[allow(dead_code)]
 pub fn write_csv<P: AsRef<Path>>(
@@ -222,5 +235,40 @@ mod tests {
         let header_only = dir.path().join("header.csv");
         std::fs::write(&header_only, "Time,rpm\n").unwrap();
         assert!(read_csv(&header_only).is_err());
+    }
+    #[test]
+    fn read_log_picks_the_reader_from_the_extension() {
+        let dir = tempfile::tempdir().unwrap();
+        let csv = dir.path().join("log.csv");
+        std::fs::write(&csv, "Time,rpm\n0.0,900\n").unwrap();
+
+        let (channels, entries) = read_log(&csv).unwrap();
+
+        assert_eq!(channels, vec!["rpm"]);
+        assert_eq!(entries[0].values, vec![900.0]);
+    }
+
+    #[test]
+    fn read_log_rejects_an_extension_it_has_no_reader_for() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("log.msl");
+        std::fs::write(&path, "Time\n0.0\n").unwrap();
+
+        assert!(read_log(&path).is_err());
+    }
+    #[test]
+    fn read_log_sends_mlg_files_to_the_mlg_reader() {
+        let dir = tempfile::tempdir().unwrap();
+        // CSV text under an .mlg name, long enough to reach the signature
+        // check: only the MLG reader rejects it, so this proves the dispatch.
+        let path = dir.path().join("log.mlg");
+        std::fs::write(&path, "Time,rpm\n0.0,900\n1.0,1000\n2.0,1100\n").unwrap();
+
+        let error = read_log(&path).unwrap_err();
+
+        assert!(
+            error.to_string().contains("signature"),
+            "expected the MLG reader to reject it, got: {error}"
+        );
     }
 }

--- a/crates/libretune-core/src/datalog/mlg.rs
+++ b/crates/libretune-core/src/datalog/mlg.rs
@@ -38,6 +38,11 @@ const MARKER_TEXT_LEN: usize = 50;
 /// The record clock counts 10 µs ticks and wraps every 65536 of them.
 const CLOCK_TICK_MICROS: u64 = 10;
 const CLOCK_WRAP: u64 = 1 << 16;
+/// A rollover lands the clock near zero, so a backward step is only read as
+/// one when it crosses most of the range. Smaller backward steps are records
+/// out of order, or a corrupt prefix — it carries no checksum of its own —
+/// and must not be paid for with 655 ms of invented elapsed time.
+const CLOCK_WRAP_MARGIN: u16 = 1 << 15;
 
 /// A scalar as stored in a record payload.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -275,12 +280,13 @@ struct Clock {
 
 impl Clock {
     fn advance(&mut self, raw: u16) -> u64 {
-        if self.start.is_some() && raw < self.previous {
+        if self.start.is_some() && self.previous.saturating_sub(raw) > CLOCK_WRAP_MARGIN {
             self.wraps += 1;
         }
         self.previous = raw;
         let absolute = self.wraps * CLOCK_WRAP + raw as u64;
-        absolute - *self.start.get_or_insert(absolute)
+        // A record that arrived out of order can sit before the first one.
+        absolute.saturating_sub(*self.start.get_or_insert(absolute))
     }
 }
 #[cfg(test)]
@@ -345,15 +351,27 @@ mod tests {
     }
 
     fn build_log(version: u16, fields: &[&TestField], records: &[Vec<u8>]) -> Vec<u8> {
+        build_log_with_info(version, fields, "", records)
+    }
+
+    /// `info` stands in for the MSQ tune text TunerStudio parks between the
+    /// field descriptors and the first record.
+    fn build_log_with_info(
+        version: u16,
+        fields: &[&TestField],
+        info: &str,
+        records: &[Vec<u8>],
+    ) -> Vec<u8> {
         let record_len: usize = fields.iter().map(|f| f.width).sum();
         let info_start = HEADER_LEN + fields.len() * DESCRIPTOR_LEN;
+        let data_start = info_start + info.len();
 
         let mut out = Vec::new();
         out.extend_from_slice(MAGIC);
         out.extend_from_slice(&version.to_be_bytes());
         out.extend_from_slice(&1_784_378_352u32.to_be_bytes()); // capture time
         out.extend_from_slice(&(info_start as u32).to_be_bytes());
-        out.extend_from_slice(&(info_start as u32).to_be_bytes()); // no info block
+        out.extend_from_slice(&(data_start as u32).to_be_bytes());
         out.extend_from_slice(&(record_len as u16).to_be_bytes());
         out.extend_from_slice(&(fields.len() as u16).to_be_bytes());
         assert_eq!(out.len(), HEADER_LEN);
@@ -376,6 +394,7 @@ mod tests {
             assert_eq!(out.len() - start, DESCRIPTOR_LEN);
         }
 
+        out.extend_from_slice(info.as_bytes());
         for r in records {
             out.extend_from_slice(r);
         }
@@ -521,6 +540,204 @@ mod tests {
         let (_dir, path) = write_temp(&bytes);
 
         assert!(read_mlg(&path).is_err());
+    }
+
+    #[test]
+    fn a_wrapped_clock_keeps_time_moving_forward() {
+        // The 16-bit clock rolls over every 65536 ticks, roughly twice a second.
+        let bytes = build_log(
+            2,
+            &[&TIME, &CLT, &STFT],
+            &[
+                record(0, 65_000, &payload(0.0, 8741, 1.0)),
+                record(1, 200, &payload(0.01, 8741, 1.0)),
+            ],
+        );
+        let (_dir, path) = write_temp(&bytes);
+
+        let (_, entries) = read_mlg(&path).unwrap();
+
+        // 65536 + 200 - 65000 = 736 ticks.
+        assert_eq!(entries[1].timestamp, Duration::from_micros(7_360));
+    }
+
+    #[test]
+    fn a_small_backward_clock_step_is_not_a_wrap() {
+        // The record prefix carries no checksum, so a single corrupt byte can
+        // send the clock backwards. Reading that as a rollover would add
+        // 655 ms to every record after it.
+        let bytes = build_log(
+            2,
+            &[&TIME, &CLT, &STFT],
+            &[
+                record(0, 1_000, &payload(0.0, 8741, 1.0)),
+                record(1, 900, &payload(0.01, 8741, 1.0)),
+                record(2, 1_100, &payload(0.02, 8741, 1.0)),
+            ],
+        );
+        let (_dir, path) = write_temp(&bytes);
+
+        let (_, entries) = read_mlg(&path).unwrap();
+
+        assert_eq!(entries.len(), 3);
+        assert_eq!(entries[2].timestamp, Duration::from_micros(1_000));
+    }
+
+    /// Records the reader drops still carry a clock reading, and losing it
+    /// loses the rollover it was about to prove: the next record looks like a
+    /// step backwards instead of the far side of a wrap.
+    #[test]
+    fn a_dropped_record_still_advances_the_clock() {
+        let mut corrupt = record(1, 60_000, &payload(0.01, 8741, 1.0));
+        let last = corrupt.len() - 1;
+        corrupt[last] ^= 0xff;
+
+        let bytes = build_log(
+            2,
+            &[&TIME, &CLT, &STFT],
+            &[
+                record(0, 1_000, &payload(0.0, 8741, 1.0)),
+                corrupt,
+                record(2, 200, &payload(0.02, 8741, 1.0)),
+            ],
+        );
+        let (_dir, path) = write_temp(&bytes);
+
+        let (_, entries) = read_mlg(&path).unwrap();
+
+        assert_eq!(entries.len(), 2);
+        // 65536 + 200 - 1000 = 64736 ticks.
+        assert_eq!(entries[1].timestamp, Duration::from_micros(647_360));
+    }
+
+    #[test]
+    fn a_marker_still_advances_the_clock() {
+        let bytes = build_log(
+            2,
+            &[&TIME, &CLT, &STFT],
+            &[
+                record(0, 1_000, &payload(0.0, 8741, 1.0)),
+                marker(1, 60_000, "MARK 000 - Going Offline"),
+                record(2, 200, &payload(0.02, 8741, 1.0)),
+            ],
+        );
+        let (_dir, path) = write_temp(&bytes);
+
+        let (_, entries) = read_mlg(&path).unwrap();
+
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[1].timestamp, Duration::from_micros(647_360));
+    }
+
+    #[test]
+    fn skips_the_tune_text_between_the_descriptors_and_the_data() {
+        // Real captures carry the whole MSQ tune here — 400 kB is typical.
+        let bytes = build_log_with_info(
+            2,
+            &[&TIME, &CLT, &STFT],
+            "<msq><constant name=\"veTable\">80 82 84</constant></msq>",
+            &[record(0, 1_000, &payload(0.0, 8741, 1.0))],
+        );
+        let (_dir, path) = write_temp(&bytes);
+
+        let (_, entries) = read_mlg(&path).unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert!((entries[0].values[1] - 87.41).abs() < 1e-4);
+    }
+
+    #[test]
+    fn decodes_every_scalar_type_the_format_defines() {
+        const TYPES: [TestField; 7] = [
+            TestField {
+                code: 0,
+                width: 1,
+                name: "u8",
+                units: "",
+                scale: 1.0,
+                transform: 0.0,
+            },
+            TestField {
+                code: 1,
+                width: 1,
+                name: "i8",
+                units: "",
+                scale: 1.0,
+                transform: 0.0,
+            },
+            TestField {
+                code: 2,
+                width: 2,
+                name: "u16",
+                units: "",
+                scale: 1.0,
+                transform: 0.0,
+            },
+            TestField {
+                code: 3,
+                width: 2,
+                name: "i16",
+                units: "",
+                scale: 1.0,
+                transform: 0.0,
+            },
+            TestField {
+                code: 4,
+                width: 4,
+                name: "u32",
+                units: "",
+                scale: 1.0,
+                transform: 0.0,
+            },
+            TestField {
+                code: 5,
+                width: 4,
+                name: "i32",
+                units: "",
+                scale: 1.0,
+                transform: 0.0,
+            },
+            TestField {
+                code: 6,
+                width: 8,
+                name: "i64",
+                units: "",
+                scale: 1.0,
+                transform: 0.0,
+            },
+        ];
+
+        let mut wide = Vec::new();
+        wide.push(200u8);
+        wide.extend_from_slice(&(-5i8).to_be_bytes());
+        wide.extend_from_slice(&8741u16.to_be_bytes());
+        wide.extend_from_slice(&(-1234i16).to_be_bytes());
+        wide.extend_from_slice(&70_000u32.to_be_bytes());
+        wide.extend_from_slice(&(-70_000i32).to_be_bytes());
+        wide.extend_from_slice(&(-5_000_000_000i64).to_be_bytes());
+
+        let fields: Vec<&TestField> = TYPES.iter().collect();
+        let bytes = build_log(2, &fields, &[record(0, 0, &wide)]);
+        let (_dir, path) = write_temp(&bytes);
+
+        let (channels, entries) = read_mlg(&path).unwrap();
+
+        assert_eq!(
+            channels,
+            vec!["u8", "i8", "u16", "i16", "u32", "i32", "i64"]
+        );
+        assert_eq!(
+            entries[0].values,
+            vec![
+                200.0,
+                -5.0,
+                8741.0,
+                -1234.0,
+                70_000.0,
+                -70_000.0,
+                -5_000_000_000.0
+            ]
+        );
     }
 
     /// Checks the reader against a log TunerStudio actually wrote. Repo

--- a/crates/libretune-core/src/datalog/mlg.rs
+++ b/crates/libretune-core/src/datalog/mlg.rs
@@ -1,0 +1,567 @@
+//! MegaLogViewer binary logs (`.mlg`, format version 2).
+//!
+//! The format TunerStudio writes and MegaLogViewer reads. Only reading is
+//! implemented: LibreTune records to CSV, and the reason to understand `.mlg`
+//! is to open logs captured by TunerStudio.
+//!
+//! Layout, all values big-endian:
+//!
+//! ```text
+//! header      24 bytes  "MLVLG\0", version u16, capture time u32,
+//!                       info offset u32, data offset u32,
+//!                       record length u16, field count u16
+//! field       89 bytes  type u8, name [34], units [10], display style u8,
+//!                       scale f32, transform f32, digits u8, category [34]
+//! info                  the tune the log was captured with, as MSQ text
+//! record                kind u8, counter u8, clock u16 (10 µs ticks), then
+//!                       either a payload plus its checksum u8 (kind 0), or
+//!                       50 bytes of marker text (kind 1)
+//! ```
+
+use std::fs::File;
+use std::io::{self, BufReader, Read, Seek, SeekFrom};
+use std::path::Path;
+use std::time::Duration;
+
+use super::LogEntry;
+
+const MAGIC: &[u8; 6] = b"MLVLG\0";
+const VERSION: u16 = 2;
+const HEADER_LEN: usize = 24;
+const DESCRIPTOR_LEN: usize = 89;
+/// kind + counter + 16-bit clock, ahead of every record payload.
+const RECORD_PREFIX_LEN: usize = 4;
+const KIND_DATA: u8 = 0;
+const KIND_MARKER: u8 = 1;
+/// Marker text is a fixed-width field, so a marker record is always 54 bytes.
+const MARKER_TEXT_LEN: usize = 50;
+/// The record clock counts 10 µs ticks and wraps every 65536 of them.
+const CLOCK_TICK_MICROS: u64 = 10;
+const CLOCK_WRAP: u64 = 1 << 16;
+
+/// A scalar as stored in a record payload.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FieldType {
+    U8,
+    I8,
+    U16,
+    I16,
+    U32,
+    I32,
+    I64,
+    F32,
+}
+
+impl FieldType {
+    fn from_code(code: u8) -> Option<Self> {
+        Some(match code {
+            0 => Self::U8,
+            1 => Self::I8,
+            2 => Self::U16,
+            3 => Self::I16,
+            4 => Self::U32,
+            5 => Self::I32,
+            6 => Self::I64,
+            7 => Self::F32,
+            _ => return None,
+        })
+    }
+
+    fn width(self) -> usize {
+        match self {
+            Self::U8 | Self::I8 => 1,
+            Self::U16 | Self::I16 => 2,
+            Self::U32 | Self::I32 | Self::F32 => 4,
+            Self::I64 => 8,
+        }
+    }
+
+    /// Decode exactly `self.width()` bytes into the stored number.
+    fn read(self, bytes: &[u8]) -> f64 {
+        fn array<const N: usize>(bytes: &[u8]) -> [u8; N] {
+            bytes[..N].try_into().expect("caller slices to width")
+        }
+        match self {
+            Self::U8 => bytes[0] as f64,
+            Self::I8 => bytes[0] as i8 as f64,
+            Self::U16 => u16::from_be_bytes(array(bytes)) as f64,
+            Self::I16 => i16::from_be_bytes(array(bytes)) as f64,
+            Self::U32 => u32::from_be_bytes(array(bytes)) as f64,
+            Self::I32 => i32::from_be_bytes(array(bytes)) as f64,
+            Self::I64 => i64::from_be_bytes(array(bytes)) as f64,
+            Self::F32 => f32::from_be_bytes(array(bytes)) as f64,
+        }
+    }
+}
+
+struct MlgField {
+    name: String,
+    field_type: FieldType,
+    offset: usize,
+    scale: f32,
+    transform: f32,
+}
+
+impl MlgField {
+    fn value(&self, payload: &[u8]) -> f64 {
+        let raw = self
+            .field_type
+            .read(&payload[self.offset..self.offset + self.field_type.width()]);
+        (raw + self.transform as f64) * self.scale as f64
+    }
+}
+
+fn invalid(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message.into())
+}
+
+/// A fixed-width, NUL-padded string. TunerStudio writes UTF-8 into these.
+fn read_name(bytes: &[u8]) -> String {
+    let end = bytes.iter().position(|b| *b == 0).unwrap_or(bytes.len());
+    String::from_utf8_lossy(&bytes[..end]).trim().to_string()
+}
+
+struct Header {
+    data_start: u64,
+    record_len: usize,
+    field_count: usize,
+}
+
+fn read_header(reader: &mut impl Read) -> io::Result<Header> {
+    let mut bytes = [0u8; HEADER_LEN];
+    reader
+        .read_exact(&mut bytes)
+        .map_err(|_| invalid("file is too short to be an MLG log"))?;
+    if &bytes[..6] != MAGIC {
+        return Err(invalid("not an MLG log (bad file signature)"));
+    }
+    let version = u16::from_be_bytes([bytes[6], bytes[7]]);
+    if version != VERSION {
+        return Err(invalid(format!(
+            "MLG format version {version} is not supported, expected {VERSION}"
+        )));
+    }
+    Ok(Header {
+        data_start: u32::from_be_bytes(bytes[16..20].try_into().expect("fixed slice")) as u64,
+        record_len: u16::from_be_bytes([bytes[20], bytes[21]]) as usize,
+        field_count: u16::from_be_bytes([bytes[22], bytes[23]]) as usize,
+    })
+}
+
+fn read_fields(reader: &mut impl Read, header: &Header) -> io::Result<Vec<MlgField>> {
+    let mut bytes = vec![0u8; header.field_count * DESCRIPTOR_LEN];
+    reader
+        .read_exact(&mut bytes)
+        .map_err(|_| invalid("log ends inside its field descriptors"))?;
+
+    let mut fields = Vec::with_capacity(header.field_count);
+    let mut offset = 0usize;
+    for (index, descriptor) in bytes.chunks_exact(DESCRIPTOR_LEN).enumerate() {
+        let field_type = FieldType::from_code(descriptor[0]).ok_or_else(|| {
+            invalid(format!(
+                "field {index} has unknown storage type {}",
+                descriptor[0]
+            ))
+        })?;
+        let scale = f32::from_be_bytes(descriptor[46..50].try_into().expect("fixed slice"));
+        let transform = f32::from_be_bytes(descriptor[50..54].try_into().expect("fixed slice"));
+        if !scale.is_finite() || !transform.is_finite() {
+            return Err(invalid(format!("field {index} has a non-finite scale")));
+        }
+        fields.push(MlgField {
+            name: read_name(&descriptor[1..35]),
+            field_type,
+            offset,
+            scale,
+            transform,
+        });
+        offset += field_type.width();
+    }
+    if offset != header.record_len {
+        return Err(invalid(format!(
+            "header declares {}-byte records but the fields need {offset}",
+            header.record_len
+        )));
+    }
+    Ok(fields)
+}
+
+/// Read an `.mlg` log into the same `(channels, entries)` shape as
+/// [`super::format::read_csv`].
+///
+/// Marker records — the notes TunerStudio writes when logging goes offline and
+/// back online — advance the clock but carry no channel values, so they are
+/// skipped.
+///
+/// Tolerates the damage real logs carry: a record cut short by a disconnect
+/// ends the read, and a record whose checksum disagrees with its payload is
+/// dropped rather than failing the whole file.
+///
+/// The whole log is held in memory, exactly like `read_csv`, and `.mlg`
+/// captures are large: a few hundred channels over half an hour decode to
+/// gigabytes of `f64`. Reading only the channels a caller asked for is the way
+/// past that ceiling when it starts to bite.
+pub fn read_mlg<P: AsRef<Path>>(path: P) -> io::Result<(Vec<String>, Vec<LogEntry>)> {
+    let mut reader = BufReader::new(File::open(path)?);
+    let header = read_header(&mut reader)?;
+    let fields = read_fields(&mut reader, &header)?;
+
+    let descriptors_end = (HEADER_LEN + header.field_count * DESCRIPTOR_LEN) as u64;
+    if header.data_start < descriptors_end {
+        return Err(invalid("log data would start inside its own header"));
+    }
+    reader.seek(SeekFrom::Start(header.data_start))?;
+
+    let channels = fields.iter().map(|f| f.name.clone()).collect();
+    let mut entries = Vec::new();
+    let mut prefix = [0u8; RECORD_PREFIX_LEN];
+    let mut data = vec![0u8; header.record_len + 1]; // payload then checksum
+    let mut marker = [0u8; MARKER_TEXT_LEN];
+    let mut clock = Clock::default();
+
+    loop {
+        if ends_log(reader.read_exact(&mut prefix))? {
+            break;
+        }
+        // Advanced for every record, including ones dropped below, so that
+        // damage does not shift the timestamps of what follows.
+        let ticks = clock.advance(u16::from_be_bytes([prefix[2], prefix[3]]));
+        match prefix[0] {
+            KIND_DATA => {
+                if ends_log(reader.read_exact(&mut data))? {
+                    break;
+                }
+                let (payload, checksum) = data.split_at(header.record_len);
+                if payload.iter().fold(0u8, |sum, b| sum.wrapping_add(*b)) != checksum[0] {
+                    continue;
+                }
+                entries.push(LogEntry::new(
+                    Duration::from_micros(ticks * CLOCK_TICK_MICROS),
+                    fields.iter().map(|f| f.value(payload)).collect(),
+                ));
+            }
+            KIND_MARKER => {
+                if ends_log(reader.read_exact(&mut marker))? {
+                    break;
+                }
+            }
+            // Nothing else has a known length, so there is no way to resync.
+            _ => break,
+        }
+    }
+    if entries.is_empty() {
+        return Err(invalid("MLG log contains no readable records"));
+    }
+    Ok((channels, entries))
+}
+
+/// Whether a read ran off the end of the log — the shape a capture cut short
+/// by a disconnect or a full card takes. Any other failure is a real error.
+fn ends_log(result: io::Result<()>) -> io::Result<bool> {
+    match result {
+        Ok(()) => Ok(false),
+        Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => Ok(true),
+        Err(e) => Err(e),
+    }
+}
+
+/// Turns the 16-bit record clock back into a tick count from the first record.
+#[derive(Default)]
+struct Clock {
+    start: Option<u64>,
+    previous: u16,
+    wraps: u64,
+}
+
+impl Clock {
+    fn advance(&mut self, raw: u16) -> u64 {
+        if self.start.is_some() && raw < self.previous {
+            self.wraps += 1;
+        }
+        self.previous = raw;
+        let absolute = self.wraps * CLOCK_WRAP + raw as u64;
+        absolute - *self.start.get_or_insert(absolute)
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MAGIC: &[u8; 6] = b"MLVLG\0";
+    const HEADER_LEN: usize = 24;
+    const DESCRIPTOR_LEN: usize = 89;
+
+    struct TestField {
+        code: u8,
+        width: usize,
+        name: &'static str,
+        units: &'static str,
+        scale: f32,
+        transform: f32,
+    }
+
+    const TIME: TestField = TestField {
+        code: 7,
+        width: 4,
+        name: "Time",
+        units: "s",
+        scale: 1.0,
+        transform: 0.0,
+    };
+    const CLT: TestField = TestField {
+        code: 2,
+        width: 2,
+        name: "CLT",
+        units: "deg C",
+        scale: 0.01,
+        transform: 0.0,
+    };
+    const STFT: TestField = TestField {
+        code: 7,
+        width: 4,
+        name: "STFT: Bank 1",
+        units: "%",
+        scale: 100.0,
+        transform: -1.0,
+    };
+
+    /// A marker record: kind 1, counter, 16-bit clock, 50 bytes of text.
+    /// TunerStudio writes one whenever logging goes offline or back online.
+    fn marker(counter: u8, timestamp_10us: u16, text: &str) -> Vec<u8> {
+        let mut out = vec![1u8, counter];
+        out.extend_from_slice(&timestamp_10us.to_be_bytes());
+        out.extend_from_slice(text.as_bytes());
+        out.extend(std::iter::repeat_n(0u8, 50 - text.len()));
+        out
+    }
+
+    /// One data record: kind 0, counter, 16-bit timestamp, payload, checksum.
+    fn record(counter: u8, timestamp_10us: u16, payload: &[u8]) -> Vec<u8> {
+        let mut out = vec![0u8, counter];
+        out.extend_from_slice(&timestamp_10us.to_be_bytes());
+        out.extend_from_slice(payload);
+        out.push(payload.iter().fold(0u8, |sum, b| sum.wrapping_add(*b)));
+        out
+    }
+
+    fn build_log(version: u16, fields: &[&TestField], records: &[Vec<u8>]) -> Vec<u8> {
+        let record_len: usize = fields.iter().map(|f| f.width).sum();
+        let info_start = HEADER_LEN + fields.len() * DESCRIPTOR_LEN;
+
+        let mut out = Vec::new();
+        out.extend_from_slice(MAGIC);
+        out.extend_from_slice(&version.to_be_bytes());
+        out.extend_from_slice(&1_784_378_352u32.to_be_bytes()); // capture time
+        out.extend_from_slice(&(info_start as u32).to_be_bytes());
+        out.extend_from_slice(&(info_start as u32).to_be_bytes()); // no info block
+        out.extend_from_slice(&(record_len as u16).to_be_bytes());
+        out.extend_from_slice(&(fields.len() as u16).to_be_bytes());
+        assert_eq!(out.len(), HEADER_LEN);
+
+        for field in fields {
+            let start = out.len();
+            out.push(field.code);
+            let mut fixed = |text: &str, len: usize| {
+                let bytes = text.as_bytes();
+                out.extend_from_slice(bytes);
+                out.extend(std::iter::repeat_n(0u8, len - bytes.len()));
+            };
+            fixed(field.name, 34);
+            fixed(field.units, 10);
+            out.push(0); // display style
+            out.extend_from_slice(&field.scale.to_be_bytes());
+            out.extend_from_slice(&field.transform.to_be_bytes());
+            out.push(3); // digits
+            out.extend(std::iter::repeat_n(0u8, 34)); // category
+            assert_eq!(out.len() - start, DESCRIPTOR_LEN);
+        }
+
+        for r in records {
+            out.extend_from_slice(r);
+        }
+        out
+    }
+
+    fn write_temp(bytes: &[u8]) -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("log.mlg");
+        std::fs::write(&path, bytes).unwrap();
+        (dir, path)
+    }
+
+    fn payload(time: f32, clt: u16, stft: f32) -> Vec<u8> {
+        let mut p = time.to_be_bytes().to_vec();
+        p.extend_from_slice(&clt.to_be_bytes());
+        p.extend_from_slice(&stft.to_be_bytes());
+        p
+    }
+
+    #[test]
+    fn reads_channel_names_and_physically_scaled_values() {
+        let bytes = build_log(
+            2,
+            &[&TIME, &CLT, &STFT],
+            &[
+                record(0, 1_000, &payload(0.0, 8741, 0.935_228_5)),
+                record(1, 2_000, &payload(0.01, 8747, 1.0)),
+            ],
+        );
+        let (_dir, path) = write_temp(&bytes);
+
+        let (channels, entries) = read_mlg(&path).unwrap();
+
+        assert_eq!(channels, vec!["Time", "CLT", "STFT: Bank 1"]);
+        assert_eq!(entries.len(), 2);
+        // physical = (raw + transform) * scale
+        assert!((entries[0].values[1] - 87.41).abs() < 1e-4, "CLT scaling");
+        assert!(
+            (entries[0].values[2] + 6.477).abs() < 1e-3,
+            "trim transform"
+        );
+        // an untrimmed bank reads raw 1.0, which is 0 % of correction
+        assert!(entries[1].values[2].abs() < 1e-4, "neutral trim is 0 %");
+    }
+
+    #[test]
+    fn timestamps_start_at_zero_and_step_by_the_record_clock() {
+        let bytes = build_log(
+            2,
+            &[&TIME, &CLT, &STFT],
+            &[
+                record(0, 1_000, &payload(0.0, 8741, 1.0)),
+                record(1, 2_000, &payload(0.01, 8741, 1.0)),
+            ],
+        );
+        let (_dir, path) = write_temp(&bytes);
+
+        let (_, entries) = read_mlg(&path).unwrap();
+
+        // The record clock counts 10 µs ticks: 1000 ticks apart is 10 ms.
+        assert_eq!(entries[0].timestamp, std::time::Duration::ZERO);
+        assert_eq!(
+            entries[1].timestamp,
+            std::time::Duration::from_micros(10_000)
+        );
+    }
+
+    #[test]
+    fn rejects_a_file_that_is_not_an_mlg_log() {
+        let (_dir, path) = write_temp(b"Time,rpm\n0.0,900\n");
+        assert!(read_mlg(&path).is_err());
+    }
+
+    #[test]
+    fn rejects_a_format_version_it_cannot_decode() {
+        let bytes = build_log(1, &[&TIME], &[record(0, 0, &0.0f32.to_be_bytes())]);
+        let (_dir, path) = write_temp(&bytes);
+        assert!(read_mlg(&path).is_err());
+    }
+
+    #[test]
+    fn keeps_the_records_before_a_truncated_tail() {
+        // Logs cut short by a disconnect or a full SD card end mid-record.
+        let mut bytes = build_log(
+            2,
+            &[&TIME, &CLT, &STFT],
+            &[
+                record(0, 1_000, &payload(0.0, 8741, 1.0)),
+                record(1, 2_000, &payload(0.01, 8747, 1.0)),
+            ],
+        );
+        bytes.truncate(bytes.len() - 5);
+
+        let (_dir, path) = write_temp(&bytes);
+        let (_, entries) = read_mlg(&path).unwrap();
+
+        assert_eq!(entries.len(), 1);
+    }
+
+    #[test]
+    fn skips_a_record_whose_checksum_does_not_match() {
+        let mut corrupt = record(0, 1_000, &payload(0.0, 8741, 1.0));
+        let last = corrupt.len() - 1;
+        corrupt[last] ^= 0xff;
+
+        let bytes = build_log(
+            2,
+            &[&TIME, &CLT, &STFT],
+            &[corrupt, record(1, 2_000, &payload(0.01, 8747, 1.0))],
+        );
+        let (_dir, path) = write_temp(&bytes);
+
+        let (_, entries) = read_mlg(&path).unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert!((entries[0].values[1] - 87.47).abs() < 1e-4);
+    }
+    #[test]
+    fn keeps_the_records_that_follow_a_marker() {
+        // Markers are shorter than data records, so a reader that mistakes one
+        // for a data record loses everything recorded after it.
+        let bytes = build_log(
+            2,
+            &[&TIME, &CLT, &STFT],
+            &[
+                record(0, 1_000, &payload(0.0, 8741, 1.0)),
+                marker(1, 1_500, "MARK 000 - Going Offline"),
+                record(2, 2_000, &payload(0.01, 8747, 1.0)),
+            ],
+        );
+        let (_dir, path) = write_temp(&bytes);
+
+        let (_, entries) = read_mlg(&path).unwrap();
+
+        assert_eq!(entries.len(), 2);
+        assert!((entries[1].values[1] - 87.47).abs() < 1e-4);
+    }
+
+    #[test]
+    fn rejects_a_log_that_decodes_to_no_records() {
+        let bytes = build_log(2, &[&TIME, &CLT, &STFT], &[]);
+        let (_dir, path) = write_temp(&bytes);
+
+        assert!(read_mlg(&path).is_err());
+    }
+
+    /// Checks the reader against a log TunerStudio actually wrote. Repo
+    /// fixtures are synthetic because real logs run to hundreds of megabytes,
+    /// so point this at one by hand:
+    ///
+    /// ```text
+    /// LIBRETUNE_MLG_FIXTURE=/path/to/log.mlg \
+    ///   cargo test -p libretune-core reads_a_real_tunerstudio_log -- --ignored --nocapture
+    /// ```
+    #[test]
+    #[ignore = "needs a real .mlg log, see LIBRETUNE_MLG_FIXTURE"]
+    fn reads_a_real_tunerstudio_log() {
+        let Ok(fixture) = std::env::var("LIBRETUNE_MLG_FIXTURE") else {
+            panic!("set LIBRETUNE_MLG_FIXTURE to a .mlg log");
+        };
+
+        let (channels, entries) = read_mlg(&fixture).unwrap();
+
+        assert!(!channels.is_empty(), "log declares no channels");
+        assert!(!entries.is_empty(), "log decoded to no records");
+        for entry in &entries {
+            assert_eq!(entry.values.len(), channels.len());
+        }
+        let rpm = channels
+            .iter()
+            .position(|c| c == "RPM")
+            .expect("a rusEFI log has an RPM channel");
+        let peak = entries
+            .iter()
+            .map(|e| e.values[rpm])
+            .fold(f64::MIN, f64::max);
+        assert!(
+            (0.0..=20_000.0).contains(&peak),
+            "peak RPM {peak} is not a physical engine speed"
+        );
+        println!(
+            "{} channels, {} records, {:?} long, peak RPM {peak}",
+            channels.len(),
+            entries.len(),
+            entries.last().unwrap().timestamp,
+        );
+    }
+}

--- a/crates/libretune-core/src/datalog/mlg.rs
+++ b/crates/libretune-core/src/datalog/mlg.rs
@@ -198,15 +198,20 @@ fn read_fields(reader: &mut impl Read, header: &Header) -> io::Result<Vec<MlgFie
 /// back online — advance the clock but carry no channel values, so they are
 /// skipped.
 ///
-/// Tolerates the damage real logs carry: a record cut short by a disconnect
-/// ends the read, and a record whose checksum disagrees with its payload is
-/// dropped rather than failing the whole file.
+/// Damage is reported rather than absorbed: a log that ends mid-record, or
+/// carries a record kind with no known length, is an error, because reading on
+/// would mean guessing where the next record starts. The one exception is a
+/// record whose checksum disagrees with its payload. Those turn up in ordinary
+/// captures — five of the thirty-four used to develop this reader carry
+/// between one and five of them — so they are left out and counted in a
+/// warning instead of costing the user the whole log.
 ///
 /// The whole log is held in memory, exactly like `read_csv`, and `.mlg`
 /// captures are large: a few hundred channels over half an hour decode to
 /// gigabytes of `f64`. Reading only the channels a caller asked for is the way
 /// past that ceiling when it starts to bite.
 pub fn read_mlg<P: AsRef<Path>>(path: P) -> io::Result<(Vec<String>, Vec<LogEntry>)> {
+    let path = path.as_ref();
     let mut reader = BufReader::new(File::open(path)?);
     let header = read_header(&mut reader)?;
     let fields = read_fields(&mut reader, &header)?;
@@ -223,36 +228,55 @@ pub fn read_mlg<P: AsRef<Path>>(path: P) -> io::Result<(Vec<String>, Vec<LogEntr
     let mut data = vec![0u8; header.record_len + 1]; // payload then checksum
     let mut marker = [0u8; MARKER_TEXT_LEN];
     let mut clock = Clock::default();
+    let mut index = 0usize;
+    let mut dropped = 0usize;
 
     loop {
-        if ends_log(reader.read_exact(&mut prefix))? {
-            break;
+        match fill(&mut reader, &mut prefix)? {
+            0 => break,
+            filled if filled < prefix.len() => return Err(cut_short(index)),
+            _ => {}
         }
-        // Advanced for every record, including ones dropped below, so that
-        // damage does not shift the timestamps of what follows.
+        // Advanced for every record, including ones dropped below, so that a
+        // rollover on the far side of one is still recognised.
         let ticks = clock.advance(u16::from_be_bytes([prefix[2], prefix[3]]));
         match prefix[0] {
             KIND_DATA => {
-                if ends_log(reader.read_exact(&mut data))? {
-                    break;
+                if fill(&mut reader, &mut data)? < data.len() {
+                    return Err(cut_short(index));
                 }
                 let (payload, checksum) = data.split_at(header.record_len);
-                if payload.iter().fold(0u8, |sum, b| sum.wrapping_add(*b)) != checksum[0] {
-                    continue;
+                if payload.iter().fold(0u8, |sum, b| sum.wrapping_add(*b)) == checksum[0] {
+                    entries.push(LogEntry::new(
+                        Duration::from_micros(ticks * CLOCK_TICK_MICROS),
+                        fields.iter().map(|f| f.value(payload)).collect(),
+                    ));
+                } else {
+                    dropped += 1;
                 }
-                entries.push(LogEntry::new(
-                    Duration::from_micros(ticks * CLOCK_TICK_MICROS),
-                    fields.iter().map(|f| f.value(payload)).collect(),
-                ));
             }
             KIND_MARKER => {
-                if ends_log(reader.read_exact(&mut marker))? {
-                    break;
+                if fill(&mut reader, &mut marker)? < marker.len() {
+                    return Err(cut_short(index));
                 }
             }
-            // Nothing else has a known length, so there is no way to resync.
-            _ => break,
+            // Nothing else has a known length, so there is no way to resync,
+            // and reading on would drop the rest of the log in silence.
+            kind => {
+                return Err(invalid(format!(
+                    "record kind {kind} at record {index} is not one this reader knows"
+                )))
+            }
         }
+        index += 1;
+    }
+    if dropped > 0 {
+        tracing::warn!(
+            log = %path.display(),
+            dropped,
+            kept = entries.len(),
+            "MLG records failed their checksum and were left out of the log"
+        );
     }
     if entries.is_empty() {
         return Err(invalid("MLG log contains no readable records"));
@@ -260,14 +284,21 @@ pub fn read_mlg<P: AsRef<Path>>(path: P) -> io::Result<(Vec<String>, Vec<LogEntr
     Ok((channels, entries))
 }
 
-/// Whether a read ran off the end of the log — the shape a capture cut short
-/// by a disconnect or a full card takes. Any other failure is a real error.
-fn ends_log(result: io::Result<()>) -> io::Result<bool> {
-    match result {
-        Ok(()) => Ok(false),
-        Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => Ok(true),
-        Err(e) => Err(e),
+/// Reads until `buf` is full or the file runs out, returning how many bytes
+/// were there. Anything short of a full buffer means the log stops mid-record.
+fn fill(reader: &mut impl Read, buf: &mut [u8]) -> io::Result<usize> {
+    let mut filled = 0;
+    while filled < buf.len() {
+        match reader.read(&mut buf[filled..])? {
+            0 => break,
+            n => filled += n,
+        }
     }
+    Ok(filled)
+}
+
+fn cut_short(index: usize) -> io::Error {
+    invalid(format!("log ends part-way through record {index}"))
 }
 
 /// Turns the 16-bit record clock back into a tick count from the first record.
@@ -477,8 +508,7 @@ mod tests {
     }
 
     #[test]
-    fn keeps_the_records_before_a_truncated_tail() {
-        // Logs cut short by a disconnect or a full SD card end mid-record.
+    fn rejects_a_log_that_ends_mid_record() {
         let mut bytes = build_log(
             2,
             &[&TIME, &CLT, &STFT],
@@ -490,9 +520,31 @@ mod tests {
         bytes.truncate(bytes.len() - 5);
 
         let (_dir, path) = write_temp(&bytes);
-        let (_, entries) = read_mlg(&path).unwrap();
 
-        assert_eq!(entries.len(), 1);
+        assert!(read_mlg(&path).is_err());
+    }
+
+    #[test]
+    fn rejects_a_record_kind_it_cannot_decode() {
+        // Only kinds 0 and 1 have a known length, so an unknown one leaves no
+        // way to find the next record — reading on would drop the rest of the
+        // log without saying so.
+        let mut unknown = vec![2u8, 0, 0x0b, 0xb8];
+        unknown.extend(std::iter::repeat_n(0u8, 32));
+
+        let bytes = build_log(
+            2,
+            &[&TIME, &CLT, &STFT],
+            &[record(0, 1_000, &payload(0.0, 8741, 1.0)), unknown],
+        );
+        let (_dir, path) = write_temp(&bytes);
+
+        let error = read_mlg(&path).unwrap_err();
+
+        assert!(
+            error.to_string().contains("record kind 2"),
+            "expected the unknown kind to be named, got: {error}"
+        );
     }
 
     #[test]

--- a/crates/libretune-core/src/datalog/mlg.rs
+++ b/crates/libretune-core/src/datalog/mlg.rs
@@ -101,6 +101,7 @@ impl FieldType {
 
 struct MlgField {
     name: String,
+    units: String,
     field_type: FieldType,
     offset: usize,
     scale: f32,
@@ -114,6 +115,22 @@ impl MlgField {
             .read(&payload[self.offset..self.offset + self.field_type.width()]);
         (raw + self.transform as f64) * self.scale as f64
     }
+}
+
+/// The elapsed-seconds channel TunerStudio writes as field 0. Where a log has
+/// it, it is the only timeline that survives a pause in logging: the 16-bit
+/// record clock wraps every 655 ms, so a longer gap cannot be recovered from
+/// it at all.
+fn time_channel(fields: &[MlgField]) -> Option<usize> {
+    fields
+        .iter()
+        .position(|f| f.name.eq_ignore_ascii_case("time") && f.units == "s")
+}
+
+/// Seconds since the first record, as a `Duration`. Guards the conversion:
+/// the values come from the file, so they can be negative, NaN, or absurd.
+fn elapsed(seconds: f64) -> Duration {
+    Duration::try_from_secs_f64(seconds).unwrap_or(Duration::ZERO)
 }
 
 fn invalid(message: impl Into<String>) -> io::Error {
@@ -175,6 +192,7 @@ fn read_fields(reader: &mut impl Read, header: &Header) -> io::Result<Vec<MlgFie
         }
         fields.push(MlgField {
             name: read_name(&descriptor[1..35]),
+            units: read_name(&descriptor[35..45]),
             field_type,
             offset,
             scale,
@@ -193,6 +211,11 @@ fn read_fields(reader: &mut impl Read, header: &Header) -> io::Result<Vec<MlgFie
 
 /// Read an `.mlg` log into the same `(channels, entries)` shape as
 /// [`super::format::read_csv`].
+///
+/// Timestamps come from the log's own elapsed-seconds channel where it has
+/// one, and from the 16-bit record clock otherwise. The record clock wraps
+/// every 655 ms, which is shorter than a pause in logging, so it cannot stand
+/// in for a real timeline across one.
 ///
 /// Marker records — the notes TunerStudio writes when logging goes offline and
 /// back online — advance the clock but carry no channel values, so they are
@@ -228,6 +251,8 @@ pub fn read_mlg<P: AsRef<Path>>(path: P) -> io::Result<(Vec<String>, Vec<LogEntr
     let mut data = vec![0u8; header.record_len + 1]; // payload then checksum
     let mut marker = [0u8; MARKER_TEXT_LEN];
     let mut clock = Clock::default();
+    let time = time_channel(&fields);
+    let mut first_seconds = None;
     let mut index = 0usize;
     let mut dropped = 0usize;
 
@@ -247,8 +272,15 @@ pub fn read_mlg<P: AsRef<Path>>(path: P) -> io::Result<(Vec<String>, Vec<LogEntr
                 }
                 let (payload, checksum) = data.split_at(header.record_len);
                 if payload.iter().fold(0u8, |sum, b| sum.wrapping_add(*b)) == checksum[0] {
+                    let timestamp = match time {
+                        Some(i) => {
+                            let seconds = fields[i].value(payload);
+                            elapsed(seconds - *first_seconds.get_or_insert(seconds))
+                        }
+                        None => Duration::from_micros(ticks * CLOCK_TICK_MICROS),
+                    };
                     entries.push(LogEntry::new(
-                        Duration::from_micros(ticks * CLOCK_TICK_MICROS),
+                        timestamp,
                         fields.iter().map(|f| f.value(payload)).collect(),
                     ));
                 } else {
@@ -289,9 +321,12 @@ pub fn read_mlg<P: AsRef<Path>>(path: P) -> io::Result<(Vec<String>, Vec<LogEntr
 fn fill(reader: &mut impl Read, buf: &mut [u8]) -> io::Result<usize> {
     let mut filled = 0;
     while filled < buf.len() {
-        match reader.read(&mut buf[filled..])? {
-            0 => break,
-            n => filled += n,
+        match reader.read(&mut buf[filled..]) {
+            Ok(0) => break,
+            Ok(n) => filled += n,
+            // A signal, not a damaged log.
+            Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
+            Err(e) => return Err(e),
         }
     }
     Ok(filled)
@@ -439,6 +474,14 @@ mod tests {
         (dir, path)
     }
 
+    /// The channel set of a log with no Time channel, where the record clock
+    /// is the only timeline available.
+    fn untimed(clt: u16, stft: f32) -> Vec<u8> {
+        let mut p = clt.to_be_bytes().to_vec();
+        p.extend_from_slice(&stft.to_be_bytes());
+        p
+    }
+
     fn payload(time: f32, clt: u16, stft: f32) -> Vec<u8> {
         let mut p = time.to_be_bytes().to_vec();
         p.extend_from_slice(&clt.to_be_bytes());
@@ -476,10 +519,10 @@ mod tests {
     fn timestamps_start_at_zero_and_step_by_the_record_clock() {
         let bytes = build_log(
             2,
-            &[&TIME, &CLT, &STFT],
+            &[&CLT, &STFT],
             &[
-                record(0, 1_000, &payload(0.0, 8741, 1.0)),
-                record(1, 2_000, &payload(0.01, 8741, 1.0)),
+                record(0, 1_000, &untimed(8741, 1.0)),
+                record(1, 2_000, &untimed(8741, 1.0)),
             ],
         );
         let (_dir, path) = write_temp(&bytes);
@@ -505,6 +548,55 @@ mod tests {
         let bytes = build_log(1, &[&TIME], &[record(0, 0, &0.0f32.to_be_bytes())]);
         let (_dir, path) = write_temp(&bytes);
         assert!(read_mlg(&path).is_err());
+    }
+
+    #[test]
+    fn the_fallback_clock_starts_at_the_first_record_of_any_kind() {
+        // A log that opens with a marker: taking the start from the first
+        // *kept* record instead would swallow the interval before it.
+        let bytes = build_log(
+            2,
+            &[&CLT, &STFT],
+            &[
+                marker(0, 1_000, "MARK 000 - Going Online"),
+                record(1, 3_000, &untimed(8741, 1.0)),
+            ],
+        );
+        let (_dir, path) = write_temp(&bytes);
+
+        let (_, entries) = read_mlg(&path).unwrap();
+
+        assert_eq!(entries[0].timestamp, Duration::from_micros(20_000));
+    }
+
+    /// A reader that hands back `Interrupted` once before every real read,
+    /// the way a signal arriving mid-read looks.
+    struct Interrupting<R> {
+        inner: R,
+        armed: bool,
+    }
+
+    impl<R: Read> Read for Interrupting<R> {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            if self.armed {
+                self.armed = false;
+                return Err(io::Error::from(io::ErrorKind::Interrupted));
+            }
+            self.armed = true;
+            self.inner.read(buf)
+        }
+    }
+
+    #[test]
+    fn an_interrupted_read_is_retried_rather_than_failing_the_log() {
+        let mut reader = Interrupting {
+            inner: &b"abcd"[..],
+            armed: true,
+        };
+        let mut buf = [0u8; 4];
+
+        assert_eq!(fill(&mut reader, &mut buf).unwrap(), 4);
+        assert_eq!(&buf, b"abcd");
     }
 
     #[test]
@@ -595,14 +687,36 @@ mod tests {
     }
 
     #[test]
-    fn a_wrapped_clock_keeps_time_moving_forward() {
-        // The 16-bit clock rolls over every 65536 ticks, roughly twice a second.
+    fn takes_the_timeline_from_the_time_channel_when_the_log_has_one() {
+        // Logging pauses: 8 of 34 real captures contain a gap longer than the
+        // 655 ms the record clock can represent, one of them 25 hours long.
+        // Only the Time channel survives that.
         let bytes = build_log(
             2,
             &[&TIME, &CLT, &STFT],
             &[
-                record(0, 65_000, &payload(0.0, 8741, 1.0)),
-                record(1, 200, &payload(0.01, 8741, 1.0)),
+                record(0, 1_000, &payload(10.0, 8741, 1.0)),
+                record(1, 2_000, &payload(4_010.0, 8741, 1.0)),
+            ],
+        );
+        let (_dir, path) = write_temp(&bytes);
+
+        let (_, entries) = read_mlg(&path).unwrap();
+
+        // The clock only moved 1000 ticks, but an hour passed.
+        assert_eq!(entries[0].timestamp, Duration::ZERO);
+        assert_eq!(entries[1].timestamp, Duration::from_secs(4_000));
+    }
+
+    #[test]
+    fn a_wrapped_clock_keeps_time_moving_forward() {
+        // The 16-bit clock rolls over every 65536 ticks, roughly twice a second.
+        let bytes = build_log(
+            2,
+            &[&CLT, &STFT],
+            &[
+                record(0, 65_000, &untimed(8741, 1.0)),
+                record(1, 200, &untimed(8741, 1.0)),
             ],
         );
         let (_dir, path) = write_temp(&bytes);
@@ -620,11 +734,11 @@ mod tests {
         // 655 ms to every record after it.
         let bytes = build_log(
             2,
-            &[&TIME, &CLT, &STFT],
+            &[&CLT, &STFT],
             &[
-                record(0, 1_000, &payload(0.0, 8741, 1.0)),
-                record(1, 900, &payload(0.01, 8741, 1.0)),
-                record(2, 1_100, &payload(0.02, 8741, 1.0)),
+                record(0, 1_000, &untimed(8741, 1.0)),
+                record(1, 900, &untimed(8741, 1.0)),
+                record(2, 1_100, &untimed(8741, 1.0)),
             ],
         );
         let (_dir, path) = write_temp(&bytes);
@@ -640,17 +754,17 @@ mod tests {
     /// step backwards instead of the far side of a wrap.
     #[test]
     fn a_dropped_record_still_advances_the_clock() {
-        let mut corrupt = record(1, 60_000, &payload(0.01, 8741, 1.0));
+        let mut corrupt = record(1, 60_000, &untimed(8741, 1.0));
         let last = corrupt.len() - 1;
         corrupt[last] ^= 0xff;
 
         let bytes = build_log(
             2,
-            &[&TIME, &CLT, &STFT],
+            &[&CLT, &STFT],
             &[
-                record(0, 1_000, &payload(0.0, 8741, 1.0)),
+                record(0, 1_000, &untimed(8741, 1.0)),
                 corrupt,
-                record(2, 200, &payload(0.02, 8741, 1.0)),
+                record(2, 200, &untimed(8741, 1.0)),
             ],
         );
         let (_dir, path) = write_temp(&bytes);
@@ -666,11 +780,11 @@ mod tests {
     fn a_marker_still_advances_the_clock() {
         let bytes = build_log(
             2,
-            &[&TIME, &CLT, &STFT],
+            &[&CLT, &STFT],
             &[
-                record(0, 1_000, &payload(0.0, 8741, 1.0)),
+                record(0, 1_000, &untimed(8741, 1.0)),
                 marker(1, 60_000, "MARK 000 - Going Offline"),
-                record(2, 200, &payload(0.02, 8741, 1.0)),
+                record(2, 200, &untimed(8741, 1.0)),
             ],
         );
         let (_dir, path) = write_temp(&bytes);

--- a/crates/libretune-core/src/datalog/mlg.rs
+++ b/crates/libretune-core/src/datalog/mlg.rs
@@ -227,7 +227,8 @@ fn read_fields(reader: &mut impl Read, header: &Header) -> io::Result<Vec<MlgFie
 /// record whose checksum disagrees with its payload. Those turn up in ordinary
 /// captures — five of the thirty-four used to develop this reader carry
 /// between one and five of them — so they are left out and counted in a
-/// warning instead of costing the user the whole log.
+/// warning instead of costing the user the whole log. A record whose own
+/// elapsed-seconds reading is not a finite number goes the same way.
 ///
 /// The whole log is held in memory, exactly like `read_csv`, and `.mlg`
 /// captures are large: a few hundred channels over half an hour decode to
@@ -254,7 +255,8 @@ pub fn read_mlg<P: AsRef<Path>>(path: P) -> io::Result<(Vec<String>, Vec<LogEntr
     let time = time_channel(&fields);
     let mut first_seconds = None;
     let mut index = 0usize;
-    let mut dropped = 0usize;
+    let mut failed_checksum = 0usize;
+    let mut unusable_timestamp = 0usize;
 
     loop {
         match fill(&mut reader, &mut prefix)? {
@@ -271,21 +273,31 @@ pub fn read_mlg<P: AsRef<Path>>(path: P) -> io::Result<(Vec<String>, Vec<LogEntr
                     return Err(cut_short(index));
                 }
                 let (payload, checksum) = data.split_at(header.record_len);
-                if payload.iter().fold(0u8, |sum, b| sum.wrapping_add(*b)) == checksum[0] {
-                    let timestamp = match time {
-                        Some(i) => {
-                            let seconds = fields[i].value(payload);
-                            elapsed(seconds - *first_seconds.get_or_insert(seconds))
-                        }
-                        None => Duration::from_micros(ticks * CLOCK_TICK_MICROS),
-                    };
-                    entries.push(LogEntry::new(
-                        timestamp,
-                        fields.iter().map(|f| f.value(payload)).collect(),
-                    ));
-                } else {
-                    dropped += 1;
+                if payload.iter().fold(0u8, |sum, b| sum.wrapping_add(*b)) != checksum[0] {
+                    failed_checksum += 1;
+                    index += 1;
+                    continue;
                 }
+                let timestamp = match time {
+                    Some(i) => {
+                        let seconds = fields[i].value(payload);
+                        // A record whose own clock reading is nonsense is left
+                        // out: keeping it would mean either an invented
+                        // timestamp, or a baseline that turns every later
+                        // subtraction into NaN.
+                        if !seconds.is_finite() {
+                            unusable_timestamp += 1;
+                            index += 1;
+                            continue;
+                        }
+                        elapsed(seconds - *first_seconds.get_or_insert(seconds))
+                    }
+                    None => Duration::from_micros(ticks * CLOCK_TICK_MICROS),
+                };
+                entries.push(LogEntry::new(
+                    timestamp,
+                    fields.iter().map(|f| f.value(payload)).collect(),
+                ));
             }
             KIND_MARKER => {
                 if fill(&mut reader, &mut marker)? < marker.len() {
@@ -302,12 +314,13 @@ pub fn read_mlg<P: AsRef<Path>>(path: P) -> io::Result<(Vec<String>, Vec<LogEntr
         }
         index += 1;
     }
-    if dropped > 0 {
+    if failed_checksum > 0 || unusable_timestamp > 0 {
         tracing::warn!(
             log = %path.display(),
-            dropped,
+            failed_checksum,
+            unusable_timestamp,
             kept = entries.len(),
-            "MLG records failed their checksum and were left out of the log"
+            "MLG records were left out of the log"
         );
     }
     if entries.is_empty() {
@@ -706,6 +719,28 @@ mod tests {
         // The clock only moved 1000 ticks, but an hour passed.
         assert_eq!(entries[0].timestamp, Duration::ZERO);
         assert_eq!(entries[1].timestamp, Duration::from_secs(4_000));
+    }
+
+    #[test]
+    fn a_non_finite_time_value_does_not_flatten_the_whole_log() {
+        // The baseline is taken from the first record, so a NaN there would
+        // make every later subtraction NaN and report the entire log at zero.
+        let bytes = build_log(
+            2,
+            &[&TIME, &CLT, &STFT],
+            &[
+                record(0, 1_000, &payload(f32::NAN, 8741, 1.0)),
+                record(1, 2_000, &payload(10.0, 8741, 1.0)),
+                record(2, 3_000, &payload(12.0, 8741, 1.0)),
+            ],
+        );
+        let (_dir, path) = write_temp(&bytes);
+
+        let (_, entries) = read_mlg(&path).unwrap();
+
+        assert_eq!(entries.len(), 2, "the unusable record is left out");
+        assert_eq!(entries[0].timestamp, Duration::ZERO);
+        assert_eq!(entries[1].timestamp, Duration::from_secs(2));
     }
 
     #[test]

--- a/crates/libretune-core/src/datalog/mlg.rs
+++ b/crates/libretune-core/src/datalog/mlg.rs
@@ -178,7 +178,7 @@ fn read_fields(reader: &mut impl Read, header: &Header) -> io::Result<Vec<MlgFie
 
     let mut fields = Vec::with_capacity(header.field_count);
     let mut offset = 0usize;
-    for (index, descriptor) in bytes.chunks_exact(DESCRIPTOR_LEN).enumerate() {
+    for (index, descriptor) in bytes.as_chunks::<DESCRIPTOR_LEN>().0.iter().enumerate() {
         let field_type = FieldType::from_code(descriptor[0]).ok_or_else(|| {
             invalid(format!(
                 "field {index} has unknown storage type {}",

--- a/crates/libretune-core/src/datalog/mod.rs
+++ b/crates/libretune-core/src/datalog/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod dyno;
 pub mod format;
+pub mod mlg;
 mod playback;
 mod recorder;
 


### PR DESCRIPTION
## Description

Adds a reader for TunerStudio / MegaLogViewer binary datalogs (`.mlg`, format
version 2), so logs captured in TunerStudio can be opened in LibreTune.

`LogFormat` has listed `Mlg` since it was written, but nothing could read one:
saved logs went through `read_csv`, and the datalog listing hid every file that
was not a `.csv`. Dropping a `.mlg` into a project's `datalogs/` folder now
lists and loads it exactly like a CSV, which also makes those logs reachable
from the assistant's `query_datalog` tool.

No public spec was used. The format was reverse-engineered and then verified
against 34 real rusEFI captures from a Mazda MX-5 (1.6 MB to 569 MB, 979
channels each, up to 190k records). All 34 decode with physically sane values —
peak RPM 930 to 7698, coolant around 87 °C, battery 14.3 V, lambda 0.90.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `libretune-core/src/datalog/mlg.rs` — the MLG v2 reader.
- `libretune-core/src/datalog/format.rs` — `read_log()`, which picks the reader
  by file extension, so callers do not have to.
- `libretune-app/src-tauri/src/commands/data_logging.rs` — `load_datalog_file`
  goes through `read_log`, and the listing filter uses
  `LogFormat::from_extension` instead of a hard-coded `!= "csv"`.

### The format, as implemented

All big-endian.

```
header      24 bytes  "MLVLG\0", version u16, capture time u32,
                      info offset u32, data offset u32,
                      record length u16, field count u16
field       89 bytes  type u8, name [34], units [10], display style u8,
                      scale f32, transform f32, digits u8, category [34]
info                  the tune the log was captured with, as MSQ text
record                kind u8, counter u8, clock u16 (10 µs ticks), then
                      either a payload plus its checksum u8 (kind 0), or
                      50 bytes of marker text (kind 1)
```

Three details cost real data if guessed wrong, so they are worth calling out:

- **Physical values are `(raw + transform) * scale`,** not
  `raw * scale + transform`. Fuel trims disambiguate the two: an untrimmed bank
  logs raw `1.0` with scale `100` and transform `-1`, which is 0 % of correction
  under the first formula and 99 % under the second.
- **Marker records are 54 bytes,** not the record length. Reading one as a data
  record loses everything logged after it — 13 % of one 306 MB capture here.
- **The 16-bit record clock is not a usable timeline.** It wraps every 655.36 ms,
  which is shorter than a pause in logging, so a longer gap cannot be recovered
  from it at all. 8 of the 34 captures contain such a gap; in one the car sat
  between two sessions a day apart, and timing by the record clock reported a
  25-hour log as 17 minutes. Timestamps therefore come from the log's own
  elapsed-seconds channel where it has one — the same channel `read_csv` already
  uses — with the record clock kept as the fallback.

### Damage handling

Real captures are not pristine, so the policy is deliberate:

| Damage | Behaviour | Why |
| --- | --- | --- |
| Unknown record kind | error, naming the record | No known length, so there is no way to find the next record; reading on would drop the rest of the log in silence. 0 of 34 captures affected. |
| Log ends mid-record | error, naming the record | 0 of 34 affected — every one ends exactly on a record boundary. |
| Checksum mismatch | record left out, counted | 5 of 34 captures carry 1–5 of these. Failing the read would cost the whole log over a handful of samples out of hundreds of thousands. |
| Non-finite timestamp | record left out, counted | Keeping it would mean either an invented timestamp or a baseline that turns every later subtraction into NaN. |

The two counts go out together in a `tracing::warn!`, so a damaged log says
which kind of damage it carries rather than quietly returning fewer records.

## Testing

- [x] I have tested these changes locally
- [x] New and existing tests pass (`cargo test --workspace`)
- [ ] The UI works correctly with these changes — see *Not in this PR* below

20 unit tests in `mlg.rs`, plus 3 for the dispatcher in `format.rs`. **Every one
of them was checked by mutating the production code and confirming the test
fails** — an early version of the "a dropped record still advances the clock"
test survived its mutation and was rewritten until it did not.

There is also `reads_a_real_tunerstudio_log`, marked `#[ignore]` because repo
fixtures cannot be hundreds of megabytes. Point it at a real capture:

```
LIBRETUNE_MLG_FIXTURE=/path/to/log.mlg \
  cargo test -p libretune-core reads_a_real_tunerstudio_log -- --ignored --nocapture
```

## Checklist

- [x] Code compiles without errors
- [x] No new clippy warnings (`cargo clippy --workspace -- -D warnings`)
- [x] Code is formatted (`cargo fmt --all -- --check`)
- [x] TypeScript compiles without errors — no frontend changes in this PR
- [x] Documentation updated if needed — the format is documented in the module header
- [x] Commit messages follow conventional format

## Not in this PR

- **The Open-log dialog still cannot pick a `.mlg`.** `DatalogViewer` and
  `DataLogView` read the file as text through `read_file_contents` and parse it
  in TypeScript, so binary logs need a Tauri command — and 979 channels ×
  190k records is roughly 1.5 GB of JSON, so that command has to take a list of
  wanted channels rather than hand back everything. That is a design question of
  its own, and this PR is already useful without it: `.mlg` files in a project's
  `datalogs/` folder load and are queryable today.
- **The whole log is materialised, like `read_csv`.** Measured 1.57 GB RSS for
  the 569 MB capture. The field offsets are already centralised, so a
  channel-projecting reader can filter before collecting values, with the
  present all-channel API kept as a wrapper.

Happy to fold either of those into this PR if you would rather they land
together.
