### PR TITLE
feat(tables): toggle Y axis direction (zero at top / bottom) from the table view

### DIFF
--- a/crates/libretune-app/public/manual/features/table-editing.md
+++ b/crates/libretune-app/public/manual/features/table-editing.md
@@ -116,6 +116,14 @@ Notes:
 - `Ctrl+Z` - Undo last change
 - `Ctrl+Y` or `Ctrl+Shift+Z` - Redo
 
+## Y Axis Direction
+
+By default the Y axis (load) starts at the top of the table and increases downward.
+Click the **Y axis** toolbar button (arrows icon) to flip it so the lowest load row sits
+at the bottom, matching a classic graph layout. The same option is available in
+**Settings → Table Display → Table Y axis zero at bottom**. It applies to every table
+and is remembered between sessions.
+
 ## Follow Mode
 
 Enable **Follow Mode** to automatically highlight the cell corresponding to current engine operation:

--- a/crates/libretune-app/src/components/tables/3d/SceneComponents.tsx
+++ b/crates/libretune-app/src/components/tables/3d/SceneComponents.tsx
@@ -507,14 +507,19 @@ export function AxisLabels({
   y_label, 
   z_label,
   x_bins,
-  y_bins
+  y_bins,
+  yAxisBottom = false
 }: { 
   x_label?: string; 
   y_label?: string; 
   z_label?: string;
   x_bins: number[];
   y_bins: number[];
+  /** Data group is mirrored along world Z, so the near/far Y labels swap. */
+  yAxisBottom?: boolean;
 }) {
+  const yNear = yAxisBottom ? y_bins[y_bins.length - 1] : y_bins[0];
+  const yFar = yAxisBottom ? y_bins[0] : y_bins[y_bins.length - 1];
   return (
     <>
       {/* 3D Box Frame (The "Z lines") */}
@@ -583,16 +588,16 @@ export function AxisLabels({
       
       {/* Axis value labels - Corners */}
       <Text position={[-0.3, -0.3, -0.3]} fontSize={0.25} color="#888888">
-        {x_bins[0]?.toFixed(0)}/{y_bins[0]?.toFixed(0)}
+        {x_bins[0]?.toFixed(0)}/{yNear?.toFixed(0)}
       </Text>
       <Text position={[10.3, -0.3, -0.3]} fontSize={0.25} color="#888888">
         {x_bins[x_bins.length - 1]?.toFixed(0)}
       </Text>
       <Text position={[-0.3, -0.3, 10.3]} fontSize={0.25} color="#888888">
-        {y_bins[y_bins.length - 1]?.toFixed(0)}
+        {yFar?.toFixed(0)}
       </Text>
       <Text position={[10.3, -0.3, 10.3]} fontSize={0.25} color="#888888">
-        {x_bins[x_bins.length - 1]?.toFixed(0)}/{y_bins[y_bins.length - 1]?.toFixed(0)}
+        {x_bins[x_bins.length - 1]?.toFixed(0)}/{yFar?.toFixed(0)}
       </Text>
     </>
   );
@@ -641,7 +646,8 @@ export function Scene({
   liveCell,
   historyTrail,
   wireframe,
-  showCells
+  showCells,
+  yAxisBottom = false
 }: {
   x_bins: number[];
   y_bins: number[];
@@ -656,6 +662,8 @@ export function Scene({
   historyTrail?: Array<{ row: number; col: number; time: number }>;
   wireframe: boolean;
   showCells: boolean;
+  /** Mirror table Y (world Z) so the lowest Y bin sits nearest the camera, matching the 2D grid. */
+  yAxisBottom?: boolean;
 }) {
   const [hoveredCell, _setHoveredCell] = useState<{ x: number; y: number } | null>(null);
 
@@ -675,7 +683,10 @@ export function Scene({
       <directionalLight position={[10, 15, 10]} intensity={0.8} castShadow />
       <directionalLight position={[-5, 10, -5]} intensity={0.3} />
       
-      {/* Surface mesh */}
+      {/* Data group. A negative Z scale mirrors table Y about the box centre;
+          three.js flips front-face winding for negative-determinant matrices,
+          so lighting and picking keep working. */}
+      <group position={[0, 0, yAxisBottom ? 10 : 0]} scale={[1, 1, yAxisBottom ? -1 : 1]}>
       <SurfaceMesh
         x_bins={x_bins}
         y_bins={y_bins}
@@ -705,6 +716,7 @@ export function Scene({
           historyTrail={historyTrail}
         />
       )}
+      </group>
       
       {/* Axis labels and grid */}
       <AxisLabels 
@@ -713,6 +725,7 @@ export function Scene({
         z_label={z_label}
         x_bins={x_bins}
         y_bins={y_bins}
+        yAxisBottom={yAxisBottom}
       />
       
       {/* Tooltip */}

--- a/crates/libretune-app/src/components/tables/TableComponents.css
+++ b/crates/libretune-app/src/components/tables/TableComponents.css
@@ -132,6 +132,15 @@
   white-space: nowrap;
 }
 
+/* Y axis zero at bottom: the X header row sits under the data, sticky bottom */
+.table-editor-2d .table-grid-container--x-axis-bottom .axis-bin-label.x-bin,
+.table-editor-2d .table-grid-container--x-axis-bottom .axis-corner {
+  top: auto;
+  bottom: 0;
+  border-bottom: none;
+  border-top: 1px solid var(--table-grid-line);
+}
+
 .table-editor-2d .axis-bin-label {
   width: 100%;
   height: 100%;

--- a/crates/libretune-app/src/components/tables/TableEditor2D.tsx
+++ b/crates/libretune-app/src/components/tables/TableEditor2D.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react'
 import { invoke } from '@tauri-apps/api/core';
 import { open, save } from '@tauri-apps/plugin-dialog';
 import { emit } from '@tauri-apps/api/event';
-import { ArrowLeft, Save, Zap, ExternalLink, AlertTriangle, Palette, MapPin, Crosshair, Box, Scaling } from 'lucide-react';
+import { ArrowLeft, Save, Zap, ExternalLink, AlertTriangle, Palette, MapPin, Crosshair, Box, Scaling, ArrowUpDown } from 'lucide-react';
 import TableToolbar from './TableToolbar';
 import TableGrid, { SelectionRange } from './TableGrid';
 import TableEditor3D from './TableEditor3D';
@@ -1314,6 +1314,14 @@ export default function TableEditor2D({
           >
             <Box size={14} />
           </button>
+          <button
+            className={`embedded-toggle ${yAxisBottom ? 'active' : ''}`}
+            onClick={() => setTableYAxisBottom(!yAxisBottom)}
+            title={`Y axis zero at ${yAxisBottom ? 'bottom' : 'top'} - click to flip`}
+            aria-label="Flip Y axis direction"
+          >
+            <ArrowUpDown size={14} />
+          </button>
           {sizeInfo?.resizable && (
             <button
               className="embedded-toggle"
@@ -1376,6 +1384,14 @@ export default function TableEditor2D({
               aria-label="Toggle 3D View"
             >
               <span className="action-icon"><Box size={16} /></span>
+            </button>
+            <button
+              className={`action-btn ${yAxisBottom ? 'active' : ''}`}
+              onClick={() => setTableYAxisBottom(!yAxisBottom)}
+              title={`Y axis zero at ${yAxisBottom ? 'bottom' : 'top'} - click to flip`}
+              aria-label="Flip Y axis direction"
+            >
+              <span className="action-icon"><ArrowUpDown size={16} /></span>
             </button>
             <button className="action-btn" onClick={handleSave} title="Save (S)">
               <Save size={18} />

--- a/crates/libretune-app/src/components/tables/TableEditor2D.tsx
+++ b/crates/libretune-app/src/components/tables/TableEditor2D.tsx
@@ -654,7 +654,7 @@ export default function TableEditor2D({
 
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [selectionRange, followMode, activeCell, localZValues]);
+  }, [selectionRange, followMode, activeCell, localZValues, yAxisBottom]);
 
   // Arrow key navigation helper
   const handleArrowNavigation = (key: string, extendSelection: boolean) => {
@@ -1318,7 +1318,8 @@ export default function TableEditor2D({
             className={`embedded-toggle ${yAxisBottom ? 'active' : ''}`}
             onClick={() => setTableYAxisBottom(!yAxisBottom)}
             title={`Y axis zero at ${yAxisBottom ? 'bottom' : 'top'} - click to flip`}
-            aria-label="Flip Y axis direction"
+            aria-pressed={yAxisBottom}
+            aria-label="Y axis zero at bottom"
           >
             <ArrowUpDown size={14} />
           </button>
@@ -1389,7 +1390,8 @@ export default function TableEditor2D({
               className={`action-btn ${yAxisBottom ? 'active' : ''}`}
               onClick={() => setTableYAxisBottom(!yAxisBottom)}
               title={`Y axis zero at ${yAxisBottom ? 'bottom' : 'top'} - click to flip`}
-              aria-label="Flip Y axis direction"
+              aria-pressed={yAxisBottom}
+              aria-label="Y axis zero at bottom"
             >
               <span className="action-icon"><ArrowUpDown size={16} /></span>
             </button>

--- a/crates/libretune-app/src/components/tables/TableEditor2D.tsx
+++ b/crates/libretune-app/src/components/tables/TableEditor2D.tsx
@@ -16,7 +16,7 @@ import { Dialog, Button, FormField } from '../common';
 import type { BackendTableData, TableSizeInfo } from '../../types/app';
 import LambdaPreviewTable from './LambdaPreviewTable';
 import { useHeatmapSettings } from '../../utils/useHeatmapSettings';
-import { useTableYAxisBottom, useTrailFadeSec } from '../../utils/useTableOrientation';
+import { useTableYAxisBottom, setTableYAxisBottom, useTrailFadeSec } from '../../utils/useTableOrientation';
 import { useChannels } from '../../stores/realtimeStore';
 import { useToast } from '../../contexts/ToastContext';
 import { getHotkeyManager } from '../../services/hotkeyService';
@@ -1407,6 +1407,8 @@ export default function TableEditor2D({
           canPaste={true}
           followMode={followMode}
           onFollowModeToggle={() => setFollowMode(!followMode)}
+          yAxisBottom={yAxisBottom}
+          onYAxisBottomToggle={() => setTableYAxisBottom(!yAxisBottom)}
           showColorShade={showColorShade}
           onColorShadeToggle={() => setShowColorShade(!showColorShade)}
           show3D={show3D}

--- a/crates/libretune-app/src/components/tables/TableEditor3D.tsx
+++ b/crates/libretune-app/src/components/tables/TableEditor3D.tsx
@@ -31,6 +31,7 @@ interface TableEditor3DProps {
 }
 
 import { Scene } from './3d/SceneComponents';
+import { useTableYAxisBottom } from '../../utils/useTableOrientation';
 
 export default function TableEditor3D({
   title,
@@ -54,6 +55,7 @@ export default function TableEditor3D({
   const [showCells, setShowCells] = useState(false);
   const [fullscreen, setFullscreen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  const yAxisBottom = useTableYAxisBottom();
 
   const canRender3D = x_bins.length > 1 && y_bins.length > 1 && z_values.length > 0 && z_values[0]?.length > 0;
 
@@ -147,6 +149,7 @@ export default function TableEditor3D({
             historyTrail={historyTrail}
             wireframe={wireframe}
             showCells={showCells}
+            yAxisBottom={yAxisBottom}
           />
         </Canvas>
       </div>

--- a/crates/libretune-app/src/components/tables/TableGrid.tsx
+++ b/crates/libretune-app/src/components/tables/TableGrid.tsx
@@ -347,7 +347,7 @@ export default function TableGrid({
     const observer = new ResizeObserver(measure);
     observer.observe(grid);
     return () => observer.disconnect();
-  }, [x_size, y_size, compact]);
+  }, [x_size, y_size, compact, yAxisBottom]);
 
   const cellCenter = (x: number, y: number) => {
     if (!cellMetrics) return null;
@@ -482,18 +482,14 @@ export default function TableGrid({
       }
     : { gridTemplateColumns };
 
-  const grid = (
-    <div
-      ref={gridRef}
-      className={`table-grid-container${compact ? ' table-grid-container--compact' : ''}${fitViewport ? ' table-grid-container--fit-ve' : ''}`}
-      onMouseUp={handleMouseUp}
-      onMouseMove={handleCellMouseMove}
-      style={gridStyle}
-    >
-      {/* Corner cell (row 0, col 0) */}
+  // Header row (corner + X bins). CSS grid auto-placement puts it wherever
+  // it lands in DOM order, so it is emitted before or after the data rows.
+  const xHeaderRow = (
+    <>
+      {/* Corner cell where the axes meet */}
       <div className="axis-corner" />
 
-      {/* X-axis headers (row 0, cols 1..N) */}
+      {/* X-axis headers; rendered above or below the rows depending on yAxisBottom */}
       {x_bins.map((val, i) => {
         const isEditingThis = editingAxis?.axis === 'x' && editingAxis.index === i;
         const isHeaderSelected = selectionRange && 
@@ -532,6 +528,18 @@ export default function TableGrid({
           </div>
         );
       })}
+    </>
+  );
+
+  const grid = (
+    <div
+      ref={gridRef}
+      className={`table-grid-container${compact ? ' table-grid-container--compact' : ''}${fitViewport ? ' table-grid-container--fit-ve' : ''}${yAxisBottom ? ' table-grid-container--x-axis-bottom' : ''}`}
+      onMouseUp={handleMouseUp}
+      onMouseMove={handleCellMouseMove}
+      style={gridStyle}
+    >
+      {!yAxisBottom && xHeaderRow}
 
       {/* Data rows: each row = y-axis label + data cells.
           Display order only — all coordinates stay in data space. */}
@@ -631,6 +639,8 @@ export default function TableGrid({
           </Fragment>
         );
       })}
+
+      {yAxisBottom && xHeaderRow}
 
       {renderHistoryTrail()}
       

--- a/crates/libretune-app/src/components/tables/TableToolbar.tsx
+++ b/crates/libretune-app/src/components/tables/TableToolbar.tsx
@@ -239,6 +239,8 @@ export default function TableToolbar({
             className={`ts-toolbar-btn ${yAxisBottom ? 'ts-toolbar-btn-active' : ''}`}
             title={yAxisBottom ? 'Y axis: zero at bottom (click for zero at top)' : 'Y axis: zero at top (click for zero at bottom)'}
             onClick={onYAxisBottomToggle}
+            aria-pressed={yAxisBottom}
+            aria-label="Y axis zero at bottom"
           >
             <ArrowUpDown size={14} />
           </button>

--- a/crates/libretune-app/src/components/tables/TableToolbar.tsx
+++ b/crates/libretune-app/src/components/tables/TableToolbar.tsx
@@ -17,7 +17,8 @@ import {
   Wand2,
   Upload,
   Download,
-  Bot
+  Bot,
+  ArrowUpDown
 } from 'lucide-react';
 
 interface TableToolbarProps {
@@ -38,6 +39,9 @@ interface TableToolbarProps {
   canPaste: boolean;
   followMode?: boolean;
   onFollowModeToggle?: () => void;
+  /** Y axis zero at bottom (rows reversed). Toggles the global table_y_axis_bottom setting. */
+  yAxisBottom?: boolean;
+  onYAxisBottomToggle?: () => void;
   showColorShade?: boolean;
   onColorShadeToggle?: () => void;
   show3D?: boolean;
@@ -70,6 +74,8 @@ export default function TableToolbar({
   canPaste,
   followMode = false,
   onFollowModeToggle,
+  yAxisBottom = false,
+  onYAxisBottomToggle,
   showColorShade = false,
   onColorShadeToggle,
   show3D = false,
@@ -226,6 +232,15 @@ export default function TableToolbar({
             onClick={onColorShadeToggle}
           >
             <Palette size={14} />
+          </button>
+        )}
+        {onYAxisBottomToggle && (
+          <button
+            className={`ts-toolbar-btn ${yAxisBottom ? 'ts-toolbar-btn-active' : ''}`}
+            title={yAxisBottom ? 'Y axis: zero at bottom (click for zero at top)' : 'Y axis: zero at top (click for zero at bottom)'}
+            onClick={onYAxisBottomToggle}
+          >
+            <ArrowUpDown size={14} />
           </button>
         )}
         {onToggle3D && (

--- a/crates/libretune-app/src/components/tuner-ui/TableEditor.css
+++ b/crates/libretune-app/src/components/tuner-ui/TableEditor.css
@@ -120,6 +120,13 @@
   min-width: 50px;
 }
 
+/* Y axis zero at bottom: header row lives in <tfoot>, sticky to the bottom edge */
+.table-grid tfoot .table-corner,
+.table-grid tfoot .table-x-header {
+  top: auto;
+  bottom: 0;
+}
+
 .table-y-header {
   position: sticky;
   left: 0;

--- a/crates/libretune-app/src/components/tuner-ui/TableEditor.css
+++ b/crates/libretune-app/src/components/tuner-ui/TableEditor.css
@@ -202,13 +202,13 @@
   border-color: var(--border-default);
 }
 
-.table-toolbar-btn-follow.active {
+.table-toolbar-btn.active {
   background: var(--primary);
   border-color: var(--primary);
   color: white;
 }
 
-.table-toolbar-btn-follow.active:hover {
+.table-toolbar-btn.active:hover {
   background: var(--primary-hover);
   border-color: var(--primary-hover);
 }

--- a/crates/libretune-app/src/components/tuner-ui/TableEditor.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/TableEditor.tsx
@@ -5,7 +5,7 @@ import { useChannels } from '../../stores/realtimeStore';
 import { useHeatmapSettings } from '../../utils/useHeatmapSettings';
 import { contrastTextColor } from '../../utils/heatmapColors';
 import { askNumber } from '../../utils/askNumber';
-import { useTableYAxisBottom, useTrailFadeSec } from '../../utils/useTableOrientation';
+import { useTableYAxisBottom, setTableYAxisBottom, useTrailFadeSec } from '../../utils/useTableOrientation';
 import './TableEditor.css';
 import TableEditor3D from '../tables/TableEditor3D';
 import TableToolbar from './table-editor/TableToolbar';
@@ -1185,6 +1185,8 @@ export function TableEditor({
         // The rpm/map fallback (see calculatedLivePosition) makes follow mode
         // usable even when the INI declares no axis channels.
         hasOutputChannels={true}
+        yAxisBottom={yAxisBottom}
+        onToggleYAxisBottom={() => setTableYAxisBottom(!yAxisBottom)}
         show3D={show3D}
         onToggle3D={() => setShow3D(!show3D)}
         onGenerate={generatableKind ? () => setShowGenerateDialog(true) : undefined}

--- a/crates/libretune-app/src/components/tuner-ui/TableEditor.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/TableEditor.tsx
@@ -371,7 +371,7 @@ export function TableEditor({
       // scroll to get coordinates that stay correct as the user scrolls.
       const left = tRect.left - hRect.left + host.scrollLeft;
       const top = tRect.top - hRect.top + host.scrollTop;
-      const cols = Array.from(table.querySelectorAll<HTMLTableCellElement>('thead th'))
+      const cols = Array.from(table.querySelectorAll<HTMLTableCellElement>('thead th, tfoot th'))
         .slice(1) // the corner cell is not a column
         .map((th) => {
           const r = th.getBoundingClientRect();
@@ -1220,7 +1220,7 @@ export function TableEditor({
       {!show3D && (
       <div className="table-grid-container" ref={scrollHostRef}>
         <table className="table-grid" ref={tableElRef}>
-          <thead>
+          {!yAxisBottom && <thead>
             <tr>
               <th className="table-corner">
                 {data.yLabel || 'Y'} / {data.xLabel || 'X'}
@@ -1231,7 +1231,7 @@ export function TableEditor({
                 </th>
               ))}
             </tr>
-          </thead>
+          </thead>}
           <tbody>
             {/* Display order only — rowIndex stays in data space */}
             {/* One timestamp per render: the fade refreshes when the trail
@@ -1288,6 +1288,18 @@ export function TableEditor({
               ));
             })()}
           </tbody>
+          {yAxisBottom && <tfoot>
+            <tr>
+              <th className="table-corner">
+                {data.yLabel || 'Y'} / {data.xLabel || 'X'}
+              </th>
+              {data.xAxis.map((x, i) => (
+                <th key={i} className="table-x-header">
+                  {x}
+                </th>
+              ))}
+            </tr>
+          </tfoot>}
         </table>
         {renderTrailOverlay()}
       </div>

--- a/crates/libretune-app/src/components/tuner-ui/table-editor/TableToolbar.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/table-editor/TableToolbar.tsx
@@ -1,4 +1,4 @@
-import { Copy, Clipboard, Undo2, Redo2, Flame, Crosshair, Box, Wand2, Upload, Download } from 'lucide-react';
+import { Copy, Clipboard, Undo2, Redo2, Flame, Crosshair, Box, Wand2, Upload, Download, ArrowUpDown } from 'lucide-react';
 import '../TableEditor.css';
 
 interface TableToolbarProps {
@@ -22,6 +22,9 @@ interface TableToolbarProps {
   followMode: boolean;
   onToggleFollowMode: () => void;
   hasOutputChannels: boolean;
+  /** Y axis zero at bottom (rows reversed). Toggles the global table_y_axis_bottom setting. */
+  yAxisBottom: boolean;
+  onToggleYAxisBottom: () => void;
   show3D: boolean;
   onToggle3D: () => void;
   /** Generate the whole table from engine specs (VE/ignition/AFR only). */
@@ -53,6 +56,8 @@ export default function TableToolbar({
   followMode,
   onToggleFollowMode,
   hasOutputChannels,
+  yAxisBottom,
+  onToggleYAxisBottom,
   show3D,
   onToggle3D,
   onGenerate,
@@ -204,6 +209,14 @@ export default function TableToolbar({
         <Crosshair size={14} /> Follow
       </button>
       
+      <button
+        className={`table-toolbar-btn ${yAxisBottom ? 'active' : ''}`}
+        onClick={onToggleYAxisBottom}
+        title={`Y axis zero at ${yAxisBottom ? 'bottom' : 'top'} - click to flip`}
+      >
+        <ArrowUpDown size={14} /> Y{yAxisBottom ? '↑' : '↓'}
+      </button>
+
       <button
         className={`table-toolbar-btn table-toolbar-btn-3d ${show3D ? 'active' : ''}`}
         onClick={onToggle3D}

--- a/crates/libretune-app/src/components/tuner-ui/table-editor/TableToolbar.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/table-editor/TableToolbar.tsx
@@ -212,6 +212,8 @@ export default function TableToolbar({
       <button
         className={`table-toolbar-btn ${yAxisBottom ? 'active' : ''}`}
         onClick={onToggleYAxisBottom}
+        aria-pressed={yAxisBottom}
+        aria-label="Y axis zero at bottom"
         title={`Y axis zero at ${yAxisBottom ? 'bottom' : 'top'} - click to flip`}
       >
         <ArrowUpDown size={14} /> Y{yAxisBottom ? '↑' : '↓'}

--- a/crates/libretune-app/src/utils/__tests__/useTableOrientation.test.ts
+++ b/crates/libretune-app/src/utils/__tests__/useTableOrientation.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect, vi } from 'vitest';
+import { invoke } from '@tauri-apps/api/core';
+import { setTableYAxisBottom } from '../useTableOrientation';
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn(() => Promise.resolve()) }));
+vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn() }));
+
+describe('setTableYAxisBottom', () => {
+  it('persists the flag via update_setting as a string', async () => {
+    await setTableYAxisBottom(true);
+    expect(invoke).toHaveBeenCalledWith('update_setting', { key: 'table_y_axis_bottom', value: 'true' });
+  });
+
+  it('swallows backend errors', async () => {
+    vi.mocked(invoke).mockRejectedValueOnce(new Error('boom'));
+    await expect(setTableYAxisBottom(false)).resolves.toBeUndefined();
+  });
+});

--- a/crates/libretune-app/src/utils/useTableOrientation.ts
+++ b/crates/libretune-app/src/utils/useTableOrientation.ts
@@ -105,3 +105,11 @@ export function useTableYAxisBottom(): boolean {
 
   return bottom;
 }
+
+/**
+ * Persist the Y-axis orientation. The backend emits `settings:changed`, so
+ * every mounted `useTableYAxisBottom` (and the Settings dialog) picks it up.
+ */
+export function setTableYAxisBottom(bottom: boolean): Promise<void> {
+  return invoke<void>('update_setting', { key: 'table_y_axis_bottom', value: String(bottom) }).catch(() => {});
+}

--- a/docs/src/features/table-editing.md
+++ b/docs/src/features/table-editing.md
@@ -116,6 +116,14 @@ Notes:
 - `Ctrl+Z` - Undo last change
 - `Ctrl+Y` or `Ctrl+Shift+Z` - Redo
 
+## Y Axis Direction
+
+By default the Y axis (load) starts at the top of the table and increases downward.
+Click the **Y axis** toolbar button (arrows icon) to flip it so the lowest load row sits
+at the bottom, matching a classic graph layout. The same option is available in
+**Settings → Table Display → Table Y axis zero at bottom**. It applies to every table
+and is remembered between sessions.
+
 ## Follow Mode
 
 Enable **Follow Mode** to automatically highlight the cell corresponding to current engine operation:


### PR DESCRIPTION
## Description
Lets the user flip a table between **X right / Y down** (zero at top, default) and **X right / Y up** (zero at bottom) directly from the table view, instead of only via Settings. The toggle reuses the existing global `table_y_axis_bottom` setting, so both editor implementations, the Settings checkbox and arrow-key navigation stay in sync and the choice persists.

When Y zero is at the bottom, the X axis labels now render **below** the grid (sticky-bottom) and the 3D view mirrors the surface so the lowest load row is nearest the camera.

## Type of Change
- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Related Issues
N/A

## Changes Made
- ↕ toggle button in both table toolbars, in the dialog-embedded table header and in the standalone header (`setTableYAxisBottom()` helper in `useTableOrientation.ts`)
- X header row moves under the data rows when flipped: CSS-grid order in `TableGrid.tsx`, `<tfoot>` in the tuner-ui `TableEditor.tsx`, matching sticky-bottom CSS
- 3D view: data group mirrored along world Z and near/far corner labels swapped (`SceneComponents.tsx`, `TableEditor3D.tsx`)
- Review follow-ups: keydown effect in `TableEditor2D` now re-binds on orientation change; generic `.table-toolbar-btn.active` style; `aria-pressed` on the toggles
- Docs: "Y Axis Direction" section in `table-editing.md` (docs/src and public/manual)
- Test: `useTableOrientation.test.ts`

## Testing
- [x] I have tested these changes locally
- [x] New and existing tests pass (`npx vitest run` for tables/tuner-ui/utils)
- [x] The UI works correctly with these changes

## Checklist
- [x] Code compiles without errors
- [ ] No new clippy warnings (`cargo clippy`) — no Rust changes
- [ ] Code is formatted (`cargo fmt`) — no Rust changes
- [x] TypeScript compiles without errors (`npx tsc --noEmit`)
- [x] Documentation updated if needed
- [x] Commit messages follow conventional format

## Screenshots (if applicable)
N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)