### PR TITLE
ci: test on macOS as well as Linux and Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,20 @@ jobs:
       - name: Test
         run: cargo test --workspace
 
+  rust-macos:
+    name: Rust (macOS)
+    runs-on: macos-latest
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: ./.github/actions/setup-rust
+        with:
+          cache_key: rust-macos
+
+      - name: Test
+        run: cargo test --workspace
+
   frontend:
     name: Frontend
     runs-on: ubuntu-latest
@@ -116,7 +130,7 @@ jobs:
   ci:
     name: CI
     if: always()
-    needs: [format, rust-linux, rust-windows, frontend, security-audit]
+    needs: [format, rust-linux, rust-windows, rust-macos, frontend, security-audit]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -127,6 +141,7 @@ jobs:
             "${{ needs.format.result }}"
             "${{ needs.rust-linux.result }}"
             "${{ needs.rust-windows.result }}"
+            "${{ needs.rust-macos.result }}"
             "${{ needs.frontend.result }}"
             "${{ needs.security-audit.result }}"
           )


### PR DESCRIPTION
## Why

`release.yml` already has a `build-macos` job that produces the macOS bundle shipped to users, but `ci.yml` only tests on `ubuntu-latest` and `windows-latest`. Nothing compiles or runs the workspace on macOS until a release is cut, so a macOS-only break stays invisible until it is already in a published artifact.

## What

- New `rust-macos` job on `macos-latest`, mirroring the existing `rust-windows` job exactly (same `setup-rust` composite, same `cargo test --workspace`, same 35-minute cap, its own `rust-macos` cache key).
- Added to the aggregate `ci` job's `needs` and result loop, so branch protection covers it. The required status check name stays `CI` — no branch-protection change needed.

Deliberately kept to `cargo test`, not clippy: `rust-linux` already owns the lint gate, and duplicating it would just triple the failure surface for the same warnings.

## Test plan

- [x] `cargo test --workspace` on macOS (Apple silicon, macOS 15) at this branch's base — all suites pass, 0 failures.
- [x] `ci.yml` parses as valid YAML; job graph resolves to `format, rust-linux, rust-windows, rust-macos, frontend, security-audit, ci`.
- [ ] Green `Rust (macOS)` job on this PR.

## Cost note

macOS runners bill at 10× the Linux rate, but this repository is public, so GitHub-hosted minutes are free. No billing impact.