### PR TITLE
feat(mcp): local read-only MCP server for external AI agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,6 +175,17 @@ The project aims to provide professional ECU tuning workflow and functionality w
 - Safety: the model only ever PROPOSES; nothing burns automatically. Gated by an "at your own risk" enablement (RiskAcknowledgement shared primitive). Settings reset risk-ack on provider/key change. `SendCommand`/`ExecuteLuaScript` remain unreachable by the model.
 - Gap closures motivated by this feature: extended validate_action_set (min/max, cell bounds, DataType range, bits enum); TableRole enum + infer_table_roles(); summarize_tune_context(); constant safety tiering.
 
+### 13. MCP Server (local, read-only)
+- Backend: `crates/libretune-app/src-tauri/src/mcp/` — `handler.rs` (rmcp `ServerHandler`), `server.rs` (axum loopback + bearer auth + start/stop/reconcile), `token.rs` (per-install token file), `commands.rs` (Tauri surface), `tests.rs`
+- Frontend: `crates/libretune-app/src/components/tuner-ui/dialogs/McpServerSection.tsx` (Settings → AI Assistant → MCP server)
+- Ported from OpenTune's `ai_mcp.rs` / `ai_mcp_server.rs`, retargeted onto LibreTune's `agent::tools` catalogue
+- Exposes ONLY the 8 read tools, dispatched through the same `LiveReadExecutor` the in-app assistant uses (so the two surfaces cannot drift). `propose_*` are withheld from `tools/list` AND refused by name — a proposal is meaningless without the in-app review queue
+- Handler takes an `ExecutorFactory` (`Arc<dyn Fn() -> Arc<dyn ReadToolExecutor>>`), not an `AppHandle`, so the whole module is testable with a stub executor and no `tauri::App`
+- Security: binds 127.0.0.1 only; constant-time bearer compare (`tokens_match`); rmcp Host AND Origin allow-lists pinned to loopback (rmcp's Origin default is an empty list = validation OFF); token file is 0600 on unix and never in `settings.json`
+- Settings: `mcp_enabled` / `mcp_port` (default 8765), off by default. NOT routed through `update_setting` — the toggle reconciles a real socket, which the batch settings path cannot await; `mcp::commands` are called directly
+- Docs: `docs/src/features/mcp-server.md` (synced to `public/manual`)
+- Deferred: propose-over-MCP needs a backend proposal store + Tauri event, since `ProposalQueue` state is per-chat frontend state today
+
 ## Development Commands
 
 ### Backend (Rust)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,42 @@ relevant.
 
 ## [Unreleased]
 
+### 2026-08-31 — Local MCP server (read-only)
+
+Ported OpenTune's MCP server onto LibreTune's agent tooling. External MCP
+clients (Claude Code, Claude Desktop, …) can now read the loaded tune with
+the same eight deterministic tools the in-app assistant uses.
+
+#### Added
+
+- **MCP server** (`crates/libretune-app/src-tauri/src/mcp/`): loopback HTTP
+  transport (rmcp 2.2 + axum 0.8) exposing `list_tables`, `read_table`,
+  `read_constant`, `list_features`, `summarize_tune_context`,
+  `tune_health_check`, `get_realtime_snapshot`, and `query_datalog`.
+  Dispatched through the existing `LiveReadExecutor`, so the external and
+  in-app tool surfaces cannot drift apart.
+- **Settings UI**: *AI Assistant → MCP server (local)* — enable toggle with
+  live status, port field, token show/regenerate, and a ready-to-copy
+  `claude mcp add` command. These controls apply immediately rather than on
+  OK, because each binds or releases a socket.
+- **Documentation**: `docs/src/features/mcp-server.md`, linked from the AI
+  Assistant page and synced into the in-app manual.
+
+#### Security
+
+- Binds `127.0.0.1` only; never `0.0.0.0`.
+- Bearer token required on every request, compared in constant time.
+- rmcp's Host **and** Origin allow-lists pinned to loopback forms — the
+  library's Origin default is an empty list, which skips validation entirely.
+- Per-install token stored in its own `mcp-token` file (mode 0600 on unix),
+  never in `settings.json` and never logged. Regenerating restarts a running
+  server on the same port so the old token stops working at once.
+- No write surface: the assistant's `propose_*` tools are withheld from
+  `tools/list` *and* refused when called by name.
+
+Off by default. Propose-over-MCP is deliberately deferred — a proposal needs
+the in-app review queue to mean anything.
+
 ### 2026-08-28 — AutoTune second-table picker & table trace line (issue #132 follow-ups)
 
 Two reports from the issue #132 thread after the Aug 20 fixes: a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,6 +235,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,6 +524,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.1",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,6 +656,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
@@ -839,8 +911,18 @@ version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -858,12 +940,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core",
+ "darling_core 0.21.3",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.114",
 ]
@@ -1593,6 +1699,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1878,6 +1985,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1890,6 +2003,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -2408,11 +2522,15 @@ name = "libretune-app"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "axum",
  "byteorder",
  "chrono",
  "dirs 5.0.1",
  "keyring",
  "libretune-core",
+ "rand 0.8.5",
+ "reqwest 0.12.28",
+ "rmcp",
  "serde",
  "serde_json",
  "tauri",
@@ -2616,6 +2734,12 @@ name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
@@ -3155,6 +3279,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3657,6 +3787,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.1",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3712,6 +3853,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_hc"
@@ -3963,6 +4110,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmcp"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14db48ee17a9ba61810ab1a9c1beb7d06d8136ae39ac25a1137f10d357af01af"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "futures",
+ "http",
+ "http-body",
+ "http-body-util",
+ "pastey",
+ "pin-project-lite",
+ "rand 0.10.2",
+ "rmcp-macros",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "sse-stream",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower-service",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "783d787bf21813b285f13019adc49e11af501c658890c1e519f31f937c68b7e3"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4060,7 +4251,7 @@ checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
  "indexmap 1.9.3",
- "schemars_derive",
+ "schemars_derive 0.8.22",
  "serde",
  "serde_json",
  "url",
@@ -4085,8 +4276,10 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "ref-cast",
+ "schemars_derive 1.2.1",
  "serde",
  "serde_json",
 ]
@@ -4096,6 +4289,18 @@ name = "schemars_derive"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4240,6 +4445,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4305,7 +4521,7 @@ version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -4394,7 +4610,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -4512,6 +4728,19 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "sse-stream"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c123f296ade4ec4b8b0f6162116e6629f5146922ca5ab40ca9d3c2e73ab4761e"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -5186,6 +5415,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5307,6 +5547,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -5345,6 +5586,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Project-based workflow with restore points, Git-based tune versioning, CSV expor
 
 ### Additional
 - **AI Assistant**: Bring-your-own-LLM co-pilot (OpenAI / Anthropic / Google / local Ollama or LM Studio, with one-click presets) that reads your tables, realtime data, and datalogs, diagnoses problems, and *proposes* validated, authority-clamped changes for explicit review — applied only after your approval (restore point first) and never burned automatically. OS-keychain API-key storage, capability tiers, pin-conflict warnings, and an "Ask AI" button on every table editor.
+- **MCP Server** (local, read-only): expose the same tune-inspection tools to external agents (Claude Code, Claude Desktop, any MCP client) over a loopback HTTP server with bearer auth. Off by default; no tool can edit a tune or touch the ECU.
 - **Multi-monitor**: Pop out any tab to its own window with bidirectional sync
 - **Unit preferences**: Temperature (°C/°F/K), pressure (kPa/PSI/bar/inHg), AFR/Lambda
 - **Performance calculator**: Estimated HP/torque curves and acceleration times

--- a/crates/libretune-app/public/manual/SUMMARY.md
+++ b/crates/libretune-app/public/manual/SUMMARY.md
@@ -38,6 +38,7 @@
 - [Pop-out Windows](./features/popout-windows.md)
 - [ECU Console](./features/ecu-console.md)
 - [AI Assistant](./features/ai-assistant.md)
+  - [MCP Server](./features/mcp-server.md)
 - [Tune Migration](./features/tune-migration.md)
 - [Hardware Configuration](./technical/port-editor.md)
 - [Action Scripting](./reference/action-scripting.md)

--- a/crates/libretune-app/public/manual/features/ai-assistant.md
+++ b/crates/libretune-app/public/manual/features/ai-assistant.md
@@ -34,6 +34,10 @@ What the assistant can do:
 - **Propose ECU configuration changes** (feature enablement, scalar constants).
 - **Propose tune edits** to individual cells or bulk regions.
 
+The assistant's read tools are also available to **external** agents (Claude
+Code, Claude Desktop, …) over a local, read-only
+[MCP server](./mcp-server.md) — off by default.
+
 The assistant is **not** a closed-loop controller. It does not run every
 realtime tick — that remains the job of the algorithmic [AutoTune](./autotune.md)
 engine. Think of it as a smart strategy and explanation layer on top of the

--- a/crates/libretune-app/public/manual/features/mcp-server.md
+++ b/crates/libretune-app/public/manual/features/mcp-server.md
@@ -1,0 +1,148 @@
+# MCP Server
+
+LibreTune can expose its tune-inspection tools to **external AI agents** over
+a local [Model Context Protocol](https://modelcontextprotocol.io) server. An
+agent running in Claude Code, Claude Desktop, or any other MCP client can then
+read the tune you have open and reason about it, using the same deterministic
+tools as the built-in [AI Assistant](./ai-assistant.md).
+
+> **Read-only.** The MCP server exposes no tool that can edit a tune, stage a
+> proposal, or touch the ECU. An outside agent can look; only you can change
+> anything.
+
+The server is **off by default** and only ever listens on `127.0.0.1` — it is
+never reachable from another machine.
+
+## Enabling the server
+
+1. Open **Tools → Settings**.
+2. Scroll to **AI Assistant (at your own risk) → MCP server (local)**.
+3. Tick **Expose tools over MCP**.
+
+The server starts immediately and the checkbox label shows the bound address,
+e.g. `Running on 127.0.0.1:8765`. Untick it, or close LibreTune, to stop it.
+The setting is remembered, so a server left enabled restarts on the next
+launch.
+
+Unlike the rest of the Settings dialog, the MCP controls apply the moment you
+use them rather than on **OK** — each one binds or releases a real socket.
+
+## Authentication
+
+Every request must carry a bearer token:
+
+```
+Authorization: Bearer <token>
+```
+
+The token is unique per installation, 64 hex characters, and shown under
+**Access token** in the settings section (click **Show**). It is stored in
+`mcp-token` in LibreTune's app data directory, readable only by your user
+account on macOS and Linux, and is never written to `settings.json` or to any
+log.
+
+Click **Regenerate** to mint a fresh token. The old one stops working
+immediately: if the server is running, it restarts on the same port with the
+new token. Update your client configuration afterwards.
+
+## Available tools
+
+All eight are read-only. They are the same tools the in-app assistant uses, so
+what an external agent sees can never drift from what the assistant sees.
+
+| Tool | What it returns |
+|------|-----------------|
+| `list_tables` | Every editable table with its role (VE / Ignition / AFR target / …) and dimensions. Call this first to discover names. |
+| `read_table` | Current values, axis bins, and units for one table. |
+| `read_constant` | One constant's value, min/max, units, and options. |
+| `list_features` | Feature-toggle (bits) constants and their available options. |
+| `summarize_tune_context` | Per-cell AFR error, data coverage, suspect cells, and unexplored cells for a VE table. |
+| `tune_health_check` | Overall health score and per-region coverage for a table. |
+| `get_realtime_snapshot` | Current sensor values (RPM, MAP, TPS, CLT, AFR, …). Requires a live connection. |
+| `query_datalog` | Per-channel statistics, or the last rows, from the current session or a saved log. |
+
+Values come back in **raw ECU units**, not your display preferences — an
+external model has no display context, and a silently converted number would
+be worse than useless to something doing arithmetic on it.
+
+The assistant's `propose_*` tools are deliberately **not** exposed. A proposal
+only means something inside LibreTune's review queue, and an agent calling one
+of those names over MCP is refused rather than quietly ignored.
+
+## Connecting Claude Code
+
+```bash
+claude mcp add --transport http libretune http://127.0.0.1:8765/mcp \
+  --header "Authorization: Bearer TOKEN"
+```
+
+Replace `TOKEN` with the value from **Access token**. The settings section
+also renders this command with your current port filled in — click it to
+select, then copy.
+
+## Connecting Claude Desktop
+
+Claude Desktop's config UI cannot send static headers, so route it through the
+`mcp-remote` bridge (requires Node.js):
+
+```json
+{
+  "mcpServers": {
+    "libretune": {
+      "command": "npx",
+      "args": ["mcp-remote", "http://127.0.0.1:8765/mcp", "--allow-http",
+               "--transport", "http-only",
+               "--header", "Authorization:${AUTH_HEADER}"],
+      "env": { "AUTH_HEADER": "Bearer TOKEN" }
+    }
+  }
+}
+```
+
+The space after `Authorization:` belongs inside the environment variable, as
+written above — it works around an argument-escaping quirk in Claude Desktop.
+
+## Changing the port
+
+Set **Port** (minimum 1024) and click **Apply port**. The server restarts on
+the new port if it was running. If the port is already taken, the error
+appears under the controls and the server stays stopped — pick another one, or
+free the port (`lsof -i :8765` on macOS/Linux, `netstat -ano` on Windows).
+
+## Security
+
+- **Loopback only.** The listener binds `127.0.0.1`, never `0.0.0.0`.
+- **Constant-time token check.** The bearer token is compared without an early
+  exit, so its bytes cannot be recovered from response timing.
+- **Host and Origin validation.** Both are pinned to loopback forms, blocking
+  DNS-rebinding attacks from a browser page.
+- **No write surface.** There is no `apply`, no `burn`, and no `propose` tool
+  to call.
+
+A failed request gets a bare `401` with no body — it never echoes back what
+was sent.
+
+## Example session
+
+1. Open a project in LibreTune and enable the MCP server.
+2. Connect Claude Code with the command above.
+3. Ask it something that needs the tune:
+   - *"Read my VE table and tell me where the coverage is thin."*
+   - *"Summarize the tune health for veTable1."*
+   - *"What are the sensors reading right now?"*
+4. It calls `list_tables`, `read_table`, `summarize_tune_context`, and so on,
+   and answers from the real data.
+5. To act on the advice, make the change yourself — in the table editor, or by
+   asking the in-app [AI Assistant](./ai-assistant.md), which does have
+   propose tools and a review queue.
+
+## Troubleshooting
+
+| Problem | Likely cause / fix |
+|---------|-------------------|
+| Client reports 401 Unauthorized | The token was regenerated since the client was configured. Copy the current one from Settings. |
+| Server will not start | The port is in use. Pick another port, or free it. |
+| `get_realtime_snapshot` returns an error | No live ECU connection. Connect first. |
+| `read_table` says no INI definition is loaded | Open a project so a definition and tune are loaded. |
+| `query_datalog` finds no entries | Start datalogging, or name a saved log from the project's datalogs folder. |
+| Tools list is empty in the client | The client connected but the session dropped — reconnect. Check that LibreTune is still running with the toggle on. |

--- a/crates/libretune-app/public/manual/getting-started/settings.md
+++ b/crates/libretune-app/public/manual/getting-started/settings.md
@@ -346,6 +346,21 @@ Tiers are cumulative — each includes the previous one:
 - **Config — tune + propose constant changes** — constants and feature
   toggles; pin-affecting changes are flagged **Dangerous**.
 
+### MCP server (local)
+
+Exposes LibreTune's read-only tune tools to external MCP clients (Claude
+Code, Claude Desktop, …) on `127.0.0.1` only. Off by default, and it cannot
+change anything — see [MCP Server](../features/mcp-server.md).
+
+- **Expose tools over MCP** — starts/stops the server; the label shows the
+  bound address while it runs.
+- **Port** — minimum 1024, default 8765. **Apply port** restarts the server.
+- **Access token** — the bearer token every client must send. **Show**
+  reveals it; **Regenerate** invalidates the old one immediately.
+
+These three apply the moment you use them, not on **OK**, because each one
+binds or releases a real socket.
+
 ---
 
 ## AutoTune Settings

