### PR TITLE
chore: silence the two dead-code warnings the test build emits

### DIFF
--- a/crates/libretune-core/src/autotune/mod.rs
+++ b/crates/libretune-core/src/autotune/mod.rs
@@ -2440,7 +2440,6 @@ mod hit_weighting_tests {
     fn the_weighted_mean_reduces_to_the_plain_mean_under_uniform() {
         let samples: [f64; 4] = [90.0, 100.0, 110.0, 95.0];
         let (mut cma, mut wtot) = (samples[0], 0.0);
-        cma = samples[0];
         for (i, x) in samples.iter().enumerate() {
             let w = 1.0;
             wtot += w;

--- a/crates/libretune-core/src/protocol/connection.rs
+++ b/crates/libretune-core/src/protocol/connection.rs
@@ -3854,8 +3854,6 @@ mod tests {
 
 #[cfg(test)]
 mod burn_page_tests {
-    use super::*;
-
     /// Speeduino's INI declares one `burnCommand` per page, each taking the page
     /// number. A burn that only ever sends page 0 therefore commits the main
     /// config page and leaves every table in RAM - where it reads back correctly


### PR DESCRIPTION
## Why

`cargo test --workspace` builds the `#[cfg(test)]` trees, so both of these warnings print on every CI test run on all three platforms. Neither is caught by `cargo clippy --workspace`, because that does not build test targets — which is why they have gone unnoticed.

## What

Three lines deleted, no behaviour touched:

- `protocol/connection.rs` — `mod burn_page_tests` glob-imports `super::*` and then names nothing from it; every assertion in it uses fully qualified paths (`std::collections::BTreeSet`). The sibling `page_crc_tests` module genuinely needs its `use super::*` and is left alone.
- `autotune/mod.rs` — `cma` is seeded to `samples[0]` by the tuple destructuring and then immediately assigned `samples[0]` again on the next line; the loop's `i == 0` arm sets it a third time regardless. `rustc` flags the middle one as a dead store.

## Test plan

- [x] `cargo test --workspace` — 0 failures, and the test build now emits **0 warnings** (was 2).
- [x] The four touched tests specifically: `burn_page_tests` (3 passed) and `the_weighted_mean_reduces_to_the_plain_mean_under_uniform` (1 passed).
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --workspace -- -D warnings` clean.

Verified on macOS; the warnings are platform-independent, so Linux and Windows behave the same.