### PR TITLE
fix(autotune): clamp panic, exclusive bilinear corners, anomaly/health math

### DIFF
--- a/crates/libretune-core/src/autotune/accel_enrich.rs
+++ b/crates/libretune-core/src/autotune/accel_enrich.rs
@@ -175,9 +175,18 @@ pub fn analyze_events(samples: &[AeSample], cfg: &AeConfig) -> Vec<AeEvent> {
             let resp_lo = peak_ts + cfg.delay_ms;
             let resp_hi = resp_lo + settle_ms;
 
+            // `samples` is time-ordered, so the response window and the two
+            // baseline windows that bracket it are one contiguous slice.
+            // Binary-searching for its bounds turns what was a full rescan of
+            // the log per tip-in - O(events x n) - into O(events x window).
+            let lo_ts = (start_ts - base_span_ms).min(resp_lo);
+            let hi_ts = resp_hi + base_span_ms;
+            let from = samples.partition_point(|s| (s.timestamp_ms as f64) < lo_ts);
+            let to = samples.partition_point(|s| (s.timestamp_ms as f64) <= hi_ts);
+
             let mut resp = Vec::new();
             let mut base = Vec::new();
-            for s in samples {
+            for s in &samples[from..to] {
                 let ts = s.timestamp_ms as f64;
                 if ts >= resp_lo && ts <= resp_hi {
                     resp.push(afr_err(s, cfg.target_afr_fallback));
@@ -361,6 +370,94 @@ mod tests {
             assert_eq!(
                 r.recommended_rate, r.current_rate,
                 "an unseen bin must be held, not moved"
+            );
+        }
+    }
+}
+
+/// Regression for the 2026-09-05 audit finding that `analyze_events` rescans
+/// the whole log for every tip-in.
+#[cfg(test)]
+mod audit_regression_tests {
+    use super::*;
+
+    /// `samples` is documented as time-ordered, so the response and baseline
+    /// windows are a contiguous slice: binary-searching for it turns the
+    /// O(events x n) pass into O(events x window + n log n).
+    fn drive_log(events: usize) -> Vec<AeSample> {
+        let dt = 20u64; // 50 Hz
+        let target = 14.7;
+        // One tip-in every 100 samples (2 s), which is wider than the whole
+        // response-plus-baseline bracket of 800..1860 ms after the tip.
+        let gap = 100u64;
+        let mut v = Vec::new();
+        for i in 0..(events * gap as usize) {
+            let t = i as u64 * dt;
+            let is_tip = i as u64 % gap == 10;
+            let since_tip = (i as u64 % gap) as i64 - 10;
+            // delay_ms = 800 -> +40 samples; settle = aeTime 160 + 500 -> +33.
+            let in_response = (40..=73).contains(&since_tip);
+            v.push(AeSample {
+                timestamp_ms: t,
+                tps_dot: if is_tip { 100.0 } else { 0.0 },
+                afr: target + if in_response { 0.6 } else { 0.0 },
+                afr_target: target,
+                clt: 85.0,
+            });
+        }
+        v
+    }
+
+    /// Cost must scale with the log length, not with length x events.
+    ///
+    /// Quadrupling a log quadruples both its sample count and its tip-in count,
+    /// so a full rescan per event costs ~16x while a windowed scan costs ~4x.
+    /// Comparing the two runs makes the assertion about the algorithm's shape
+    /// rather than about how fast the machine happens to be.
+    #[test]
+    fn cost_scales_with_log_length_not_length_times_events() {
+        let cfg = AeConfig {
+            min_events: 1,
+            delay_ms: 800.0,
+            ..Default::default()
+        };
+        let time_for = |events: usize| {
+            let samples = drive_log(events);
+            let began = std::time::Instant::now();
+            let found = analyze_events(&samples, &cfg);
+            assert!(!found.is_empty(), "the synthetic tip-ins must be detected");
+            began.elapsed().as_nanos().max(1)
+        };
+
+        // Warm the allocator/caches so the small run is not paying for both.
+        let _ = time_for(500);
+        let small = time_for(500);
+        let large = time_for(2_000);
+
+        let ratio = large as f64 / small as f64;
+        assert!(
+            ratio < 8.0,
+            "4x the log took {ratio:.1}x the time: the scan is still per-event \
+             (linear would be ~4x, quadratic ~16x)"
+        );
+    }
+
+    /// Narrowing the scan must not change which samples land in the response
+    /// and baseline windows.
+    #[test]
+    fn windowing_still_finds_the_same_residual() {
+        let cfg = AeConfig {
+            min_events: 1,
+            delay_ms: 800.0,
+            ..Default::default()
+        };
+        let events = analyze_events(&drive_log(3), &cfg);
+        assert!(!events.is_empty());
+        for e in &events {
+            assert!(
+                (e.residual_afr - 0.6).abs() < 0.2,
+                "a +0.6 AFR excursion must survive the narrowed scan, got {}",
+                e.residual_afr
             );
         }
     }

--- a/crates/libretune-core/src/autotune/anomaly.rs
+++ b/crates/libretune-core/src/autotune/anomaly.rs
@@ -189,8 +189,16 @@ impl AnomalyDetector {
                     }
                 }
 
-                // Need at least 3 non-collinear points for a plane fit.
-                if pts.len() < 3 {
+                // A plane has three parameters, so three points fit it
+                // *exactly*: every residual is zero, `residual_std` is zero,
+                // and the degenerate "clean plane" branch below fires - which
+                // is precisely the situation at all four grid corners, which
+                // have exactly three neighbours each. Every corner of every
+                // table therefore came out with the saturated severity 1.0 and
+                // headed the severity-sorted list. Require at least one point
+                // more than the fit consumes so there is a residual to speak of.
+                const PLANE_PARAMS: usize = 3;
+                if pts.len() <= PLANE_PARAMS {
                     continue;
                 }
 
@@ -224,9 +232,15 @@ impl AnomalyDetector {
                         .iter()
                         .map(|(x, y, z)| z - (a * x + b * y + cc))
                         .collect();
-                    let rstd = (resid.iter().map(|v| v.powi(2)).sum::<f64>()
-                        / resid.len().max(1) as f64)
-                        .sqrt();
+                    // Divide by the residual degrees of freedom, not the point
+                    // count: the plane was fitted to these same points, so
+                    // three of them are spent on it. Over the usual eight
+                    // neighbours the biased divisor understated sigma by
+                    // sqrt(5/8) and inflated every z-score by 1.27x - enough to
+                    // report a true 1.58 sigma deviation as a 2.0 sigma outlier
+                    // at the default threshold.
+                    let dof = resid.len().saturating_sub(PLANE_PARAMS).max(1) as f64;
+                    let rstd = (resid.iter().map(|v| v.powi(2)).sum::<f64>() / dof).sqrt();
                     (expected, rstd)
                 } else {
                     // Degenerate (collinear) neighborhood — fall back to mean.
@@ -240,10 +254,23 @@ impl AnomalyDetector {
                     // signal — flag it by an absolute residual threshold.
                     let residual = (val - expected).abs();
                     const CLEAN_PLANE_RESIDUAL_THRESHOLD: f64 = 5.0;
-                    if residual > CLEAN_PLANE_RESIDUAL_THRESHOLD {
-                        let z_score = residual / 0.01; // residual_std was ~0 → very high
+                    const DEFAULT_OUTLIER_SIGMA: f64 = 2.0;
+                    // `outlier_sigma` is the caller's strictness knob, but
+                    // there is no meaningful sigma on a clean plane, so it
+                    // scales the absolute VE gate instead - otherwise raising
+                    // the threshold would tighten every branch except this one.
+                    let gate = CLEAN_PLANE_RESIDUAL_THRESHOLD
+                        * (self.config.outlier_sigma / DEFAULT_OUTLIER_SIGMA).max(0.0);
+                    if residual > gate {
+                        // Grade by the residual itself. Dividing by a fixed
+                        // 0.01 made the "z-score" saturate the severity for
+                        // anything above 0.05 VE, while the branch is only
+                        // entered above the gate - so a 5.1 VE deviation and a
+                        // 50 VE one were reported as equally severe, and every
+                        // flagged cell headed the severity-sorted list.
+                        const CLEAN_PLANE_SEVERITY_SPAN: f64 = 45.0;
                         let severity =
-                            ((z_score - self.config.outlier_sigma) / 3.0).clamp(0.0, 1.0);
+                            ((residual - gate) / CLEAN_PLANE_SEVERITY_SPAN).clamp(0.0, 1.0);
                         anomalies.push(TuneAnomaly {
                             row: r,
                             col: c,
@@ -873,5 +900,168 @@ mod tests {
             "retained anomaly should be high severity, got {}",
             retained.severity
         );
+    }
+}
+
+/// Regressions for the 2026-09-05 audit findings in the outlier detector: the
+/// degenerate plane fit at grid corners and the residual-σ divisor.
+#[cfg(test)]
+mod audit_regression_tests {
+    use super::*;
+
+    /// A grid corner has exactly three neighbours, and three non-collinear
+    /// points fit a three-parameter plane *exactly* — every residual is zero,
+    /// so `residual_std < 0.01` fires for all four corners of every table.
+    /// Inside that branch the z-score is `residual / 0.01`, which saturates the
+    /// severity at 1.0 for any residual above 0.05 VE, so every flagged corner
+    /// heads the severity-sorted list regardless of how wrong it actually is.
+    #[test]
+    fn a_grid_corner_is_not_flagged_from_an_exact_three_point_plane() {
+        // Other detectors are suppressed so the per-cell dedup cannot mask a
+        // statistical outlier behind a gradient or monotonicity finding.
+        let detector = AnomalyDetector::new(AnomalyConfig {
+            gradient_threshold: 1e9,
+            monotonicity_load_floor_kpa: 1e9,
+            max_reasonable_ve: 1000.0,
+            ..AnomalyConfig::default()
+        });
+        // A planar table, so every interior neighbourhood fits exactly, with
+        // each corner nudged well past the 5.0 VE "clean plane" threshold.
+        let mut table: Vec<Vec<f64>> = (0..5)
+            .map(|r| {
+                (0..5)
+                    .map(|c| 50.0 + r as f64 * 4.0 + c as f64 * 2.0)
+                    .collect()
+            })
+            .collect();
+        for (r, c) in [(0usize, 0usize), (0, 4), (4, 0), (4, 4)] {
+            table[r][c] += 8.0;
+        }
+        let x_bins: Vec<f64> = (0..5).map(|i| 1000.0 + i as f64 * 1000.0).collect();
+        let y_bins: Vec<f64> = (0..5).map(|i| 20.0 + i as f64 * 20.0).collect();
+
+        let anomalies = detector.detect_anomalies(&table, &x_bins, &y_bins);
+        let flagged_corners: Vec<_> = anomalies
+            .iter()
+            .filter(|a| {
+                a.anomaly_type == AnomalyType::StatisticalOutlier
+                    && (a.row == 0 || a.row == 4)
+                    && (a.col == 0 || a.col == 4)
+            })
+            .collect();
+        assert!(
+            flagged_corners.is_empty(),
+            "a corner has too few neighbours for a plane fit to say anything, \
+             got {flagged_corners:?}"
+        );
+    }
+
+    /// The clean-plane branch divided by a fixed 0.01, so severity saturated at
+    /// 1.0 for every residual above 0.05 VE while the branch is only entered
+    /// above 5.0 VE. A 5.1 VE deviation and a 50 VE deviation were reported as
+    /// equally severe.
+    #[test]
+    fn clean_plane_severity_scales_with_the_residual() {
+        let detector = AnomalyDetector::new(AnomalyConfig {
+            // Keep the other detectors out of the way: the per-cell dedup keeps
+            // only the highest-severity finding, whatever its type.
+            max_reasonable_ve: 1000.0,
+            gradient_threshold: 1e9,
+            monotonicity_load_floor_kpa: 1e9,
+            ..AnomalyConfig::default()
+        });
+        let x_bins: Vec<f64> = (0..5).map(|i| 1000.0 + i as f64 * 1000.0).collect();
+        let y_bins: Vec<f64> = (0..5).map(|i| 20.0 + i as f64 * 20.0).collect();
+
+        let severity_for = |bump: f64| {
+            // Perfectly planar table so the interior neighbourhood fits exactly.
+            let mut table: Vec<Vec<f64>> = (0..5)
+                .map(|r| {
+                    (0..5)
+                        .map(|c| 50.0 + r as f64 * 4.0 + c as f64 * 2.0)
+                        .collect()
+                })
+                .collect();
+            table[2][2] += bump;
+            detector
+                .detect_anomalies(&table, &x_bins, &y_bins)
+                .into_iter()
+                .find(|a| {
+                    a.anomaly_type == AnomalyType::StatisticalOutlier && a.row == 2 && a.col == 2
+                })
+                .map(|a| a.severity)
+                .unwrap_or_else(|| panic!("a {bump} VE bump on a clean plane must be flagged"))
+        };
+
+        let small = severity_for(5.5);
+        let large = severity_for(50.0);
+        assert!(
+            large > small,
+            "a 50 VE deviation must outrank a 5.5 VE one: {large} vs {small}"
+        );
+        assert!(
+            small < 1.0,
+            "a marginal deviation must not saturate: {small}"
+        );
+    }
+
+    /// The residual σ divided by the number of points rather than the residual
+    /// degrees of freedom (`n - 3` for a three-parameter plane), understating σ
+    /// by `sqrt(5/8)` on a full 8-neighbour interior cell and inflating every
+    /// z-score by 1.27×. A true 1.58σ deviation was reported as a 2.0σ outlier.
+    #[test]
+    fn residual_sigma_uses_the_plane_fit_degrees_of_freedom() {
+        let detector = AnomalyDetector::new(AnomalyConfig {
+            gradient_threshold: 1e9,
+            monotonicity_load_floor_kpa: 1e9,
+            ..AnomalyConfig::default()
+        });
+        let x_bins: Vec<f64> = (0..5).map(|i| 1000.0 + i as f64 * 1000.0).collect();
+        let y_bins: Vec<f64> = (0..5).map(|i| 20.0 + i as f64 * 20.0).collect();
+
+        // A planar table with a repeatable ±1.0 VE ripple on the neighbours of
+        // (2,2), giving a real residual spread, plus a deviation sized to sit
+        // between the biased and the unbiased threshold.
+        let mut table: Vec<Vec<f64>> = (0..5)
+            .map(|r| {
+                (0..5)
+                    .map(|c| 50.0 + r as f64 * 4.0 + c as f64 * 2.0)
+                    .collect()
+            })
+            .collect();
+        let ripple = [
+            (1usize, 1usize, 1.0),
+            (1, 2, -1.0),
+            (1, 3, 1.0),
+            (2, 1, -1.0),
+            (2, 3, 1.0),
+            (3, 1, 1.0),
+            (3, 2, -1.0),
+            (3, 3, 1.0),
+        ];
+        for (r, c, d) in ripple {
+            table[r][c] += d;
+        }
+        // Biased σ over these 8 residuals ≈ 1.0; unbiased (n−3 = 5) ≈ 1.265.
+        // A 2.3 VE deviation is 2.3σ biased (flagged) but 1.82σ unbiased.
+        table[2][2] += 2.3;
+
+        let flagged = |t: &[Vec<f64>]| {
+            detector
+                .detect_anomalies(t, &x_bins, &y_bins)
+                .into_iter()
+                .any(|a| {
+                    a.anomaly_type == AnomalyType::StatisticalOutlier && a.row == 2 && a.col == 2
+                })
+        };
+        assert!(
+            !flagged(&table),
+            "a 1.75σ deviation must not be reported as a 2σ outlier"
+        );
+
+        // ...and the gate must still fire on a genuine one: 2.55 VE is 2.18σ
+        // against the unbiased estimate.
+        table[2][2] += 0.5;
+        assert!(flagged(&table), "a 2.18σ deviation is a real outlier");
     }
 }

--- a/crates/libretune-core/src/autotune/health.rs
+++ b/crates/libretune-core/src/autotune/health.rs
@@ -324,7 +324,15 @@ impl HealthScorer {
         let cruise_col_start = (idle_col_end + 1).min(cols - 1);
         let cruise_col_end = wot_col_start.saturating_sub(1).max(cruise_col_start);
         let cruise_row_start = (idle_row_end + 1).min(rows - 1);
-        let cruise_row_end = wot_row_start.saturating_sub(1).max(cruise_row_start);
+        // Do NOT clamp the end upward to meet the start. WOT owns every column
+        // from `wot_row_start` down, so raising the end to `cruise_row_start`
+        // when WOT begins at or below it tiles that row twice - and
+        // `overall_score` is a cell-count-weighted average, so every cell in
+        // the row is counted twice. On a boosted 20-250 kPa axis that is the
+        // ordinary case: the 0.3 idle fraction ends idle at row 4 and the
+        // 90 kPa absolute WOT threshold starts WOT at row 5. When the band is
+        // empty the region is simply not emitted; the rows are WOT's.
+        let cruise_row_end = wot_row_start.saturating_sub(1);
 
         if cruise_col_end >= cruise_col_start && cruise_row_end >= cruise_row_start {
             regions.push((
@@ -372,7 +380,8 @@ impl HealthScorer {
         // Cruise, or WOT rectangles so regions don't double-score the same
         // cells. Left slice = low-RPM/high-load, right slice = high-RPM/mid-load.
         let pt_row_start = (idle_row_end + 1).min(rows - 1);
-        let pt_row_end = wot_row_start.saturating_sub(1).max(pt_row_start);
+        // Same reasoning as `cruise_row_end` above.
+        let pt_row_end = wot_row_start.saturating_sub(1);
         if pt_row_end >= pt_row_start {
             if idle_col_end > 0 {
                 regions.push((
@@ -656,9 +665,9 @@ mod tests {
 
         let mut covered = vec![vec![0u32; cols]; rows];
         for (_, _, (r0, r1), (c0, c1)) in &regions {
-            for r in *r0..=*r1 {
-                for c in *c0..=*c1 {
-                    covered[r][c] += 1;
+            for row in covered.iter_mut().take(r1 + 1).skip(*r0) {
+                for cell in row.iter_mut().take(c1 + 1).skip(*c0) {
+                    *cell += 1;
                 }
             }
         }
@@ -827,9 +836,9 @@ mod tests {
             })
             .collect();
         // Inject a checkerboard wave (+/-5) on top of the planar ramp.
-        for r in 0..8 {
-            for c in 0..8 {
-                table[r][c] += if (r + c) % 2 == 0 { 5.0 } else { -5.0 };
+        for (r, row) in table.iter_mut().enumerate() {
+            for (c, cell) in row.iter_mut().enumerate() {
+                *cell += if (r + c) % 2 == 0 { 5.0 } else { -5.0 };
             }
         }
 
@@ -856,9 +865,10 @@ mod tests {
     fn test_monotonicity_floor_ignores_low_load() {
         // Bug #10: a VE drop below the configured load floor should not tank
         // the monotonicity score, but a drop above the floor should.
-        let mut config = HealthConfig::default();
-        config.monotonicity_load_floor_kpa = 35.0;
-        let scorer = HealthScorer::new(config);
+        let scorer = HealthScorer::new(HealthConfig {
+            monotonicity_load_floor_kpa: 35.0,
+            ..HealthConfig::default()
+        });
 
         // 8 load rows: 20..100 kPa. Cruise region covers rows with load >= 35.
         // Drop at row 5 (load 70 kPa, above floor); small drop at row 1 (load
@@ -970,5 +980,56 @@ mod tests {
                 cruise.row_range
             );
         }
+    }
+}
+
+/// Regression for the 2026-09-05 audit finding that the Cruise and
+/// Part-Throttle bands are clamped upward past the start of WOT.
+#[cfg(test)]
+mod audit_regression_tests {
+    use super::*;
+
+    /// `cruise_row_end`/`pt_row_end` were `wot_row_start - 1` clamped *up* to
+    /// the band start, so whenever WOT begins at or below the first non-idle
+    /// row the band swallows `wot_row_start` itself. WOT spans every column
+    /// from that row down, so the whole row is tiled twice and every cell in it
+    /// is counted twice by the cell-count-weighted `overall_score`.
+    ///
+    /// A 20–250 kPa boosted axis is the ordinary trigger: the 0.3 idle fraction
+    /// puts `idle_row_end` at row 4 and the 90 kPa absolute WOT threshold puts
+    /// `wot_row_start` at row 5, i.e. exactly the first cruise row.
+    #[test]
+    fn regions_tile_a_boosted_load_axis_exactly_once() {
+        let scorer = HealthScorer::new(HealthConfig::default());
+        let (rows, cols) = (16, 16);
+        let x_bins: Vec<f64> = (0..cols).map(|i| 500.0 + i as f64 * 500.0).collect();
+        let y_bins: Vec<f64> = (0..rows)
+            .map(|i| 20.0 + i as f64 * (230.0 / (rows - 1) as f64))
+            .collect();
+
+        let regions = scorer.define_regions(&x_bins, &y_bins, rows, cols);
+
+        let mut covered = vec![vec![0u32; cols]; rows];
+        for (_, _, (r0, r1), (c0, c1)) in &regions {
+            for row in covered.iter_mut().take(r1 + 1).skip(*r0) {
+                for cell in row.iter_mut().take(c1 + 1).skip(*c0) {
+                    *cell += 1;
+                }
+            }
+        }
+
+        let wrong: Vec<(usize, usize, u32)> = (0..rows)
+            .flat_map(|r| (0..cols).map(move |c| (r, c)))
+            .map(|(r, c)| (r, c, covered[r][c]))
+            .filter(|(_, _, n)| *n != 1)
+            .collect();
+
+        assert!(
+            wrong.is_empty(),
+            "{} of {} cells are not tiled exactly once (e.g. {:?})",
+            wrong.len(),
+            rows * cols,
+            &wrong[..wrong.len().min(6)]
+        );
     }
 }

--- a/crates/libretune-core/src/autotune/mod.rs
+++ b/crates/libretune-core/src/autotune/mod.rs
@@ -25,7 +25,7 @@ pub mod replay;
 use crate::ini::{EcuDefinition, TableRole};
 use evalexpr::{eval_with_context, ContextWithMutableVariables, HashMapContext, Value};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 /// Why `table_name` must not be fuel-tuned, or `None` if it may be.
 ///
@@ -452,7 +452,13 @@ pub struct AutoTuneReferenceTables {
 #[derive(Debug)]
 pub struct AutoTuneState {
     pub is_running: bool,
-    pub locked_cells: Vec<(usize, usize)>,
+    /// A set, not a list: the UI resends the *whole* current selection on
+    /// every Lock click, so a `Vec` accumulated the same cell once per click
+    /// and `unlock_cells` - which removed a single match - left the backend
+    /// silently skipping a cell the frontend showed as unlocked. Set
+    /// semantics fix that, bound the growth, and make `is_cell_locked` (called
+    /// per accepted sample) constant-time instead of a linear scan.
+    pub locked_cells: HashSet<(usize, usize)>,
     pub recommendations: HashMap<(usize, usize), AutoTuneRecommendation>,
     // Lambda delay buffer - stores recent data points for delayed correlation
     data_buffer: std::collections::VecDeque<VEDataPoint>,
@@ -488,7 +494,7 @@ impl Default for AutoTuneState {
     fn default() -> Self {
         Self {
             is_running: false,
-            locked_cells: Vec::new(),
+            locked_cells: HashSet::new(),
             recommendations: HashMap::new(),
             data_buffer: std::collections::VecDeque::new(),
             buffer_max_age_ms: 500, // Keep 500ms of data for lambda delay correlation
@@ -662,9 +668,7 @@ impl AutoTuneState {
 
     pub fn unlock_cells(&mut self, cells: Vec<(usize, usize)>) {
         for cell in cells {
-            if let Some(pos) = self.locked_cells.iter().position(|c| c == &cell) {
-                self.locked_cells.remove(pos);
-            }
+            self.locked_cells.remove(&cell);
         }
     }
 
@@ -1184,15 +1188,32 @@ impl AutoTuneState {
     ) -> f64 {
         let delta = recommended_value - beginning_value;
 
-        // Clamp by absolute value change
-        let clamped_delta = delta.clamp(
-            -authority.max_cell_value_change,
-            authority.max_cell_value_change,
-        );
+        // Both limits are magnitudes, so take them as such rather than
+        // trusting the sign: `f64::clamp` panics when `lo > hi`, and a
+        // negative limit is exactly what the UI sends when a tuner types "-5"
+        // into a `<input type="number">` that carries no `min`. Same reasoning
+        // as `clamp_to_rails`, which orders its pair for the same reason - but
+        // here the panic lands on the *first* accepted sample, inside the
+        // spawned realtime-stream task, which then dies with the gauges frozen
+        // and nothing surfaced to the user.
+        let max_abs_delta = authority.max_cell_value_change.abs();
+        let clamped_delta = if max_abs_delta.is_finite() {
+            delta.clamp(-max_abs_delta, max_abs_delta)
+        } else {
+            delta
+        };
 
-        // Clamp by percentage change
-        let max_pct_delta = beginning_value * (authority.max_cell_percentage_change / 100.0);
-        let final_delta = clamped_delta.clamp(-max_pct_delta, max_pct_delta);
+        // Clamp by percentage change. A non-finite `beginning_value` reaches
+        // here from the replay path (`LogChannels::point` passes a parsed NaN
+        // VE straight through), and `NaN <= NaN` is false, so the clamp would
+        // panic rather than propagate.
+        let max_pct_delta =
+            (beginning_value * (authority.max_cell_percentage_change / 100.0)).abs();
+        let final_delta = if max_pct_delta.is_finite() {
+            clamped_delta.clamp(-max_pct_delta, max_pct_delta)
+        } else {
+            clamped_delta
+        };
 
         // Absolute rails last, so they bound the result no matter what the two
         // relative clamps allowed. Both of those are measured from
@@ -1214,6 +1235,22 @@ impl AutoTuneState {
             return Some(i);
         }
 
+        // Reject samples that fall outside the axis rather than pinning them to
+        // the nearest end bin. `axis_weight` deliberately hands an edge cell's
+        // sample full weight (there is no neighbour to share with), so an
+        // out-of-range sample used to vote at weight 1.0 in a cell it was never
+        // in - the exact over-weighting `HitWeighting` exists to remove. The
+        // defaults make it the normal case: `max_rpm` is 7000 while plenty of
+        // rpm axes stop at 6000, and `max_y_axis` is `None`, so every boost
+        // sample above the top load bin landed in the top row.
+        //
+        // "Outside" means further than half the adjacent bin span past the
+        // first/last bin, which is the same half-way rule that decides
+        // ownership between two interior bins.
+        if !Self::is_within_axis(value, bins) {
+            return None;
+        }
+
         bins.iter()
             .enumerate()
             .min_by(|(_, a), (_, b)| {
@@ -1222,6 +1259,33 @@ impl AutoTuneState {
                 da.partial_cmp(&db).unwrap_or(std::cmp::Ordering::Equal)
             })
             .map(|(i, _)| i)
+    }
+
+    /// Whether `value` is close enough to the axis to belong to one of its
+    /// bins. A single-bin axis has no span to reason about, so it accepts
+    /// everything, as it did before.
+    fn is_within_axis(value: f64, bins: &[f64]) -> bool {
+        let (Some(&first), Some(&last)) = (bins.first(), bins.last()) else {
+            return false;
+        };
+        if bins.len() < 2 {
+            return true;
+        }
+        // Axes are ascending in practice, but a descending one costs nothing
+        // to support and would otherwise reject every sample.
+        let (lo, lo_next) = if first <= last {
+            (first, bins[1])
+        } else {
+            (last, bins[bins.len() - 2])
+        };
+        let (hi, hi_prev) = if first <= last {
+            (last, bins[bins.len() - 2])
+        } else {
+            (first, bins[1])
+        };
+        let lo_margin = (lo_next - lo).abs() / 2.0;
+        let hi_margin = (hi - hi_prev).abs() / 2.0;
+        value >= lo - lo_margin && value <= hi + hi_margin
     }
 
     fn evaluate_custom_filter(&self, expr: &str, point: &VEDataPoint) -> Result<bool, String> {
@@ -2722,5 +2786,111 @@ mod weighting_approach_tests {
                 "{w:?} discounted a sample taken exactly at the cell centre"
             );
         }
+    }
+}
+
+/// Regressions for the 2026-09-05 audit findings that live in this module:
+/// authority-limit clamp ordering, `lock_cells` duplication and the missing
+/// axis range check in `find_bin_index`.
+#[cfg(test)]
+mod audit_regression_tests {
+    use super::*;
+
+    fn rails() -> AutoTuneAuthorityLimits {
+        AutoTuneAuthorityLimits {
+            max_cell_value_change: 10.0,
+            max_cell_percentage_change: 20.0,
+            min_cell_value: 0.0,
+            max_cell_value: 200.0,
+        }
+    }
+
+    /// `Max Change/Cell` is a bare `<input type="number">` with no `min`, so a
+    /// typed "-5" reaches this function verbatim. `f64::clamp` panics when
+    /// `lo > hi`, and this runs on the *first* accepted sample inside the
+    /// spawned realtime-stream task — which dies silently, freezing the gauges
+    /// with no error surfaced anywhere.
+    #[test]
+    fn a_negative_authority_limit_clamps_instead_of_panicking() {
+        let authority = AutoTuneAuthorityLimits {
+            max_cell_value_change: -5.0,
+            ..rails()
+        };
+        let got = AutoTuneState::apply_authority_limits(50.0, 55.0, &authority);
+        assert!(
+            (got - 55.0).abs() < 1e-9,
+            "a -5 limit must behave as a 5 limit, got {got}"
+        );
+
+        let authority = AutoTuneAuthorityLimits {
+            max_cell_percentage_change: -20.0,
+            ..rails()
+        };
+        let got = AutoTuneState::apply_authority_limits(50.0, 58.0, &authority);
+        assert!(
+            (got - 58.0).abs() < 1e-9,
+            "a -20% limit must behave as a 20% limit, got {got}"
+        );
+    }
+
+    /// The replay path parses a VE straight out of the log, so a `NaN` cell
+    /// value reaches here unfiltered. `NaN * 0.2` is `NaN`, and
+    /// `clamp(-NaN, NaN)` fails the `min <= max` assertion.
+    #[test]
+    fn a_non_finite_beginning_value_does_not_panic() {
+        for begin in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            let got = AutoTuneState::apply_authority_limits(begin, 55.0, &rails());
+            assert!(
+                got.is_finite() || got.is_nan(),
+                "must return, not panic (begin={begin}, got={got})"
+            );
+        }
+    }
+
+    /// The UI sends the *current selection* on every Lock click, so locking A,
+    /// extending the selection to A+B and locking again stores A twice.
+    /// `unlock_cells` removed only the first match, leaving the backend
+    /// silently skipping a cell the frontend shows as unlocked.
+    #[test]
+    fn locking_a_cell_twice_still_unlocks_it_in_one_call() {
+        let mut state = AutoTuneState::new();
+        state.lock_cells(vec![(1, 2)]);
+        state.lock_cells(vec![(1, 2), (3, 4)]);
+        assert!(state.is_cell_locked(1, 2));
+
+        state.unlock_cells(vec![(1, 2)]);
+        assert!(
+            !state.is_cell_locked(1, 2),
+            "one unlock must undo any number of locks of the same cell"
+        );
+        assert!(state.is_cell_locked(3, 4), "unrelated locks must survive");
+    }
+
+    /// `find_bin_index` fell through to a nearest-bin search with no range
+    /// check, so a sample far outside the axis landed in the edge cell — and
+    /// `axis_weight` hands an edge cell's sample full weight, which is exactly
+    /// the over-weighting `HitWeighting` exists to remove. The default
+    /// `max_rpm` of 7000 on a 6000-rpm axis makes this the normal case.
+    #[test]
+    fn a_sample_far_outside_the_axis_gets_no_bin() {
+        let state = AutoTuneState::new();
+        let rpm = [1000.0, 2000.0, 3000.0, 4000.0, 5000.0, 6000.0];
+
+        assert_eq!(
+            state.find_bin_index(7000.0, &rpm),
+            None,
+            "1000 rpm past 6000"
+        );
+        assert_eq!(
+            state.find_bin_index(300.0, &rpm),
+            None,
+            "700 rpm below 1000"
+        );
+
+        // Within half the adjacent bin span the sample is genuinely the edge
+        // cell's, and rejecting it would discard the ends of the map.
+        assert_eq!(state.find_bin_index(6400.0, &rpm), Some(5));
+        assert_eq!(state.find_bin_index(600.0, &rpm), Some(0));
+        assert_eq!(state.find_bin_index(3400.0, &rpm), Some(2));
     }
 }

--- a/crates/libretune-core/src/autotune/predictor.rs
+++ b/crates/libretune-core/src/autotune/predictor.rs
@@ -251,8 +251,20 @@ impl VePredictor {
         let dl = self.find_nearest_known(row, col, 1, -1, rows, cols, known);
         let dr = self.find_nearest_known(row, col, 1, 1, rows, cols, known);
 
-        // Need at least 3 corners for reasonable interpolation
-        let corners: Vec<_> = [ul, ur, dl, dr].iter().filter_map(|c| *c).collect();
+        // Need at least 3 *distinct* corners for reasonable interpolation.
+        //
+        // The quadrants below are a partition, so two searches can no longer
+        // return the same cell - but the fit's honesty rests on that, and a
+        // duplicate would silently inflate `corner_factor` to 1.0 without
+        // moving the predicted value (identical weights cancel in
+        // `weighted_sum / weight_sum`), which is undetectable from the output.
+        // De-duplicating here makes the count mean what it says regardless.
+        let mut corners: Vec<(usize, usize)> = Vec::with_capacity(4);
+        for corner in [ul, ur, dl, dr].into_iter().flatten() {
+            if !corners.contains(&corner) {
+                corners.push(corner);
+            }
+        }
         if corners.len() < 3 {
             return None;
         }
@@ -293,10 +305,27 @@ impl VePredictor {
 
         let predicted = weighted_sum / weight_sum;
 
-        // Confidence based on: number of corners and max distance
+        // Confidence based on: number of distinct corners and max distance.
+        //
+        // `max_dist` is a *normalised* axis fraction (each axis distance is
+        // divided by that axis' span, so it lives in 0..=1.41), while
+        // `max_search_radius` counts cells. Dividing one by the other compared
+        // apples to pears: with the default radius of 5 the denominator was
+        // 7.5, so `distance_factor` never fell below 0.81 and a fit five cells
+        // from the nearest data scored the same as one sitting next to it.
+        // Express the radius as the same fraction - `max_search_radius` bins
+        // out of the axis' bin count - so the two share units.
         let corner_factor = corners.len() as f64 / 4.0;
-        let distance_factor =
-            (1.0 - max_dist / (self.config.max_search_radius as f64 * 1.5)).max(0.0);
+        let radius_fraction = |bins: &[f64]| {
+            let steps = bins.len().saturating_sub(1).max(1) as f64;
+            (self.config.max_search_radius as f64 / steps).min(1.0)
+        };
+        let rx = radius_fraction(x_bins);
+        let ry = radius_fraction(y_bins);
+        // The 1.5 slack is kept: a fit exactly at the search limit should not
+        // score zero on distance alone.
+        let max_norm_dist = ((rx * rx + ry * ry).sqrt() * 1.5).max(1e-6);
+        let distance_factor = (1.0 - max_dist / max_norm_dist).max(0.0);
         let confidence = corner_factor * 0.7 + distance_factor * 0.3;
 
         // Apply axis-based sanity check: VE should be physically reasonable
@@ -314,14 +343,48 @@ impl VePredictor {
         })
     }
 
-    /// Find nearest known cell in a given direction (quadrant).
+    /// Whether the signed offset `(dr, dc)` belongs to the quadrant named by
+    /// `(row_dir, col_dir)`.
     ///
-    /// Bug #6: the previous implementation stepped strictly along the 45°
+    /// The four quadrants are half-open, so every offset except the origin
+    /// belongs to **exactly one** of them: each takes one of the two axis
+    /// half-lines that bound it, going round clockwise. That is what makes the
+    /// four searches in `try_bilinear` independent.
+    ///
+    /// The previous scheme let each quadrant see both of its bounding
+    /// half-lines, and the ring was scanned in ascending Euclidean order with a
+    /// *stable* sort - so the orthogonal offset (distance 1) always beat the
+    /// diagonal (distance 1.41) on the tie. Up-left and down-left therefore
+    /// both returned `(row, col - 1)`, up-right and down-right both returned
+    /// `(row, col + 1)`, and a "4 corner" bilinear fit was two cells counted
+    /// twice with the load axis never consulted at all.
+    fn in_quadrant(dr: i32, dc: i32, row_dir: i32, col_dir: i32) -> bool {
+        match (row_dir, col_dir) {
+            // Up-left owns straight up.
+            (-1, -1) => dr < 0 && dc <= 0,
+            // Up-right owns straight right.
+            (-1, 1) => dr <= 0 && dc > 0,
+            // Down-right owns straight down.
+            (1, 1) => dr > 0 && dc >= 0,
+            // Down-left owns straight left.
+            (1, -1) => dr >= 0 && dc < 0,
+            // A zero direction means "stay on this line".
+            (0, c) => dr == 0 && dc * c > 0,
+            (r, 0) => dc == 0 && dr * r > 0,
+            _ => false,
+        }
+    }
+
+    /// Find the nearest known cell in one quadrant.
+    ///
+    /// Bug #6: the original implementation stepped strictly along the 45°
     /// diagonal (row ± d, col ± d), so it could not find an orthogonal
     /// neighbor sitting directly above/below/left/right of the target. This
     /// version expands a 2D quadrant ring by ring (Chebyshev distance),
     /// scanning every cell in the quadrant at that radius in ascending
     /// Euclidean-distance order, returning the first known cell encountered.
+    /// Orthogonal neighbours are still reachable - each simply belongs to one
+    /// quadrant rather than two (see [`Self::in_quadrant`]).
     #[allow(clippy::too_many_arguments)]
     fn find_nearest_known(
         &self,
@@ -333,39 +396,31 @@ impl VePredictor {
         cols: usize,
         known: &HashMap<(usize, usize), (f64, u32)>,
     ) -> Option<(usize, usize)> {
-        let max_r = self.config.max_search_radius;
+        let max_r = self.config.max_search_radius as i32;
 
         for ring in 1..=max_r {
             // Collect candidate (dr, dc) offsets in this quadrant at Chebyshev
             // distance exactly `ring`, then sort by Euclidean distance so the
             // nearest known cell wins.
             let mut candidates: Vec<(i32, i32, f64)> = Vec::new();
-            for dr in 0..=ring {
-                for dc in 0..=ring {
-                    if dr == 0 && dc == 0 {
-                        continue;
-                    }
+            for dr in -ring..=ring {
+                for dc in -ring..=ring {
                     // Only the outer ring of the expanding square.
-                    if dr != ring && dc != ring {
+                    if dr.abs() != ring && dc.abs() != ring {
                         continue;
                     }
-                    // Respect zero directions: a 0 axis means "same line".
-                    if (row_dir == 0 && dr != 0) || (col_dir == 0 && dc != 0) {
+                    if !Self::in_quadrant(dr, dc, row_dir, col_dir) {
                         continue;
                     }
-                    let (dr_i, dc_i) = (dr as i32, dc as i32);
-                    let euclid = ((dr_i * dr_i + dc_i * dc_i) as f64).sqrt();
-                    candidates.push((dr_i, dc_i, euclid));
+                    let euclid = ((dr * dr + dc * dc) as f64).sqrt();
+                    candidates.push((dr, dc, euclid));
                 }
             }
             candidates.sort_by(|a, b| a.2.partial_cmp(&b.2).unwrap_or(std::cmp::Ordering::Equal));
 
             for (dr, dc, _) in candidates {
-                // dr, dc are non-negative magnitudes; row_dir/col_dir give the
-                // sign. (The 0-axis case was filtered above, so a non-zero
-                // magnitude always pairs with a ±1 direction.)
-                let r = row as i32 + dr * row_dir;
-                let c = col as i32 + dc * col_dir;
+                let r = row as i32 + dr;
+                let c = col as i32 + dc;
                 if r < 0 || r >= rows as i32 || c < 0 || c >= cols as i32 {
                     continue;
                 }
@@ -852,27 +907,48 @@ mod tests {
     #[test]
     fn test_quadrant_search_finds_orthogonal_neighbors() {
         // Bug #6: the old diagonal-only ray missed neighbors directly above,
-        // below, left, or right of the target cell.
+        // below, left, or right of the target cell. They are still reachable
+        // now that the quadrants are a half-open partition — each orthogonal
+        // offset simply belongs to exactly one quadrant instead of two, which
+        // is what stops a "4 corner" fit from being two cells counted twice.
+        //
+        // (The old version of this test supplied only two of the four
+        // orthogonal neighbours and passed *because* of that double-count:
+        // `[ul, ur, dl, dr]` came back as three entries covering two cells.)
         let config = PredictorConfig::default();
         let predictor = VePredictor::new(config);
 
         let mut table = make_table(5, 5, 50.0);
         let mut hits = make_hits(5, 5, 0);
 
-        // Known cells directly above (row 1) and left (col 1) of the target
-        // at (row 2, col 2), but no diagonal cells.
-        hits[1][2] = 10;
-        table[1][2] = 55.0;
-        hits[2][1] = 10;
-        table[2][1] = 53.0;
+        // Known cells directly above, below, left and right of the target at
+        // (row 2, col 2) — and no diagonal cells at all.
+        for (r, c, v) in [
+            (1usize, 2usize, 55.0),
+            (3, 2, 57.0),
+            (2, 1, 53.0),
+            (2, 3, 59.0),
+        ] {
+            hits[r][c] = 10;
+            table[r][c] = v;
+        }
 
         let x_bins = vec![1000.0, 2000.0, 3000.0, 4000.0, 5000.0];
         let y_bins = vec![20.0, 40.0, 60.0, 80.0, 100.0];
 
         let predictions = predictor.predict_cells(&table, &hits, &x_bins, &y_bins);
+        let target = predictions
+            .iter()
+            .find(|p| p.row == 2 && p.col == 2)
+            .expect("target (2,2) should be predicted from orthogonal neighbors");
         assert!(
-            predictions.iter().any(|p| p.row == 2 && p.col == 2),
-            "target (2,2) should be predicted from orthogonal neighbors"
+            matches!(target.method, PredictionMethod::BilinearInterpolation),
+            "four orthogonal neighbours are a full bilinear bracket, got {:?}",
+            target.method
+        );
+        assert_eq!(
+            target.neighbor_count, 4,
+            "each orthogonal neighbour must land in its own quadrant"
         );
     }
 
@@ -882,11 +958,15 @@ mod tests {
         // cells one index apart but spanning a huge physical RPM gap should
         // weight less than an equal-physical-gap pair.
         //
-        // Setup: target at (row 0, col 0). Two known cells in the first column
-        // but far apart in physical RPM. The top-left (row 0, col 1) is only
-        // 100 RPM away in x but same row; the bottom-left (row 1, col 0) is
-        // 1000 RPM away but same col. Physical-distance weighting should rank
-        // the 100 RPM neighbor higher.
+        // Setup: target at (row 0, col 0) with two known neighbours, one on
+        // each axis. Distances are normalised *per axis*, so the axes have to
+        // differ in how far along their own span the neighbour sits: the rpm
+        // neighbour is 5% of the rpm span away, the load neighbour 50% of the
+        // load span. Physical-distance weighting must rank the rpm one higher.
+        //
+        // (The original axes put both neighbours at exactly 50% of their own
+        // span — identical normalised distances — so the assertion below only
+        // held because the bilinear fit double-counted the rpm neighbour.)
         let config = PredictorConfig {
             min_confidence: 0.0, // accept everything for comparison
             max_search_radius: 3,
@@ -903,8 +983,9 @@ mod tests {
         hits[1][0] = 10;
         table[1][0] = 70.0; // same col, y_gap = 1000 "load" units
 
-        // Very compressed x axis: 0,100,200; very stretched y axis: 0,1000,2000
-        let x_bins = vec![0.0, 100.0, 200.0];
+        // x: the known neighbour sits 100 of a 2000-wide span away (5%).
+        // y: the known neighbour sits 1000 of a 2000-wide span away (50%).
+        let x_bins = vec![0.0, 100.0, 2000.0];
         let y_bins = vec![0.0, 1000.0, 2000.0];
 
         let predictions = predictor.predict_cells(&table, &hits, &x_bins, &y_bins);
@@ -1070,6 +1151,151 @@ mod tests {
             "off-peak RPM (got {}) should predict lower VE than peak RPM (got {})",
             low_rpm_pred.predicted_value,
             peak_pred.predicted_value
+        );
+    }
+}
+
+/// Regressions for the 2026-09-05 audit findings in the predictor: overlapping
+/// quadrant searches and the distance/radius unit mismatch in the bilinear
+/// confidence.
+#[cfg(test)]
+mod audit_regression_tests {
+    use super::*;
+
+    fn table(rows: usize, cols: usize) -> Vec<Vec<f64>> {
+        vec![vec![50.0; cols]; rows]
+    }
+
+    fn hits(rows: usize, cols: usize) -> Vec<Vec<u32>> {
+        vec![vec![0u32; cols]; rows]
+    }
+
+    /// Every quadrant ring put the two orthogonal offsets ahead of the diagonal
+    /// on an equal-Euclidean tie-break, and the sort is stable, so the two
+    /// left-hand quadrants both returned `(row, col - 1)` and the two
+    /// right-hand ones both returned `(row, col + 1)`. Four "corners", two
+    /// cells, and the load axis never consulted.
+    #[test]
+    fn bilinear_consults_the_load_axis_not_just_the_rpm_neighbours() {
+        let predictor = VePredictor::new(PredictorConfig {
+            min_hit_count: 1,
+            ..PredictorConfig::default()
+        });
+
+        let mut values = table(3, 3);
+        let mut counts = hits(3, 3);
+        // Horizontal neighbours straddle 50; the vertical ones are far richer.
+        for (r, c, v) in [
+            (1usize, 0usize, 40.0),
+            (1, 2, 60.0),
+            (0, 1, 100.0),
+            (2, 1, 100.0),
+        ] {
+            values[r][c] = v;
+            counts[r][c] = 10;
+        }
+        // Axes chosen so all four neighbours sit at the same normalised
+        // distance, making the expected answer the plain mean of the four.
+        let x_bins = vec![1000.0, 2000.0, 3000.0];
+        let y_bins = vec![20.0, 60.0, 100.0];
+
+        let predictions = predictor.predict_cells(&values, &counts, &x_bins, &y_bins);
+        let centre = predictions
+            .iter()
+            .find(|p| p.row == 1 && p.col == 1)
+            .expect("the centre cell should be predicted");
+
+        assert!(
+            matches!(centre.method, PredictionMethod::BilinearInterpolation),
+            "expected a bilinear fit, got {:?}",
+            centre.method
+        );
+        assert!(
+            centre.predicted_value > 60.0,
+            "the load-axis neighbours must contribute; got {} (50.0 means only \
+             the rpm neighbours were seen, each counted twice)",
+            centre.predicted_value
+        );
+    }
+
+    /// A duplicated corner also inflated `corner_factor` to 4/4. With only
+    /// three distinct cells around it the fit must report three.
+    #[test]
+    fn corner_count_reports_distinct_cells() {
+        let predictor = VePredictor::new(PredictorConfig {
+            min_hit_count: 1,
+            min_confidence: 0.0,
+            ..PredictorConfig::default()
+        });
+
+        let mut values = table(3, 3);
+        let mut counts = hits(3, 3);
+        for (r, c, v) in [(1usize, 0usize, 40.0), (1, 2, 60.0), (0, 1, 55.0)] {
+            values[r][c] = v;
+            counts[r][c] = 10;
+        }
+        let x_bins = vec![1000.0, 2000.0, 3000.0];
+        let y_bins = vec![20.0, 60.0, 100.0];
+
+        let predictions = predictor.predict_cells(&values, &counts, &x_bins, &y_bins);
+        let centre = predictions
+            .iter()
+            .find(|p| {
+                p.row == 1
+                    && p.col == 1
+                    && matches!(p.method, PredictionMethod::BilinearInterpolation)
+            })
+            .expect("the centre cell should get a bilinear fit from three cells");
+
+        assert_eq!(
+            centre.neighbor_count, 3,
+            "three known cells surround the target, not four"
+        );
+    }
+
+    /// `max_dist` is a normalised axis fraction (0..1.41) but the radius it was
+    /// divided by was a count of cells scaled by 1.5 (7.5 by default), so
+    /// `distance_factor` never fell below 0.81 and a fit five cells from any
+    /// data scored the same as one sitting right next to it.
+    #[test]
+    fn bilinear_confidence_falls_off_with_distance() {
+        let predictor = VePredictor::new(PredictorConfig {
+            min_hit_count: 1,
+            min_confidence: 0.0,
+            ..PredictorConfig::default()
+        });
+        let x_bins: Vec<f64> = (0..16).map(|i| 500.0 + i as f64 * 500.0).collect();
+        let y_bins: Vec<f64> = (0..16).map(|i| 20.0 + i as f64 * 10.0).collect();
+
+        let confidence_at = |offset: usize| {
+            let mut values = table(16, 16);
+            let mut counts = hits(16, 16);
+            for (r, c) in [
+                (8 - offset, 8 - offset),
+                (8 - offset, 8 + offset),
+                (8 + offset, 8 - offset),
+                (8 + offset, 8 + offset),
+            ] {
+                values[r][c] = 60.0;
+                counts[r][c] = 10;
+            }
+            predictor
+                .predict_cells(&values, &counts, &x_bins, &y_bins)
+                .into_iter()
+                .find(|p| {
+                    p.row == 8
+                        && p.col == 8
+                        && matches!(p.method, PredictionMethod::BilinearInterpolation)
+                })
+                .map(|p| p.confidence)
+                .expect("centre should get a bilinear fit")
+        };
+
+        let near = confidence_at(1);
+        let far = confidence_at(5);
+        assert!(
+            near - far > 0.10,
+            "distance must move confidence materially: near={near}, far={far}"
         );
     }
 }

--- a/crates/libretune-core/src/autotune/replay.rs
+++ b/crates/libretune-core/src/autotune/replay.rs
@@ -434,6 +434,20 @@ pub fn validate(
 /// window covers the whole exhaust path.
 pub const VALIDATION_STEADY_MS: f64 = 800.0;
 
+/// Hard cap on how many samples the backward steadiness walk may inspect.
+///
+/// The walk is otherwise bounded only by [`VALIDATION_STEADY_MS`] of log time,
+/// which a broken or constant time column never satisfies - the walk then runs
+/// to index 0 for every sample and the pass becomes O(n²). The rpm/load
+/// tolerances usually cut it short, but a long idle or steady-state hold keeps
+/// those satisfied too.
+///
+/// 512 samples is far beyond any real 800 ms window (8 samples at 10 Hz, 80 at
+/// 100 Hz), so this changes no verdict on a sane log. On an insane one the walk
+/// simply stops without setting `reached_back`, which already means "not
+/// evidence of steadiness".
+const MAX_STEADY_LOOKBACK: usize = 512;
+
 /// Which samples had rpm and load unchanged for the whole window before them.
 ///
 /// Independent of [`AutoTuneFilters::min_steady_ms`] on purpose: the score must
@@ -450,7 +464,7 @@ fn steady_mask(log: &LogChannels) -> Vec<bool> {
         let start = log.time_ms[i] - VALIDATION_STEADY_MS;
         let mut reached_back = false;
         let mut steady = true;
-        for j in (0..=i).rev() {
+        for j in (i.saturating_sub(MAX_STEADY_LOOKBACK)..=i).rev() {
             if log.time_ms[j] < start {
                 reached_back = true;
                 break;
@@ -585,5 +599,79 @@ mod tests {
         assert_eq!(log.len(), 40);
         let report = replay(&log, &X, &Y, &tables(), &config());
         assert_eq!(report.verdicts.len(), 40);
+    }
+}
+
+/// Regression for the 2026-09-05 audit finding that `steady_mask`'s backward
+/// walk is bounded only by log time.
+#[cfg(test)]
+mod audit_regression_tests {
+    use super::*;
+
+    /// A log whose time channel does not advance never satisfies
+    /// `time_ms[j] < start`, so the walk runs to index 0 for every sample and
+    /// the whole pass becomes O(n²). The rpm/load tolerances usually cut it
+    /// short, but a long steady hold (or an idle) keeps them satisfied too.
+    /// Capping the walk by index as well as by time bounds the cost without
+    /// changing the verdict: not reaching back far enough is still not
+    /// evidence of steadiness.
+    #[test]
+    fn a_stalled_time_channel_does_not_take_quadratic_time() {
+        let n = 20_000;
+        let log = LogChannels {
+            time_ms: vec![0.0; n],
+            rpm: vec![3000.0; n],
+            load: vec![50.0; n],
+            afr: vec![14.7; n],
+            ve: vec![50.0; n],
+            clt: vec![90.0; n],
+            tps: vec![20.0; n],
+            tps_rate: vec![0.0; n],
+            fuel_cut: vec![0.0; n],
+            accel_enrich: vec![0.0; n],
+        };
+
+        let began = std::time::Instant::now();
+        let mask = steady_mask(&log);
+        let elapsed = began.elapsed();
+
+        assert_eq!(mask.len(), n);
+        assert!(
+            mask.iter().all(|s| !s),
+            "a log that never reaches back 800ms cannot claim steadiness"
+        );
+        assert!(
+            elapsed < std::time::Duration::from_secs(3),
+            "the backward walk must be bounded, took {elapsed:?} for {n} samples"
+        );
+    }
+
+    /// The index cap must sit far above any realistic sample rate, so a normal
+    /// log's verdicts are untouched: 800ms holds 8 samples at 10Hz and 80 at
+    /// 100Hz, against a cap in the hundreds.
+    #[test]
+    fn a_normal_log_still_reports_its_steady_stretch() {
+        let n = 200;
+        let log = LogChannels {
+            time_ms: (0..n).map(|i| i as f64 * 100.0).collect(),
+            rpm: vec![3000.0; n],
+            load: vec![50.0; n],
+            afr: vec![14.7; n],
+            ve: vec![50.0; n],
+            clt: vec![90.0; n],
+            tps: vec![20.0; n],
+            tps_rate: vec![0.0; n],
+            fuel_cut: vec![0.0; n],
+            accel_enrich: vec![0.0; n],
+        };
+
+        let mask = steady_mask(&log);
+        // The first 800ms cannot reach back; everything after it is steady.
+        assert!(!mask[0], "the start of the log has no history");
+        assert!(mask[100], "a long steady hold must be marked steady");
+        assert!(
+            mask.iter().filter(|s| **s).count() > n / 2,
+            "most of a wholly steady log must be marked steady"
+        );
     }
 }

--- a/crates/libretune-core/src/datalog/dyno.rs
+++ b/crates/libretune-core/src/datalog/dyno.rs
@@ -568,8 +568,12 @@ where
                 Some(v1 + t * (v2 - v1))
             }
         }
-        (Some((_, v)), None) | (None, Some((_, v))) => Some(v),
-        (None, None) => None,
+        // Outside the run's own measured range there is nothing to
+        // interpolate between, and holding the nearest endpoint flat invents
+        // data: a run measured 3000-6000 rpm was reported as making its 6000
+        // rpm power at 6500 and again at 7000, and `DynoComparison::compare`
+        // folds those fabricated points into the headline mean change.
+        (Some(_), None) | (None, Some(_)) | (None, None) => None,
     }
 }
 
@@ -745,6 +749,67 @@ mod tests {
         // HP should be +10 at 3000, +15 at 5000
         assert!((cmp.hp_diff[0].1 - 10.0).abs() < 1e-6);
         assert!((cmp.hp_diff[1].1 - 15.0).abs() < 1e-6);
+    }
+
+    /// A run queried outside its own measured RPM range used to report its
+    /// nearest endpoint value, so a short run was extrapolated flat across
+    /// every RPM the other run covered — and those fabricated points were
+    /// folded into the headline `total_hp_change` mean.
+    #[test]
+    fn comparison_excludes_rpm_outside_the_other_runs_range() {
+        let point = |rpm: f64, hp: f64| DynoDataPoint {
+            rpm,
+            hp: Some(hp),
+            torque: Some(hp * 2.0),
+            afr: None,
+            boost: None,
+            time: None,
+        };
+
+        let mut run_a = DynoRun::new("Baseline", "#ff0000");
+        run_a.data = vec![
+            point(2000.0, 80.0),
+            point(3000.0, 100.0),
+            point(6000.0, 200.0),
+            point(7000.0, 210.0),
+        ];
+
+        // Run B only covers 3000-6000 rpm.
+        let mut run_b = DynoRun::new("After Tune", "#00ff00");
+        run_b.data = vec![point(3000.0, 110.0), point(6000.0, 215.0)];
+
+        let cmp = DynoComparison::compare(run_a, run_b);
+        let rpms: Vec<f64> = cmp.hp_diff.iter().map(|(rpm, _)| *rpm).collect();
+        assert_eq!(
+            rpms,
+            vec![3000.0, 6000.0],
+            "only the overlapping rpm range may be compared"
+        );
+
+        // Both overlapping points are +10/+15, so the mean is 12.5. The two
+        // extrapolated points used to drag it toward +30 and +10.
+        let mean = cmp.total_hp_change.expect("an overlap exists");
+        assert!((mean - 12.5).abs() < 1e-9, "got {mean}");
+    }
+
+    /// The interpolator itself must refuse out-of-range queries — it is the
+    /// single place `compare` gets its values from.
+    #[test]
+    fn interpolate_at_rpm_returns_none_outside_the_measured_range() {
+        let point = |rpm: f64, hp: f64| DynoDataPoint {
+            rpm,
+            hp: Some(hp),
+            torque: None,
+            afr: None,
+            boost: None,
+            time: None,
+        };
+        let data = vec![point(3000.0, 100.0), point(6000.0, 200.0)];
+
+        assert_eq!(interpolate_at_rpm(&data, 2999.0, |p| p.hp), None);
+        assert_eq!(interpolate_at_rpm(&data, 6001.0, |p| p.hp), None);
+        assert_eq!(interpolate_at_rpm(&data, 3000.0, |p| p.hp), Some(100.0));
+        assert_eq!(interpolate_at_rpm(&data, 6000.0, |p| p.hp), Some(200.0));
     }
 
     #[test]


### PR DESCRIPTION
## Description
Numeric and robustness fixes in the AutoTune core, each verified with a worked example before fixing.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made
- `apply_authority_limits` passed unordered bounds to `f64::clamp`; a negative or NaN limit (the UI input has no `min`) panicked inside the realtime sample path. Bounds now use magnitudes like the sibling `clamp_to_rails`.
- Bilinear predictor: the four quadrant searches overlapped on the axis lines and the stable sort made the horizontal neighbour win twice, so the load axis was never consulted and `corner_factor` over-reported. Quadrants are now a half-open partition, corners are deduped, and confidence falls off with normalised distance (was effectively distance-independent due to a unit mismatch).
- Anomaly detection: 3-neighbour corner cells produced an exact plane fit (residual 0) and always saturated at severity 1.0; residual sigma divided by n instead of n-3. Both fixed.
- Health score: cruise / part-throttle row ends were clamped upward into the WOT band on boosted load axes, counting those cells 2-3x. Regions now tile the axis exactly once (test asserts it on a 20-250 kPa axis).
- `locked_cells` is a `HashSet` so a cell locked twice unlocks in one call.
- Samples far outside the table axes no longer land in the edge cell at full weight.
- Dyno comparison returns `None` outside the measured RPM range instead of extrapolating.
- `steady_mask` backward walk capped by index (was O(n^2) on a stalled time channel, 6.6 s on a 20k-sample log); `accel_enrich` windows via `partition_point`.

Two pre-existing predictor tests were re-aimed because they only passed thanks to the double-count; explained in their doc comments.

## Testing
- [x] I have tested these changes locally
- [x] New and existing tests pass (`cargo test`)
- [ ] The UI works correctly with these changes (not exercised against hardware)

## Checklist
- [x] Code compiles without errors
- [x] No new clippy warnings (`cargo clippy`)
- [x] Code is formatted (`cargo fmt`)
- [x] TypeScript compiles without errors (`npm run typecheck`)
- [ ] Documentation updated if needed
- [x] Commit messages follow conventional format

Part of a full-app audit; each area is a separate PR so they can be reviewed and merged independently. Every finding was verified against the code path by a second pass before being fixed, and each fix has a regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