--- a/crates/libretune-app/public/manual/toc.json
+++ b/crates/libretune-app/public/manual/toc.json
@@ -1,280 +1,322 @@
 [
   {
-    "title": "Installation",
+    "title": "Getting Started",
     "path": "getting-started/installation",
-    "children": []
-  },
-  {
-    "title": "Creating Your First Project",
-    "path": "getting-started/first-project",
-    "children": []
-  },
-  {
-    "title": "Connecting to Your ECU",
-    "path": "getting-started/connecting",
-    "children": []
-  },
-  {
-    "title": "Settings & Preferences",
-    "path": "getting-started/settings",
-    "children": []
-  },
-  {
-    "title": "Table Editing",
-    "path": "features/table-editing",
     "children": [
       {
-        "title": "2D Tables",
-        "path": "features/table-editing/2d-tables",
+        "title": "Installation",
+        "path": "getting-started/installation",
         "children": []
       },
       {
-        "title": "3D Visualization",
-        "path": "features/table-editing/3d-visualization",
+        "title": "Creating Your First Project",
+        "path": "getting-started/first-project",
+        "children": []
+      },
+      {
+        "title": "Connecting to Your ECU",
+        "path": "getting-started/connecting",
+        "children": []
+      },
+      {
+        "title": "Settings & Preferences",
+        "path": "getting-started/settings",
+        "children": []
+      }
+    ]
+  },
+  {
+    "title": "Core Features",
+    "path": "features/table-editing",
+    "children": [
+      {
+        "title": "Table Editing",
+        "path": "features/table-editing",
+        "children": [
+          {
+            "title": "2D Tables",
+            "path": "features/table-editing/2d-tables",
+            "children": []
+          },
+          {
+            "title": "3D Visualization",
+            "path": "features/table-editing/3d-visualization",
+            "children": []
+          },
+          {
+            "title": "Keyboard Shortcuts",
+            "path": "features/table-editing/shortcuts",
+            "children": []
+          }
+        ]
+      },
+      {
+        "title": "AutoTune",
+        "path": "features/autotune",
+        "children": [
+          {
+            "title": "Usage Guide",
+            "path": "features/autotune/usage-guide",
+            "children": []
+          },
+          {
+            "title": "Setting Up AutoTune",
+            "path": "features/autotune/setup",
+            "children": []
+          },
+          {
+            "title": "Understanding Recommendations",
+            "path": "features/autotune/recommendations",
+            "children": []
+          },
+          {
+            "title": "Filters and Authority",
+            "path": "features/autotune/filters",
+            "children": []
+          }
+        ]
+      },
+      {
+        "title": "Dashboards",
+        "path": "features/dashboards",
+        "children": [
+          {
+            "title": "Using Dashboards",
+            "path": "features/dashboards/using",
+            "children": []
+          },
+          {
+            "title": "Customizing Gauges",
+            "path": "features/dashboards/customizing",
+            "children": []
+          },
+          {
+            "title": "Creating Dashboards",
+            "path": "features/dashboards/creating",
+            "children": []
+          },
+          {
+            "title": "Dashboard Validation",
+            "path": "features/dashboards/validation",
+            "children": []
+          }
+        ]
+      },
+      {
+        "title": "Math Channels",
+        "path": "features/math-channels",
+        "children": []
+      },
+      {
+        "title": "Data Logging",
+        "path": "features/datalog",
+        "children": []
+      },
+      {
+        "title": "Smart Recording",
+        "path": "features/smart-recording",
+        "children": []
+      },
+      {
+        "title": "Data Statistics",
+        "path": "features/data-statistics",
+        "children": []
+      },
+      {
+        "title": "Alert Rules",
+        "path": "features/alert-rules",
+        "children": []
+      },
+      {
+        "title": "Lua Scripting",
+        "path": "features/lua-scripting",
+        "children": []
+      },
+      {
+        "title": "Base Map Generator",
+        "path": "features/base-map",
+        "children": []
+      },
+      {
+        "title": "Performance Calculator",
+        "path": "features/performance-calculator",
+        "children": []
+      },
+      {
+        "title": "Diagnostic Loggers",
+        "path": "features/diagnostic-loggers",
+        "children": []
+      },
+      {
+        "title": "Tools",
+        "path": "features/tools",
+        "children": []
+      },
+      {
+        "title": "Pop-out Windows",
+        "path": "features/popout-windows",
+        "children": []
+      },
+      {
+        "title": "ECU Console",
+        "path": "features/ecu-console",
+        "children": []
+      },
+      {
+        "title": "AI Assistant",
+        "path": "features/ai-assistant",
+        "children": [
+          {
+            "title": "MCP Server",
+            "path": "features/mcp-server",
+            "children": []
+          }
+        ]
+      },
+      {
+        "title": "Tune Migration",
+        "path": "features/tune-migration",
+        "children": []
+      },
+      {
+        "title": "Hardware Configuration",
+        "path": "technical/port-editor",
+        "children": []
+      },
+      {
+        "title": "Action Scripting",
+        "path": "reference/action-scripting",
+        "children": []
+      }
+    ]
+  },
+  {
+    "title": "Project Management",
+    "path": "projects/tunes",
+    "children": [
+      {
+        "title": "Managing Tunes",
+        "path": "projects/tunes",
+        "children": []
+      },
+      {
+        "title": "Version Control",
+        "path": "projects/version-control",
+        "children": []
+      },
+      {
+        "title": "Change Annotations",
+        "path": "projects/change-annotations",
+        "children": []
+      },
+      {
+        "title": "Restore Points",
+        "path": "projects/restore-points",
+        "children": []
+      },
+      {
+        "title": "Importing Projects",
+        "path": "projects/importing",
+        "children": []
+      }
+    ]
+  },
+  {
+    "title": "Reference",
+    "path": "reference/supported-ecus",
+    "children": [
+      {
+        "title": "Supported ECUs",
+        "path": "reference/supported-ecus",
+        "children": []
+      },
+      {
+        "title": "INI File Format",
+        "path": "reference/ini-format",
         "children": []
       },
       {
         "title": "Keyboard Shortcuts",
-        "path": "features/table-editing/shortcuts",
+        "path": "reference/shortcuts",
+        "children": []
+      },
+      {
+        "title": "Troubleshooting",
+        "path": "reference/troubleshooting",
+        "children": []
+      },
+      {
+        "title": "Java → WASM Migration",
+        "path": "reference/java-to-wasm-migration",
         "children": []
       }
     ]
   },
   {
-    "title": "AutoTune",
-    "path": "features/autotune",
-    "children": [
-      {
-        "title": "Usage Guide",
-        "path": "features/autotune/usage-guide",
-        "children": []
-      },
-      {
-        "title": "Setting Up AutoTune",
-        "path": "features/autotune/setup",
-        "children": []
-      },
-      {
-        "title": "Understanding Recommendations",
-        "path": "features/autotune/recommendations",
-        "children": []
-      },
-      {
-        "title": "Filters and Authority",
-        "path": "features/autotune/filters",
-        "children": []
-      }
-    ]
-  },
-  {
-    "title": "Dashboards",
-    "path": "features/dashboards",
-    "children": [
-      {
-        "title": "Using Dashboards",
-        "path": "features/dashboards/using",
-        "children": []
-      },
-      {
-        "title": "Customizing Gauges",
-        "path": "features/dashboards/customizing",
-        "children": []
-      },
-      {
-        "title": "Creating Dashboards",
-        "path": "features/dashboards/creating",
-        "children": []
-      },
-      {
-        "title": "Dashboard Validation",
-        "path": "features/dashboards/validation",
-        "children": []
-      }
-    ]
-  },
-  {
-    "title": "Math Channels",
-    "path": "features/math-channels",
-    "children": []
-  },
-  {
-    "title": "Data Logging",
-    "path": "features/datalog",
-    "children": []
-  },
-  {
-    "title": "Smart Recording",
-    "path": "features/smart-recording",
-    "children": []
-  },
-  {
-    "title": "Data Statistics",
-    "path": "features/data-statistics",
-    "children": []
-  },
-  {
-    "title": "Alert Rules",
-    "path": "features/alert-rules",
-    "children": []
-  },
-  {
-    "title": "Lua Scripting",
-    "path": "features/lua-scripting",
-    "children": []
-  },
-  {
-    "title": "Base Map Generator",
-    "path": "features/base-map",
-    "children": []
-  },
-  {
-    "title": "Performance Calculator",
-    "path": "features/performance-calculator",
-    "children": []
-  },
-  {
-    "title": "Diagnostic Loggers",
-    "path": "features/diagnostic-loggers",
-    "children": []
-  },
-  {
-    "title": "Tools",
-    "path": "features/tools",
-    "children": []
-  },
-  {
-    "title": "Pop-out Windows",
-    "path": "features/popout-windows",
-    "children": []
-  },
-  {
-    "title": "ECU Console",
-    "path": "features/ecu-console",
-    "children": []
-  },
-  {
-    "title": "AI Assistant",
-    "path": "features/ai-assistant",
-    "children": []
-  },
-  {
-    "title": "Tune Migration",
-    "path": "features/tune-migration",
-    "children": []
-  },
-  {
-    "title": "Hardware Configuration",
-    "path": "technical/port-editor",
-    "children": []
-  },
-  {
-    "title": "Action Scripting",
-    "path": "reference/action-scripting",
-    "children": []
-  },
-  {
-    "title": "Managing Tunes",
-    "path": "projects/tunes",
-    "children": []
-  },
-  {
-    "title": "Version Control",
-    "path": "projects/version-control",
-    "children": []
-  },
-  {
-    "title": "Change Annotations",
-    "path": "projects/change-annotations",
-    "children": []
-  },
-  {
-    "title": "Restore Points",
-    "path": "projects/restore-points",
-    "children": []
-  },
-  {
-    "title": "Importing Projects",
-    "path": "projects/importing",
-    "children": []
-  },
-  {
-    "title": "Supported ECUs",
-    "path": "reference/supported-ecus",
-    "children": []
-  },
-  {
-    "title": "INI File Format",
-    "path": "reference/ini-format",
-    "children": []
-  },
-  {
-    "title": "Keyboard Shortcuts",
-    "path": "reference/shortcuts",
-    "children": []
-  },
-  {
-    "title": "Troubleshooting",
-    "path": "reference/troubleshooting",
-    "children": []
-  },
-  {
-    "title": "Java → WASM Migration",
-    "path": "reference/java-to-wasm-migration",
-    "children": []
-  },
-  {
-    "title": "Overview",
+    "title": "Technical Reference",
     "path": "technical/README",
-    "children": []
+    "children": [
+      {
+        "title": "Overview",
+        "path": "technical/README",
+        "children": []
+      },
+      {
+        "title": "AutoTune Algorithm",
+        "path": "technical/autotune-algorithm",
+        "children": []
+      },
+      {
+        "title": "Table Operations",
+        "path": "technical/table-operations",
+        "children": []
+      },
+      {
+        "title": "INI Parser",
+        "path": "technical/ini-parser",
+        "children": []
+      },
+      {
+        "title": "ECU Protocol",
+        "path": "technical/ecu-protocol",
+        "children": []
+      },
+      {
+        "title": "Version Control",
+        "path": "technical/version-control",
+        "children": []
+      },
+      {
+        "title": "Lua Scripting",
+        "path": "technical/lua-scripting",
+        "children": []
+      },
+      {
+        "title": "Plugin System",
+        "path": "technical/plugin-system",
+        "children": []
+      },
+      {
+        "title": "Port Editor",
+        "path": "technical/port-editor",
+        "children": []
+      },
+      {
+        "title": "AI Assistant",
+        "path": "technical/ai-assistant",
+        "children": []
+      }
+    ]
   },
   {
-    "title": "AutoTune Algorithm",
-    "path": "technical/autotune-algorithm",
-    "children": []
-  },
-  {
-    "title": "Table Operations",
-    "path": "technical/table-operations",
-    "children": []
-  },
-  {
-    "title": "INI Parser",
-    "path": "technical/ini-parser",
-    "children": []
-  },
-  {
-    "title": "ECU Protocol",
-    "path": "technical/ecu-protocol",
-    "children": []
-  },
-  {
-    "title": "Version Control",
-    "path": "technical/version-control",
-    "children": []
-  },
-  {
-    "title": "Lua Scripting",
-    "path": "technical/lua-scripting",
-    "children": []
-  },
-  {
-    "title": "Plugin System",
-    "path": "technical/plugin-system",
-    "children": []
-  },
-  {
-    "title": "Port Editor",
-    "path": "technical/port-editor",
-    "children": []
-  },
-  {
-    "title": "AI Assistant",
-    "path": "technical/ai-assistant",
-    "children": []
-  },
-  {
-    "title": "Frequently Asked Questions",
+    "title": "FAQ",
     "path": "faq",
-    "children": []
+    "children": [
+      {
+        "title": "Frequently Asked Questions",
+        "path": "faq",
+        "children": []
+      }
+    ]
   }
 ]

