### PR TITLE
fix(core): drop datalog rows whose column count doesn't match the schema

### DIFF
--- a/crates/libretune-core/src/datalog/recorder.rs
+++ b/crates/libretune-core/src/datalog/recorder.rs
@@ -53,6 +53,10 @@ pub struct DataLogger {
     stream_path: Option<PathBuf>,
     /// Rows written to the stream file (used to flush periodically).
     rows_written: u64,
+    /// Rows dropped because their column count did not match `channels` — a
+    /// torn/misaligned serial read. Nonzero means a few samples were skipped
+    /// (never written with wrong columns), surfaced rather than silent.
+    malformed: u64,
 }
 
 impl DataLogger {
@@ -70,6 +74,7 @@ impl DataLogger {
             stream: None,
             stream_path: None,
             rows_written: 0,
+            malformed: 0,
         }
     }
 
@@ -156,6 +161,24 @@ impl DataLogger {
             return;
         }
 
+        // Guard the append point against a torn/misaligned read. A row with the
+        // wrong column count would either desync every column after it (stream)
+        // or store a short/over-long entry (buffer); dropping it and counting
+        // is safer than persisting corrupt data. Empty `channels` = no schema
+        // to check against, so accept (keeps existing behaviour/tests).
+        if !self.channels.is_empty() && values.len() != self.channels.len() {
+            if self.malformed == 0 {
+                tracing::warn!(
+                    "Data log row had {} values but {} channels; dropping it (and any \
+                     further mismatched rows). Likely a partial serial read.",
+                    values.len(),
+                    self.channels.len()
+                );
+            }
+            self.malformed += 1;
+            return;
+        }
+
         let now = Instant::now();
 
         // Check sample rate
@@ -233,6 +256,11 @@ impl DataLogger {
         self.discarded
     }
 
+    /// Rows dropped for having the wrong column count (a torn serial read).
+    pub fn malformed_count(&self) -> u64 {
+        self.malformed
+    }
+
     /// Get the number of recorded entries
     pub fn entry_count(&self) -> usize {
         self.buffer.len()
@@ -285,6 +313,22 @@ mod tests {
 
         logger.stop();
         assert!(!logger.is_recording());
+    }
+
+    #[test]
+    fn test_malformed_row_is_dropped_not_stored() {
+        let mut logger = DataLogger::new(vec!["rpm".into(), "map".into()]);
+        logger.start();
+
+        logger.record(vec![1000.0, 100.0]); // ok
+        logger.record(vec![1000.0]); // short — torn read
+        logger.record(vec![1.0, 2.0, 3.0]); // long — misaligned
+
+        // Only the well-formed row is stored; the two mismatched rows are
+        // dropped and counted (the sample-rate limiter is downstream of the
+        // guard, so it never even sees them).
+        assert_eq!(logger.entry_count(), 1);
+        assert_eq!(logger.malformed_count(), 2);
     }
 
     #[test]


### PR DESCRIPTION
A torn or misaligned serial read could hand record() a short or over-long
values vector. Stored as-is it desyncs every following column in the streamed
CSV, or writes a malformed in-memory entry. Guard the single append point:
a row whose length != channels.len() is dropped and counted (warn-once),
never persisted. Empty-schema loggers are unaffected.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>



🤖 Generated with [Claude Code](https://claude.com/claude-code)