### PR TITLE
feat(app): signed in-app updater

### DIFF
--- a/.github/actions/collect-tauri-artifacts/action.yml
+++ b/.github/actions/collect-tauri-artifacts/action.yml
@@ -59,14 +59,19 @@ runs:
           linux)
             for root in "${SEARCH_ROOTS[@]}"; do
               copy_glob "$root/*/release/bundle/appimage/*.AppImage"
+              copy_glob "$root/*/release/bundle/appimage/*.AppImage.sig"
               copy_glob "$root/*/release/bundle/deb/*.deb"
+              copy_glob "$root/*/release/bundle/deb/*.deb.sig"
               copy_glob "$root/*/release/bundle/rpm/*.rpm"
+              copy_glob "$root/*/release/bundle/rpm/*.rpm.sig"
             done
             ;;
           windows)
             for root in "${SEARCH_ROOTS[@]}"; do
               copy_glob "$root/*/release/bundle/nsis/*.exe"
+              copy_glob "$root/*/release/bundle/nsis/*.exe.sig"
               copy_glob "$root/*/release/bundle/msi/*.msi"
+              copy_glob "$root/*/release/bundle/msi/*.msi.sig"
               # Portable / --no-bundle builds
               if [ -f "$root/x86_64-pc-windows-msvc/release/libretune-app.exe" ]; then
                 cp "$root/x86_64-pc-windows-msvc/release/libretune-app.exe" \
@@ -79,6 +84,17 @@ runs:
           macos)
             for root in "${SEARCH_ROOTS[@]}"; do
               copy_glob "$root/*/release/bundle/dmg/*.dmg"
