### PR TITLE
test(a11y): axe-core smoke test for the App shell

### DIFF
--- a/crates/libretune-app/package-lock.json
+++ b/crates/libretune-app/package-lock.json
@@ -37,6 +37,7 @@
         "@types/react": "^18.2.8",
         "@types/react-dom": "^18.2.4",
         "@vitejs/plugin-react": "^4.6.0",
+        "axe-core": "^4.13.0",
         "jsdom": "^22.1.0",
         "typedoc": "^0.27.0",
         "typedoc-plugin-missing-exports": "^3.0.0",
@@ -2198,6 +2199,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.13.0.tgz",
+      "integrity": "sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/balanced-match": {

--- a/crates/libretune-app/package.json
+++ b/crates/libretune-app/package.json
@@ -57,6 +57,7 @@
     "@types/react": "^18.2.8",
     "@types/react-dom": "^18.2.4",
     "@vitejs/plugin-react": "^4.6.0",
+    "axe-core": "^4.13.0",
     "jsdom": "^22.1.0",
     "typedoc": "^0.27.0",
     "typedoc-plugin-missing-exports": "^3.0.0",

--- a/crates/libretune-app/src/__tests__/App.a11y.test.tsx
+++ b/crates/libretune-app/src/__tests__/App.a11y.test.tsx
@@ -1,0 +1,111 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import axe from 'axe-core';
+import { vi } from 'vitest';
+
+vi.mock('@tauri-apps/api/window', () => ({
+  getCurrentWindow: () => ({ setTitle: vi.fn().mockResolvedValue(undefined) }),
+}));
+
+import { LoadingProvider } from '../contexts/LoadingContext';
+import { ToastProvider } from '../contexts/ToastContext';
+import { UnitPreferencesProvider } from '../contexts/useUnitPreferences';
+import { invoke } from '@tauri-apps/api/core';
+import { setupTauriMocks, tearDownTauriMocks } from '../test-utils/tauriMocks';
+
+const CONNECTED = { state: 'Connected', has_definition: true, signature: 'TEST', ini_name: 'test.ini' };
+const DISCONNECTED = { state: 'Disconnected', has_definition: false };
+
+function mockBackend(connectionStatus: unknown) {
+  (invoke as unknown as ReturnType<typeof vi.fn>).mockImplementation((cmd: string) => {
+    switch (cmd) {
+      case 'list_repository_inis':
+      case 'list_projects':
+      case 'get_serial_ports':
+      case 'get_status_bar_defaults':
+      case 'get_available_channels':
+      case 'get_menu_tree':
+        return Promise.resolve([]);
+      case 'get_settings':
+        return Promise.resolve({ runtime_packet_mode: 'Auto', units_system: 'metric' });
+      case 'get_current_project':
+        return Promise.resolve(null);
+      case 'is_onboarding_completed':
+        return Promise.resolve(false);
+      case 'get_connection_status':
+        return Promise.resolve(connectionStatus);
+      case 'get_protocol_defaults':
+        return Promise.resolve({ default_baud_rate: 115200, timeout_ms: 2000 });
+      case 'get_searchable_index':
+        return Promise.resolve({});
+      default:
+        return Promise.resolve();
+    }
+  });
+}
+
+async function renderApp() {
+  const { default: App } = await import('../App');
+  return render(
+    <LoadingProvider>
+      <ToastProvider>
+        <UnitPreferencesProvider>
+          <App />
+        </UnitPreferencesProvider>
+      </ToastProvider>
+    </LoadingProvider>,
+  );
+}
+
+// `initializeApp` opens the onboarding dialog part-way through and hides the
+// loading overlay in its `finally`; waiting for both means axe scans the
+// settled DOM rather than the first synchronous render.
+async function waitForInitialized(container: HTMLElement) {
+  await screen.findByRole('dialog', {}, { timeout: 10_000 });
+  await waitFor(() => expect(container.querySelector('.loading-overlay')).toBeNull(), {
+    timeout: 10_000,
+  });
+}
+
+async function expectNoViolations(container: HTMLElement) {
+  const result = await axe.run(container, {
+    rules: {
+      // jsdom has no layout engine, so axe cannot compute contrast here.
+      // Contrast stays a manual check in a real browser.
+      'color-contrast': { enabled: false },
+    },
+  });
+  expect(result.violations.map(({ id, help, nodes }) => ({
+    id,
+    help,
+    targets: nodes.map((n) => n.target.join(' ')),
+  }))).toEqual([]);
+}
+
+describe('App accessibility smoke (axe-core)', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    setupTauriMocks({});
+  });
+
+  afterEach(() => {
+    tearDownTauriMocks();
+  });
+
+  it('has no automated violations while disconnected', async () => {
+    mockBackend(DISCONNECTED);
+    const { container } = await renderApp();
+    await waitForInitialized(container);
+    expect(container.querySelector('.packet-mode')?.textContent).toBe('—');
+
+    await expectNoViolations(container);
+  }, 15_000);
+
+  it('has no automated violations while connected', async () => {
+    mockBackend(CONNECTED);
+    const { container } = await renderApp();
+    await waitForInitialized(container);
+    await waitFor(() => expect(screen.getByText('Auto')).toBeInTheDocument(), { timeout: 10_000 });
+
+    await expectNoViolations(container);
+  }, 15_000);
+});

