### PR TITLE
fix: re-read project INI on connect, and hex-trace framed packets

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/connect_to_ecu.rs
+++ b/crates/libretune-app/src-tauri/src/commands/connect_to_ecu.rs
@@ -63,6 +63,32 @@ pub async fn connect_to_ecu(
         config.timeout_ms
     );
 
+    // Re-read the project INI before reading protocol settings, so an on-disk
+    // edit (the classic one: uncommenting `messageEnvelopeFormat` to move a
+    // Speeduino onto the CRC protocol) is picked up on reconnect instead of
+    // only after a full app restart. This reuses the load_ini path verbatim —
+    // it rebuilds the definition and every dependent cache exactly as a fresh
+    // load does — so there is no duplicated parse/cache logic here. A bad
+    // on-disk edit just logs and leaves the previously cached definition in
+    // place rather than blocking the connection.
+    //
+    // ponytail: reloads the whole INI on every connect. If that ever shows up
+    // on a profile, gate it on the file's mtime; it is sub-ms next to the
+    // multi-second connect budget today.
+    if state.connection_factory.lock().await.is_none()
+        && state.current_project.lock().await.is_some()
+    {
+        if let Some(ini_path) = load_settings(&app).last_ini_path.clone() {
+            if let Err(e) =
+                crate::commands::load_ini::load_ini(app.clone(), state.clone(), ini_path).await
+            {
+                eprintln!(
+                    "[WARN] connect_to_ecu: INI re-read failed ({e}); using cached definition"
+                );
+            }
+        }
+    }
+
     // Get protocol settings from loaded definition if available
     let def_guard = state.definition.lock().await;
     let protocol_settings = def_guard.as_ref().map(|d| d.protocol.clone());

--- a/crates/libretune-core/src/protocol/connection.rs
+++ b/crates/libretune-core/src/protocol/connection.rs
@@ -1176,6 +1176,10 @@ impl Connection {
 
         // Send packet and wait for transmission
         let bytes = packet.to_bytes_ordered(self.envelope_order);
+        // Trace the actual bytes (capped) so a lost capture can be reconstructed
+        // from the session log — the framed path only counted bytes before, so
+        // tooth/composite payloads left no trace. Legacy path already does this.
+        tracing::trace!("send_packet: tx {} bytes: {:02x?}", bytes.len(), &bytes[..bytes.len().min(64)]);
         // Use write_and_wait which avoids the blocking tcdrain issue
         self.tx_bytes = self.tx_bytes.saturating_add(bytes.len() as u64);
         self.tx_packets = self.tx_packets.saturating_add(1);
@@ -1303,6 +1307,9 @@ impl Connection {
         // Track received bytes/packets for metrics display
         self.rx_bytes = self.rx_bytes.saturating_add(full_packet.len() as u64);
         self.rx_packets = self.rx_packets.saturating_add(1);
+        // Trace the raw response (capped) before CRC parsing, so it survives in
+        // the log even when CRC validation subsequently fails.
+        tracing::trace!("send_packet: rx {} bytes: {:02x?}", full_packet.len(), &full_packet[..full_packet.len().min(64)]);
 
         // If CRC parsing fails, the full packet was already consumed from the TCP
         // stream (exact bytes read = 2 + length + 4), so the stream IS aligned.


### PR DESCRIPTION
Two field-diagnostics fixes from the 2026-09-01 drive:

connect_to_ecu now re-reads the project INI before it reads protocol settings,
so an on-disk edit (uncommenting messageEnvelopeFormat to move a Speeduino
onto the CRC protocol) is picked up on reconnect instead of only after a full
app restart. It reuses load_ini verbatim - definition and every dependent
cache rebuild exactly as a fresh load - so no parse/cache logic is duplicated;
a bad edit is logged and the cached definition is kept rather than blocking
the connect.

send_packet now trace-logs the actual tx and rx bytes (capped at 64), so a
lost tooth/composite capture can be reconstructed from the session log. The
framed path previously only counted bytes; the legacy path already hex-logs.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>



🤖 Generated with [Claude Code](https://claude.com/claude-code)