--- a/crates/libretune-app/src-tauri/Cargo.toml
+++ b/crates/libretune-app/src-tauri/Cargo.toml
@@ -41,6 +41,16 @@ keyring = { version = "3", features = [
     "linux-native",
 ] }
 
+# Local MCP (Model Context Protocol) server: lets external agents (Claude
+# Code, Claude Desktop, ...) call LibreTune's read-only tune tools over a
+# loopback HTTP transport. `rmcp` owns the protocol; `axum` mounts its
+# `StreamableHttpService` behind our bearer-token middleware. axum 0.8 is
+# what rmcp 2.2 itself is tested against.
+rmcp = { version = "2.2", features = ["server", "transport-streamable-http-server"] }
+axum = "0.8"
+rand = { workspace = true }
+
 [dev-dependencies]
 tempfile = "3"
+reqwest = { version = "0.12", default-features = false, features = ["json"] }
 

--- a/crates/libretune-app/src-tauri/src/commands/agent.rs
+++ b/crates/libretune-app/src-tauri/src/commands/agent.rs
@@ -260,10 +260,19 @@ pub struct AgentStatus {
 ///
 /// Holds a [`tauri::AppHandle`] (cheap to clone) to reach managed `AppState`
 /// without borrowing the `tauri::State` lifetime into the executor.
-struct LiveReadExecutor {
+pub(crate) struct LiveReadExecutor {
     app: tauri::AppHandle,
     /// Display-unit preferences for read results (None = raw values).
     unit_prefs: Option<UnitPrefs>,
+}
+
+impl LiveReadExecutor {
+    /// Build an executor over the live app state. `unit_prefs: None` returns
+    /// raw ECU units — what the MCP server (`crate::mcp`) wants, since an
+    /// external agent has no display context to convert for.
+    pub(crate) fn new(app: tauri::AppHandle, unit_prefs: Option<UnitPrefs>) -> Self {
+        Self { app, unit_prefs }
+    }
 }
 
 #[async_trait::async_trait]
@@ -922,10 +931,7 @@ pub async fn agent_send_message(
     }
 
     let client = build_client(&s).map_err(|e| e.to_string())?;
-    let executor = LiveReadExecutor {
-        app: app.clone(),
-        unit_prefs: request.unit_prefs.clone(),
-    };
+    let executor = LiveReadExecutor::new(app.clone(), request.unit_prefs.clone());
 
     let history: Vec<Message> = request.history.into_iter().map(Into::into).collect();
     let inputs = OrchestratorInputs {

--- a/crates/libretune-app/src-tauri/src/commands/app_settings.rs
+++ b/crates/libretune-app/src-tauri/src/commands/app_settings.rs
@@ -185,6 +185,22 @@ pub(crate) struct Settings {
     /// Capability the assistant is unlocked for: "read" | "tune" | "config".
     #[serde(default = "default_ai_capability")]
     pub(crate) ai_capability_tier: String,
+
+    // --- Local MCP server (see `crate::mcp`) ---
+    /// Expose the read-only tune tools to external MCP clients on loopback.
+    /// Off by default: turning it on opens a socket, so it stays an explicit
+    /// choice rather than something an update can switch on for the user.
+    #[serde(default = "default_false")]
+    pub(crate) mcp_enabled: bool,
+    /// Loopback port for the MCP server.
+    #[serde(default = "default_mcp_port")]
+    pub(crate) mcp_port: u16,
+}
+
+/// Default MCP port. Same 8765 OpenTune used, so a client config ported over
+/// only needs its URL changed.
+pub(crate) fn default_mcp_port() -> u16 {
+    8765
 }
 
 pub(crate) fn default_runtime_packet_mode() -> String {
@@ -397,6 +413,8 @@ fn default_settings() -> Settings {
         ai_api_key: String::new(),
         ai_model: String::new(),
         ai_capability_tier: default_ai_capability(),
+        mcp_enabled: false,
+        mcp_port: default_mcp_port(),
     }
 }
 

--- a/crates/libretune-app/src-tauri/src/lib.rs
+++ b/crates/libretune-app/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ use libretune_core::project::OnlineIniRepository;
 use tokio::sync::Mutex;
 
 mod commands;
+mod mcp;
 mod paths;
 mod port_editor; // used by commands/ini_dialogs.rs
 mod state;
@@ -506,8 +507,28 @@ pub fn run() {
             list_wasm_plugins,
             execute_wasm_plugin,
             get_wasm_plugin_info,
-            log_webview_message
+            log_webview_message,
+            // Local MCP server (read-only tune tools for external agents)
+            mcp::commands::mcp_status,
+            mcp::commands::mcp_set_enabled,
+            mcp::commands::mcp_set_port,
+            mcp::commands::mcp_get_token,
+            mcp::commands::mcp_regenerate_token
         ])
+        .manage(mcp::server::McpServerState::default())
+        .setup(|app| {
+            // Restart the MCP server if the user left it enabled last run.
+            // Spawned rather than awaited: a busy port must not block the
+            // window from opening, and the failure surfaces in the Settings
+            // dialog's status line either way.
+            let handle = app.handle().clone();
+            tauri::async_runtime::spawn(async move {
+                if let Err(e) = mcp::commands::start_on_boot(&handle).await {
+                    tracing::warn!("MCP server did not start on boot: {e}");
+                }
+            });
+            Ok(())
+        })
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/crates/libretune-app/src-tauri/src/mcp/commands.rs
+++ b/crates/libretune-app/src-tauri/src/mcp/commands.rs
@@ -1,0 +1,171 @@
+//! Tauri command layer for the local MCP server.
+//!
+//! Everything that needs a live `AppHandle` lives here, so
+//! [`super::server`] and [`super::handler`] stay testable without a running
+//! app.
+//!
+//! The MCP toggle and port are NOT routed through the generic
+//! `update_setting` command: flipping them has to reconcile a real socket,
+//! and that is async work the batch settings path has no way to await. The
+//! Settings dialog calls these commands directly instead.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use serde::Serialize;
+
+use libretune_core::agent::orchestrator::ReadToolExecutor;
+
+use crate::commands::agent::LiveReadExecutor;
+use crate::mcp::handler::ExecutorFactory;
+use crate::mcp::server::{
+    reconcile_mcp_server, regenerate_and_restart, McpServerState, MIN_MCP_PORT,
+};
+use crate::mcp::token::load_or_create_token;
+use crate::paths::get_app_data_dir;
+
+/// Where the bearer token lives. Same directory as `settings.json`.
+fn config_dir(app: &tauri::AppHandle) -> PathBuf {
+    get_app_data_dir(app)
+}
+
+/// Build the per-session executor factory.
+///
+/// `unit_prefs: None` on purpose — an external agent gets raw ECU units, not
+/// whatever the user happens to have the UI set to. Display conversion is a
+/// human-facing concern, and a silently °F-converted coolant reading would
+/// be worse than useless to a model doing arithmetic on it.
+fn executor_factory(app: &tauri::AppHandle) -> ExecutorFactory {
+    let app = app.clone();
+    Arc::new(move || {
+        Arc::new(LiveReadExecutor::new(app.clone(), None)) as Arc<dyn ReadToolExecutor>
+    })
+}
+
+/// Server status for the Settings UI. `port` is the *bound* port while
+/// running (meaningful even when the configured port was 0) and 0 when
+/// stopped.
+#[derive(Debug, Clone, Serialize)]
+pub struct McpStatus {
+    pub running: bool,
+    pub port: u16,
+}
+
+fn status_of(state: &McpServerState) -> McpStatus {
+    match state.local_addr() {
+        Some(addr) => McpStatus {
+            running: true,
+            port: addr.port(),
+        },
+        None => McpStatus {
+            running: false,
+            port: 0,
+        },
+    }
+}
+
+#[tauri::command]
+pub async fn mcp_status(state: tauri::State<'_, McpServerState>) -> Result<McpStatus, String> {
+    Ok(status_of(&state))
+}
+
+/// Enable or disable the server, persisting the choice and reconciling the
+/// socket in one step.
+///
+/// A failed reconcile (a taken port, most often) rolls the persisted setting
+/// back — otherwise the app would keep believing MCP is on, retry the same
+/// doomed bind on every launch, and show a checkbox that disagrees with the
+/// status line beside it.
+#[tauri::command]
+pub async fn mcp_set_enabled(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, McpServerState>,
+    enabled: bool,
+) -> Result<McpStatus, String> {
+    let (previous, port) = crate::with_settings(&app, |s| {
+        let previous = s.mcp_enabled;
+        s.mcp_enabled = enabled;
+        (previous, s.mcp_port)
+    });
+
+    if let Err(e) = reconcile_mcp_server(
+        &state,
+        executor_factory(&app),
+        config_dir(&app),
+        enabled,
+        port,
+    )
+    .await
+    {
+        crate::with_settings(&app, |s| s.mcp_enabled = previous);
+        return Err(e);
+    }
+    Ok(status_of(&state))
+}
+
+/// Change the listening port. Restarts the server when it is running, and
+/// rolls the setting back if the new port cannot be bound.
+#[tauri::command]
+pub async fn mcp_set_port(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, McpServerState>,
+    port: u16,
+) -> Result<McpStatus, String> {
+    if port < MIN_MCP_PORT {
+        return Err(format!("Port must be {MIN_MCP_PORT} or higher"));
+    }
+    let (previous, enabled) = crate::with_settings(&app, |s| {
+        let previous = s.mcp_port;
+        s.mcp_port = port;
+        (previous, s.mcp_enabled)
+    });
+
+    if let Err(e) = reconcile_mcp_server(
+        &state,
+        executor_factory(&app),
+        config_dir(&app),
+        enabled,
+        port,
+    )
+    .await
+    {
+        crate::with_settings(&app, |s| s.mcp_port = previous);
+        return Err(e);
+    }
+    Ok(status_of(&state))
+}
+
+/// The current bearer token, minting one on first read.
+#[tauri::command]
+pub async fn mcp_get_token(app: tauri::AppHandle) -> Result<String, String> {
+    load_or_create_token(&config_dir(&app))
+}
+
+/// Mint a fresh token, invalidating the old one immediately.
+#[tauri::command]
+pub async fn mcp_regenerate_token(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, McpServerState>,
+) -> Result<String, String> {
+    regenerate_and_restart(&state, executor_factory(&app), config_dir(&app)).await
+}
+
+/// Start the server at launch when it was left enabled. A no-op — not an
+/// error — when disabled, which is every default install.
+pub async fn start_on_boot(app: &tauri::AppHandle) -> Result<(), String> {
+    use tauri::Manager;
+
+    let settings = crate::load_settings(app);
+    if !settings.mcp_enabled {
+        return Ok(());
+    }
+    let state = app.state::<McpServerState>();
+    reconcile_mcp_server(
+        &state,
+        executor_factory(app),
+        config_dir(app),
+        true,
+        settings.mcp_port,
+    )
+    .await
+}

--- a/crates/libretune-app/src-tauri/src/mcp/handler.rs
+++ b/crates/libretune-app/src-tauri/src/mcp/handler.rs
@@ -1,0 +1,154 @@
+//! MCP protocol handler: maps LibreTune's agent read-tool catalogue onto
+//! rmcp's [`ServerHandler`].
+//!
+//! This module owns the protocol translation only — no sockets, no HTTP
+//! (that is [`super::server`]), and no tune knowledge (that is
+//! [`libretune_core::agent`] and the Tauri-side [`ReadToolExecutor`]).
+//!
+//! The handler is deliberately built over an `Arc<dyn ReadToolExecutor>`
+//! rather than a `tauri::AppHandle`: the executor trait is the same seam the
+//! in-app assistant already runs through, so the MCP surface can never
+//! drift from what the assistant sees, and the tests below can drive the
+//! whole handler with a stub executor instead of a live app.
+//!
+//! ## Scope: read-only
+//! Only [`libretune_core::agent::tools::is_read_tool`] tools are listed and
+//! dispatched. The `propose_*` tools are withheld on purpose — a proposal
+//! needs the review queue in the app UI to mean anything, and that queue is
+//! per-chat-session frontend state today. Withholding them here is a
+//! stronger guarantee than a client-side prompt: an external agent cannot
+//! call what is not in `tools/list`.
+
+use std::sync::Arc;
+
+use rmcp::model::{
+    CallToolRequestParams, CallToolResult, ContentBlock, Implementation, ListToolsResult,
+    PaginatedRequestParams, ServerCapabilities, ServerInfo, Tool,
+};
+use rmcp::service::RequestContext;
+use rmcp::{ErrorData as McpError, RoleServer, ServerHandler};
+use serde_json::{Map as JsonMap, Value as Json};
+
+use libretune_core::agent::orchestrator::ReadToolExecutor;
+use libretune_core::agent::tools;
+
+/// Builds the executor that serves one MCP session. A factory rather than a
+/// shared instance so each session reads through a freshly-resolved view of
+/// app state, matching how `agent_send_message` builds one per turn.
+pub type ExecutorFactory = Arc<dyn Fn() -> Arc<dyn ReadToolExecutor> + Send + Sync>;
+
+/// The contract shown to the connecting agent. Adapted from the in-app
+/// assistant's framing: an MCP client's model never sees LibreTune's UI, so
+/// the "you cannot apply anything" rule has to be stated here or the model
+/// will assume otherwise.
+const MCP_INSTRUCTIONS: &str = "LibreTune's read-only tune inspection tools. \
+     All numeric analysis must come from these tools — never invent or \
+     compute tuning numbers yourself. You can NOT change the tune, apply \
+     edits, or burn to the ECU: no write tools are offered here. To change \
+     anything, the user must use LibreTune's own AI assistant or edit \
+     manually — say so rather than claiming a change was made. If a tool \
+     returns an object with an `error` field, report that reason honestly \
+     instead of guessing at the answer.";
+
+/// One MCP server session over LibreTune's read tools.
+pub struct LibreTuneMcp {
+    executor: ExecutorFactory,
+}
+
+impl LibreTuneMcp {
+    pub fn new(executor: ExecutorFactory) -> Self {
+        Self { executor }
+    }
+
+    /// The read-only tool list in rmcp's shape. A plain inherent method (not
+    /// the trait method) so tests can call it without constructing rmcp's
+    /// `RequestContext`, which has no public constructor outside a real
+    /// transport.
+    pub(crate) fn read_tools(&self) -> Vec<Tool> {
+        tools::catalogue()
+            .into_iter()
+            .filter(|def| tools::is_read_tool(&def.name))
+            .map(to_rmcp_tool)
+            .collect()
+    }
+
+    /// Run one tool call. Never returns `Err`: a refused or failed tool is
+    /// *data* for the calling model (MCP's tool-level error), not a
+    /// JSON-RPC protocol fault.
+    pub(crate) async fn dispatch(
+        &self,
+        name: &str,
+        arguments: Option<JsonMap<String, Json>>,
+    ) -> CallToolResult {
+        if !tools::is_read_tool(name) {
+            return tool_error(format!(
+                "unknown tool '{name}' — this server exposes read-only tune tools only"
+            ));
+        }
+
+        let executor = (self.executor)();
+        if !executor.handles(name) {
+            return tool_error(format!("tool '{name}' is not available right now"));
+        }
+
+        let args = Json::Object(arguments.unwrap_or_default()).to_string();
+        to_call_result(executor.execute(name, &args).await)
+    }
+}
+
+/// A tool-level MCP error carrying `message` as plain text.
+fn tool_error(message: String) -> CallToolResult {
+    CallToolResult::error(vec![ContentBlock::text(message)])
+}
+
+/// Turn the executor's JSON-string answer into an MCP result.
+///
+/// The executor signals failure in-band as `{"error": "..."}` (see
+/// `commands::agent::json_err`) because that is what an LLM tool-result
+/// message wants. MCP has a real error channel, so unwrap it here — an
+/// agent that only reads `isError` must not mistake a failure for data.
+fn to_call_result(raw: String) -> CallToolResult {
+    match serde_json::from_str::<Json>(&raw) {
+        Ok(Json::Object(map)) => {
+            if let Some(Json::String(message)) = map.get("error") {
+                return tool_error(message.clone());
+            }
+            CallToolResult::structured(Json::Object(map))
+        }
+        // Non-object JSON (or not JSON at all): pass it through as text
+        // rather than inventing a wrapper object the schema never promised.
+        _ => CallToolResult::success(vec![ContentBlock::text(raw)]),
+    }
+}
+
+/// `ToolDef::parameters` is an object schema for every tool in the
+/// catalogue (`tools.rs` writes them as literals); `unwrap_or_default` is a
+/// guard on that invariant, not a swallowed error.
+fn to_rmcp_tool(def: libretune_core::llm::types::ToolDef) -> Tool {
+    let schema = def.parameters.as_object().cloned().unwrap_or_default();
+    Tool::new(def.name, def.description, Arc::new(schema))
+}
+
+impl ServerHandler for LibreTuneMcp {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_server_info(Implementation::new("libretune", env!("CARGO_PKG_VERSION")))
+            .with_instructions(MCP_INSTRUCTIONS)
+    }
+
+    async fn list_tools(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListToolsResult, McpError> {
+        Ok(ListToolsResult::with_all_items(self.read_tools()))
+    }
+
+    async fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(self.dispatch(&request.name, request.arguments).await)
+    }
+}

--- a/crates/libretune-app/src-tauri/src/mcp/mod.rs
+++ b/crates/libretune-app/src-tauri/src/mcp/mod.rs
@@ -1,0 +1,26 @@
+//! Local MCP (Model Context Protocol) server.
+//!
+//! Lets external agents — Claude Code, Claude Desktop, any MCP client —
+//! call LibreTune's read-only tune tools over a loopback HTTP transport,
+//! so a model outside the app can inspect the same tune the in-app
+//! assistant sees.
+//!
+//! Ported from OpenTune's `ai_mcp*.rs`, retargeted onto LibreTune's
+//! [`libretune_core::agent`] tool catalogue.
+//!
+//! - [`token`] — the per-install bearer token on disk.
+//! - [`handler`] — protocol translation (tool list, tool dispatch).
+//! - [`server`] — loopback socket, auth middleware, start/stop/reconcile.
+//! - [`commands`] — the Tauri command surface the Settings dialog drives.
+//!
+//! The server is **advisory and read-only**: it exposes no tool that can
+//! change a tune or touch the ECU. Off by default; the user turns it on in
+//! Settings → AI Assistant → MCP server.
+
+pub mod commands;
+pub mod handler;
+pub mod server;
+pub mod token;
+
+#[cfg(test)]
+mod tests;

--- a/crates/libretune-app/src-tauri/src/mcp/server.rs
+++ b/crates/libretune-app/src-tauri/src/mcp/server.rs
@@ -1,0 +1,259 @@
+//! Loopback HTTP transport and lifecycle for the MCP server.
+//!
+//! Ported from OpenTune's `ai_mcp_server.rs`. This module binds the socket
+//! and guards it; the protocol lives in [`super::handler`] and never sees a
+//! request that failed the checks here.
+//!
+//! ## Security invariants
+//! - Binds `127.0.0.1` only — never `0.0.0.0`, so the tune is never
+//!   reachable off-box even on a hostile network.
+//! - Every request must carry `Authorization: Bearer <token>` matching the
+//!   per-install token, compared in constant time ([`tokens_match`]) so a
+//!   local attacker cannot recover it byte-by-byte from response timing.
+//! - rmcp's Host check (DNS-rebinding prevention) is pinned to loopback
+//!   forms explicitly rather than inherited from the library default.
+//! - rmcp's Origin check is turned on explicitly: its default
+//!   `allowed_origins` is an *empty* list, which means "skip Origin
+//!   validation entirely". The entries are deliberately portless — rmcp
+//!   only compares the port when the allow-list entry names one, and the
+//!   bound port is unpredictable when the configured port is `0`.
+//! - The token is never logged: no error path here names it.
+
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use axum::extract::{Request, State as AxumState};
+use axum::http::{header, StatusCode};
+use axum::middleware::{self, Next};
+use axum::response::{IntoResponse, Response};
+use axum::Router;
+use tokio::net::TcpListener;
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+
+use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
+use rmcp::transport::streamable_http_server::{StreamableHttpServerConfig, StreamableHttpService};
+
+use super::handler::{ExecutorFactory, LibreTuneMcp};
+use super::token::load_or_create_token;
+
+const BEARER_PREFIX: &str = "Bearer ";
+
+/// Lowest port the settings UI accepts. Below 1024 needs elevation on unix
+/// and is reserved for well-known services everywhere.
+pub const MIN_MCP_PORT: u16 = 1024;
+
+/// Constant-time token comparison. The length check up front is safe (the
+/// token's *length* is not the secret); the xor-fold that follows has no
+/// early return, so no timing signal reveals which byte differed.
+pub(crate) fn tokens_match(candidate: &[u8], expected: &[u8]) -> bool {
+    if candidate.len() != expected.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (a, b) in candidate.iter().zip(expected.iter()) {
+        diff |= a ^ b;
+    }
+    diff == 0
+}
+
+/// Reject anything without a matching bearer token with a bare 401 — no
+/// body, so the response never echoes what was sent or hints at why.
+async fn require_bearer_token(
+    AxumState(expected): AxumState<Arc<str>>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let provided = request
+        .headers()
+        .get(header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.strip_prefix(BEARER_PREFIX));
+
+    match provided {
+        Some(candidate) if tokens_match(candidate.as_bytes(), expected.as_bytes()) => {
+            next.run(request).await
+        }
+        _ => StatusCode::UNAUTHORIZED.into_response(),
+    }
+}
+
+/// The single-route (`/mcp`) router: rmcp's streamable-HTTP service behind
+/// the bearer layer.
+pub(crate) fn build_router(executor: ExecutorFactory, token: String) -> Router {
+    let service = StreamableHttpService::new(
+        move || Ok(LibreTuneMcp::new(Arc::clone(&executor))),
+        Arc::new(LocalSessionManager::default()),
+        StreamableHttpServerConfig::default()
+            .with_allowed_hosts(["localhost", "127.0.0.1", "::1"])
+            .with_allowed_origins(["http://localhost", "http://127.0.0.1", "http://[::1]"]),
+    );
+
+    Router::new()
+        .nest_service("/mcp", service)
+        .layer(middleware::from_fn_with_state(
+            Arc::<str>::from(token),
+            require_bearer_token,
+        ))
+}
+
+/// One running server's handles.
+struct RunningServer {
+    shutdown_tx: oneshot::Sender<()>,
+    join_handle: JoinHandle<()>,
+    local_addr: SocketAddr,
+}
+
+/// Managed app-wide: the current server, or `None` when stopped.
+#[derive(Default)]
+pub struct McpServerState(Mutex<Option<RunningServer>>);
+
+impl McpServerState {
+    /// The bound address while running. Mutex poisoning is recovered from
+    /// rather than propagated — a panic elsewhere should not permanently
+    /// wedge the Settings UI's status query.
+    pub fn local_addr(&self) -> Option<SocketAddr> {
+        self.0
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .as_ref()
+            .map(|running| running.local_addr)
+    }
+}
+
+/// Bind loopback and start serving. `port == 0` asks the OS for a free
+/// port; read the real one back via [`McpServerState::local_addr`] (that is
+/// how the tests avoid a fixed port and a sleep).
+///
+/// Returns `Err` without side effects when a server is already running —
+/// callers that mean to restart call [`stop_mcp_server`] first.
+pub async fn start_mcp_server(
+    state: &McpServerState,
+    executor: ExecutorFactory,
+    token: String,
+    port: u16,
+) -> Result<(), String> {
+    if state.local_addr().is_some() {
+        return Err("The MCP server is already running — stop it first".into());
+    }
+
+    let listener = TcpListener::bind(("127.0.0.1", port))
+        .await
+        .map_err(|e| format!("Could not start the MCP server on 127.0.0.1:{port}: {e}"))?;
+    let local_addr = listener
+        .local_addr()
+        .map_err(|e| format!("Could not read the MCP server's bound address: {e}"))?;
+
+    let router = build_router(executor, token);
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let join_handle = tokio::spawn(async move {
+        let _ = axum::serve(listener, router)
+            .with_graceful_shutdown(async move {
+                let _ = shutdown_rx.await;
+            })
+            .await;
+    });
+
+    let mut guard = lock_state(state);
+    *guard = Some(RunningServer {
+        shutdown_tx,
+        join_handle,
+        local_addr,
+    });
+    Ok(())
+}
+
+fn lock_state(state: &McpServerState) -> std::sync::MutexGuard<'_, Option<RunningServer>> {
+    state
+        .0
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Stop the running server. Idempotent.
+///
+/// Signal-then-abort: the oneshot is best-effort (it only lands if the task
+/// is still polling `with_graceful_shutdown`), the abort is what guarantees
+/// the listener closes. Awaiting the aborted handle is what makes
+/// "stop, then start on the same port" deterministic — by the time this
+/// returns, the socket is released.
+pub async fn stop_mcp_server(state: &McpServerState) {
+    let running = lock_state(state).take();
+    let Some(running) = running else {
+        return;
+    };
+    let _ = running.shutdown_tx.send(());
+    running.join_handle.abort();
+    let _ = running.join_handle.await;
+}
+
+/// What reconciling desired settings against reality requires. Extracted so
+/// the decision matrix is unit-testable without a socket.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ReconcileAction {
+    NoOp,
+    Start,
+    Stop,
+    Restart,
+}
+
+pub(crate) fn reconcile_action(
+    desired_enabled: bool,
+    desired_port: u16,
+    running_port: Option<u16>,
+) -> ReconcileAction {
+    match (desired_enabled, running_port) {
+        (false, None) => ReconcileAction::NoOp,
+        (false, Some(_)) => ReconcileAction::Stop,
+        (true, None) => ReconcileAction::Start,
+        (true, Some(port)) if port == desired_port => ReconcileAction::NoOp,
+        (true, Some(_)) => ReconcileAction::Restart,
+    }
+}
+
+/// Bring the server in line with the saved settings — covers enable,
+/// disable, and a port change while enabled. Loads or creates the token
+/// itself, and only on the paths that actually need one.
+pub async fn reconcile_mcp_server(
+    state: &McpServerState,
+    executor: ExecutorFactory,
+    config_dir: PathBuf,
+    desired_enabled: bool,
+    desired_port: u16,
+) -> Result<(), String> {
+    let action = reconcile_action(
+        desired_enabled,
+        desired_port,
+        state.local_addr().map(|addr| addr.port()),
+    );
+
+    if matches!(action, ReconcileAction::Stop | ReconcileAction::Restart) {
+        stop_mcp_server(state).await;
+    }
+    if matches!(action, ReconcileAction::Start | ReconcileAction::Restart) {
+        let token = load_or_create_token(&config_dir)?;
+        start_mcp_server(state, executor, token, desired_port).await?;
+    }
+    Ok(())
+}
+
+/// Mint a fresh token and, if a server is running, restart it on the *same*
+/// port so the new token takes effect at once.
+///
+/// Without the restart, "Regenerate" would be actively harmful: the running
+/// server would keep honouring the old (possibly leaked) token while the
+/// token shown in Settings 401s. When nothing is running this stays a pure
+/// token swap — regenerating must not start a server the user never enabled.
+pub async fn regenerate_and_restart(
+    state: &McpServerState,
+    executor: ExecutorFactory,
+    config_dir: PathBuf,
+) -> Result<String, String> {
+    let token = super::token::regenerate_token(&config_dir)?;
+    if let Some(port) = state.local_addr().map(|addr| addr.port()) {
+        stop_mcp_server(state).await;
+        start_mcp_server(state, executor, token.clone(), port).await?;
+    }
+    Ok(token)
+}