+              # Updater archive (+ signature) emitted when createUpdaterArtifacts
+              # is on; same file name for both arches, so suffix the triple.
+              shopt -s nullglob
+              tars=("$root"/*/release/bundle/macos/*.app.tar.gz)
+              shopt -u nullglob
+              for tar in "${tars[@]+"${tars[@]}"}"; do
+                triple="$(basename "$(dirname "$(dirname "$(dirname "$(dirname "$tar")")")")")"
+                base="$(basename "$tar" .app.tar.gz)"
+                copy_glob "$tar" "${base}_${triple}.app.tar.gz"
+                copy_glob "$tar.sig" "${base}_${triple}.app.tar.gz.sig"
+              done
               shopt -s nullglob
               apps=("$root"/*/release/bundle/macos/*.app)
               shopt -u nullglob

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,10 @@ jobs:
     timeout-minutes: 5
     outputs:
       tag_name: ${{ steps.get_version.outputs.VERSION || 'manual' }}
+      # JSON merged into tauri.conf.json by `tauri build --config` (RFC 7396).
+      # Tag builds stamp the version from the tag and produce signed updater
+      # artifacts; manual runs build exactly what is in the repo, unsigned.
+      tauri_config: ${{ steps.get_version.outputs.TAURI_CONFIG || '{}' }}
     steps:
       - uses: actions/checkout@v5
 
@@ -30,6 +34,23 @@ jobs:
         run: |
           VERSION=${GITHUB_REF#refs/tags/}
           echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+          SEMVER=${VERSION#v}
+          echo "TAURI_CONFIG={\"version\":\"$SEMVER\",\"bundle\":{\"createUpdaterArtifacts\":true}}" >> "$GITHUB_OUTPUT"
+
+      - name: Require updater signing key for tagged releases
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+        run: |
+          pubkey="$(jq -r '.plugins.updater.pubkey' crates/libretune-app/src-tauri/tauri.conf.json)"
+          if [ -z "$pubkey" ]; then
+            echo "::error::plugins.updater.pubkey in tauri.conf.json is empty; see CONTRIBUTING.md → Release Builds"
+            exit 1
+          fi
+          if [ -z "$TAURI_SIGNING_PRIVATE_KEY" ]; then
+            echo "::error::TAURI_SIGNING_PRIVATE_KEY secret is not set; see CONTRIBUTING.md → Release Builds"
+            exit 1
+          fi
 
   build-linux:
     name: Build Linux
@@ -58,7 +79,10 @@ jobs:
 
       - name: Build Tauri app (Linux)
         working-directory: crates/libretune-app
-        run: npx tauri build --target x86_64-unknown-linux-gnu
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ startsWith(github.ref, 'refs/tags/') && secrets.TAURI_SIGNING_PRIVATE_KEY || '' }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ startsWith(github.ref, 'refs/tags/') && secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD || '' }}
+        run: npx tauri build --target x86_64-unknown-linux-gnu --config '${{ needs.create-release.outputs.tauri_config }}'
 
       - uses: ./.github/actions/collect-tauri-artifacts
         with:
@@ -98,7 +122,10 @@ jobs:
 
       - name: Build Tauri app (Windows)
         working-directory: crates/libretune-app
-        run: npx tauri build --target x86_64-pc-windows-msvc
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ startsWith(github.ref, 'refs/tags/') && secrets.TAURI_SIGNING_PRIVATE_KEY || '' }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ startsWith(github.ref, 'refs/tags/') && secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD || '' }}
+        run: npx tauri build --target x86_64-pc-windows-msvc --config '${{ needs.create-release.outputs.tauri_config }}'
 
       - uses: ./.github/actions/collect-tauri-artifacts
         with:
@@ -143,11 +170,17 @@ jobs:
 
       - name: Build Tauri app (macOS ARM)
         working-directory: crates/libretune-app
-        run: npx tauri build --target aarch64-apple-darwin
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ startsWith(github.ref, 'refs/tags/') && secrets.TAURI_SIGNING_PRIVATE_KEY || '' }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ startsWith(github.ref, 'refs/tags/') && secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD || '' }}
+        run: npx tauri build --target aarch64-apple-darwin --config '${{ needs.create-release.outputs.tauri_config }}'
 
       - name: Build Tauri app (macOS Intel)
         working-directory: crates/libretune-app
-        run: npx tauri build --target x86_64-apple-darwin
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ startsWith(github.ref, 'refs/tags/') && secrets.TAURI_SIGNING_PRIVATE_KEY || '' }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ startsWith(github.ref, 'refs/tags/') && secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD || '' }}
+        run: npx tauri build --target x86_64-apple-darwin --config '${{ needs.create-release.outputs.tauri_config }}'
 
       - uses: ./.github/actions/collect-tauri-artifacts
         with:
@@ -168,12 +201,78 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      - uses: actions/checkout@v5
+
       - name: Download all artifacts
         uses: actions/download-artifact@v6
         with:
           path: artifacts
           pattern: "*"
           merge-multiple: false
+
+      # The in-app updater reads releases/latest/download/latest.json. Build it
+      # from the .sig files the bundler emitted, and refuse to publish unless
+      # every platform's signature verifies against the public key the app
+      # ships with — a wrong key would otherwise only surface on users' machines.
+      - name: Build and verify updater manifest
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          TAG: ${{ needs.create-release.outputs.tag_name }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          sudo apt-get update -q && sudo apt-get install -y -q minisign
+          jq -r '.plugins.updater.pubkey' crates/libretune-app/src-tauri/tauri.conf.json \
+            | base64 -d > updater.pub
+
+          one() { # one <glob> → exactly one match or fail
+            local m=( $1 )
+            [ "${#m[@]}" -eq 1 ] || { echo "::error::expected one file for $1, got ${#m[@]}: ${m[*]:-none}"; exit 1; }
+            echo "${m[0]}"
+          }
+          # Verify one artifact and append its manifest entry. Runs as a plain
+          # top-level command so `set -e` sees every failure (a process
+          # substitution would not propagate one).
+          entry() { # entry <platform-key> <artifact>
+            local sig="$2.sig"
+            [ -f "$sig" ] || { echo "::error::missing signature $sig"; exit 1; }
+            base64 -d "$sig" > /tmp/sig.minisig
+            minisign -Vq -p updater.pub -x /tmp/sig.minisig -m "$2" \
+              || { echo "::error::signature of $2 does not verify against plugins.updater.pubkey"; exit 1; }
+            jq -n --arg k "$1" --arg sig "$(cat "$sig")" \
+              --arg url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/download/${TAG}/$(basename "$2")" \
+              '{($k): {signature: $sig, url: $url}}' >> /tmp/platforms.jsonl
+          }
+
+          appimage="$(one 'artifacts/linux-x86_64/*.AppImage')"
+          deb="$(one 'artifacts/linux-x86_64/*.deb')"
+          nsis="$(one 'artifacts/windows-x86_64/*-setup.exe')"
+          msi="$(one 'artifacts/windows-x86_64/*.msi')"
+          mac_arm="$(one 'artifacts/macos-aarch64-x86_64/*_aarch64-apple-darwin.app.tar.gz')"
+          mac_x64="$(one 'artifacts/macos-aarch64-x86_64/*_x86_64-apple-darwin.app.tar.gz')"
+
+          # The plugin looks up "<target>-<arch>-<installer>" first and falls
+          # back to "<target>-<arch>", so a .deb install must not be handed an
+          # AppImage. Generic keys point at the documented default installer.
+          : > /tmp/platforms.jsonl
+          entry linux-x86_64-appimage "$appimage"
+          entry linux-x86_64-deb      "$deb"
+          entry linux-x86_64          "$appimage"
+          entry windows-x86_64-nsis   "$nsis"
+          entry windows-x86_64-msi    "$msi"
+          entry windows-x86_64        "$nsis"
+          entry darwin-aarch64        "$mac_arm"
+          entry darwin-x86_64         "$mac_x64"
+          [ "$(wc -l < /tmp/platforms.jsonl)" -eq 8 ] || { echo "::error::expected 8 platform entries"; exit 1; }
+
+          mkdir -p artifacts/updater
+          jq -n --arg version "${TAG#v}" --arg date "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --arg notes "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/tag/${TAG}" \
+            --slurpfile p /tmp/platforms.jsonl \
+            '{version: $version, pub_date: $date, notes: $notes, platforms: ($p | add)}' \
+            > artifacts/updater/latest.json
+          jq -e '.platforms | length == 8' artifacts/updater/latest.json > /dev/null
+          cat artifacts/updater/latest.json
 
       - name: Get tag name
         id: tag
@@ -194,6 +293,7 @@ jobs:
             artifacts/linux-x86_64/**/*
             artifacts/windows-x86_64/**/*
             artifacts/macos-aarch64-x86_64/**/*
+            artifacts/updater/latest.json
           draft: false
           prerelease: false
           generate_release_notes: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@ relevant.
 
 ## [Unreleased]
 
+### 2026-09-02 — Signed in-app updater
+
+#### Added
+
+- In-app updater: one non-blocking check after startup, a toast when a newer
+  signed release exists, and **Check for updates** / **Install and restart**
+  in Help → About LibreTune. Updates are minisign-verified against a public
+  key built into the app; an unverifiable download is refused.
+- Tagged releases now emit updater artifacts and `latest.json`; the release
+  workflow verifies every signature against the committed public key before
+  publishing, and stamps the version from the tag. Maintainer key setup is
+  documented in CONTRIBUTING.md → Release Builds.
+
 ### 2026-08-28 — AutoTune second-table picker & table trace line (issue #132 follow-ups)
 
 Two reports from the issue #132 thread after the Aug 20 fixes: a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -254,7 +254,29 @@ The build ID is displayed in the **About** dialog for bug reporting and is verif
 
 ### Release Builds
 
-For release builds, increment `version` in `tauri.conf.json` (e.g., `0.2.0`) and create a git tag matching the version.
+Push a tag `vX.Y.Z`. The release workflow stamps `X.Y.Z` into `tauri.conf.json`
+via `tauri build --config`, so the version in the repo can stay at the nightly
+placeholder; you only need to bump it when you want local builds to report it.
+
+Tagged releases also produce **signed updater artifacts** that the in-app
+updater (`Help → About LibreTune`) installs. The workflow refuses to run
+without the signing key, so a maintainer sets it up once:
+
+```bash
+# 1. Generate a key pair. Keep the private key OUT of the repo and backed up:
+#    losing it means existing installs can never be updated again.
+cd crates/libretune-app && npx tauri signer generate -w ~/.tauri/libretune.key
+```
+
+2. Paste the printed **public** key into `plugins.updater.pubkey` in
+   `crates/libretune-app/src-tauri/tauri.conf.json` and commit it.
+3. Add two repository secrets: `TAURI_SIGNING_PRIVATE_KEY` (contents of
+   `~/.tauri/libretune.key`) and `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` (the
+   password you chose, empty if none).
+
+The upload job rebuilds `latest.json` from the emitted `.sig` files and
+verifies every signature against the committed public key before publishing,
+so a key mismatch fails the release instead of surfacing on users' machines.
 
 ## Reporting Issues
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,9 @@ name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "async-broadcast"
@@ -888,6 +891,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -965,7 +979,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1171,7 +1185,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1224,6 +1238,16 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -1933,9 +1957,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2419,6 +2445,8 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
+ "tauri-plugin-process",
+ "tauri-plugin-updater",
  "tauri-plugin-window-state",
  "tempfile",
  "tokio",
@@ -2648,6 +2676,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2802,7 +2836,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3004,6 +3038,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3085,6 +3131,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3098,6 +3150,20 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3904,15 +3970,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3993,7 +4064,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4011,6 +4082,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.6.0",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4019,6 +4102,33 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework 3.6.0",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -4050,6 +4160,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4611,6 +4730,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4672,6 +4812,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -4880,6 +5031,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
+]
+
+[[package]]
+name = "tauri-plugin-updater"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b28d8cabdeb0564f03ae261963de4bc3d98321cd3d213e76a81b7d344e5df606"
+dependencies = [
+ "base64 0.22.1",
+ "dirs 6.0.0",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest 0.13.2",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
+]
+
+[[package]]
 name = "tauri-plugin-window-state"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5005,7 +5199,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6178,6 +6372,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6256,7 +6459,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6381,6 +6584,17 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -6948,6 +7162,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7115,6 +7339,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.14.0",
