### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -15,12 +15,13 @@ runs:
   using: composite
   steps:
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
       with:
+        toolchain: stable
         components: ${{ inputs.components }}
 
     - name: Cache Rust build
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       with:
         shared-key: ${{ inputs.cache_key }}
         cache-targets: "true"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# Keeps the SHA-pinned actions current; without this, pins rot.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    # `/` covers .github/workflows only; nested composite actions need their
+    # own entry (dependabot/dependabot-core#6345).
+    directories:
+      - /
+      - /.github/actions/setup-rust
+      - /.github/actions/setup-linux-deps
+      - /.github/actions/collect-tauri-artifacts
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
+          toolchain: stable
           components: rustfmt
 
       - name: Check formatting
@@ -34,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 35
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - uses: ./.github/actions/setup-rust
         with:
@@ -57,7 +58,7 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 35
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - uses: ./.github/actions/setup-rust
         with:
@@ -71,7 +72,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 35
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - uses: ./.github/actions/setup-rust
         with:
@@ -88,10 +89,10 @@ jobs:
       run:
         working-directory: crates/libretune-app
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: "24"
           cache: npm
@@ -114,12 +115,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
+        with:
+          toolchain: stable
 
       - name: Install cargo-audit
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@e67fa11c4b9316fa714ddf0abed07a0c3143b95b # v2.87.4
         with:
           tool: cargo-audit
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -25,7 +25,7 @@ jobs:
       has_changes: ${{ steps.check.outputs.has_changes }}
       date_stamp: ${{ steps.date.outputs.date }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           fetch-depth: 0
 
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 35
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - uses: ./.github/actions/setup-rust
         with:
@@ -68,7 +68,7 @@ jobs:
         run: cargo clippy --workspace -- -D warnings
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: "24"
           cache: npm
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - uses: ./.github/actions/setup-rust
         with:
@@ -95,7 +95,7 @@ jobs:
       - uses: ./.github/actions/setup-linux-deps
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: "24"
           cache: npm
@@ -122,7 +122,7 @@ jobs:
           dest: crates/libretune-app/artifacts/linux
 
       - name: Upload Linux artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: linux-x86_64-${{ needs.check-changes.outputs.date_stamp }}
           path: crates/libretune-app/artifacts/linux/*
@@ -135,14 +135,14 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - uses: ./.github/actions/setup-rust
         with:
           cache_key: nightly-windows
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: "24"
           cache: npm
@@ -162,7 +162,7 @@ jobs:
           dest: crates/libretune-app/artifacts/windows
 
       - name: Upload Windows artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: windows-x86_64-${{ needs.check-changes.outputs.date_stamp }}
           path: crates/libretune-app/artifacts/windows/*
@@ -175,14 +175,14 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - uses: ./.github/actions/setup-rust
         with:
           cache_key: nightly-macos
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: "24"
           cache: npm
@@ -218,7 +218,7 @@ jobs:
           dest: crates/libretune-app/artifacts/macos
 
       - name: Upload macOS artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: macos-aarch64-x86_64-${{ needs.check-changes.outputs.date_stamp }}
           path: crates/libretune-app/artifacts/macos/*
@@ -232,7 +232,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           path: artifacts
           pattern: "*"
@@ -271,7 +271,7 @@ jobs:
           fi
 
       - name: Create/Update Nightly Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: nightly
           name: Nightly Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     outputs:
       tag_name: ${{ steps.get_version.outputs.VERSION || 'manual' }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Get version from tag
         id: get_version
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - uses: ./.github/actions/setup-rust
         with:
@@ -46,7 +46,7 @@ jobs:
       - uses: ./.github/actions/setup-linux-deps
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: "24"
           cache: npm
@@ -66,7 +66,7 @@ jobs:
           dest: crates/libretune-app/artifacts/linux
 
       - name: Upload Linux artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: linux-x86_64
           path: crates/libretune-app/artifacts/linux/*
@@ -79,14 +79,14 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - uses: ./.github/actions/setup-rust
         with:
           cache_key: release-windows
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: "24"
           cache: npm
@@ -106,7 +106,7 @@ jobs:
           dest: crates/libretune-app/artifacts/windows
 
       - name: Upload Windows artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: windows-x86_64
           path: crates/libretune-app/artifacts/windows/*
@@ -119,14 +119,14 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - uses: ./.github/actions/setup-rust
         with:
           cache_key: release-macos
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: "24"
           cache: npm
@@ -155,7 +155,7 @@ jobs:
           dest: crates/libretune-app/artifacts/macos
 
       - name: Upload macOS artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: macos-aarch64-x86_64
           path: crates/libretune-app/artifacts/macos/*
@@ -169,7 +169,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           path: artifacts
           pattern: "*"
@@ -186,7 +186,7 @@ jobs:
 
       - name: Create Release (only for tags)
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
           name: Release ${{ steps.tag.outputs.tag }}
@@ -203,7 +203,7 @@ jobs:
 
       - name: Upload artifacts (manual build)
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: build-artifacts
           path: artifacts/**


### PR DESCRIPTION
## Summary

Every external action in `.github/` was referenced by a mutable tag (`@v5`, `@v2`, `@stable`). A compromised or force-pushed tag would run arbitrary code in CI with `contents: write` (see the tj-actions/changed-files incident). This pins each action to the commit its tag resolves to today, keeping the version as a trailing comment:

| Action | Pinned |
|---|---|
| actions/checkout | v5.1.0 |
| actions/setup-node | v5.0.0 |
| actions/upload-artifact / download-artifact | v6.0.0 |
| softprops/action-gh-release | v2.6.2 |
| Swatinem/rust-cache | v2.9.2 |
| taiki-e/install-action | v2.87.4 |
| dtolnay/rust-toolchain | `master` head |

`dtolnay/rust-toolchain` infers the toolchain from the ref name, which a SHA no longer carries, so the three call sites now pass `with: toolchain: stable` explicitly. Its README requires SHA pins to come from `master` history (the `@stable` ref is a generated commit that may be garbage-collected), hence the `master` head rather than the `stable` commit. Behaviour is otherwise unchanged.

Also adds `.github/dependabot.yml` for the `github-actions` ecosystem (weekly, one grouped PR) so the pins do not rot. `directory: /` only covers `.github/workflows`, so the three composite actions get their own entries.

## Test plan

- [x] All YAML files parse
- [x] Every SHA cross-checked against the tag/release page (independent review caught a wrong `taiki-e` comment and the `dtolnay` history issue; both fixed)
- [x] No unpinned external `uses:` left
- [ ] CI green (exercises every pinned action except the release/nightly ones)
