### PR TITLE
fix(core): preserve per-gauge/indicator visibility condition and hysteresis on save

### DIFF
--- a/crates/libretune-core/src/dash/parser.rs
+++ b/crates/libretune-core/src/dash/parser.rs
@@ -64,10 +64,21 @@ pub fn parse_dash_file(xml: &str) -> Result<DashFile, DashParseError> {
                 handle_empty_element(&mut dash, &mut state, e)?;
             }
             Ok(Event::Text(ref e)) => {
-                text_buf = e.decode().map(|c| c.into_owned()).unwrap_or_default();
+                // Accumulate, don't overwrite: an escaped character (a
+                // condition's `>`/`<`/`&`) arrives as its own text fragment, so
+                // overwriting kept only the last piece ("rpm > 3000" -> "3000").
+                text_buf.push_str(&e.decode().map(|c| c.into_owned()).unwrap_or_default());
             }
             Ok(Event::CData(ref e)) => {
-                text_buf = String::from_utf8_lossy(e.as_ref()).to_string();
+                text_buf.push_str(&String::from_utf8_lossy(e.as_ref()));
+            }
+            // quick-xml delivers each `&gt;`/`&amp;`/… as its own event; resolve
+            // it back into the text so an escaped condition read from a
+            // TunerStudio file keeps its operators.
+            Ok(Event::GeneralRef(ref e)) => {
+                if let Some(c) = resolve_entity(&String::from_utf8_lossy(e.as_ref())) {
+                    text_buf.push(c);
+                }
             }
             Ok(Event::Eof) => break,
             Err(e) => return Err(DashParseError::XmlError(e)),
@@ -77,6 +88,18 @@ pub fn parse_dash_file(xml: &str) -> Result<DashFile, DashParseError> {
     }
 
     Ok(dash)
+}
+
+/// Resolve one of the five predefined XML entities to its character.
+fn resolve_entity(name: &str) -> Option<char> {
+    match name {
+        "amp" => Some('&'),
+        "lt" => Some('<'),
+        "gt" => Some('>'),
+        "quot" => Some('"'),
+        "apos" => Some('\''),
+        _ => None,
+    }
 }
 
 /// Parse a TunerStudio .gauge file from a string.
@@ -169,10 +192,15 @@ pub fn parse_gauge_file(xml: &str) -> Result<GaugeFile, DashParseError> {
                 }
             }
             Ok(Event::Text(ref e)) => {
-                text_buf = e.decode().map(|c| c.into_owned()).unwrap_or_default();
+                text_buf.push_str(&e.decode().map(|c| c.into_owned()).unwrap_or_default());
             }
             Ok(Event::CData(ref e)) => {
-                text_buf = String::from_utf8_lossy(e.as_ref()).to_string();
+                text_buf.push_str(&String::from_utf8_lossy(e.as_ref()));
+            }
+            Ok(Event::GeneralRef(ref e)) => {
+                if let Some(c) = resolve_entity(&String::from_utf8_lossy(e.as_ref())) {
+                    text_buf.push(c);
+                }
             }
             Ok(Event::Eof) => break,
             Err(e) => return Err(DashParseError::XmlError(e)),
@@ -642,6 +670,14 @@ fn set_gauge_property(gauge: &mut GaugeConfig, prop: &str, value: &str) {
         "GaugeStyle" => gauge.gauge_style = value.to_string(),
         "GaugePainter" => gauge.gauge_painter = GaugePainter::from_ts_string(value),
         "RunDemo" => gauge.run_demo = value.parse().unwrap_or(false),
+        "EnabledCondition" => {
+            gauge.enabled_condition = if value.is_empty() {
+                None
+            } else {
+                Some(value.to_string())
+            }
+        }
+        "Hysteresis" => gauge.hysteresis = value.parse().ok(),
         // Preserve unrecognized properties (painter-specific lt_* attributes,
         // future TunerStudio additions) instead of silently dropping them —
         // the writer emits `extra_attrs` back out, so they round-trip.
@@ -706,7 +742,20 @@ fn set_indicator_property(indicator: &mut IndicatorConfig, prop: &str, value: &s
         }
         "Painter" => indicator.indicator_painter = IndicatorPainter::from_ts_string(value),
         "RunDemo" => indicator.run_demo = value.parse().unwrap_or(false),
-        _ => {}
+        "EnabledCondition" => {
+            indicator.enabled_condition = if value.is_empty() {
+                None
+            } else {
+                Some(value.to_string())
+            }
+        }
+        // Preserve unrecognized properties so the writer's extra_attrs loop can
+        // round-trip them, matching the gauge reader (was silently dropped).
+        other => {
+            indicator
+                .extra_attrs
+                .insert(other.to_string(), value.to_string());
+        }
     }
 }
 

--- a/crates/libretune-core/src/dash/writer.rs
+++ b/crates/libretune-core/src/dash/writer.rs
@@ -3,7 +3,7 @@
 //! Writes .dash and .gauge files in TS XML format (version 3.0).
 
 use super::types::*;
-use quick_xml::events::{BytesDecl, BytesEnd, BytesStart, BytesText, Event};
+use quick_xml::events::{BytesCData, BytesDecl, BytesEnd, BytesStart, BytesText, Event};
 use quick_xml::Writer;
 use std::io::Write;
 