+ "memchr",
 ]
 
 [[package]]

--- a/crates/libretune-app/package-lock.json
+++ b/crates/libretune-app/package-lock.json
@@ -16,6 +16,8 @@
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-dialog": "^2.6.0",
         "@tauri-apps/plugin-opener": "^2",
+        "@tauri-apps/plugin-process": "^2.3.1",
+        "@tauri-apps/plugin-updater": "^2.11.0",
         "@types/three": "^0.182.0",
         "framer-motion": "^12.23.26",
         "i18next": "^23.16.8",
@@ -1361,9 +1363,9 @@
       "license": "MIT"
     },
     "node_modules/@tauri-apps/api": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.10.1.tgz",
-      "integrity": "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.11.1.tgz",
+      "integrity": "sha512-M2FPuYND2m+wh5hfW9ZpSdxMPdEJovPBWwoHJmwUpysTYNHaOkVFN419m/K0LIgjb/7KU2vBgsUepJWugQCvAA==",
       "license": "Apache-2.0 OR MIT",
       "funding": {
         "type": "opencollective",
@@ -1590,6 +1592,24 @@
       "integrity": "sha512-ei/yRRoCklWHImwpCcDK3VhNXx+QXM9793aQ64YxpqVF0BDuuIlXhZgiAkc15wnPVav+IbkYhmDJIv5R326Mew==",
       "dependencies": {
         "@tauri-apps/api": "^2.8.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-process": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-process/-/plugin-process-2.3.1.tgz",
+      "integrity": "sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-updater": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-updater/-/plugin-updater-2.11.0.tgz",
+      "integrity": "sha512-AE36XkOoSna24G40jZMY15nzAnkXEPL/73tGoseGrtGOHuI/cZwWzHpZFLjKXDPgzYZ435z1gHu28LgrsBwIxQ==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.11.0"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/crates/libretune-app/package.json
+++ b/crates/libretune-app/package.json
@@ -36,6 +36,8 @@
     "@tauri-apps/api": "^2.10.1",
     "@tauri-apps/plugin-dialog": "^2.6.0",
     "@tauri-apps/plugin-opener": "^2",
+    "@tauri-apps/plugin-process": "^2.3.1",
+    "@tauri-apps/plugin-updater": "^2.11.0",
     "@types/three": "^0.182.0",
     "framer-motion": "^12.23.26",
     "i18next": "^23.16.8",

--- a/crates/libretune-app/src-tauri/Cargo.toml
+++ b/crates/libretune-app/src-tauri/Cargo.toml
@@ -29,6 +29,8 @@ async-trait = { workspace = true }
 dirs = "5"
 tokio = { workspace = true }
 tauri-plugin-dialog = "2"
+tauri-plugin-updater = "2"
+tauri-plugin-process = "2"
 chrono = { workspace = true }
 byteorder = "1"
 tracing = { workspace = true }

--- a/crates/libretune-app/src-tauri/capabilities/default.json
+++ b/crates/libretune-app/src-tauri/capabilities/default.json
@@ -9,6 +9,8 @@
     "core:default",
     "opener:default",
     "dialog:default",
+    "updater:default",
+    "process:allow-restart",
     "core:window:allow-create",
     "core:webview:allow-create-webview-window",
     "core:window:allow-close",

--- a/crates/libretune-app/src-tauri/src/lib.rs
+++ b/crates/libretune-app/src-tauri/src/lib.rs
@@ -210,6 +210,8 @@ pub fn run() {
         .plugin(tauri_plugin_window_state::Builder::default().build())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_updater::Builder::new().build())
+        .plugin(tauri_plugin_process::init())
         .manage(AppState {
             connection: Mutex::new(None),
             connection_transition: Mutex::new(()),

--- a/crates/libretune-app/src-tauri/tauri.conf.json
+++ b/crates/libretune-app/src-tauri/tauri.conf.json
@@ -58,5 +58,13 @@
         "installerIcon": "icons/icon.ico"
       }
     }
+  },
+  "plugins": {
+    "updater": {
+      "pubkey": "",
+      "endpoints": [
+        "https://github.com/RallyPat/LibreTune/releases/latest/download/latest.json"
+      ]
+    }
   }
 }