--- a/crates/libretune-app/src/components/common/Dialog.tsx
+++ b/crates/libretune-app/src/components/common/Dialog.tsx
@@ -15,7 +15,7 @@
  *   </Dialog>
  */
 
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useId, useRef } from 'react';
 import { X } from 'lucide-react';
 import './Dialog.css';
 
@@ -59,6 +59,7 @@ export function Dialog({
   ariaLabel,
 }: DialogProps) {
   const cardRef = useRef<HTMLDivElement>(null);
+  const titleId = useId();
 
   useEffect(() => {
     if (!open || !closeOnEscape) return;
@@ -83,11 +84,12 @@ export function Dialog({
         className={`lt-dialog lt-dialog--${size}${className ? ` ${className}` : ''}`}
         role="dialog"
         aria-modal="true"
-        aria-label={typeof title === 'string' ? title : ariaLabel}
+        aria-labelledby={title && !noHeader ? titleId : undefined}
+        aria-label={title && !noHeader ? undefined : ariaLabel}
       >
         {!noHeader && (title || !hideClose) && (
           <header className="lt-dialog__header">
-            <div className="lt-dialog__title">
+            <div className="lt-dialog__title" id={titleId}>
               {title}
               {titleAdornment}
             </div>

--- a/crates/libretune-app/src/components/tuner-ui/MenuBar.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/MenuBar.tsx
@@ -161,8 +161,8 @@ export function MenuBar({ items }: MenuBarProps) {
   const openItem = openMenuId ? items.find((item) => item.id === openMenuId) : undefined;
 
   return (
-    <div className="menubar" ref={menuBarRef} role="menubar">
-      <div className="menubar-items" onScroll={handleItemsScroll}>
+    <div className="menubar" ref={menuBarRef}>
+      <div className="menubar-items" onScroll={handleItemsScroll} role="menubar">
         {items.map((item, index) => {
           // Top-level separators render as a non-focusable vertical rule.
           if (item.separator) {
@@ -179,7 +179,7 @@ export function MenuBar({ items }: MenuBarProps) {
           const isOpen = openMenuId === item.id;
 
           return (
-            <div key={item.id} className="menubar-item-wrapper">
+            <div key={item.id} className="menubar-item-wrapper" role="none">
               <button
                 ref={(el) => {
                   itemRefs.current[item.id] = el;


### PR DESCRIPTION
## Summary

Adds an automated accessibility smoke test: mount the whole `App` (disconnected and connected, Tauri mocked the same way as `App.integration.test.tsx`) and assert zero [axe-core](https://github.com/dequelabs/axe-core) violations once `initializeApp` has settled. `color-contrast` is disabled because jsdom has no layout engine; contrast stays a manual check in a real browser.

The test immediately found two real violations, fixed in the same PR so it lands green:

- **`Dialog`**: `role="dialog"` only got an `aria-label` when `title` was a string, so every dialog with a ReactNode title (e.g. the onboarding dialog) had no accessible name. Now labelled via `aria-labelledby` → the title element (`useId`), falling back to `ariaLabel` when there is no header.
- **`MenuBar`**: `role="menubar"` sat on the outer wrapper whose only child was a role-less `div`, failing `aria-required-children`. Moved the role onto `.menubar-items` and marked the per-item wrappers `role="none"`. Ref-based positioning and keyboard handling are unchanged (they never queried roles).

New dev dependency: `axe-core` (test-only).

## Test plan

- [x] `npx vitest run` — 43 files / 289 tests pass (287 existing + 2 new)
- [x] `npx tsc --noEmit` clean
- [x] New test run 3× in a row, no flakes
- [ ] CI green on Linux / Windows / macOS