--- a/crates/libretune-app/src-tauri/src/mcp/tests.rs
+++ b/crates/libretune-app/src-tauri/src/mcp/tests.rs
@@ -1,0 +1,371 @@
+//! Tests for the local MCP server.
+//!
+//! Everything here runs without a `tauri::App`: the handler is built over a
+//! stub [`ReadToolExecutor`], which is exactly why the production handler
+//! takes a factory instead of an `AppHandle`.
+
+use std::sync::Arc;
+
+use libretune_core::agent::orchestrator::ReadToolExecutor;
+use libretune_core::agent::tools;
+use serde_json::json;
+
+use super::handler::{ExecutorFactory, LibreTuneMcp};
+use super::server::{
+    build_router, reconcile_action, start_mcp_server, stop_mcp_server, tokens_match,
+    McpServerState, ReconcileAction,
+};
+use super::token::{load_or_create_token, regenerate_token, MCP_TOKEN_FILE};
+
+// ---------------------------------------------------------------- stubs
+
+/// Answers every read tool with a fixed payload, echoing back what it was
+/// asked so dispatch's argument plumbing is observable.
+struct StubExecutor {
+    /// When set, every call returns this raw string instead of the echo.
+    canned: Option<String>,
+}
+
+#[async_trait::async_trait]
+impl ReadToolExecutor for StubExecutor {
+    fn handles(&self, tool_name: &str) -> bool {
+        tools::is_read_tool(tool_name)
+    }
+
+    async fn execute(&self, tool_name: &str, arguments: &str) -> String {
+        if let Some(canned) = &self.canned {
+            return canned.clone();
+        }
+        json!({ "tool": tool_name, "arguments": arguments }).to_string()
+    }
+}
+
+fn stub_factory(canned: Option<String>) -> ExecutorFactory {
+    Arc::new(move || {
+        Arc::new(StubExecutor {
+            canned: canned.clone(),
+        }) as Arc<dyn ReadToolExecutor>
+    })
+}
+
+fn temp_dir(tag: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!("libretune-mcp-{tag}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("temp dir created");
+    dir
+}
+
+// ---------------------------------------------------------------- token
+
+#[test]
+fn token_is_created_once_and_reused() {
+    let dir = temp_dir("token-reuse");
+    let first = load_or_create_token(&dir).expect("token minted");
+    assert_eq!(first.len(), 64, "32 random bytes, hex encoded");
+    assert!(first.chars().all(|c| c.is_ascii_hexdigit()));
+    assert_eq!(first, load_or_create_token(&dir).expect("token reread"));
+}
+
+#[test]
+fn blank_token_file_is_replaced_not_trusted() {
+    // A truncated or hand-emptied file must not become an empty bearer
+    // token — that would authenticate `Authorization: Bearer `.
+    let dir = temp_dir("token-blank");
+    std::fs::write(dir.join(MCP_TOKEN_FILE), "   \n").expect("blank file written");
+    let token = load_or_create_token(&dir).expect("token minted");
+    assert_eq!(token.len(), 64);
+}
+
+#[test]
+fn regenerate_invalidates_the_previous_token() {
+    let dir = temp_dir("token-regen");
+    let first = load_or_create_token(&dir).expect("token minted");
+    let second = regenerate_token(&dir).expect("token regenerated");
+    assert_ne!(first, second);
+    assert_eq!(second, load_or_create_token(&dir).expect("token reread"));
+}
+
+#[cfg(unix)]
+#[test]
+fn token_file_is_owner_only() {
+    use std::os::unix::fs::PermissionsExt;
+    let dir = temp_dir("token-perms");
+    load_or_create_token(&dir).expect("token minted");
+    let mode = std::fs::metadata(dir.join(MCP_TOKEN_FILE))
+        .expect("token file exists")
+        .permissions()
+        .mode();
+    assert_eq!(
+        mode & 0o777,
+        0o600,
+        "no other local user may read the token"
+    );
+}
+
+// ------------------------------------------------------------ auth check
+
+#[test]
+fn tokens_match_only_on_exact_equality() {
+    assert!(tokens_match(b"abc123", b"abc123"));
+    assert!(!tokens_match(b"abc123", b"abc124"));
+    assert!(
+        !tokens_match(b"abc12", b"abc123"),
+        "length mismatch rejected"
+    );
+    assert!(!tokens_match(b"", b"abc123"));
+}
+
+// -------------------------------------------------------------- handler
+
+#[tokio::test]
+async fn only_read_tools_are_advertised() {
+    let mcp = LibreTuneMcp::new(stub_factory(None));
+    let names: Vec<String> = mcp
+        .read_tools()
+        .iter()
+        .map(|t| t.name.to_string())
+        .collect();
+
+    assert_eq!(names.len(), 8, "the eight read tools, no more: {names:?}");
+    for name in &names {
+        assert!(tools::is_read_tool(name), "{name} is not a read tool");
+    }
+    for withheld in [
+        tools::tool_names::PROPOSE_TABLE_EDIT,
+        tools::tool_names::PROPOSE_BULK_OP,
+        tools::tool_names::PROPOSE_CONSTANT_CHANGE,
+    ] {
+        assert!(
+            !names.iter().any(|n| n == withheld),
+            "{withheld} must never reach an external agent"
+        );
+    }
+}
+
+#[tokio::test]
+async fn every_advertised_tool_has_an_object_schema() {
+    // rmcp serializes `input_schema` straight to the wire; a non-object
+    // schema would make the tool uncallable for a conforming client.
+    let mcp = LibreTuneMcp::new(stub_factory(None));
+    for tool in mcp.read_tools() {
+        assert_eq!(
+            tool.input_schema.get("type").and_then(|t| t.as_str()),
+            Some("object"),
+            "{} has a non-object schema",
+            tool.name
+        );
+    }
+}
+
+#[tokio::test]
+async fn dispatch_forwards_arguments_and_returns_structured_content() {
+    let mcp = LibreTuneMcp::new(stub_factory(None));
+    let mut args = serde_json::Map::new();
+    args.insert("table_name".into(), json!("veTable1"));
+
+    let result = mcp
+        .dispatch(tools::tool_names::READ_TABLE, Some(args))
+        .await;
+
+    assert_eq!(result.is_error, Some(false));
+    let structured = result.structured_content.expect("structured content");
+    assert_eq!(structured["tool"], json!(tools::tool_names::READ_TABLE));
+    assert!(
+        structured["arguments"]
+            .as_str()
+            .expect("arguments echoed as a JSON string")
+            .contains("veTable1"),
+        "arguments were not forwarded: {structured}"
+    );
+}
+
+#[tokio::test]
+async fn unknown_tool_is_a_tool_level_error_not_a_protocol_fault() {
+    let mcp = LibreTuneMcp::new(stub_factory(None));
+    let result = mcp.dispatch("burn_now", None).await;
+    assert_eq!(result.is_error, Some(true));
+}
+
+#[tokio::test]
+async fn propose_tools_are_refused_even_when_named_directly() {
+    // Withholding them from `tools/list` is not enough on its own: a client
+    // can call any name it likes.
+    let mcp = LibreTuneMcp::new(stub_factory(None));
+    let result = mcp
+        .dispatch(tools::tool_names::PROPOSE_TABLE_EDIT, None)
+        .await;
+    assert_eq!(result.is_error, Some(true));
+}
+
+#[tokio::test]
+async fn executor_error_object_becomes_an_mcp_error() {
+    // The executor reports failure in-band as {"error": ...} because that is
+    // what an LLM tool-result wants; MCP has a real error channel, and an
+    // agent reading only `isError` must not mistake this for data.
+    let canned = json!({ "error": "No INI definition loaded" }).to_string();
+    let mcp = LibreTuneMcp::new(stub_factory(Some(canned)));
+
+    let result = mcp.dispatch(tools::tool_names::LIST_TABLES, None).await;
+
+    assert_eq!(result.is_error, Some(true));
+    assert!(result.structured_content.is_none());
+}
+
+// ------------------------------------------------------------- lifecycle
+
+#[test]
+fn reconcile_matrix_covers_every_transition() {
+    use ReconcileAction::*;
+    assert_eq!(reconcile_action(false, 8765, None), NoOp);
+    assert_eq!(reconcile_action(false, 8765, Some(8765)), Stop);
+    assert_eq!(reconcile_action(true, 8765, None), Start);
+    assert_eq!(reconcile_action(true, 8765, Some(8765)), NoOp);
+    assert_eq!(reconcile_action(true, 9000, Some(8765)), Restart);
+}
+
+#[tokio::test]
+async fn stop_is_idempotent() {
+    let state = McpServerState::default();
+    stop_mcp_server(&state).await;
+    assert!(state.local_addr().is_none());
+}
+
+#[tokio::test]
+async fn starting_twice_is_refused_without_disturbing_the_running_server() {
+    let state = McpServerState::default();
+    start_mcp_server(&state, stub_factory(None), "tok".into(), 0)
+        .await
+        .expect("first start binds");
+    let addr = state.local_addr().expect("bound");
+
+    let second = start_mcp_server(&state, stub_factory(None), "tok".into(), 0).await;
+
+    assert!(second.is_err());
+    assert_eq!(state.local_addr(), Some(addr), "original server untouched");
+    stop_mcp_server(&state).await;
+}
+
+// ------------------------------------------------------------------ HTTP
+
+/// An initialize request — the first thing any MCP client sends.
+fn initialize_body() -> serde_json::Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": { "name": "libretune-test", "version": "0" }
+        }
+    })
+}
+
+async fn serve_on_ephemeral_port(token: &str) -> (McpServerState, String) {
+    let state = McpServerState::default();
+    start_mcp_server(&state, stub_factory(None), token.to_string(), 0)
+        .await
+        .expect("server binds an ephemeral loopback port");
+    let addr = state.local_addr().expect("bound address");
+    let url = format!("http://127.0.0.1:{}/mcp", addr.port());
+    (state, url)
+}
+
+fn client() -> reqwest::Client {
+    reqwest::Client::new()
+}
+
+#[tokio::test]
+async fn server_binds_loopback_only() {
+    let (state, _url) = serve_on_ephemeral_port("tok").await;
+    let addr = state.local_addr().expect("bound");
+    assert!(addr.ip().is_loopback(), "bound {addr}, not loopback");
+    stop_mcp_server(&state).await;
+}
+
+#[tokio::test]
+async fn request_without_a_token_is_rejected() {
+    let (state, url) = serve_on_ephemeral_port("secret-token").await;
+
+    let response = client()
+        .post(&url)
+        .header("Accept", "application/json, text/event-stream")
+        .json(&initialize_body())
+        .send()
+        .await
+        .expect("request sent");
+
+    assert_eq!(response.status(), reqwest::StatusCode::UNAUTHORIZED);
+    assert!(
+        response.text().await.unwrap_or_default().is_empty(),
+        "401 must not echo anything back"
+    );
+    stop_mcp_server(&state).await;
+}
+
+#[tokio::test]
+async fn request_with_the_wrong_token_is_rejected() {
+    let (state, url) = serve_on_ephemeral_port("secret-token").await;
+
+    let response = client()
+        .post(&url)
+        .header("Authorization", "Bearer wrong-token")
+        .header("Accept", "application/json, text/event-stream")
+        .json(&initialize_body())
+        .send()
+        .await
+        .expect("request sent");
+
+    assert_eq!(response.status(), reqwest::StatusCode::UNAUTHORIZED);
+    stop_mcp_server(&state).await;
+}
+
+#[tokio::test]
+async fn initialize_succeeds_with_the_right_token() {
+    let (state, url) = serve_on_ephemeral_port("secret-token").await;
+
+    let response = client()
+        .post(&url)
+        .header("Authorization", "Bearer secret-token")
+        .header("Accept", "application/json, text/event-stream")
+        .json(&initialize_body())
+        .send()
+        .await
+        .expect("request sent");
+
+    assert!(
+        response.status().is_success(),
+        "status {}",
+        response.status()
+    );
+    let body = response.text().await.expect("body");
+    assert!(
+        body.contains("libretune"),
+        "serverInfo missing from: {body}"
+    );
+    stop_mcp_server(&state).await;
+}
+
+#[tokio::test]
+async fn stopping_frees_the_port() {
+    // The whole point of awaiting the aborted task in `stop_mcp_server`.
+    let state = McpServerState::default();
+    start_mcp_server(&state, stub_factory(None), "tok".into(), 0)
+        .await
+        .expect("first bind");
+    let port = state.local_addr().expect("bound").port();
+    stop_mcp_server(&state).await;
+
+    let restarted = McpServerState::default();
+    start_mcp_server(&restarted, stub_factory(None), "tok".into(), port)
+        .await
+        .expect("the same port is free again");
+    stop_mcp_server(&restarted).await;
+}
+
+#[test]
+fn router_builds_without_a_socket() {
+    // Cheap guard on the rmcp/axum wiring: a service-type mismatch here is a
+    // compile error, and a panicking builder would be caught at runtime.
+    let _ = build_router(stub_factory(None), "tok".into());
+}