--- a/crates/libretune-app/src/App.tsx
+++ b/crates/libretune-app/src/App.tsx
@@ -25,6 +25,7 @@ import { BaseMapResult } from "./components/dialogs/BaseMapDialog";
 import { useErrorDialog } from "./components/dialogs/ErrorDetailsDialog";
 import ErrorBoundary from "./components/common/ErrorBoundary";
 import { DialogOverlays } from "./components/DialogOverlays";
+import { checkForUpdateQuietly } from "./components/tuner-ui/dialogs/UpdateSection";
 import { useBackendEventListeners } from "./hooks/useBackendEventListeners";
 import { useRealtimeStream } from "./hooks/useRealtimeStream";
 import { useTabPopout } from "./hooks/useTabPopout";
@@ -122,6 +123,20 @@ function AppContent() {
   const { showLoading, hideLoading } = useLoading();
   const { showToast } = useToast();
   const { isOpen: errorDialogOpen, errorInfo, showError, hideError } = useErrorDialog();
+
+  // Startup update check: one non-blocking request, one toast if a newer
+  // signed release exists. Install happens from Help → About LibreTune.
+  useEffect(() => {
+    let active = true;
+    void checkForUpdateQuietly().then((version) => {
+      if (active && version) {
+        showToast(`LibreTune ${version} is available — Help → About LibreTune to install.`, "info", 10000);
+      }
+    });
+    return () => {
+      active = false;
+    };
+  }, [showToast]);
 
   // Project state
   const [currentProject, setCurrentProject] = useState<CurrentProject | null>(null);

--- a/crates/libretune-app/src/components/tuner-ui/Dialogs.css
+++ b/crates/libretune-app/src/components/tuner-ui/Dialogs.css
@@ -562,6 +562,33 @@
   margin-bottom: 16px !important;
 }
 