@@ -345,6 +345,17 @@ fn write_gauge_component<W: Write>(
     write_string_property(writer, "GaugePainter", gauge.gauge_painter.to_ts_string())?;
     write_boolean_property(writer, "RunDemo", gauge.run_demo)?;
 
+    // Per-gauge visibility condition and warning-flicker hysteresis. These are
+    // editable in the designer and live on GaugeConfig, but were never written,
+    // so a saved dashboard lost them on the next load. Gated on Some(...), so a
+    // gauge that never set them serializes byte-identical to before.
+    if let Some(ref cond) = gauge.enabled_condition {
+        write_string_property(writer, "EnabledCondition", cond)?;
+    }
+    if let Some(h) = gauge.hysteresis {
+        write_double_property(writer, "Hysteresis", h)?;
+    }
+
     // Lossless extras: painter-specific properties (MultiChannelTrend's
     // lt_seriesN_* overlay series, TelemetryStat's lt_target_channel) and any
     // unrecognized properties captured at parse time. Without this, a
@@ -427,6 +438,16 @@ fn write_indicator_component<W: Write>(
     )?;
     write_boolean_property(writer, "RunDemo", indicator.run_demo)?;
 
+    // Visibility condition (same fix as gauges — was dropped on save).
+    if let Some(ref cond) = indicator.enabled_condition {
+        write_string_property(writer, "EnabledCondition", cond)?;
+    }
+    // Lossless extras, matching the gauge writer — this loop was missing, so
+    // any unrecognized indicator property was dropped on save.
+    for (k, v) in &indicator.extra_attrs {
+        write_string_property(writer, k, v)?;
+    }
+
     writer.write_event(Event::End(BytesEnd::new("dashComp")))?;
     Ok(())
 }
@@ -439,7 +460,16 @@ fn write_string_property<W: Write>(
     let mut elem = BytesStart::new(name);
     elem.push_attribute(("type", "String"));
     writer.write_event(Event::Start(elem))?;
-    writer.write_event(Event::Text(BytesText::new(value)))?;
+    // A value with markup characters (a visibility condition's `>`/`<`/`&`)
+    // goes in CDATA so it survives the round trip verbatim, spaces and all —
+    // the reader splits escaped entities into separate events and the trim
+    // config eats the surrounding spaces, so `rpm > 3000` came back mangled.
+    // Plain values (the overwhelming majority) keep the exact old encoding.
+    if value.contains(['<', '>', '&']) {
+        writer.write_event(Event::CData(BytesCData::new(value)))?;
+    } else {
+        writer.write_event(Event::Text(BytesText::new(value)))?;
+    }
     writer.write_event(Event::End(BytesEnd::new(name)))?;
     Ok(())
 }
@@ -616,6 +646,55 @@ mod tests {
         } else {
             panic!("Expected Gauge component");
         }
+    }
+
+    #[test]
+    fn gauge_and_indicator_condition_hysteresis_roundtrip() {
+        // Per-gauge visibility condition + hysteresis, and the indicator
+        // visibility condition, used to be dropped on save. They must survive
+        // write → parse now.
+        let mut dash = DashFile::default();
+        let gauge = GaugeConfig {
+            id: "boost".to_string(),
+            output_channel: "map".to_string(),
+            enabled_condition: Some("rpm > 3000".to_string()),
+            hysteresis: Some(2.5),
+            ..Default::default()
+        };
+        let indicator = IndicatorConfig {
+            id: "warn".to_string(),
+            output_channel: "clt".to_string(),
+            enabled_condition: Some("clt > 105".to_string()),
+            ..Default::default()
+        };
+        dash.gauge_cluster
+            .components
+            .push(DashComponent::Gauge(Box::new(gauge)));
+        dash.gauge_cluster
+            .components
+            .push(DashComponent::Indicator(Box::new(indicator)));
+
+        let xml = write_dash_file(&dash).unwrap();
+        let parsed = super::super::parser::parse_dash_file(&xml).unwrap();
+
+        match &parsed.gauge_cluster.components[0] {
+            DashComponent::Gauge(g) => {
+                assert_eq!(g.enabled_condition.as_deref(), Some("rpm > 3000"));
+                assert_eq!(g.hysteresis, Some(2.5));
+            }
+            _ => panic!("expected gauge"),
+        }
+        match &parsed.gauge_cluster.components[1] {
+            DashComponent::Indicator(i) => {
+                assert_eq!(i.enabled_condition.as_deref(), Some("clt > 105"));
+            }
+            _ => panic!("expected indicator"),
+        }
+
+        // And a gauge that never set them still serializes without the tags
+        // (backward-compatible: no spurious EnabledCondition/Hysteresis).
+        let plain = DashFile::default();
+        assert!(!write_dash_file(&plain).unwrap().contains("EnabledCondition"));
     }
 
     #[test]


### PR DESCRIPTION
The .dash/.gauge writer walks GaugeConfig field by field and never emitted
EnabledCondition or Hysteresis, and the indicator writer skipped
EnabledCondition and its extra_attrs entirely — so a dashboard's per-gauge
visibility conditions and warning hysteresis were lost on the next load. Add
the missing writes (gated on Some, so gauges that never set them serialize
byte-identically) and the matching reader arms.

Conditions contain markup (`rpm > 3000`): quick-xml 0.41 emits each escaped
entity as its own GeneralRef event and the trim config ate the boundary
spaces, so an escaped value round-tripped mangled. Write such values as CDATA
(verbatim), and resolve GeneralRef on read so TunerStudio-authored escaped
conditions still parse. Text accumulation fixed in both parse loops.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>



🤖 Generated with [Claude Code](https://claude.com/claude-code)