### PR TITLE
fix(ui): open menubar overflow dropdown leftward

### DIFF
--- a/crates/libretune-app/src/components/tuner-ui/MenuBar.css
+++ b/crates/libretune-app/src/components/tuner-ui/MenuBar.css
@@ -171,3 +171,17 @@
   background: var(--border-default);
   margin: var(--space-1) var(--space-3);
 }
+
+/* The "⋯" overflow button sits at the right edge, so its dropdown (and any
+   nested submenus) must open leftward or they land outside the window. */
+.menubar-more-wrap > .menu-dropdown {
+  left: auto;
+  right: 0;
+}
+
+.menubar-more-wrap .menu-dropdown-level-1,
+.menubar-more-wrap .menu-dropdown-level-2,
+.menubar-more-wrap .menu-dropdown-level-3 {
+  left: auto;
+  right: 100%;
+}


### PR DESCRIPTION
## Summary
- The "⋯" overflow button at the right end of the menu bar opened its dropdown to the right, outside the window. Nested submenus opened further right.
- Cause: the dropdown reused `.menu-dropdown { left: 0 }` and `.menu-dropdown-level-N { left: 100% }`, which are correct for menus at the left of the bar but not for a button anchored at the right edge.
- Fix: inside `.menubar-more-wrap`, anchor the dropdown to `right: 0` and open submenus with `right: 100%`.

## Test plan
- [x] Verified in browser at 864px width: dropdown right edge = button right edge, submenu opens to the left of the dropdown.
- [x] Open the app, click "⋯" at the right of the menu bar, hover a menu with submenus — everything stays inside the window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)