+.dialog-update {
+  margin: 0.75rem 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.dialog-update p {
+  margin: 0;
+}
+
+.dialog-update-notes {
+  white-space: pre-wrap;
+  font-size: 0.85em;
+  opacity: 0.85;
+}
+
+.dialog-update-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.dialog-update-error {
+  color: var(--error);
+}
+
 .dialog-about-links {
   display: flex;
   justify-content: center;

--- a/crates/libretune-app/src/components/tuner-ui/dialogs/AboutDialog.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/dialogs/AboutDialog.tsx
@@ -4,6 +4,7 @@ import { invoke } from '@tauri-apps/api/core';
 import { openUrl } from '@tauri-apps/plugin-opener';
 import { Dialog, Button } from '../../common';
 import { DialogProps, BuildInfo } from './types';
+import { UpdateSection } from './UpdateSection';
 import '../Dialogs.css';
 
 export function AboutDialog({ isOpen, onClose }: DialogProps) {
@@ -32,6 +33,8 @@ export function AboutDialog({ isOpen, onClose }: DialogProps) {
         <p className="dialog-build">
           Build {buildInfo?.build_id ?? 'unknown'}
         </p>
+
+        <UpdateSection />
 
         <p>Open-source ECU tuning software compatible with standard INI definition files.</p>
 

--- a/crates/libretune-app/src/components/tuner-ui/dialogs/UpdateSection.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/dialogs/UpdateSection.tsx
@@ -1,0 +1,135 @@
+import { useCallback, useEffect, useState } from 'react';
+import { check, type Update } from '@tauri-apps/plugin-updater';
+import { relaunch } from '@tauri-apps/plugin-process';
+import { Button } from '../../common';
+
+type UpdateState =
+  | { kind: 'checking' }
+  | { kind: 'idle'; checked: boolean }
+  | { kind: 'available'; update: Update }
+  | { kind: 'installing'; update: Update }
+  | { kind: 'error'; message: string };
+
+async function requestUpdate(): Promise<UpdateState> {
+  try {
+    const update = await check();
+    return update ? { kind: 'available', update } : { kind: 'idle', checked: true };
+  } catch (e) {
+    return { kind: 'error', message: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+/**
+ * Fire-and-forget startup check. Resolves to the available version, or null
+ * when there is none or the check failed (offline, no release yet). Never
+ * throws, never blocks anything. The plugin-side resource is released here;
+ * installing goes through the About dialog, which runs its own check.
+ */
+export async function checkForUpdateQuietly(): Promise<string | null> {
+  const state = await requestUpdate();
+  if (state.kind !== 'available') return null;
+  const { version } = state.update;
+  await state.update.close().catch(() => undefined);
+  return version;
+}
+
+/** Every non-null `check()` holds a Tauri resource until closed. */
+function discard(state: UpdateState) {
+  if (state.kind === 'available' || state.kind === 'installing') {
+    void state.update.close().catch(() => undefined);
+  }
+}
+
+/** "Check for updates" block shown in the About dialog. */
+export function UpdateSection() {
+  const [state, setState] = useState<UpdateState>({ kind: 'idle', checked: false });
+
+  const checkNow = useCallback(async () => {
+    setState((prev) => {
+      discard(prev);
+      return { kind: 'checking' };
+    });
+    setState(await requestUpdate());
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+    setState({ kind: 'checking' });
+    void requestUpdate().then((next) => {
+      if (active) setState(next);
+      else discard(next);
+    });
+    return () => {
+      active = false;
+      setState((prev) => {
+        discard(prev);
+        return prev;
+      });
+    };
+  }, []);
+
+  const install = async (update: Update) => {
+    setState({ kind: 'installing', update });
+    try {
+      await update.downloadAndInstall();
+      await relaunch();
+    } catch (e) {
+      setState({ kind: 'error', message: e instanceof Error ? e.message : String(e) });
+    }
+  };
+
+  if (state.kind === 'available' || state.kind === 'installing') {
+    const { update } = state;
+    const installing = state.kind === 'installing';
+    return (
+      <section className="dialog-update" role="status">
+        <p>
+          Version <strong>{update.version}</strong> is available.
+        </p>
+        {update.body && <p className="dialog-update-notes">{update.body}</p>}
+        <div className="dialog-update-actions">
+          <Button
+            variant="primary"
+            size="sm"
+            disabled={installing}
+            aria-busy={installing}
+            onClick={() => void install(update)}
+          >
+            {installing ? 'Installing…' : 'Install and restart'}
+          </Button>
+          <Button
+            size="sm"
+            disabled={installing}
+            onClick={() => {
+              discard(state);
+              setState({ kind: 'idle', checked: false });
+            }}
+          >
+            Later
+          </Button>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="dialog-update" aria-label="Application updates">
+      {state.kind === 'error' && (
+        <p className="dialog-update-error" role="alert">
+          Update check failed: {state.message}
+        </p>
+      )}
+      {state.kind === 'idle' && state.checked && (
+        <p role="status">LibreTune is up to date.</p>
+      )}
+      <Button
+        size="sm"
+        disabled={state.kind === 'checking'}
+        aria-busy={state.kind === 'checking'}
+        onClick={() => void checkNow()}
+      >
+        {state.kind === 'checking' ? 'Checking…' : 'Check for updates'}
+      </Button>
+    </section>
+  );
+}

--- a/crates/libretune-app/src/components/tuner-ui/dialogs/__tests__/UpdateSection.test.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/dialogs/__tests__/UpdateSection.test.tsx
@@ -1,0 +1,102 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+import { check } from '@tauri-apps/plugin-updater';
+import { relaunch } from '@tauri-apps/plugin-process';
+import { UpdateSection, checkForUpdateQuietly } from '../UpdateSection';
+
+vi.mock('@tauri-apps/plugin-updater', () => ({ check: vi.fn() }));
+vi.mock('@tauri-apps/plugin-process', () => ({ relaunch: vi.fn() }));
+
+function availableUpdate() {
+  return {
+    version: '0.2.0',
+    body: 'Faster table editing',
+    downloadAndInstall: vi.fn(async () => undefined),
+    close: vi.fn(async () => undefined),
+  };
+}
+
+describe('UpdateSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(relaunch).mockResolvedValue(undefined);
+  });
+
+  it('reports up to date and keeps a manual check when nothing is available', async () => {
+    vi.mocked(check).mockResolvedValue(null);
+
+    render(<UpdateSection />);
+
+    await screen.findByText('LibreTune is up to date.');
+    expect(check).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByRole('button', { name: 'Check for updates' }));
+    await waitFor(() => expect(check).toHaveBeenCalledTimes(2));
+  });
+
+  it('offers the update and installs then relaunches on confirm', async () => {
+    const update = availableUpdate();
+    vi.mocked(check).mockResolvedValue(update as never);
+
+    render(<UpdateSection />);
+
+    await screen.findByText('0.2.0');
+    expect(screen.getByText('Faster table editing')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Install and restart' }));
+
+    await waitFor(() => expect(update.downloadAndInstall).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(relaunch).toHaveBeenCalledTimes(1));
+  });
+
+  it('shows the failure reason and stays retryable', async () => {
+    vi.mocked(check).mockRejectedValue(new Error('404 Not Found'));
+
+    render(<UpdateSection />);
+
+    await screen.findByRole('alert');
+    expect(screen.getByRole('alert')).toHaveTextContent('404 Not Found');
+    expect(screen.getByRole('button', { name: 'Check for updates' })).toBeEnabled();
+  });
+
+  it('never relaunches when the install fails', async () => {
+    const update = availableUpdate();
+    update.downloadAndInstall.mockRejectedValue(new Error('bad signature'));
+    vi.mocked(check).mockResolvedValue(update as never);
+
+    render(<UpdateSection />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Install and restart' }));
+
+    await screen.findByRole('alert');
+    expect(relaunch).not.toHaveBeenCalled();
+  });
+
+  it('releases the plugin resource when the user picks Later', async () => {
+    const update = availableUpdate();
+    vi.mocked(check).mockResolvedValue(update as never);
+
+    render(<UpdateSection />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Later' }));
+
+    await waitFor(() => expect(update.close).toHaveBeenCalledTimes(1));
+    expect(screen.getByRole('button', { name: 'Check for updates' })).toBeInTheDocument();
+  });
+});
+
+describe('checkForUpdateQuietly', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns null instead of throwing when the check fails', async () => {
+    vi.mocked(check).mockRejectedValue(new Error('offline'));
+    await expect(checkForUpdateQuietly()).resolves.toBeNull();
+  });
+
+  it('returns the version and releases the resource when one is available', async () => {
+    const update = availableUpdate();
+    vi.mocked(check).mockResolvedValue(update as never);
+    await expect(checkForUpdateQuietly()).resolves.toBe('0.2.0');
+    expect(update.close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -97,6 +97,23 @@ sudo usermod -a -G dialout $USER
 
 Log out and back in for the change to take effect.
 
+## Updating
+
+LibreTune checks for a newer release once after startup, without blocking
+anything: if one exists you get a short notice, and **Help → About LibreTune**
+has an **Install and restart** button (and a manual **Check for updates**).
+Nothing is downloaded or installed until you press it.
+
+Updates are cryptographically signed. The public key is built into the app,
+and an update whose signature does not verify is refused before it is
+installed. This is separate from macOS notarization and Windows publisher
+signing, which the project does not have yet, so a first install may still
+require **Open Anyway** (macOS) or **More info → Run anyway** (Windows).
+
+Official builds, nightlies included, carry the release public key. A build
+you made yourself without it can still *see* a newer release, but the download
+is refused at the signature check and nothing is installed.
+
 ## Building from Source
 
 For developers who want to build LibreTune from source, see the [Contributing Guide](../contributing.md).


### PR DESCRIPTION
## Summary

Signed in-app updates via `tauri-plugin-updater`. Draft because **one maintainer step is required before this can work: generating the signing key** (see below). Everything else is wired and verified.

**In the app**
- One non-blocking check after startup; an info toast if a newer signed release exists.
- **Help → About LibreTune** gets *Check for updates* and *Install and restart* (new `UpdateSection`, 7 tests).
- Downloads are minisign-verified against the public key in `tauri.conf.json`; an unverifiable artifact is refused before anything is installed. Plugin resources are released when not used.

**Release pipeline (`release.yml`)**
- `create-release` emits a `tauri build --config` override for tag builds: `{"version":"X.Y.Z","bundle":{"createUpdaterArtifacts":true}}`. The repo keeps its `0.1.0-nightly` placeholder; nightly and local builds never touch signing. A guard step fails tag builds early if the pubkey or the private-key secret is missing.
- Signing secrets are passed only to tag builds.
- `collect-tauri-artifacts` also gathers `.sig` files and the macOS `.app.tar.gz` updater archive (triple-suffixed, both arches share a file name).
- `upload-release` builds `latest.json` with installer-specific entries (`linux-x86_64-appimage` / `-deb`, `windows-x86_64-nsis` / `-msi`, `darwin-aarch64` / `darwin-x86_64` plus the generic fallbacks) and verifies **every** signature against the committed public key with `minisign` before publishing. A key mismatch fails the release instead of surfacing on users' machines.

**Docs:** `installation.md` "Updating", `CONTRIBUTING.md` → Release Builds runbook, CHANGELOG entry.

## Maintainer TODO before un-drafting

```bash
cd crates/libretune-app && npx tauri signer generate -w ~/.tauri/libretune.key
```
1. Paste the printed **public** key into `plugins.updater.pubkey` in `crates/libretune-app/src-tauri/tauri.conf.json` (commit on this branch or after merge; the app only needs it for the first *signed* release).
2. Add repository secrets `TAURI_SIGNING_PRIVATE_KEY` (file contents) and `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`.
3. Back up the private key. Losing it means existing installs can never update again.

Until the key is in place: the app starts and runs normally, tag releases fail at the guard step with a pointer to CONTRIBUTING, nightlies are unaffected.

## Notes
- `@tauri-apps/api` moved 2.10.1 → 2.11.1 as a peer of the updater plugin.
- The updater compares semver, so once the first stable release is out, nightly users (`0.1.0-nightly.*`) will be offered it. Say if you'd rather gate the check on non-nightly builds.
- Independent review (Codex) found two release-path defects during drafting, both fixed here: `.deb` installs would have been handed an AppImage, and a process-substitution failure could have produced a partial manifest.

## Test plan
- [x] `npx vitest run` 43 files / 294 tests, `npx tsc --noEmit`
- [x] `cargo check -p libretune-app`, `cargo clippy --workspace -- -D warnings`, `cargo fmt --check`
- [x] Workflow YAML parses; manifest script passes `bash -n`
- [ ] CI green
- [ ] Maintainer: key generated, first tagged release produces `latest.json` with 8 verified entries, in-app update from that release to the next