--- a/crates/libretune-app/src-tauri/src/mcp/token.rs
+++ b/crates/libretune-app/src-tauri/src/mcp/token.rs
@@ -1,0 +1,86 @@
+//! Per-install bearer token for the local MCP server.
+//!
+//! The token is the only thing standing between a local process and the
+//! tune-reading tools, so it lives in its own file (never in
+//! `settings.json`, which is world-readable and gets copied around in bug
+//! reports) and is written owner-only on unix.
+//!
+//! Ported from OpenTune's `ai_settings.rs` token helpers; the file name and
+//! the 64-char hex shape are kept identical so an existing OpenTune client
+//! config only needs its URL changed.
+
+use std::path::{Path, PathBuf};
+
+use rand::Rng;
+
+/// Token file name inside the app data directory.
+pub const MCP_TOKEN_FILE: &str = "mcp-token";
+
+/// Generate a random 32-byte, hex-encoded token (64 chars). Hex is folded by
+/// hand — one 32-byte encode does not justify a dependency.
+fn generate_token() -> String {
+    let mut bytes = [0u8; 32];
+    rand::thread_rng().fill(&mut bytes);
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+fn token_path(dir: &Path) -> PathBuf {
+    dir.join(MCP_TOKEN_FILE)
+}
+
+/// Write the token via a temp file + rename so a crash mid-write can never
+/// leave a truncated token behind (which would lock the user out of their
+/// own server until they regenerated it), then restrict the file to the
+/// owner on unix — the default 0644 would let any other local account read
+/// the bearer token straight off disk.
+fn write_token(dir: &Path, token: &str) -> Result<(), String> {
+    std::fs::create_dir_all(dir).map_err(|e| format!("failed to create config dir: {e}"))?;
+
+    let target = token_path(dir);
+    let temp = dir.join(format!(".{MCP_TOKEN_FILE}.{}.tmp", std::process::id()));
+    std::fs::write(&temp, token.as_bytes())
+        .map_err(|e| format!("failed to write MCP token: {e}"))?;
+    std::fs::rename(&temp, &target).map_err(|e| {
+        let _ = std::fs::remove_file(&temp);
+        format!("failed to write MCP token: {e}")
+    })?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o600))
+            .map_err(|e| format!("failed to restrict MCP token permissions: {e}"))?;
+    }
+
+    Ok(())
+}
+
+/// Read the token from `<dir>/mcp-token`, generating and persisting a fresh
+/// one when the file is missing, empty, or whitespace-only.
+pub fn load_or_create_token(dir: &Path) -> Result<String, String> {
+    match std::fs::read_to_string(token_path(dir)) {
+        Ok(text) => {
+            let token = text.trim();
+            if token.is_empty() {
+                let fresh = generate_token();
+                write_token(dir, &fresh)?;
+                Ok(fresh)
+            } else {
+                Ok(token.to_owned())
+            }
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            let fresh = generate_token();
+            write_token(dir, &fresh)?;
+            Ok(fresh)
+        }
+        Err(e) => Err(format!("failed to read MCP token: {e}")),
+    }
+}
+
+/// Always mint and persist a fresh token, invalidating the previous one.
+pub fn regenerate_token(dir: &Path) -> Result<String, String> {
+    let token = generate_token();
+    write_token(dir, &token)?;
+    Ok(token)
+}

