### PR TITLE
ci(nightly): open an issue when the nightly build fails

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -307,3 +307,26 @@ jobs:
           fail_on_unmatched_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # A red cron run notifies nobody by itself; file (at most) one open issue
+  # pointing at the failed run.
+  notify-failure:
+    name: Open issue on failure
+    needs: [check-changes, test, build-linux, build-windows, build-macos, upload-nightly]
+    if: failure()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      issues: write
+    steps:
+      - name: Open a nightly-failure issue unless one is already open
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          open_count="$(gh issue list --repo "$GITHUB_REPOSITORY" --state open \
+            --search 'Nightly build failed in:title' --json number --jq length)"
+          if [ "$open_count" -eq 0 ]; then
+            gh issue create --repo "$GITHUB_REPOSITORY" \
+              --title 'Nightly build failed' \
+              --body "Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          fi


### PR DESCRIPTION
## Summary

A red cron run currently notifies nobody: there is no PR, no push author, and GitHub's failure e-mail only goes to whoever last touched the workflow file. This adds a final `notify-failure` job to `nightly.yml` that runs when any upstream job fails and files one **"Nightly build failed"** issue linking the run, unless such an issue is already open.

- `if: failure()` on a job that `needs` every other job: fires on any failure, is *skipped* (not failed) on a quiet night where `check-changes` gates everything off.
- Job-level `permissions: issues: write` drops the workflow's `contents: write` for this job only.
- Dedup via `gh issue list --search 'Nightly build failed in:title'`, so a week of red nights is one issue, not seven.

## Test plan

- [x] YAML parses, job graph: `notify-failure` needs all six existing jobs
- [x] Shell body passes `bash -n`
- [ ] First real failed nightly opens exactly one issue (cannot be exercised from a fork PR)
