### PR TITLE
chore: rustfmt the files merged in #287/#291/#292 (Format job is red on main)

### DIFF
--- a/crates/libretune-app/src-tauri/src/commands/tooth_logger.rs
+++ b/crates/libretune-app/src-tauri/src/commands/tooth_logger.rs
@@ -159,9 +159,7 @@ async fn run_capture(
         let rpm = rt.get("rpm").copied().unwrap_or(0.0);
         let modern = {
             let conn_guard = state.connection.lock().await;
-            conn_guard
-                .as_ref()
-                .is_some_and(|c| c.is_modern_protocol())
+            conn_guard.as_ref().is_some_and(|c| c.is_modern_protocol())
         };
         if !modern && rpm > MAX_SAFE_RPM_LEGACY {
             return Err(format!(

--- a/crates/libretune-core/src/dash/writer.rs
+++ b/crates/libretune-core/src/dash/writer.rs
@@ -694,7 +694,9 @@ mod tests {
         // And a gauge that never set them still serializes without the tags
         // (backward-compatible: no spurious EnabledCondition/Hysteresis).
         let plain = DashFile::default();
-        assert!(!write_dash_file(&plain).unwrap().contains("EnabledCondition"));
+        assert!(!write_dash_file(&plain)
+            .unwrap()
+            .contains("EnabledCondition"));
     }
 
     #[test]

--- a/crates/libretune-core/src/protocol/connection.rs
+++ b/crates/libretune-core/src/protocol/connection.rs
@@ -1204,7 +1204,11 @@ impl Connection {
         // Trace the actual bytes (capped) so a lost capture can be reconstructed
         // from the session log — the framed path only counted bytes before, so
         // tooth/composite payloads left no trace. Legacy path already does this.
-        tracing::trace!("send_packet: tx {} bytes: {:02x?}", bytes.len(), &bytes[..bytes.len().min(64)]);
+        tracing::trace!(
+            "send_packet: tx {} bytes: {:02x?}",
+            bytes.len(),
+            &bytes[..bytes.len().min(64)]
+        );
         // Use write_and_wait which avoids the blocking tcdrain issue
         self.tx_bytes = self.tx_bytes.saturating_add(bytes.len() as u64);
         self.tx_packets = self.tx_packets.saturating_add(1);
@@ -1334,7 +1338,11 @@ impl Connection {
         self.rx_packets = self.rx_packets.saturating_add(1);
         // Trace the raw response (capped) before CRC parsing, so it survives in
         // the log even when CRC validation subsequently fails.
-        tracing::trace!("send_packet: rx {} bytes: {:02x?}", full_packet.len(), &full_packet[..full_packet.len().min(64)]);
+        tracing::trace!(
+            "send_packet: rx {} bytes: {:02x?}",
+            full_packet.len(),
+            &full_packet[..full_packet.len().min(64)]
+        );
 
         // If CRC parsing fails, the full packet was already consumed from the TCP
         // stream (exact bytes read = 2 + length + 4), so the stream IS aligned.


### PR DESCRIPTION
#287, #291 and #292 merged with a handful of over-long lines that `cargo fmt --check` rejects, so the **Format** job on `main` is currently failing. This runs `cargo fmt` on only those three files — no logic change, `cargo fmt --check` is clean afterward.

- `crates/libretune-core/src/dash/writer.rs`
- `crates/libretune-core/src/protocol/connection.rs`
- `crates/libretune-app/src-tauri/src/commands/tooth_logger.rs`

Apologies for the churn — those slipped through because I verified builds/tests locally but not `fmt --check` before the originals were opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)