### PR TITLE
fix(app): treat a byte-identical logger buffer as not-ready, not new data

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/tooth_logger.rs
+++ b/crates/libretune-app/src-tauri/src/commands/tooth_logger.rs
@@ -186,6 +186,7 @@ async fn run_capture(
     let (mut records, mut reads, mut empty) = (0u64, 0u64, 0u64);
     let mut batch: Vec<LoggerRecord> = Vec::new();
     let mut note = None;
+    let mut last_payload: Option<Vec<u8>> = None;
 
     loop {
         if !RUNNING.load(Ordering::SeqCst) {
@@ -225,6 +226,20 @@ async fn run_capture(
             }
             continue;
         }
+        // The ECU serves whatever its buffer holds; if we poll again before it
+        // refills (or after it stops filling), the same bytes come back and
+        // decoding them again duplicates every record. Same-bytes is "not
+        // ready", exactly like an empty read.
+        if last_payload.as_deref() == Some(payload.as_slice()) {
+            empty += 1;
+            if empty > 200 {
+                note = Some("buffer stopped refilling - same data on every read".into());
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(20));
+            continue;
+        }
+        last_payload = Some(payload.clone());
         empty = 0;
 
         let mut real = 0usize;


### PR DESCRIPTION
The tooth/composite capture loop polled on a fixed 250 ms timer and decoded
whatever came back. When the ECU serves the same buffer content on
consecutive reads (poll faster than the refill, or a capture that stopped
filling), every record was decoded and emitted again. Field failure on
2026-09-01: a composite export containing one 14-record block repeated 456
times, timestamps jumping backward at every seam.

Keep the previous payload and route same-bytes reads through the existing
not-ready path, sharing its 200-strike give-up. One guard in the shared
run_capture loop covers both loggers.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>



🤖 Generated with [Claude Code](https://claude.com/claude-code)