--- a/crates/libretune-app/src/components/tuner-ui/__tests__/McpServerSection.test.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/__tests__/McpServerSection.test.tsx
@@ -1,0 +1,154 @@
+import { render, screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+
+import { invoke } from '@tauri-apps/api/core';
+
+import { McpServerSection } from '../dialogs/McpServerSection';
+
+/** Let the mount effect's promises settle before asserting. */
+async function settle() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+describe('McpServerSection', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('shows the stopped state and the saved port on mount', async () => {
+    (invoke as unknown as any).mockImplementation((cmd: string) => {
+      if (cmd === 'mcp_status') return Promise.resolve({ running: false, port: 0 });
+      if (cmd === 'get_settings') return Promise.resolve({ mcp_port: 9100 });
+      return Promise.resolve();
+    });
+
+    render(<McpServerSection />);
+    await settle();
+
+    expect(screen.getByText('Stopped')).toBeInTheDocument();
+    expect(screen.getByLabelText('Port')).toHaveValue(9100);
+  });
+
+  it('renders the bound port when the server is already running', async () => {
+    (invoke as unknown as any).mockImplementation((cmd: string) => {
+      if (cmd === 'mcp_status') return Promise.resolve({ running: true, port: 8765 });
+      if (cmd === 'get_settings') return Promise.resolve({ mcp_port: 8765 });
+      return Promise.resolve();
+    });
+
+    render(<McpServerSection />);
+    await settle();
+
+    expect(screen.getByText('Running on 127.0.0.1:8765')).toBeInTheDocument();
+  });
+
+  it('survives commands that resolve to nothing', async () => {
+    // A stubbed or unregistered command resolves to `undefined`; reading
+    // `.running` off that would take the whole Settings dialog down.
+    (invoke as unknown as any).mockImplementation(() => Promise.resolve());
+
+    render(<McpServerSection />);
+    await settle();
+
+    expect(screen.getByText('Stopped')).toBeInTheDocument();
+  });
+
+  it('enables the server through mcp_set_enabled and shows the bound port', async () => {
+    (invoke as unknown as any).mockImplementation((cmd: string) => {
+      if (cmd === 'mcp_status') return Promise.resolve({ running: false, port: 0 });
+      if (cmd === 'get_settings') return Promise.resolve({ mcp_port: 8765 });
+      if (cmd === 'mcp_set_enabled') return Promise.resolve({ running: true, port: 8765 });
+      return Promise.resolve();
+    });
+
+    render(<McpServerSection />);
+    await settle();
+
+    await userEvent.click(screen.getByLabelText('Expose tools over MCP'));
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith('mcp_set_enabled', { enabled: true });
+    });
+    expect(await screen.findByText('Running on 127.0.0.1:8765')).toBeInTheDocument();
+  });
+
+  it('surfaces a failed start instead of silently staying stopped', async () => {
+    (invoke as unknown as any).mockImplementation((cmd: string) => {
+      if (cmd === 'mcp_status') return Promise.resolve({ running: false, port: 0 });
+      if (cmd === 'get_settings') return Promise.resolve({ mcp_port: 8765 });
+      if (cmd === 'mcp_set_enabled') return Promise.reject('Address already in use');
+      return Promise.resolve();
+    });
+
+    render(<McpServerSection />);
+    await settle();
+
+    await userEvent.click(screen.getByLabelText('Expose tools over MCP'));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Address already in use');
+    expect(screen.getByText('Stopped')).toBeInTheDocument();
+  });
+
+  it('keeps the token hidden until asked, then reveals it', async () => {
+    (invoke as unknown as any).mockImplementation((cmd: string) => {
+      if (cmd === 'mcp_status') return Promise.resolve({ running: false, port: 0 });
+      if (cmd === 'get_settings') return Promise.resolve({ mcp_port: 8765 });
+      if (cmd === 'mcp_get_token') return Promise.resolve('a'.repeat(64));
+      return Promise.resolve();
+    });
+
+    render(<McpServerSection />);
+    await settle();
+
+    const field = screen.getByLabelText('Access token');
+    expect(field).toHaveValue('••••••••••••••••');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Show' }));
+
+    await waitFor(() => expect(field).toHaveValue('a'.repeat(64)));
+  });
+
+  it('replaces the shown token when regenerating', async () => {
+    (invoke as unknown as any).mockImplementation((cmd: string) => {
+      if (cmd === 'mcp_status') return Promise.resolve({ running: false, port: 0 });
+      if (cmd === 'get_settings') return Promise.resolve({ mcp_port: 8765 });
+      if (cmd === 'mcp_get_token') return Promise.resolve('a'.repeat(64));
+      if (cmd === 'mcp_regenerate_token') return Promise.resolve('b'.repeat(64));
+      return Promise.resolve();
+    });
+
+    render(<McpServerSection />);
+    await settle();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Show' }));
+    await waitFor(() =>
+      expect(screen.getByLabelText('Access token')).toHaveValue('a'.repeat(64))
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Regenerate' }));
+
+    await waitFor(() =>
+      expect(screen.getByLabelText('Access token')).toHaveValue('b'.repeat(64))
+    );
+  });
+
+  it('rejects a port below the minimum before calling the backend', async () => {
+    (invoke as unknown as any).mockImplementation((cmd: string) => {
+      if (cmd === 'mcp_status') return Promise.resolve({ running: false, port: 0 });
+      if (cmd === 'get_settings') return Promise.resolve({ mcp_port: 8765 });
+      return Promise.resolve();
+    });
+
+    render(<McpServerSection />);
+    await settle();
+
+    await userEvent.clear(screen.getByLabelText('Port'));
+    await userEvent.type(screen.getByLabelText('Port'), '80');
+
+    expect(screen.getByRole('button', { name: 'Apply port' })).toBeDisabled();
+    expect(invoke).not.toHaveBeenCalledWith('mcp_set_port', expect.anything());
+  });
+});

