### PR TITLE
fix: auto-save tooth/composite captures to disk so tab switches can't lose them

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/data_logging.rs
+++ b/crates/libretune-app/src-tauri/src/commands/data_logging.rs
@@ -318,6 +318,13 @@ pub async fn read_text_file(path: String) -> Result<String, String> {
 
 #[tauri::command]
 pub async fn write_text_file(path: String, contents: String) -> Result<(), String> {
+    // Callers writing into a not-yet-created folder (e.g. tooth/composite
+    // capture auto-save into a project's datalogs/ before anything else has
+    // logged there) would otherwise fail with "path not found". Same
+    // create-parent-then-write pattern DataLogger::start_streaming uses.
+    if let Some(dir) = std::path::Path::new(&path).parent() {
+        let _ = std::fs::create_dir_all(dir);
+    }
     std::fs::write(&path, contents).map_err(|e| format!("Failed to write file: {}", e))
 }
 

--- a/crates/libretune-app/src/components/diagnostics/CompositeLoggerView.tsx
+++ b/crates/libretune-app/src/components/diagnostics/CompositeLoggerView.tsx
@@ -10,6 +10,8 @@ import React, { useState, useEffect, useRef, useCallback } from "react";
 import { Square, Play, Download, X, Check, XCircle } from "lucide-react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
+import { useToast } from "../../contexts/ToastContext";
+import type { CurrentProject } from "../../types/app";
 import "./CompositeLoggerView.css";
 
 interface CompositeLogEntry {
@@ -76,6 +78,17 @@ interface CompositeLoggerViewProps {
   onClose?: () => void;
 }
 
+/** Same format the manual Export button and the auto-save write to disk. */
+function buildCsv(rows: CompositeLogEntry[]): string {
+  const lines = ["Time (µs),Primary,Secondary,Sync,Voltage"];
+  rows.forEach((entry) => {
+    lines.push(
+      `${entry.time_us},${entry.primary ? 1 : 0},${entry.secondary ? 1 : 0},${entry.sync ? 1 : 0},${entry.voltage ?? ""}`
+    );
+  });
+  return lines.join("\n");
+}
+
 export const CompositeLoggerView: React.FC<CompositeLoggerViewProps> = ({ onClose }) => {
   const [logData, setLogData] = useState<CompositeLogEntry[]>([]);
   const [isCapturing, setIsCapturing] = useState(false);
@@ -83,6 +96,14 @@ export const CompositeLoggerView: React.FC<CompositeLoggerViewProps> = ({ onClos
   const [zoomLevel, setZoomLevel] = useState(1);
   const [scrollOffset, setScrollOffset] = useState(0);
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const { showToast } = useToast();
+
+  // Mirrors logData, updated synchronously in the same setState updater that
+  // appends each batch. handleCapture reads THIS (not logData) right after
+  // the capture promise resolves, so it sees the final batch even though the
+  // resolved promise carries only counts, not records, and React hasn't
+  // necessarily re-rendered with the last setLogData yet.
+  const logDataRef = useRef<CompositeLogEntry[]>([]);
 
   // Listen for real-time composite data
   useEffect(() => {
@@ -96,7 +117,9 @@ export const CompositeLoggerView: React.FC<CompositeLoggerViewProps> = ({ onClos
         const mapped = toEntries(event.payload);
         setLogData((prev) => {
           const next = prev.concat(mapped);
-          return next.length > MAX_POINTS ? next.slice(-MAX_POINTS) : next;
+          const capped = next.length > MAX_POINTS ? next.slice(-MAX_POINTS) : next;
+          logDataRef.current = capped;
+          return capped;
         });
       });
     };
@@ -298,6 +321,7 @@ export const CompositeLoggerView: React.FC<CompositeLoggerViewProps> = ({ onClos
     setIsCapturing(true);
     setError(null);
     setLogData([]);
+    logDataRef.current = [];
 
     try {
       // Ask the definition which logger draws trigger patterns rather than
@@ -312,6 +336,9 @@ export const CompositeLoggerView: React.FC<CompositeLoggerViewProps> = ({ onClos
         return;
       }
 
+      // This resolves BOTH on natural completion and after a manual Stop
+      // (handleStop just flips the running flag; this promise then resolves
+      // on its own) - so the auto-save below covers both paths for free.
       const status = await invoke<CaptureStatus>("start_tooth_capture", {
         loggerName: composite.name,
       });
@@ -321,12 +348,34 @@ export const CompositeLoggerView: React.FC<CompositeLoggerViewProps> = ({ onClos
           status.note ?? "No records captured. The logger needs the engine turning."
         );
       }
+
+      // Auto-save to disk immediately so a tab switch (which unmounts this
+      // view and its in-memory logData) can never lose a finished capture
+      // again. Ceiling: this saves logDataRef.current, which MAX_POINTS caps
+      // at 20000 - an extremely long capture only saves its most recent
+      // points. Known, acceptable, not solved here.
+      const rows = logDataRef.current;
+      if (rows.length > 0) {
+        try {
+          const project = await invoke<CurrentProject | null>("get_current_project");
+          if (project) {
+            const n = new Date();
+            const p2 = (x: number) => String(x).padStart(2, "0");
+            const stamp = `${n.getFullYear()}-${p2(n.getMonth() + 1)}-${p2(n.getDate())}_${p2(n.getHours())}.${p2(n.getMinutes())}.${p2(n.getSeconds())}`;
+            const path = `${project.path}/datalogs/composite_${stamp}.csv`;
+            await invoke("write_text_file", { path, contents: buildCsv(rows) });
+            showToast(`Saved ${rows.length} records to ${path}`, "success");
+          }
+        } catch (saveErr) {
+          showToast(`Auto-save failed: ${saveErr}`, "error");
+        }
+      }
     } catch (err) {
       setError(String(err));
     } finally {
       setIsCapturing(false);
     }
-  }, []);
+  }, [showToast]);
 
   const handleStop = useCallback(async () => {
     try {
@@ -340,14 +389,7 @@ export const CompositeLoggerView: React.FC<CompositeLoggerViewProps> = ({ onClos
   const handleExport = useCallback(() => {
     if (logData.length === 0) return;
 
-    const lines = ["Time (µs),Primary,Secondary,Sync,Voltage"];
-    logData.forEach((entry) => {
-      lines.push(
-        `${entry.time_us},${entry.primary ? 1 : 0},${entry.secondary ? 1 : 0},${entry.sync ? 1 : 0},${entry.voltage ?? ""}`
-      );
-    });
-
-    const blob = new Blob([lines.join("\n")], { type: "text/csv" });
+    const blob = new Blob([buildCsv(logData)], { type: "text/csv" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;

--- a/crates/libretune-app/src/components/diagnostics/ToothLoggerView.tsx
+++ b/crates/libretune-app/src/components/diagnostics/ToothLoggerView.tsx
@@ -10,6 +10,8 @@ import React, { useState, useEffect, useRef, useCallback } from "react";
 import { Square, Play, Download, X } from "lucide-react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
+import { useToast } from "../../contexts/ToastContext";
+import type { CurrentProject } from "../../types/app";
 import "./ToothLoggerView.css";
 
 interface ToothLogEntry {
@@ -69,6 +71,15 @@ interface ToothLoggerViewProps {
   onClose?: () => void;
 }
 
+/** Same format the manual Export button and the auto-save write to disk. */
+function buildCsv(rows: ToothLogEntry[]): string {
+  const lines = ["Tooth Number,Time (µs),Crank Angle (deg)"];
+  rows.forEach((tooth) => {
+    lines.push(`${tooth.tooth_number},${tooth.tooth_time_us},${tooth.crank_angle || ""}`);
+  });
+  return lines.join("\n");
+}
+
 export const ToothLoggerView: React.FC<ToothLoggerViewProps> = ({ onClose }) => {
   const [logData, setLogData] = useState<ToothLogEntry[]>([]);
   const [isCapturing, setIsCapturing] = useState(false);
@@ -78,6 +89,14 @@ export const ToothLoggerView: React.FC<ToothLoggerViewProps> = ({ onClose }) => 
   // Long enough to hold a gear and reach the rpm band under investigation.
   const [captureSeconds, setCaptureSeconds] = useState<number>(20);
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const { showToast } = useToast();
+
+  // Mirrors logData, updated synchronously in the same setState updater that
+  // appends each batch. handleCapture reads THIS (not logData) right after
+  // the capture promise resolves, so it sees the final batch even though the
+  // resolved promise carries only counts, not records, and React hasn't
+  // necessarily re-rendered with the last setLogData yet.
+  const logDataRef = useRef<ToothLogEntry[]>([]);
 
   // Listen for real-time tooth data
   useEffect(() => {
@@ -95,7 +114,9 @@ export const ToothLoggerView: React.FC<ToothLoggerViewProps> = ({ onClose }) => 
           const next = prev.concat(mapped);
           // Cap the view. A minute at 4500 rpm is on the order of a hundred
           // thousand teeth, which no canvas needs and no browser enjoys.
-          return next.length > MAX_POINTS ? next.slice(-MAX_POINTS) : next;
+          const capped = next.length > MAX_POINTS ? next.slice(-MAX_POINTS) : next;
+          logDataRef.current = capped;
+          return capped;
         });
       });
     };
@@ -251,11 +272,15 @@ export const ToothLoggerView: React.FC<ToothLoggerViewProps> = ({ onClose }) => 
     setIsCapturing(true);
     setError(null);
     setLogData([]);
+    logDataRef.current = [];
 
     try {
       // Runs until stopped, or the limit. The ECU's buffer holds 127 records;
       // it refills between reads, so a capture is as long as you let it be -
       // the old single-read call mistook one bufferful for the hardware limit.
+      // This resolves BOTH on natural completion and after a manual Stop
+      // (handleStop just flips the running flag; this promise then resolves
+      // on its own) - so the auto-save below covers both paths for free.
       const status = await invoke<CaptureStatus>("start_tooth_capture", {
         maxSeconds: captureSeconds,
       });
@@ -266,12 +291,34 @@ export const ToothLoggerView: React.FC<ToothLoggerViewProps> = ({ onClose }) => 
             "No records captured. The logger needs the engine turning."
         );
       }
+
+      // Auto-save to disk immediately so a tab switch (which unmounts this
+      // view and its in-memory logData) can never lose a finished capture
+      // again. Ceiling: this saves logDataRef.current, which MAX_POINTS caps
+      // at 20000 - an extremely long capture only saves its most recent
+      // points. Known, acceptable, not solved here.
+      const rows = logDataRef.current;
+      if (rows.length > 0) {
+        try {
+          const project = await invoke<CurrentProject | null>("get_current_project");
+          if (project) {
+            const n = new Date();
+            const p2 = (x: number) => String(x).padStart(2, "0");
+            const stamp = `${n.getFullYear()}-${p2(n.getMonth() + 1)}-${p2(n.getDate())}_${p2(n.getHours())}.${p2(n.getMinutes())}.${p2(n.getSeconds())}`;
+            const path = `${project.path}/datalogs/tooth_${stamp}.csv`;
+            await invoke("write_text_file", { path, contents: buildCsv(rows) });
+            showToast(`Saved ${rows.length} records to ${path}`, "success");
+          }
+        } catch (saveErr) {
+          showToast(`Auto-save failed: ${saveErr}`, "error");
+        }
+      }
     } catch (err) {
       setError(String(err));
     } finally {
       setIsCapturing(false);
     }
-  }, [captureSeconds]);
+  }, [captureSeconds, showToast]);
 
   const handleStop = useCallback(async () => {
     try {
@@ -285,14 +332,8 @@ export const ToothLoggerView: React.FC<ToothLoggerViewProps> = ({ onClose }) => 
   const handleExport = useCallback(() => {
     if (logData.length === 0) return;
 
-    // Create CSV content
-    const lines = ["Tooth Number,Time (µs),Crank Angle (deg)"];
-    logData.forEach((tooth) => {
-      lines.push(`${tooth.tooth_number},${tooth.tooth_time_us},${tooth.crank_angle || ""}`);
-    });
-
     // Download as file
-    const blob = new Blob([lines.join("\n")], { type: "text/csv" });
+    const blob = new Blob([buildCsv(logData)], { type: "text/csv" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;


### PR DESCRIPTION
Tooth and composite logger captures lived only in React component state:
switching tabs unmounted the view and lost everything, and Export CSV was
disabled until a capture finished, so there was no way to save mid-flight
either. On the 2026-09-01 drive four high-rpm captures (~12k records) were
lost this way.

Both handleCapture calls already await start_tooth_capture, which resolves
on natural completion AND after a manual Stop (Stop just flips a running
flag; the awaited promise then resolves on its own) - so a single write
right after that await covers both paths.

- Factor the CSV string building out of handleExport into buildCsv() so the
  manual Export button and the new auto-save share one format.
- Track logData in a ref, updated inside the same setLogData updater that
  appends each streamed batch, so the final records are available
  synchronously right after the capture promise resolves - the resolved
  CaptureStatus itself carries only counts, not the records.
- After a capture finishes, resolve the project dir via the existing
  get_current_project command and write a timestamped CSV to
  <project>/datalogs/tooth_<stamp>.csv (composite_<stamp>.csv) via the
  already-registered write_text_file command. Surface success/failure as a
  toast; failures never throw out of handleCapture.
- write_text_file now creates the parent directory first (same pattern
  DataLogger::start_streaming already uses), so the very first auto-save on
  a project with no datalogs/ folder yet doesn't fail.
- Noted the known ceiling: auto-save sources from logData, which MAX_POINTS
  caps at 20000, so an extremely long capture only saves its most recent
  points. Not solved here.

Verified: cargo check -p libretune-app passes; npx tsc --noEmit passes clean.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>



🤖 Generated with [Claude Code](https://claude.com/claude-code)