--- a/crates/libretune-app/src/components/tuner-ui/dialogs/McpServerSection.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/dialogs/McpServerSection.tsx
@@ -1,0 +1,207 @@
+/**
+ * McpServerSection — Settings → AI Assistant → MCP server.
+ *
+ * Lets external agents (Claude Code, Claude Desktop, any MCP client) call
+ * LibreTune's read-only tune tools over a loopback HTTP server.
+ *
+ * Unlike the rest of the Settings dialog, these controls apply immediately
+ * rather than on OK/Apply: each one has to bind or release a real socket,
+ * and the result (bound port, or the reason it failed) is only knowable
+ * after the fact. Batching them would leave the status line lying until the
+ * dialog closed.
+ */
+import { useCallback, useEffect, useState } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import { Button, FormField } from '../../common';
+
+/** Mirrors the Rust `McpStatus`. */
+interface McpStatus {
+  running: boolean;
+  /** The bound port while running; 0 when stopped. */
+  port: number;
+}
+
+/** Matches `MIN_MCP_PORT` in `src-tauri/src/mcp/server.rs`. */
+const MIN_PORT = 1024;
+
+const STOPPED: McpStatus = { running: false, port: 0 };
+
+/**
+ * Accept a status only if it actually is one. The backend always returns a
+ * well-formed `McpStatus`, but a stubbed `invoke` (tests) or a command that
+ * was never registered resolves to `undefined`, and rendering
+ * `status.running` off that takes the whole Settings dialog down with it.
+ */
+function asStatus(value: unknown): McpStatus {
+  const candidate = value as Partial<McpStatus> | undefined;
+  if (candidate && typeof candidate.running === 'boolean' && typeof candidate.port === 'number') {
+    return { running: candidate.running, port: candidate.port };
+  }
+  return STOPPED;
+}
+
+export function McpServerSection() {
+  const [status, setStatus] = useState<McpStatus>(STOPPED);
+  const [port, setPort] = useState(8765);
+  const [token, setToken] = useState('');
+  const [tokenVisible, setTokenVisible] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const [current, settings] = await Promise.all([
+          invoke<McpStatus>('mcp_status'),
+          invoke<Record<string, unknown> | undefined>('get_settings'),
+        ]);
+        if (cancelled) return;
+        setStatus(asStatus(current));
+        if (typeof settings?.mcp_port === 'number') setPort(settings.mcp_port);
+      } catch (e) {
+        if (!cancelled) setError(String(e));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  /** Run one MCP command, surfacing its error instead of throwing into the dialog. */
+  const run = useCallback(async (action: () => Promise<void>) => {
+    setBusy(true);
+    setError(null);
+    try {
+      await action();
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  const toggle = (enabled: boolean) =>
+    run(async () => {
+      setStatus(asStatus(await invoke<McpStatus>('mcp_set_enabled', { enabled })));
+    });
+
+  const applyPort = () =>
+    run(async () => {
+      setStatus(asStatus(await invoke<McpStatus>('mcp_set_port', { port })));
+    });
+
+  const revealToken = () =>
+    run(async () => {
+      setToken(String((await invoke<string>('mcp_get_token')) ?? ''));
+      setTokenVisible(true);
+    });
+
+  const regenerateToken = () =>
+    run(async () => {
+      setToken(String((await invoke<string>('mcp_regenerate_token')) ?? ''));
+      setTokenVisible(true);
+    });
+
+  const connectCommand = `claude mcp add --transport http libretune http://127.0.0.1:${
+    status.running ? status.port : port
+  }/mcp --header "Authorization: Bearer ${tokenVisible && token ? token : '<TOKEN>'}"`;
+
+  return (
+    <>
+      <h3 style={{ marginTop: '1.5rem', marginBottom: '0.5rem' }}>MCP server (local)</h3>
+      <span className="dialog-form-note">
+        Exposes LibreTune's <strong>read-only</strong> tune tools to external MCP clients on
+        127.0.0.1 only — never off this machine. No tool here can edit a tune or touch the ECU.
+        These controls apply immediately, not on OK.
+      </span>
+
+      <FormField
+        label="Expose tools over MCP"
+        help="Starts a loopback HTTP server so an outside agent can inspect the loaded tune"
+      >
+        {(id) => (
+          <label className="dialog-checkbox-option" style={{ display: 'inline-flex', gap: '0.4rem' }}>
+            <input
+              id={id}
+              type="checkbox"
+              checked={status.running}
+              disabled={busy}
+              onChange={(e) => toggle(e.target.checked)}
+            />
+            <span>
+              {status.running ? `Running on 127.0.0.1:${status.port}` : 'Stopped'}
+            </span>
+          </label>
+        )}
+      </FormField>
+
+      <FormField label="Port" help={`Minimum ${MIN_PORT}. Changing it restarts the server.`}>
+        {(id) => (
+          <span style={{ display: 'inline-flex', gap: '0.5rem', alignItems: 'center' }}>
+            <input
+              id={id}
+              type="number"
+              min={MIN_PORT}
+              max={65535}
+              value={port}
+              disabled={busy}
+              onChange={(e) => setPort(Number(e.target.value))}
+              style={{ width: '8rem', fontFamily: 'monospace' }}
+            />
+            <Button onClick={applyPort} disabled={busy || port < MIN_PORT}>
+              Apply port
+            </Button>
+          </span>
+        )}
+      </FormField>
+
+      <FormField
+        label="Access token"
+        help="Every request must send this as a bearer token. Regenerating invalidates the old one immediately."
+      >
+        {(id) => (
+          <span style={{ display: 'inline-flex', gap: '0.5rem', alignItems: 'center' }}>
+            <input
+              id={id}
+              type="text"
+              readOnly
+              value={tokenVisible ? token : '••••••••••••••••'}
+              style={{ width: '22rem', fontFamily: 'monospace' }}
+              onFocus={(e) => e.currentTarget.select()}
+            />
+            <Button onClick={revealToken} disabled={busy}>
+              Show
+            </Button>
+            <Button onClick={regenerateToken} disabled={busy}>
+              Regenerate
+            </Button>
+          </span>
+        )}
+      </FormField>
+
+      <div className="dialog-form-group">
+        <label>Connect Claude Code</label>
+        <input
+          type="text"
+          readOnly
+          value={connectCommand}
+          style={{ fontFamily: 'monospace' }}
+          onFocus={(e) => e.currentTarget.select()}
+        />
+        <span className="dialog-form-note">
+          Click to select, then copy. Claude Desktop needs the `mcp-remote` bridge — see the MCP
+          page in the manual.
+        </span>
+      </div>
+
+      {error && (
+        <span className="dialog-form-note" role="alert" style={{ color: 'var(--color-error, #d33)' }}>
+          {error}
+        </span>
+      )}
+    </>
+  );
+}
+
+export default McpServerSection;

--- a/crates/libretune-app/src/components/tuner-ui/dialogs/SettingsDialog.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/dialogs/SettingsDialog.tsx
@@ -12,6 +12,7 @@ import { Dialog, Button, FormField, RiskAcknowledgement } from '../../common';
 import { ThemeName } from '../../../themes';
 import { SUPPORTED_LANGUAGES, LANGUAGE_STORAGE_KEY, type SupportedLanguageCode } from '../../../i18n/languages';
 import ConnectionMetrics from '../../layout/ConnectionMetrics';
+import { McpServerSection } from './McpServerSection';
 import '../Dialogs.css';
 
 interface DialogProps {
@@ -1173,6 +1174,8 @@ export function SettingsDialog({ isOpen, onClose, theme, onThemeChange, onSettin
               </select>
             )}
           </FormField>
+
+          <McpServerSection />
 
           <h3 style={{ marginTop: '1.5rem', marginBottom: '0.5rem' }}>Indicator Panel</h3>
           

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -38,6 +38,7 @@
 - [Pop-out Windows](./features/popout-windows.md)
 - [ECU Console](./features/ecu-console.md)
 - [AI Assistant](./features/ai-assistant.md)
+  - [MCP Server](./features/mcp-server.md)
 - [Tune Migration](./features/tune-migration.md)
 - [Hardware Configuration](./technical/port-editor.md)
 - [Action Scripting](./reference/action-scripting.md)

--- a/docs/src/features/ai-assistant.md
+++ b/docs/src/features/ai-assistant.md
@@ -34,6 +34,10 @@ What the assistant can do:
 - **Propose ECU configuration changes** (feature enablement, scalar constants).
 - **Propose tune edits** to individual cells or bulk regions.
 
+The assistant's read tools are also available to **external** agents (Claude
+Code, Claude Desktop, …) over a local, read-only
+[MCP server](./mcp-server.md) — off by default.
+
 The assistant is **not** a closed-loop controller. It does not run every
 realtime tick — that remains the job of the algorithmic [AutoTune](./autotune.md)
 engine. Think of it as a smart strategy and explanation layer on top of the

--- a/docs/src/features/mcp-server.md
+++ b/docs/src/features/mcp-server.md
@@ -1,0 +1,148 @@
+# MCP Server
+
+LibreTune can expose its tune-inspection tools to **external AI agents** over
+a local [Model Context Protocol](https://modelcontextprotocol.io) server. An
+agent running in Claude Code, Claude Desktop, or any other MCP client can then
+read the tune you have open and reason about it, using the same deterministic
+tools as the built-in [AI Assistant](./ai-assistant.md).
+
+> **Read-only.** The MCP server exposes no tool that can edit a tune, stage a
+> proposal, or touch the ECU. An outside agent can look; only you can change
+> anything.
+
+The server is **off by default** and only ever listens on `127.0.0.1` — it is
+never reachable from another machine.
+
+## Enabling the server
+
+1. Open **Tools → Settings**.
+2. Scroll to **AI Assistant (at your own risk) → MCP server (local)**.
+3. Tick **Expose tools over MCP**.
+
+The server starts immediately and the checkbox label shows the bound address,
+e.g. `Running on 127.0.0.1:8765`. Untick it, or close LibreTune, to stop it.
+The setting is remembered, so a server left enabled restarts on the next
+launch.
+
+Unlike the rest of the Settings dialog, the MCP controls apply the moment you
+use them rather than on **OK** — each one binds or releases a real socket.
+
+## Authentication
+
+Every request must carry a bearer token:
+
+```
+Authorization: Bearer <token>
+```
+
+The token is unique per installation, 64 hex characters, and shown under
+**Access token** in the settings section (click **Show**). It is stored in
+`mcp-token` in LibreTune's app data directory, readable only by your user
+account on macOS and Linux, and is never written to `settings.json` or to any
+log.
+
+Click **Regenerate** to mint a fresh token. The old one stops working
+immediately: if the server is running, it restarts on the same port with the
+new token. Update your client configuration afterwards.
+
+## Available tools
+
+All eight are read-only. They are the same tools the in-app assistant uses, so
+what an external agent sees can never drift from what the assistant sees.
+
+| Tool | What it returns |
+|------|-----------------|
+| `list_tables` | Every editable table with its role (VE / Ignition / AFR target / …) and dimensions. Call this first to discover names. |
+| `read_table` | Current values, axis bins, and units for one table. |
+| `read_constant` | One constant's value, min/max, units, and options. |
+| `list_features` | Feature-toggle (bits) constants and their available options. |
+| `summarize_tune_context` | Per-cell AFR error, data coverage, suspect cells, and unexplored cells for a VE table. |
+| `tune_health_check` | Overall health score and per-region coverage for a table. |
+| `get_realtime_snapshot` | Current sensor values (RPM, MAP, TPS, CLT, AFR, …). Requires a live connection. |
+| `query_datalog` | Per-channel statistics, or the last rows, from the current session or a saved log. |
+
+Values come back in **raw ECU units**, not your display preferences — an
+external model has no display context, and a silently converted number would
+be worse than useless to something doing arithmetic on it.
+
+The assistant's `propose_*` tools are deliberately **not** exposed. A proposal
+only means something inside LibreTune's review queue, and an agent calling one
+of those names over MCP is refused rather than quietly ignored.
+
+## Connecting Claude Code
+
+```bash
+claude mcp add --transport http libretune http://127.0.0.1:8765/mcp \
+  --header "Authorization: Bearer TOKEN"
+```
+
+Replace `TOKEN` with the value from **Access token**. The settings section
+also renders this command with your current port filled in — click it to
+select, then copy.
+
+## Connecting Claude Desktop
+
+Claude Desktop's config UI cannot send static headers, so route it through the
+`mcp-remote` bridge (requires Node.js):
+
+```json
+{
+  "mcpServers": {
+    "libretune": {
+      "command": "npx",
+      "args": ["mcp-remote", "http://127.0.0.1:8765/mcp", "--allow-http",
+               "--transport", "http-only",
+               "--header", "Authorization:${AUTH_HEADER}"],
+      "env": { "AUTH_HEADER": "Bearer TOKEN" }
+    }
+  }
+}
+```
+
+The space after `Authorization:` belongs inside the environment variable, as
+written above — it works around an argument-escaping quirk in Claude Desktop.
+
+## Changing the port
+
+Set **Port** (minimum 1024) and click **Apply port**. The server restarts on
+the new port if it was running. If the port is already taken, the error
+appears under the controls and the server stays stopped — pick another one, or
+free the port (`lsof -i :8765` on macOS/Linux, `netstat -ano` on Windows).
+
+## Security
+
+- **Loopback only.** The listener binds `127.0.0.1`, never `0.0.0.0`.
+- **Constant-time token check.** The bearer token is compared without an early
+  exit, so its bytes cannot be recovered from response timing.
+- **Host and Origin validation.** Both are pinned to loopback forms, blocking
+  DNS-rebinding attacks from a browser page.
+- **No write surface.** There is no `apply`, no `burn`, and no `propose` tool
+  to call.
+
+A failed request gets a bare `401` with no body — it never echoes back what
+was sent.
+
+## Example session
+
+1. Open a project in LibreTune and enable the MCP server.
+2. Connect Claude Code with the command above.
+3. Ask it something that needs the tune:
+   - *"Read my VE table and tell me where the coverage is thin."*
+   - *"Summarize the tune health for veTable1."*
+   - *"What are the sensors reading right now?"*
+4. It calls `list_tables`, `read_table`, `summarize_tune_context`, and so on,
+   and answers from the real data.
+5. To act on the advice, make the change yourself — in the table editor, or by
+   asking the in-app [AI Assistant](./ai-assistant.md), which does have
+   propose tools and a review queue.
+
+## Troubleshooting
+
+| Problem | Likely cause / fix |
+|---------|-------------------|
+| Client reports 401 Unauthorized | The token was regenerated since the client was configured. Copy the current one from Settings. |
+| Server will not start | The port is in use. Pick another port, or free it. |
+| `get_realtime_snapshot` returns an error | No live ECU connection. Connect first. |
+| `read_table` says no INI definition is loaded | Open a project so a definition and tune are loaded. |
+| `query_datalog` finds no entries | Start datalogging, or name a saved log from the project's datalogs folder. |
+| Tools list is empty in the client | The client connected but the session dropped — reconnect. Check that LibreTune is still running with the toggle on. |

--- a/docs/src/getting-started/settings.md
+++ b/docs/src/getting-started/settings.md
@@ -346,6 +346,21 @@ Tiers are cumulative — each includes the previous one:
 - **Config — tune + propose constant changes** — constants and feature
   toggles; pin-affecting changes are flagged **Dangerous**.
 
+### MCP server (local)
+
+Exposes LibreTune's read-only tune tools to external MCP clients (Claude
+Code, Claude Desktop, …) on `127.0.0.1` only. Off by default, and it cannot
+change anything — see [MCP Server](../features/mcp-server.md).
+
+- **Expose tools over MCP** — starts/stops the server; the label shows the
+  bound address while it runs.
+- **Port** — minimum 1024, default 8765. **Apply port** restarts the server.
+- **Access token** — the bearer token every client must send. **Show**
+  reveals it; **Regenerate** invalidates the old one immediately.
+
+These three apply the moment you use them, not on **OK**, because each one
+binds or releases a real socket.
+
 ---
 
 ## AutoTune Settings


### PR DESCRIPTION
## Description

Adds a **local, read-only MCP (Model Context Protocol) server** to LibreTune. External MCP clients — Claude Code, Claude Desktop, any MCP-compatible agent — can connect over loopback HTTP and inspect the loaded tune using the same eight deterministic tools the in-app AI Assistant already uses.

This is a port of OpenTune's MCP server, retargeted onto LibreTune's `libretune_core::agent` tool catalogue.

**Off by default.** The server exposes no tool that can edit a tune, stage a proposal, or touch the ECU.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

None — self-contained feature.

## Changes Made

### Backend — `crates/libretune-app/src-tauri/src/mcp/`

- **`handler.rs`** — rmcp `ServerHandler`. Lists and dispatches only `agent::tools::is_read_tool` tools: `list_tables`, `read_table`, `read_constant`, `list_features`, `summarize_tune_context`, `tune_health_check`, `get_realtime_snapshot`, `query_datalog`.
- **`server.rs`** — axum loopback listener, bearer-auth middleware, and `start` / `stop` / `reconcile` lifecycle.
- **`token.rs`** — the per-install bearer token on disk.
- **`commands.rs`** — the Tauri command surface (`mcp_status`, `mcp_set_enabled`, `mcp_set_port`, `mcp_get_token`, `mcp_regenerate_token`) plus start-on-boot.
- **`tests.rs`** — 20 tests covering token lifecycle, constant-time compare, tool-list scope, dispatch, the reconcile matrix, and real HTTP auth.

### Frontend

- **`McpServerSection.tsx`** — new *Settings → AI Assistant → MCP server (local)* section: enable toggle with live status, port field, token show/regenerate, and a ready-to-copy `claude mcp add` command. Extracted into its own component rather than growing the already-1580-line `SettingsDialog.tsx` (which gains 3 lines).
- **`McpServerSection.test.tsx`** — 8 tests.

### Wiring

- `commands/agent.rs` — `LiveReadExecutor` becomes `pub(crate)` and gains a `new()` constructor; the existing call site now uses it, so there is one way to build it.
- `commands/app_settings.rs` — new `mcp_enabled` / `mcp_port` settings (default 8765, disabled).
- `lib.rs` — module registration, managed `McpServerState`, the five commands, and a `setup` hook that restarts the server if it was left enabled.
- `Cargo.toml` — `rmcp` 2.2 (`server`, `transport-streamable-http-server`), `axum` 0.8 (what rmcp 2.2 is tested against), `rand`; `reqwest` as a dev-dependency for the HTTP tests.

### Documentation

- New `docs/src/features/mcp-server.md`, linked from the AI Assistant page and from `getting-started/settings.md`; `README.md` and `AGENTS.md` updated; `CHANGELOG.md` entry.
- `public/manual/**` is the output of `node scripts/sync-manual.mjs`. **Note:** `toc.json` shows ~490 changed lines. Only one of them is mine (the new page) — the rest is the committed file catching up with what the sync script has been producing since the SUMMARY sections were restructured. `npm run dev` and `npm run build` both run `docs:sync`, so this file would have regenerated on any contributor's next build.

## Design notes worth a reviewer's attention

1. **Read-only is enforced twice.** The `propose_*` tools are withheld from `tools/list` *and* refused when called by name. Withholding alone guarantees nothing — a client can call any string it likes. A proposal is only meaningful inside LibreTune's review queue, and that queue is per-chat frontend state today, so exposing propose-over-MCP is deliberately deferred to a follow-up.

2. **The handler takes an `ExecutorFactory`, not an `AppHandle`.** Dispatch goes through the same `LiveReadExecutor` the in-app assistant uses, so the two tool surfaces cannot drift apart — and the whole module is testable with a stub executor, no `tauri::App` required.

3. **The MCP settings bypass `update_setting`.** Flipping the toggle or the port has to bind or release a real socket, which is async work the batch settings path cannot await. The dialog calls the MCP commands directly, and a failed bind rolls the persisted setting back — otherwise the app would keep believing MCP is on, retry the same doomed bind every launch, and render a checkbox that disagrees with the status line beside it.

4. **Raw ECU units over MCP.** The executor is built with `unit_prefs: None`. Display conversion is a human-facing concern; a silently °F-converted coolant reading would be worse than useless to a model doing arithmetic on it.

## Security

- **Loopback only** — binds `127.0.0.1`, never `0.0.0.0`.
- **Constant-time bearer compare** — `tokens_match` folds with xor and no early return, so the token's bytes cannot be recovered from response timing.
- **Host *and* Origin allow-lists pinned to loopback.** rmcp's `allowed_origins` default is an *empty list*, which skips Origin validation entirely — leaving it unset would silently turn the check off. Entries are portless on purpose: rmcp only compares the port when the allow-list entry names one, and the bound port is unpredictable when the configured port is `0`.
- **Token hygiene** — 64 hex chars in its own `mcp-token` file, written via temp-file + rename, `0600` on unix. Never in `settings.json`, never logged. Regenerating restarts a running server on the same port so the old token stops working immediately, rather than staying valid until the next restart.
- **No body on 401** — a rejected request is never told what it got wrong.

## Testing

- [x] I have tested these changes locally
- [x] New and existing tests pass (`cargo test`)
- [x] The UI works correctly with these changes

| Command | Result |
|---|---|
| `cargo test --workspace` | 0 failed — 20 new MCP tests |
| `npm run test:run` | 291 passed (43 files) — 8 new |
| `cargo clippy --workspace -- -D warnings` (the CI invocation) | clean |
| `cargo fmt --all --check` | clean |
| `npm run typecheck` | clean |

The HTTP tests bind an ephemeral port (`port: 0`) and read the real bound address back, so there are no fixed ports and no sleeps.

> `cargo clippy --workspace --all-targets` reports 11 pre-existing lints in `libretune-core` test and example targets (`ini/mod.rs`, `autotune/health.rs`, `examples/speeduino_test.rs`, …). None are in files this PR touches, and CI does not pass `--all-targets`. Left alone rather than mixed into this diff.

## Checklist

- [x] Code compiles without errors
- [x] No new clippy warnings (`cargo clippy`)
- [x] Code is formatted (`cargo fmt`)
- [x] TypeScript compiles without errors (`npx tsc --noEmit`)
- [x] Documentation updated if needed
- [x] Commit messages follow conventional format

## Screenshots

Not captured — the new UI is a settings section that needs a running app with a loaded project to show anything meaningful. Happy to add one if that helps review.

## Follow-up

Propose-over-MCP needs a backend proposal store plus a Tauri event so `AgentSidePanel` can pick up proposals that did not come from a chat turn. Tracked separately; the review queue stays the human gate either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
