### PR TITLE
fix(ini,tune): rebin zeroing, smooth bounds, XML escaping, parser hardening

### DIFF
--- a/crates/libretune-core/src/ini/constants.rs
+++ b/crates/libretune-core/src/ini/constants.rs
@@ -319,11 +319,22 @@ pub fn parse_constant_line(
         constant.units = parts[units_idx].trim_matches('"').to_string();
     }
 
-    // Parse scale, translate, min, max, digits.
-    // scale/translate may be `{expr}` referencing other constants (Speeduino's
-    // `{fuelLoadRes}`); those are kept for deferred resolution instead of
-    // silently collapsing to the literal fallback.
-    let scale_idx = units_idx + 1;
+    apply_scale_and_range(&mut constant, &parts, units_idx + 1);
+
+    Some(constant)
+}
+
+/// Read the trailing `scale, translate, min, max, digits` columns into
+/// `constant`, starting at `scale_idx`.
+///
+/// Any of scale/translate/min/max may be a `{expr}` reference to another
+/// constant (Speeduino's `{fuelLoadRes}`); those are recorded for deferred
+/// resolution instead of silently collapsing to the literal fallback, and a
+/// deferred min/max clears `range_resolved` so `display_to_raw` does not clamp
+/// against a range the INI never declared. Shared by `[Constants]` and
+/// `[PcVariables]`, which used to disagree: the PcVariable path parsed the same
+/// columns without any of the deferral, fabricating a 0..255 range.
+fn apply_scale_and_range(constant: &mut Constant, parts: &[&str], scale_idx: usize) {
     if parts.len() > scale_idx {
         constant.scale_expr = deferred_expr(parts[scale_idx]);
         constant.scale = parts[scale_idx].parse().unwrap_or(1.0);
@@ -344,8 +355,6 @@ pub fn parse_constant_line(
     if parts.len() > scale_idx + 4 {
         constant.digits = parts[scale_idx + 4].parse().unwrap_or(0);
     }
-
-    Some(constant)
 }
 
 /// Parse a PcVariable constant line (no offset field)
@@ -401,21 +410,7 @@ pub fn parse_pc_variable_line(name: &str, value: &str, help: Option<String>) -> 
         if parts.len() > 3 {
             constant.units = parts[3].trim_matches('"').to_string();
         }
-        if parts.len() > 4 {
-            constant.scale = parts[4].parse().unwrap_or(1.0);
-        }
-        if parts.len() > 5 {
-            constant.translate = parts[5].parse().unwrap_or(0.0);
-        }
-        if parts.len() > 6 {
-            constant.min = parts[6].parse().unwrap_or(0.0);
-        }
-        if parts.len() > 7 {
-            constant.max = parts[7].parse().unwrap_or(255.0);
-        }
-        if parts.len() > 8 {
-            constant.digits = parts[8].parse().unwrap_or(0);
-        }
+        apply_scale_and_range(&mut constant, &parts, 4);
         return Some(constant);
     }
 
@@ -423,24 +418,14 @@ pub fn parse_pc_variable_line(name: &str, value: &str, help: Option<String>) -> 
     if parts.len() > 2 {
         constant.units = parts[2].trim_matches('"').to_string();
     }
-    if parts.len() > 3 {
-        constant.scale = parts[3].parse().unwrap_or(1.0);
-    }
-    if parts.len() > 4 {
-        constant.translate = parts[4].parse().unwrap_or(0.0);
-    }
-    if parts.len() > 5 {
-        constant.min = parts[5].parse().unwrap_or(0.0);
-    }
-    if parts.len() > 6 {
-        constant.max = parts[6].parse().unwrap_or(255.0);
-    }
-    if parts.len() > 7 {
-        constant.digits = parts[7].parse().unwrap_or(0);
-    }
+    apply_scale_and_range(&mut constant, &parts, 3);
 
     Some(constant)
 }
+
+/// Widest bit index a TunerStudio bit field may name: bit fields are backed by
+/// at most a 32-bit storage type, so `[0:31]` is the largest legal range.
+const MAX_BIT_INDEX: u8 = 32;
 
 /// Parse TunerStudio bit range `[start:end]` or `[start:end+N]` / `[start:end-N]`.
 /// Returns `(start_bit, bit_count, display_offset)` where `bit_count = end - start + 1`.
@@ -473,7 +458,18 @@ fn parse_bit_range_spec(spec: &str) -> Option<(u8, u8, i8)> {
         (end_part.parse().ok()?, 0)
     };
 
-    let size = if end >= start { end - start + 1 } else { 1 };
+    // `end - start + 1` on `u8` overflows for a range like `[0:255]`: a panic
+    // under the default debug `overflow-checks`, a silent `bit_size = 0` in
+    // release. Both bounds also have to fit the widest storage type a bit
+    // field may use, which is 32 bits.
+    if start >= MAX_BIT_INDEX || end >= MAX_BIT_INDEX {
+        return None;
+    }
+    let size = if end >= start {
+        (end - start).checked_add(1)?
+    } else {
+        1
+    };
     Some((start, size, display_offset))
 }
 
@@ -710,5 +706,60 @@ mod declared_range_tests {
         c.max = -40.0;
         assert_eq!(c.display_to_raw(200.0), c.display_to_raw(70.0));
         assert_eq!(c.display_to_raw(-500.0), c.display_to_raw(-40.0));
+    }
+
+    /// `[PcVariables]` scalars go through the same `{expr}` deferral as
+    /// `[Constants]` ones. Without it a `{maxRpm}` min/max collapsed to the
+    /// literal 0.0/255.0 fallback and `display_to_raw` clamped against a range
+    /// the INI never declared.
+    #[test]
+    fn pc_variable_scalars_defer_brace_expressions_like_constants_do() {
+        let c = parse_pc_variable_line(
+            "rpmwarn",
+            "scalar, U16, \"RPM\", {rpmScale}, {rpmOffset}, {rpmMin}, {rpmMax}, 0",
+            None,
+        )
+        .expect("parses");
+
+        assert_eq!(c.scale_expr.as_deref(), Some("rpmScale"));
+        assert_eq!(c.translate_expr.as_deref(), Some("rpmOffset"));
+        assert_eq!(c.min_expr.as_deref(), Some("rpmMin"));
+        assert_eq!(c.max_expr.as_deref(), Some("rpmMax"));
+        assert!(
+            !c.range_resolved,
+            "a deferred min/max must not be treated as resolved"
+        );
+    }
+
+    /// Literal min/max still resolve immediately.
+    #[test]
+    fn pc_variable_scalars_with_literal_ranges_stay_resolved() {
+        let c = parse_pc_variable_line("rpmwarn", "scalar, U16, \"RPM\", 1, 0, 100, 9000, 0", None)
+            .expect("parses");
+
+        assert!(c.range_resolved);
+        assert!((c.min - 100.0).abs() < f64::EPSILON);
+        assert!((c.max - 9000.0).abs() < f64::EPSILON);
+    }
+
+    /// `end - start + 1` on `u8` overflows for `[0:255]`: a panic under the
+    /// default debug `overflow-checks`, a silent `bit_size = 0` in release.
+    /// The spec caps a bit field at the 32 bits of its storage type.
+    #[test]
+    fn wide_bit_ranges_are_rejected_instead_of_overflowing() {
+        let c = parse_constant_line("wide", "bits, U08, 0, [0:255], \"a\", \"b\"", 0, 0, None)
+            .expect("parses");
+        assert_eq!(c.bit_size, None, "an impossible bit range must be rejected");
+        assert_eq!(c.bit_position, None);
+
+        let pc =
+            parse_pc_variable_line("widePc", "bits, U08, [0:255], \"a\"", None).expect("parses");
+        assert_eq!(pc.bit_size, None);
+
+        // A legal range is unaffected.
+        let ok = parse_constant_line("narrow", "bits, U08, 0, [4:7], \"a\"", 0, 0, None)
+            .expect("parses");
+        assert_eq!(ok.bit_position, Some(4));
+        assert_eq!(ok.bit_size, Some(4));
     }
 }

--- a/crates/libretune-core/src/ini/expression.rs
+++ b/crates/libretune-core/src/ini/expression.rs
@@ -95,10 +95,22 @@ pub enum Expr {
     FunctionCall(String, Vec<Expr>), // function name, arguments
 }
 
+/// Maximum nesting depth the expression parser will follow.
+///
+/// `parse_primary` recurses on every `(`, ternary arm and function argument,
+/// so INI text alone could drive the parser off the end of the stack. The AST
+/// `evaluate` walks can be no deeper than what the parser accepted, so this
+/// bounds evaluation too. Real INI expressions nest a handful of levels.
+const MAX_PARSE_DEPTH: usize = 64;
+
 /// Parser for expressions
 pub struct Parser<'a> {
     tokens: Vec<Token>,
     pos: usize,
+    depth: usize,
+    /// Set when the lexer met something it could not represent. Reported from
+    /// [`Parser::parse`] so `Parser::new` keeps its infallible signature.
+    lex_error: Option<String>,
     _input: &'a str,
 }
 
@@ -136,26 +148,62 @@ enum Token {
 
 impl<'a> Parser<'a> {
     pub fn new(input: &'a str) -> Self {
-        let tokens = lex(input);
+        let (tokens, lex_error) = match lex(input) {
+            Ok(tokens) => (tokens, None),
+            Err(e) => (Vec::new(), Some(e)),
+        };
         Self {
             tokens,
             pos: 0,
+            depth: 0,
+            lex_error,
             _input: input,
         }
     }
 
+    /// Parse the whole input.
+    ///
+    /// Errors if the lexer met an unrepresentable character or if any tokens
+    /// are left over: `parse` used to return whatever prefix it understood and
+    /// drop the rest, so `mapValue * 1e3` silently evaluated as `mapValue * 1`.
     pub fn parse(&mut self) -> Result<Expr, String> {
-        self.parse_conditional()
+        if let Some(e) = &self.lex_error {
+            return Err(e.clone());
+        }
+        let expr = self.parse_expr()?;
+        if self.pos != self.tokens.len() {
+            return Err(format!(
+                "Unexpected trailing input after expression (token {} of {})",
+                self.pos + 1,
+                self.tokens.len()
+            ));
+        }
+        Ok(expr)
+    }
+
+    /// One expression, without the end-of-input check - the recursion entry
+    /// point used by parentheses, ternary arms and function arguments.
+    fn parse_expr(&mut self) -> Result<Expr, String> {
+        self.depth += 1;
+        if self.depth > MAX_PARSE_DEPTH {
+            self.depth -= 1;
+            return Err(format!(
+                "Expression nested deeper than {MAX_PARSE_DEPTH} levels"
+            ));
+        }
+        let result = self.parse_conditional();
+        self.depth -= 1;
+        result
     }
 
     fn parse_conditional(&mut self) -> Result<Expr, String> {
         let node = self.parse_logical_or()?;
         if self.match_token(Token::Question) {
-            let true_expr = self.parse()?;
+            let true_expr = self.parse_expr()?;
             if !self.match_token(Token::Colon) {
                 return Err("Expected ':' in ternary expression".to_string());
             }
-            let false_expr = self.parse()?;
+            let false_expr = self.parse_expr()?;
             Ok(Expr::Ternary(
                 Box::new(node),
                 Box::new(true_expr),
@@ -339,7 +387,7 @@ impl<'a> Parser<'a> {
                     let mut args = Vec::new();
                     if !self.match_token(Token::RParen) {
                         loop {
-                            args.push(self.parse()?);
+                            args.push(self.parse_expr()?);
                             if self.match_token(Token::RParen) {
                                 break;
                             }
@@ -355,7 +403,7 @@ impl<'a> Parser<'a> {
             }
             Some(Token::String(s)) => Ok(Expr::Literal(Value::String(s.clone()))),
             Some(Token::LParen) => {
-                let expr = self.parse()?;
+                let expr = self.parse_expr()?;
                 if !self.match_token(Token::RParen) {
                     return Err("Expected ')'".to_string());
                 }
@@ -386,13 +434,23 @@ impl<'a> Parser<'a> {
     }
 }
 
-fn lex(input: &str) -> Vec<Token> {
+/// Tokenize an expression.
+///
+/// Returns `Err` for anything it cannot represent rather than dropping it: the
+/// old lexer silently discarded unknown characters and a lone `=`, so a typo
+/// in an INI expression produced a different, plausible-looking expression
+/// instead of a diagnosable error.
+fn lex(input: &str) -> Result<Vec<Token>, String> {
     let mut tokens = Vec::new();
     let mut chars = input.chars().peekable();
 
     while let Some(ch) = chars.next() {
         match ch {
             ' ' | '\t' | '\r' | '\n' => continue,
+            // INI wraps an expression - and often each variable inside it - in
+            // braces (`{rpm} / 1000`, `{ bitStringValue(units, algo) }`). They
+            // are delimiters, not operators, so they carry no meaning here.
+            '{' | '}' => continue,
             '(' => tokens.push(Token::LParen),
             ')' => tokens.push(Token::RParen),
             ',' => tokens.push(Token::Comma),
@@ -417,6 +475,8 @@ fn lex(input: &str) -> Vec<Token> {
                 if chars.peek() == Some(&'=') {
                     chars.next();
                     tokens.push(Token::EqEq);
+                } else {
+                    return Err("Unexpected '=' (assignment is not an expression)".to_string());
                 }
             }
             '<' => {
@@ -467,7 +527,12 @@ fn lex(input: &str) -> Vec<Token> {
                 }
                 tokens.push(Token::String(s));
             }
-            ch if ch.is_ascii_digit() => {
+            // A number: digits, an optional fraction, an optional exponent.
+            // `1e3` used to lex as `Number(1)` followed by `Ident("e3")`, and
+            // `.5` was dropped entirely by the catch-all arm below.
+            ch if ch.is_ascii_digit()
+                || (ch == '.' && chars.peek().is_some_and(char::is_ascii_digit)) =>
+            {
                 let mut s = String::new();
                 s.push(ch);
                 while let Some(&next_ch) = chars.peek() {
@@ -477,8 +542,27 @@ fn lex(input: &str) -> Vec<Token> {
                         break;
                     }
                 }
-                if let Ok(n) = s.parse::<f64>() {
-                    tokens.push(Token::Number(n));
+                if matches!(chars.peek(), Some('e') | Some('E')) {
+                    // Only consume the `e` if a valid exponent follows, so
+                    // `1exp` still lexes as `1` then the identifier `exp`.
+                    let mut lookahead = chars.clone();
+                    let e = lookahead.next().expect("peeked");
+                    let mut exponent = String::new();
+                    if matches!(lookahead.peek(), Some('+') | Some('-')) {
+                        exponent.push(lookahead.next().expect("peeked"));
+                    }
+                    if lookahead.peek().is_some_and(char::is_ascii_digit) {
+                        while lookahead.peek().is_some_and(char::is_ascii_digit) {
+                            exponent.push(lookahead.next().expect("peeked"));
+                        }
+                        s.push(e);
+                        s.push_str(&exponent);
+                        chars = lookahead;
+                    }
+                }
+                match s.parse::<f64>() {
+                    Ok(n) => tokens.push(Token::Number(n)),
+                    Err(_) => return Err(format!("Malformed number literal '{s}'")),
                 }
             }
             '$' => {
@@ -506,10 +590,10 @@ fn lex(input: &str) -> Vec<Token> {
                 }
                 tokens.push(Token::Ident(s));
             }
-            _ => {}
+            other => return Err(format!("Unexpected character '{other}' in expression")),
         }
     }
-    tokens
+    Ok(tokens)
 }
 
 type StringValueFn = dyn Fn(&str) -> Option<String> + Send + Sync;
@@ -1048,6 +1132,14 @@ fn evaluate_function(
     }
 }
 
+/// A shift count usable on `i64`, or `None` if the operand is out of range.
+fn shift_count(v: f64) -> Option<u32> {
+    if !v.is_finite() || !(0.0..64.0).contains(&v) {
+        return None;
+    }
+    Some(v as u32)
+}
+
 /// Evaluates an expression against a context
 pub fn evaluate(
     expr: &Expr,
@@ -1143,11 +1235,20 @@ pub fn evaluate(
                 BinOp::BitXor => Ok(Value::Number(
                     ((l.as_f64() as i64) ^ (r.as_f64() as i64)) as f64,
                 )),
+                // A shift count outside `0..64` is undefined for `i64`: Rust
+                // panics under debug `overflow-checks` and masks the count in
+                // release. INI text reaches here unvalidated, and evaluation
+                // happens on the realtime channel task, so an out-of-range
+                // shift used to kill that task the first time it ran.
                 BinOp::Shl => Ok(Value::Number(
-                    ((l.as_f64() as i64) << (r.as_f64() as i32)) as f64,
+                    shift_count(r.as_f64())
+                        .and_then(|n| (l.as_f64() as i64).checked_shl(n))
+                        .unwrap_or(0) as f64,
                 )),
                 BinOp::Shr => Ok(Value::Number(
-                    ((l.as_f64() as i64) >> (r.as_f64() as i32)) as f64,
+                    shift_count(r.as_f64())
+                        .and_then(|n| (l.as_f64() as i64).checked_shr(n))
+                        .unwrap_or(0) as f64,
                 )),
             }
         }
@@ -1335,14 +1436,16 @@ mod tests {
             Value::String(String::new())
         );
 
-        let mut string_ctx = StringContext::default();
-        string_ctx.get_string_value = Some(Box::new(|name| {
-            if name == "gpPwmNote1" {
-                Some("Radiator Fan".to_string())
-            } else {
-                None
-            }
-        }));
+        let string_ctx = StringContext {
+            get_string_value: Some(Box::new(|name| {
+                if name == "gpPwmNote1" {
+                    Some("Radiator Fan".to_string())
+                } else {
+                    None
+                }
+            })),
+            ..StringContext::default()
+        };
         assert_eq!(
             evaluate(&expr, &context, Some(&string_ctx)).unwrap(),
             Value::String("Radiator Fan".to_string())
@@ -1365,14 +1468,16 @@ mod tests {
             Value::String("INVALID[1]".to_string())
         );
 
-        let mut string_ctx = StringContext::default();
-        string_ctx.get_bit_options = Some(Box::new(|name| {
-            if name == "pwmAxisLabels" {
-                Some(vec!["RPM".into(), "MAP".into(), "TPS".into()])
-            } else {
-                None
-            }
-        }));
+        let string_ctx = StringContext {
+            get_bit_options: Some(Box::new(|name| {
+                if name == "pwmAxisLabels" {
+                    Some(vec!["RPM".into(), "MAP".into(), "TPS".into()])
+                } else {
+                    None
+                }
+            })),
+            ..StringContext::default()
+        };
         assert_eq!(
             evaluate(&expr, &context, Some(&string_ctx)).unwrap(),
             Value::String("MAP".to_string())
@@ -1386,5 +1491,92 @@ mod tests {
             evaluate_display_string("Engine Speed", &context, None),
             "Engine Speed"
         );
+    }
+
+    /// A shift amount outside `0..64` is undefined for `i64` - Rust panics in
+    /// debug and masks the count in release. INI text reaches here directly,
+    /// so it must be rejected rather than trusted.
+    #[test]
+    fn out_of_range_shifts_yield_zero_instead_of_panicking() {
+        let context = HashMap::new();
+        for src in [
+            "1 << 64",
+            "1 << 200",
+            "1 << (0 - 1)",
+            "1 >> 64",
+            "1 >> (0 - 3)",
+        ] {
+            let expr = Parser::new(src)
+                .parse()
+                .unwrap_or_else(|e| panic!("{src}: {e}"));
+            assert_eq!(
+                evaluate_simple(&expr, &context).unwrap(),
+                Value::Number(0.0),
+                "{src} should clamp to 0"
+            );
+        }
+
+        // In-range shifts still work.
+        let expr = Parser::new("1 << 3").parse().unwrap();
+        assert_eq!(
+            evaluate_simple(&expr, &context).unwrap(),
+            Value::Number(8.0)
+        );
+    }
+
+    /// `parse_primary` recurses on every `(`, so deeply nested parentheses in
+    /// INI text overflowed the stack. Depth is bounded and reported instead.
+    #[test]
+    fn deeply_nested_parentheses_error_instead_of_overflowing_the_stack() {
+        let deep = format!("{}1{}", "(".repeat(5000), ")".repeat(5000));
+        assert!(
+            Parser::new(&deep).parse().is_err(),
+            "unbounded recursion accepted"
+        );
+
+        // A sane nesting depth still parses.
+        let shallow = format!("{}1 + 1{}", "(".repeat(16), ")".repeat(16));
+        assert!(Parser::new(&shallow).parse().is_ok());
+    }
+
+    /// The lexer used to drop anything it did not recognise and the parser
+    /// used to ignore whatever tokens were left over, so `mapValue * 1e3`
+    /// silently evaluated as `mapValue * 1`.
+    #[test]
+    fn lexer_and_parser_reject_input_they_cannot_represent() {
+        assert!(
+            Parser::new("1 2").parse().is_err(),
+            "trailing tokens ignored"
+        );
+        assert!(
+            Parser::new("1 + 2 3").parse().is_err(),
+            "trailing tokens ignored"
+        );
+        assert!(
+            Parser::new("1 @ 2").parse().is_err(),
+            "unknown character ignored"
+        );
+        assert!(Parser::new("a = 1").parse().is_err(), "lone '=' ignored");
+    }
+
+    /// Exponent and leading-dot literals are ordinary INI numbers.
+    #[test]
+    fn lexer_understands_exponent_and_leading_dot_numbers() {
+        let context = HashMap::new();
+        for (src, want) in [
+            ("1e3", 1000.0),
+            ("1E3", 1000.0),
+            ("1.5e-2", 0.015),
+            ("2e+2", 200.0),
+            (".5", 0.5),
+        ] {
+            let expr = Parser::new(src)
+                .parse()
+                .unwrap_or_else(|e| panic!("{src}: {e}"));
+            match evaluate_simple(&expr, &context).unwrap() {
+                Value::Number(n) => assert!((n - want).abs() < 1e-12, "{src} -> {n}, want {want}"),
+                other => panic!("{src} -> {other:?}"),
+            }
+        }
     }
 }

--- a/crates/libretune-core/src/ini/mod.rs
+++ b/crates/libretune-core/src/ini/mod.rs
@@ -1045,10 +1045,7 @@ mod tests {
         let field = d
             .components
             .iter()
-            .find_map(|c| match c {
-                DialogComponent::Field { name, .. } if name == "algorithm" => Some(c),
-                _ => None,
-            })
+            .find(|c| matches!(c, DialogComponent::Field { name, .. } if name == "algorithm"))
             .expect("algorithm field must be synthesized when the constant exists");
         match field {
             DialogComponent::Field { label, .. } => {

--- a/crates/libretune-core/src/ini/parser.rs
+++ b/crates/libretune-core/src/ini/parser.rs
@@ -36,6 +36,9 @@ struct ParserState {
     current_curve: Option<String>,
     current_help: Option<String>,
     current_reference_table: Option<String>,
+    /// Name of the `settingGroup` most recently opened in `[SettingGroups]`,
+    /// so its `settingOption` lines attach to it.
+    current_setting_group: Option<String>,
     /// `tableLimits` rows seen in the current `referenceTable` block; applied
     /// to its identifiers when the block closes (they may appear either side
     /// of the `tableIdentifier` line they annotate).
@@ -169,6 +172,7 @@ fn parse_ini_internal(content: &str, ctx: &mut IncludeContext) -> Result<EcuDefi
         current_curve: None,
         current_help: None,
         current_reference_table: None,
+        current_setting_group: None,
         pending_reference_limits: Vec::new(),
     };
 
@@ -199,19 +203,29 @@ fn parse_ini_internal(content: &str, ctx: &mut IncludeContext) -> Result<EcuDefi
             continue;
         }
 
-        // Handle preprocessor directives (always processed regardless of condition)
+        // Handle preprocessor directives.
+        //
+        // `#set`/`#unset` only take effect in a live branch, exactly like
+        // `#define` and `#include` below. Running them unconditionally let a
+        // symbol defined inside a dead `#if` arm leak into the live one, so an
+        // INI that guards a definition behind `#if SOME_BUILD` still picked up
+        // that build's symbols.
         if let Some(stripped) = line.strip_prefix("#set ") {
-            let symbol = stripped.trim().to_string();
-            tracing::debug!("preprocessor: #set {}", symbol);
-            ctx.defined_symbols.insert(symbol);
+            if condition_stack.iter().all(|&c| c) {
+                let symbol = stripped.trim().to_string();
+                tracing::debug!("preprocessor: #set {}", symbol);
+                ctx.defined_symbols.insert(symbol);
+            }
             i += 1;
             continue;
         }
 
         if let Some(stripped) = line.strip_prefix("#unset ") {
-            let symbol = stripped.trim();
-            tracing::debug!("preprocessor: #unset {}", symbol);
-            ctx.defined_symbols.remove(symbol);
+            if condition_stack.iter().all(|&c| c) {
+                let symbol = stripped.trim();
+                tracing::debug!("preprocessor: #unset {}", symbol);
+                ctx.defined_symbols.remove(symbol);
+            }
             i += 1;
             continue;
         }
@@ -389,7 +403,12 @@ fn parse_ini_internal(content: &str, ctx: &mut IncludeContext) -> Result<EcuDefi
                 "outputchannels" => parse_output_channel_entry(&mut definition, key, value),
                 "burstmode" => parse_burst_mode_entry(&mut definition, key, value),
                 "gaugeconfigurations" => parse_gauge_entry(&mut definition, key, value),
-                "settinggroups" => parse_setting_group_entry(&mut definition, key, value),
+                "settinggroups" => parse_setting_group_entry(
+                    &mut definition,
+                    key,
+                    value,
+                    &mut state.current_setting_group,
+                ),
                 "pcvariables" => parse_pc_variable_entry(&mut definition, key, value),
                 "datalog" => parse_datalog_entry(&mut definition, key, value),
                 "defaults" => parse_defaults_entry(&mut definition, key, value),
@@ -1072,6 +1091,10 @@ fn parse_constants_entry(
         "pageidentifier" => {
             // Parse page identifiers like "\x00\x00", "\x00\x01"
             // Also handles $tsCanId substitution
+            def.protocol.page_identifiers_raw = split_ini_line(value)
+                .into_iter()
+                .map(|s| s.trim().trim_matches('"').to_string())
+                .collect();
             def.protocol.page_identifiers = parse_page_identifiers(value, &def.pc_variables);
             return;
         }
@@ -1382,7 +1405,12 @@ fn parse_gauge_entry(def: &mut EcuDefinition, key: &str, value: &str) {
 }
 
 /// Parse [SettingGroups] section entries
-fn parse_setting_group_entry(def: &mut EcuDefinition, key: &str, value: &str) {
+fn parse_setting_group_entry(
+    def: &mut EcuDefinition,
+    key: &str,
+    value: &str,
+    current_group: &mut Option<String>,
+) {
     if key.eq_ignore_ascii_case("settinggroup") {
         // Format: settingGroup = refName, "Display Name"
         let parts: Vec<&str> = value.split(',').map(|s| s.trim()).collect();
@@ -1393,20 +1421,31 @@ fn parse_setting_group_entry(def: &mut EcuDefinition, key: &str, value: &str) {
                 options: Vec::new(),
             };
             def.setting_groups.insert(parts[0].to_string(), group);
+            *current_group = Some(parts[0].to_string());
         }
     } else if key.eq_ignore_ascii_case("settingoption") {
         // Format: settingOption = value, "Display Label"
-        // These apply to the last setting group
+        // These belong to the settingGroup line above them.
+        //
+        // This used to push onto `setting_groups.iter_mut().last()`, but
+        // `setting_groups` is a `HashMap` whose iteration order is seeded per
+        // instance, so every option landed in an arbitrary group.
         let parts: Vec<&str> = value.split(',').map(|s| s.trim()).collect();
         if parts.len() >= 2 {
             let option = SettingOption {
                 value: parts[0].to_string(),
                 label: parts[1].trim_matches('"').to_string(),
             };
-            // Add to last group - for simplicity, we'll store in a temp structure
-            // In a full implementation, we'd track the current group
-            if let Some((_name, group)) = def.setting_groups.iter_mut().last() {
+            if let Some(group) = current_group
+                .as_ref()
+                .and_then(|name| def.setting_groups.get_mut(name))
+            {
                 group.options.push(option);
+            } else {
+                tracing::warn!(
+                    "ini: settingOption '{}' before any settingGroup - dropped",
+                    option.value
+                );
             }
         }
     }
@@ -1439,9 +1478,30 @@ fn parse_pc_variable_entry(def: &mut EcuDefinition, key: &str, value: &str) {
         || type_str == "U16"
         || type_str == "S16"
     {
-        // Default to index 0
-        def.pc_variables.insert(key.to_string(), 0);
+        def.pc_variables.insert(
+            clean_key.to_string(),
+            resolve_pc_variable_byte(def, clean_key),
+        );
     }
+}
+
+/// Byte value a `$varName` reference resolves to.
+///
+/// This used to be a hard-coded `0`, so a board configured with a non-zero
+/// `tsCanId` had every `pageIdentifier` / `pageReadCommand` frame addressed to
+/// CAN id 0. The chain mirrors what the UI shows for the same variable
+/// (`commands/tune_io.rs`): the INI's declared default first, then the
+/// constant's declared minimum.
+fn resolve_pc_variable_byte(def: &EcuDefinition, name: &str) -> u8 {
+    def.default_values
+        .get(name)
+        .map(|v| v.clamp(0.0, u8::MAX as f64) as u8)
+        .or_else(|| {
+            def.constants
+                .get(name)
+                .map(|c| c.min.clamp(0.0, u8::MAX as f64) as u8)
+        })
+        .unwrap_or(0)
 }
 
 /// Parse [Defaults] section entries
@@ -1566,6 +1626,11 @@ fn parse_datalog_entry(def: &mut EcuDefinition, _key: &str, value: &str) {
     def.datalog_entries.push(entry);
 }
 
+/// Highest `gaugeN` index `[FrontPage]` may declare. The format documents
+/// `gauge1..gauge8`; the extra headroom covers INIs that go a little wider
+/// without letting a malformed suffix size the allocation.
+const MAX_FRONTPAGE_GAUGES: usize = 64;
+
 /// Parse [FrontPage] section entries
 /// Handles gauge1-gauge8 references and indicator definitions
 fn parse_frontpage_entry(def: &mut EcuDefinition, key: &str, value: &str) {
@@ -1583,13 +1648,22 @@ fn parse_frontpage_entry(def: &mut EcuDefinition, key: &str, value: &str) {
             .or_else(|| key.strip_prefix("Gauge"))
         {
             if let Ok(num) = num_str.parse::<usize>() {
+                // The suffix comes straight from arbitrary INI text, so cap it
+                // before growing the vector - `gauge4000000000` used to try to
+                // allocate four billion empty strings.
+                if num == 0 || num > MAX_FRONTPAGE_GAUGES {
+                    tracing::warn!(
+                        "ini: [FrontPage] {} out of range (1..={}) - ignored",
+                        key,
+                        MAX_FRONTPAGE_GAUGES
+                    );
+                    return;
+                }
                 // Ensure vector is large enough
                 while frontpage.gauges.len() < num {
                     frontpage.gauges.push(String::new());
                 }
-                if num > 0 && num <= frontpage.gauges.len() {
-                    frontpage.gauges[num - 1] = value.trim().to_string();
-                }
+                frontpage.gauges[num - 1] = value.trim().to_string();
             }
         }
     }
@@ -1875,6 +1949,16 @@ fn post_process_variable_substitution(def: &mut EcuDefinition) {
         return;
     }
 
+    // Re-resolve every PC variable now that the whole file has been read.
+    // `[PcVariables]` is parsed before `[Defaults]` in some INIs, so the value
+    // recorded at declaration time may predate the `defaultValue` line that
+    // sets it.
+    let names: Vec<String> = def.pc_variables.keys().cloned().collect();
+    for name in names {
+        let resolved = resolve_pc_variable_byte(def, &name);
+        def.pc_variables.insert(name, resolved);
+    }
+
     // Substitute in query_command
     def.query_command = substitute_variables(&def.query_command, &def.pc_variables);
     def.protocol.query_command =
@@ -1912,12 +1996,27 @@ fn post_process_variable_substitution(def: &mut EcuDefinition) {
         }
     }
 
-    // Re-process page identifiers
-    // This is trickier because page_identifiers are Vec<Vec<u8>>, not strings
-    // We need to check if any identifier bytes look like they might be unsubstituted
-    // For simplicity, if pc_variables exist and we have commands with '$', we should
-    // store the original command strings and re-parse. But since we've already parsed,
-    // we'll trust the initial parse worked for [Constants] section (which comes after [PcVariables])
+    // Re-process page identifiers from the source text.
+    //
+    // `page_identifiers` is `Vec<Vec<u8>>`, so the `$tsCanId` token is already
+    // gone by the time we get here - re-substituting the bytes is impossible.
+    // `page_identifiers_raw` keeps the INI's own strings precisely so this pass
+    // can redo the work with the resolved variables. Without it a board with a
+    // non-zero `tsCanId` addressed every page read/write frame to CAN id 0,
+    // since `[Constants]` is written before `[PcVariables]`.
+    if def
+        .protocol
+        .page_identifiers_raw
+        .iter()
+        .any(|s| s.contains('$'))
+    {
+        def.protocol.page_identifiers = def
+            .protocol
+            .page_identifiers_raw
+            .iter()
+            .map(|s| parse_escape_sequence(&substitute_variables(s, &pc_vars)))
+            .collect();
+    }
 
     // Handle och_get_command
     if let Some(ref cmd) = def.protocol.och_get_command {
@@ -4315,6 +4414,13 @@ table = veTable1, veTableMap, "VE Table"
         assert!(table.is_resizable());
     }
 
+    /// `[AxB]` is column-first, the order TunerStudio uses and the order the
+    /// `[{cols}x{rows}]` arm of `parse_shape_field` already used. rusEFI's
+    /// `demo.ini` is unambiguous: `cltIdleCorrTable = array, U08, 10378, [8x3]`
+    /// has an eight-entry `xBins` and a three-entry `yBins`, and
+    /// `scriptTable4 = [10x8]` a ten-entry `xBins` and an eight-entry `yBins`.
+    /// This test used to assert the opposite (row-first) reading, which only
+    /// went unnoticed because every checked-in fixture array is square.
     #[test]
     fn test_table_size_from_2d_map() {
         // Test that x_size/y_size can be inferred from the 2D map constant
@@ -4336,8 +4442,8 @@ table = veTable1, veTableMap, "VE Table"
         let table = def.tables.get("veTable1").unwrap();
 
         // When x_bins and y_bins are not specified, infer from the 2D map
-        assert_eq!(table.x_size, 12, "x_size should be 12 (cols from 8x12)");
-        assert_eq!(table.y_size, 8, "y_size should be 8 (rows from 8x12)");
+        assert_eq!(table.x_size, 8, "x_size should be 8 (cols from [8x12])");
+        assert_eq!(table.y_size, 12, "y_size should be 12 (rows from [8x12])");
     }
 
     #[test]
@@ -4468,6 +4574,156 @@ indicator = { (tps > tpsflood) && (rpm < crankRPM) }, "FLOOD OFF", "FLOOD CLEAR"
         assert_eq!(
             strip_comment("someField = 42 ; trailing note").trim(),
             "someField = 42"
+        );
+    }
+
+    /// `#set` and `#unset` used to run before the branch-suppression check, so
+    /// a symbol defined inside a dead `#if` arm leaked into the live one.
+    /// `#define` and `#include` already gate on `condition_stack`.
+    #[test]
+    #[serial(default_symbols)]
+    fn set_and_unset_are_ignored_inside_a_false_branch() {
+        set_default_symbols(Vec::<String>::new());
+
+        let ini = concat!(
+            "[Constants]\n",
+            "page = 1\n",
+            "#if NEVER_DEFINED\n",
+            "#set LEAKED\n",
+            "#endif\n",
+            "#if LEAKED\n",
+            "leaked = scalar, U08, 0, \"x\", 1, 0, 0, 255, 0\n",
+            "#else\n",
+            "clean = scalar, U08, 0, \"y\", 1, 0, 0, 255, 0\n",
+            "#endif\n",
+        );
+
+        let def = parse_ini(ini).expect("parses");
+        assert!(
+            !def.constants.contains_key("leaked"),
+            "#set inside a false #if leaked into the live branch"
+        );
+        assert!(def.constants.contains_key("clean"));
+    }
+
+    /// `#unset` in a dead branch must not clear a live symbol either.
+    #[test]
+    #[serial(default_symbols)]
+    fn unset_inside_a_false_branch_does_not_clear_a_live_symbol() {
+        set_default_symbols(Vec::<String>::new());
+
+        let ini = concat!(
+            "[Constants]\n",
+            "page = 1\n",
+            "#set KEEPME\n",
+            "#if NEVER_DEFINED\n",
+            "#unset KEEPME\n",
+            "#endif\n",
+            "#if KEEPME\n",
+            "kept = scalar, U08, 0, \"x\", 1, 0, 0, 255, 0\n",
+            "#endif\n",
+        );
+
+        let def = parse_ini(ini).expect("parses");
+        assert!(
+            def.constants.contains_key("kept"),
+            "#unset inside a false #if cleared a live symbol"
+        );
+    }
+
+    /// `settingOption` lines belong to the `settingGroup` above them.
+    /// `setting_groups` is a `HashMap`, so `.iter_mut().last()` picked an
+    /// arbitrary group - Rust seeds hash order per map instance.
+    #[test]
+    #[serial(default_symbols)]
+    fn setting_options_attach_to_the_group_that_precedes_them() {
+        set_default_symbols(Vec::<String>::new());
+
+        let mut ini = String::from("[SettingGroups]\n");
+        for i in 0..8 {
+            ini.push_str(&format!("settingGroup = grp{i}, \"Group {i}\"\n"));
+            ini.push_str(&format!("settingOption = opt{i}, \"Option {i}\"\n"));
+        }
+
+        let def = parse_ini(&ini).expect("parses");
+        assert_eq!(def.setting_groups.len(), 8);
+        for i in 0..8 {
+            let group = def
+                .setting_groups
+                .get(&format!("grp{i}"))
+                .unwrap_or_else(|| panic!("grp{i} missing"));
+            assert_eq!(
+                group
+                    .options
+                    .iter()
+                    .map(|o| o.value.as_str())
+                    .collect::<Vec<_>>(),
+                vec![format!("opt{i}").as_str()],
+                "grp{i} got the wrong options: {:?}",
+                group.options
+            );
+        }
+    }
+
+    /// `$tsCanId` used to resolve to byte 0 unconditionally, which misaddresses
+    /// every page-read/write frame on a board with a non-zero CAN id.
+    /// `[Constants]` is written before `[PcVariables]` in every real INI, so
+    /// the identifiers have to be re-resolved once the variable is known.
+    #[test]
+    #[serial(default_symbols)]
+    fn can_id_substitution_uses_the_declared_default_not_zero() {
+        set_default_symbols(Vec::<String>::new());
+
+        let ini = concat!(
+            "[Constants]\n",
+            "pageIdentifier = \"\\x00$tsCanId\"\n",
+            "pageReadCommand = \"r$tsCanId%2o%2c\"\n",
+            "[PcVariables]\n",
+            "tsCanId = scalar, U08, \"\", 1, 0, 0, 15, 0\n",
+            "[Defaults]\n",
+            "defaultValue = tsCanId, 3\n",
+        );
+
+        let def = parse_ini(ini).expect("parses");
+        assert_eq!(
+            def.pc_variables.get("tsCanId"),
+            Some(&3u8),
+            "pc_variables still hard-codes 0"
+        );
+        assert_eq!(
+            def.protocol.page_identifiers.first().map(Vec::as_slice),
+            Some([0u8, 3u8].as_slice()),
+            "page identifier not re-resolved after [PcVariables]"
+        );
+        assert_eq!(
+            def.protocol.page_read_commands.first().map(String::as_str),
+            Some("r\u{3}%2o%2c")
+        );
+    }
+
+    /// `gaugeN` grows a `Vec` to `N`. The documented range is `gauge1..gauge8`,
+    /// so a malformed `gauge4000000000` used to allocate four billion strings.
+    #[test]
+    #[serial(default_symbols)]
+    fn frontpage_gauge_indices_are_capped() {
+        set_default_symbols(Vec::<String>::new());
+
+        let ini = concat!(
+            "[FrontPage]\n",
+            "gauge1 = accelGauge\n",
+            "gauge4000000000 = bogusGauge\n",
+        );
+
+        let def = parse_ini(ini).expect("parses");
+        let frontpage = def.frontpage.expect("frontpage");
+        assert!(
+            frontpage.gauges.len() <= 64,
+            "gauge vector grew to {}",
+            frontpage.gauges.len()
+        );
+        assert_eq!(
+            frontpage.gauges.first().map(String::as_str),
+            Some("accelGauge")
         );
     }
 }

--- a/crates/libretune-core/src/ini/types.rs
+++ b/crates/libretune-core/src/ini/types.rs
@@ -427,8 +427,16 @@ pub fn parse_shape_field(s: &str) -> ParsedShape {
             if let (Some(cols), Some(rows)) = (parse_brace_name(a), parse_brace_name(b)) {
                 return ParsedShape::Dynamic2D { cols, rows };
             }
-            if let (Ok(rows), Ok(cols)) = (a.parse(), b.parse()) {
-                // Fixed form: Speeduino / LibreTune `[rows x cols]`.
+            if let (Ok(cols), Ok(rows)) = (a.parse(), b.parse()) {
+                // Same TunerStudio column-first order as the braced form above.
+                //
+                // This arm used to read `[AxB]` as `[rows x cols]` while the
+                // braced arm read the identical syntax as `[cols x rows]`.
+                // Every checked-in fixture array is square, which is why the
+                // disagreement went unnoticed. rusEFI's `demo.ini` settles it:
+                // `torqueReductionIgnitionCutTable = array, S08, 21933, [6x2]`
+                // is driven by a six-entry `xBins` and a two-entry `yBins`, so
+                // the first token is the column count.
                 return ParsedShape::Fixed(Shape::Array2D { rows, cols });
             }
         }
@@ -975,6 +983,16 @@ pub struct ProtocolSettings {
     /// Page identifiers for multi-page ECUs (raw byte sequences)
     pub page_identifiers: Vec<Vec<u8>>,
 
+    /// The `pageIdentifier` entries exactly as the INI wrote them, before
+    /// `$varName` substitution and escape decoding.
+    ///
+    /// `[Constants]` precedes `[PcVariables]` in every real INI, so the first
+    /// substitution pass runs before `$tsCanId` has a value. Keeping the source
+    /// text lets the post-parse pass redo it once the variable is known -
+    /// `page_identifiers` is `Vec<Vec<u8>>` and cannot be re-substituted.
+    #[serde(default)]
+    pub page_identifiers_raw: Vec<String>,
+
     /// Page sizes in bytes for each page
     pub page_sizes: Vec<u32>,
 
@@ -1082,6 +1100,7 @@ impl Default for ProtocolSettings {
             query_command: "Q".to_string(),
             delay_after_port_open: 0,
             page_identifiers: Vec::new(),
+            page_identifiers_raw: Vec::new(),
             page_sizes: Vec::new(),
             page_read_commands: Vec::new(),
             page_chunk_write_commands: Vec::new(),
@@ -1160,8 +1179,38 @@ mod tests {
         );
         assert_eq!(
             Shape::from_ini_str("[8X12]"),
-            Shape::Array2D { rows: 8, cols: 12 }
+            Shape::Array2D { rows: 12, cols: 8 }
         );
+    }
+
+    /// `[AxB]` is column-first in both its literal and its `{brace}` form.
+    ///
+    /// The two arms used to disagree: `[{cols}x{rows}]` mapped the first token
+    /// to columns while `[8x12]` mapped it to rows. Every checked-in fixture
+    /// array is square, which is why nothing caught it. rusEFI's `demo.ini`
+    /// settles the order - `torqueReductionIgnitionCutTable = array, S08,
+    /// 21933, [6x2]` is driven by a six-entry `xBins` and a two-entry `yBins`,
+    /// so the first token is the column count.
+    #[test]
+    fn non_square_shapes_are_column_first_in_both_forms() {
+        assert_eq!(
+            parse_shape_field("[6x2]"),
+            ParsedShape::Fixed(Shape::Array2D { rows: 2, cols: 6 }),
+            "literal [AxB] must read as [cols x rows]"
+        );
+        assert_eq!(
+            parse_shape_field("[{a}x{b}]"),
+            ParsedShape::Dynamic2D {
+                cols: "a".into(),
+                rows: "b".into(),
+            },
+            "braced [AxB] must read as [cols x rows]"
+        );
+
+        let fixed = Shape::from_ini_str("[6x2]");
+        assert_eq!(fixed.x_size(), 6);
+        assert_eq!(fixed.y_size(), 2);
+        assert_eq!(fixed.element_count(), 12);
     }
 
     #[test]

--- a/crates/libretune-core/src/table_ops.rs
+++ b/crates/libretune-core/src/table_ops.rs
@@ -26,8 +26,6 @@ pub fn rebin_table(
     new_y_bins: Vec<f64>,
     interpolate_z: bool,
 ) -> TableOperationResult {
-    let _old_x_len = old_x_bins.len();
-    let _old_y_len = old_y_bins.len();
     let new_x_len = new_x_bins.len();
     let new_y_len = new_y_bins.len();
 
@@ -43,6 +41,8 @@ pub fn rebin_table(
                     interpolate_value(target_x, target_y, old_x_bins, old_y_bins, old_z_values);
             }
         }
+    } else {
+        copy_z_by_index(old_z_values, &mut new_z_values);
     }
 
     TableOperationResult {
@@ -50,6 +50,33 @@ pub fn rebin_table(
         x_bins: new_x_bins,
         y_bins: new_y_bins,
         z_values: new_z_values,
+    }
+}
+
+/// Copy old Z values into the new grid by cell index, with no interpolation.
+///
+/// Used for `rebin_table(..., interpolate_z: false)`: re-binning without
+/// interpolation should keep values in place while only the axes change, so
+/// `new_z[y][x] = old_z[y][x]` whenever both indices exist in the old grid.
+/// Cells beyond the old grid's bounds (e.g. when growing the table) fall back
+/// to the nearest existing old cell by clamping the index, so nothing is
+/// zeroed out. An empty old grid leaves `new_z_values` untouched (zeros).
+fn copy_z_by_index(old_z_values: &[Vec<f64>], new_z_values: &mut [Vec<f64>]) {
+    let old_y_len = old_z_values.len();
+    if old_y_len == 0 {
+        return;
+    }
+
+    for (y, new_row) in new_z_values.iter_mut().enumerate() {
+        let old_row = &old_z_values[y.min(old_y_len - 1)];
+        let old_x_len = old_row.len();
+        if old_x_len == 0 {
+            continue;
+        }
+
+        for (x, cell) in new_row.iter_mut().enumerate() {
+            *cell = old_row[x.min(old_x_len - 1)];
+        }
     }
 }
 
@@ -142,6 +169,17 @@ pub fn smooth_table(
 
     // No smoothing if factor <= 0
     if factor <= 0.0 {
+        return result;
+    }
+
+    // Reject (no-op) rather than panic if the selection references cells
+    // outside the table's current dimensions — the same guard
+    // `interpolate_linear` and `fill_region` carry. "Set Table Size" resizes
+    // the grid without clearing the frontend's `selectionRange`, so the next
+    // "Smooth" arrives with coordinates that no longer exist; a cell one row
+    // past the edge still has an in-bounds `(-1,-1)` neighbour, so
+    // `weight_sum > 0.0` and the unchecked `result[y][x]` write panicked.
+    if selected_cells.iter().any(|&(y, x)| y >= rows || x >= cols) {
         return result;
     }
 

--- a/crates/libretune-core/src/tune/file.rs
+++ b/crates/libretune-core/src/tune/file.rs
@@ -182,7 +182,10 @@ impl ConstantAttrs {
             }
         }
         attrs.sort_by_key(|(k, _)| *k);
-        attrs.iter().map(|(k, v)| format!(" {k}=\"{v}\"")).collect()
+        attrs
+            .iter()
+            .map(|(k, v)| format!(" {k}=\"{}\"", xml_escape(v)))
+            .collect()
     }
 }
 
@@ -192,7 +195,7 @@ fn parse_constant_attrs(tag: &str) -> ConstantAttrs {
         let needle = format!("{key}=\"");
         let start = tag.find(&needle)? + needle.len();
         let end = tag[start..].find('"')?;
-        Some(tag[start..start + end].to_string())
+        Some(xml_unescape(&tag[start..start + end]))
     };
     ConstantAttrs {
         digits: attr("digits"),
@@ -354,14 +357,14 @@ impl TuneFile {
             if let Some(sig_start) = content[version_start..].find("signature=\"") {
                 let sig_content = &content[version_start + sig_start + 11..];
                 if let Some(sig_end) = sig_content.find('"') {
-                    tune.signature = sig_content[..sig_end].to_string();
+                    tune.signature = xml_unescape(&sig_content[..sig_end]);
                 }
             }
         } else if let Some(sig_start) = content.find("signature=\"") {
             // Fallback to <msq signature="..."> format
             let sig_content = &content[sig_start + 11..];
             if let Some(sig_end) = sig_content.find('"') {
-                tune.signature = sig_content[..sig_end].to_string();
+                tune.signature = xml_unescape(&sig_content[..sig_end]);
             }
         }
 
@@ -371,21 +374,21 @@ impl TuneFile {
             if let Some(auth_start) = content[bib_start..].find("author=\"") {
                 let auth_content = &content[bib_start + auth_start + 8..];
                 if let Some(auth_end) = auth_content.find('"') {
-                    tune.author = Some(auth_content[..auth_end].to_string());
+                    tune.author = Some(xml_unescape(&auth_content[..auth_end]));
                 }
             }
             // Find writeDate (last modified)
             if let Some(write_start) = content[bib_start..].find("writeDate=\"") {
                 let write_content = &content[bib_start + write_start + 11..];
                 if let Some(write_end) = write_content.find('"') {
-                    tune.modified = Some(write_content[..write_end].to_string());
+                    tune.modified = Some(xml_unescape(&write_content[..write_end]));
                 }
             }
             // Find created date
             if let Some(created_start) = content[bib_start..].find("created=\"") {
                 let created_content = &content[bib_start + created_start + 9..];
                 if let Some(created_end) = created_content.find('"') {
-                    tune.created = Some(created_content[..created_end].to_string());
+                    tune.created = Some(xml_unescape(&created_content[..created_end]));
                 }
             }
         } else if let Some(ts_start) = content.find("timestamp=\"") {
@@ -405,31 +408,31 @@ impl TuneFile {
             if let Some(attr_start) = ini_remaining.find("signature=\"") {
                 let attr_content = &ini_remaining[attr_start + 11..];
                 if let Some(attr_end) = attr_content.find('"') {
-                    metadata.signature = attr_content[..attr_end].to_string();
+                    metadata.signature = xml_unescape(&attr_content[..attr_end]);
                 }
             }
             if let Some(attr_start) = ini_remaining.find("name=\"") {
                 let attr_content = &ini_remaining[attr_start + 6..];
                 if let Some(attr_end) = attr_content.find('"') {
-                    metadata.name = attr_content[..attr_end].to_string();
+                    metadata.name = xml_unescape(&attr_content[..attr_end]);
                 }
             }
             if let Some(attr_start) = ini_remaining.find("hash=\"") {
                 let attr_content = &ini_remaining[attr_start + 6..];
                 if let Some(attr_end) = attr_content.find('"') {
-                    metadata.hash = attr_content[..attr_end].to_string();
+                    metadata.hash = xml_unescape(&attr_content[..attr_end]);
                 }
             }
             if let Some(attr_start) = ini_remaining.find("specVersion=\"") {
                 let attr_content = &ini_remaining[attr_start + 13..];
                 if let Some(attr_end) = attr_content.find('"') {
-                    metadata.spec_version = attr_content[..attr_end].to_string();
+                    metadata.spec_version = xml_unescape(&attr_content[..attr_end]);
                 }
             }
             if let Some(attr_start) = ini_remaining.find("savedAt=\"") {
                 let attr_content = &ini_remaining[attr_start + 9..];
                 if let Some(attr_end) = attr_content.find('"') {
-                    metadata.saved_at = attr_content[..attr_end].to_string();
+                    metadata.saved_at = xml_unescape(&attr_content[..attr_end]);
                 }
             }
 
@@ -461,13 +464,13 @@ impl TuneFile {
                     if let Some(attr_start) = entry_remaining.find("name=\"") {
                         let attr_content = &entry_remaining[attr_start + 6..];
                         if let Some(attr_end) = attr_content.find('"') {
-                            entry.name = attr_content[..attr_end].to_string();
+                            entry.name = xml_unescape(&attr_content[..attr_end]);
                         }
                     }
                     if let Some(attr_start) = entry_remaining.find("type=\"") {
                         let attr_content = &entry_remaining[attr_start + 6..];
                         if let Some(attr_end) = attr_content.find('"') {
-                            entry.data_type = attr_content[..attr_end].to_string();
+                            entry.data_type = xml_unescape(&attr_content[..attr_end]);
                         }
                     }
                     if let Some(attr_start) = entry_remaining.find("page=\"") {
@@ -542,7 +545,8 @@ impl TuneFile {
                 if unquoted == "true" || unquoted == "false" {
                     return TuneValue::Bool(unquoted == "true");
                 }
-                return TuneValue::String(unquoted.to_string());
+                // The writer XML-escapes the payload; decode it symmetrically.
+                return TuneValue::String(xml_unescape(unquoted));
             }
 
             // Unquoted values: check if it's an array (brackets or multiple space-separated numbers)
@@ -671,7 +675,7 @@ impl TuneFile {
                     let Some(q) = block[abs..].find('"') else {
                         break;
                     };
-                    tune.ecu_settings.push(block[abs..abs + q].to_string());
+                    tune.ecu_settings.push(xml_unescape(&block[abs..abs + q]));
                     pos = abs + q;
                 }
             }
@@ -715,8 +719,9 @@ impl TuneFile {
                         if let Some(name_attr_start) = const_remaining.find("name=\"") {
                             let name_start = name_attr_start + 6;
                             if let Some(name_end) = const_remaining[name_start..].find('"') {
-                                let name =
-                                    const_remaining[name_start..name_start + name_end].to_string();
+                                let name = xml_unescape(
+                                    &const_remaining[name_start..name_start + name_end],
+                                );
 
                                 if let Some(tag_end) = const_remaining.find('>') {
                                     // Check for self-closing tag: <constant name="..."/> or <constant name="..." />
@@ -765,7 +770,7 @@ impl TuneFile {
                             let name_start = name_attr_start + 6;
                             if let Some(name_end) = pc_remaining[name_start..].find('"') {
                                 let name =
-                                    pc_remaining[name_start..name_start + name_end].to_string();
+                                    xml_unescape(&pc_remaining[name_start..name_start + name_end]);
 
                                 if let Some(tag_end) = pc_remaining.find('>') {
                                     // Check for self-closing tag: <pcVariable name="..."/> or <pcVariable name="..." />
@@ -822,7 +827,7 @@ impl TuneFile {
                     if let Some(name_attr_start) = remaining.find("name=\"") {
                         let name_start = name_attr_start + 6;
                         if let Some(name_end) = remaining[name_start..].find('"') {
-                            let name = remaining[name_start..name_start + name_end].to_string();
+                            let name = xml_unescape(&remaining[name_start..name_start + name_end]);
 
                             if let Some(tag_end) = remaining.find('>') {
                                 // Check for self-closing tag: <constant name="..."/> or <constant name="..." />
@@ -860,7 +865,7 @@ impl TuneFile {
                     if let Some(name_attr_start) = remaining.find("name=\"") {
                         let name_start = name_attr_start + 6;
                         if let Some(name_end) = remaining[name_start..].find('"') {
-                            let name = remaining[name_start..name_start + name_end].to_string();
+                            let name = xml_unescape(&remaining[name_start..name_start + name_end]);
 
                             if let Some(tag_end) = remaining.find('>') {
                                 // Check for self-closing tag: <pcVariable name="..."/> or <pcVariable name="..." />
@@ -945,7 +950,7 @@ impl TuneFile {
 
         // Add metadata comment
         if let Some(ref desc) = self.description {
-            xml.push_str(&format!("<!-- {} -->\n", desc));
+            xml.push_str(&format!("<!-- {} -->\n", xml_comment_escape(desc)));
         }
 
         // Start msq tag with signature
@@ -966,20 +971,22 @@ impl TuneFile {
         );
         xml.push_str(&format!(
             "  <versionInfo signature=\"{}\" firmwareInfo=\"{}\" nPages=\"{}\"/>\n",
-            self.signature, fw_info, n_pages
+            xml_escape(&self.signature),
+            xml_escape(fw_info),
+            n_pages
         ));
 
         // Add bibliography if we have metadata
         if self.author.is_some() || self.created.is_some() || self.modified.is_some() {
             xml.push_str("  <bibliography");
             if let Some(ref author) = self.author {
-                xml.push_str(&format!(" author=\"{}\"", author));
+                xml.push_str(&format!(" author=\"{}\"", xml_escape(author)));
             }
             if let Some(ref created) = self.created {
-                xml.push_str(&format!(" created=\"{}\"", created));
+                xml.push_str(&format!(" created=\"{}\"", xml_escape(created)));
             }
             if let Some(ref modified) = self.modified {
-                xml.push_str(&format!(" writeDate=\"{}\"", modified));
+                xml.push_str(&format!(" writeDate=\"{}\"", xml_escape(modified)));
             }
             xml.push_str("/>\n");
         }
@@ -988,11 +995,11 @@ impl TuneFile {
         if let Some(ref metadata) = self.ini_metadata {
             xml.push_str(&format!(
                 "  <iniMetadata signature=\"{}\" name=\"{}\" hash=\"{}\" specVersion=\"{}\" savedAt=\"{}\"/>\n",
-                metadata.signature,
-                metadata.name,
-                metadata.hash,
-                metadata.spec_version,
-                metadata.saved_at
+                xml_escape(&metadata.signature),
+                xml_escape(&metadata.name),
+                xml_escape(&metadata.hash),
+                xml_escape(&metadata.spec_version),
+                xml_escape(&metadata.saved_at)
             ));
         }
 
@@ -1002,8 +1009,8 @@ impl TuneFile {
             for entry in manifest {
                 xml.push_str(&format!(
                     "    <entry name=\"{}\" type=\"{}\" page=\"{}\" offset=\"{}\" scale=\"{}\" translate=\"{}\"/>\n",
-                    entry.name,
-                    entry.data_type,
+                    xml_escape(&entry.name),
+                    xml_escape(&entry.data_type),
                     entry.page,
                     entry.offset,
                     entry.scale,
@@ -1037,7 +1044,7 @@ impl TuneFile {
                 xml.push_str(&format!(
                     "    <setting name=\"{}\"/>
 ",
-                    name
+                    xml_escape(name)
                 ));
             }
             xml.push_str(
@@ -1069,38 +1076,7 @@ impl TuneFile {
 
             for name in const_names {
                 if let Some(value) = self.constants.get(&name) {
-                    let value_str = match value {
-                        TuneValue::Scalar(v) => {
-                            // Use high precision format to preserve F64 values accurately
-                            // Format with enough precision to round-trip any f64 exactly
-                            let formatted = format!("{:.17}", v);
-                            // Trim unnecessary trailing zeros for cleaner output
-                            let trimmed = formatted.trim_end_matches('0').trim_end_matches('.');
-                            if trimmed.is_empty() {
-                                "0".to_string()
-                            } else {
-                                trimmed.to_string()
-                            }
-                        }
-                        TuneValue::Array(arr) => {
-                            // Format as space-separated for arrays with high precision
-                            arr.iter()
-                                .map(|v| {
-                                    let formatted = format!("{:.17}", v);
-                                    let trimmed =
-                                        formatted.trim_end_matches('0').trim_end_matches('.');
-                                    if trimmed.is_empty() {
-                                        "0".to_string()
-                                    } else {
-                                        trimmed.to_string()
-                                    }
-                                })
-                                .collect::<Vec<_>>()
-                                .join(" ")
-                        }
-                        TuneValue::String(s) => format!("\"{}\"", s),
-                        TuneValue::Bool(b) => if *b { "true" } else { "false" }.to_string(),
-                    };
+                    let value_str = format_tune_value(value);
                     let attrs = self
                         .constant_attrs
                         .get(&name)
@@ -1149,32 +1125,7 @@ impl TuneFile {
 
             for name in pc_var_names {
                 if let Some(value) = self.pc_variables.get(name) {
-                    let value_str = match value {
-                        TuneValue::Scalar(v) => {
-                            let formatted = format!("{:.17}", v);
-                            let trimmed = formatted.trim_end_matches('0').trim_end_matches('.');
-                            if trimmed.is_empty() {
-                                "0".to_string()
-                            } else {
-                                trimmed.to_string()
-                            }
-                        }
-                        TuneValue::Array(arr) => arr
-                            .iter()
-                            .map(|v| {
-                                let formatted = format!("{:.17}", v);
-                                let trimmed = formatted.trim_end_matches('0').trim_end_matches('.');
-                                if trimmed.is_empty() {
-                                    "0".to_string()
-                                } else {
-                                    trimmed.to_string()
-                                }
-                            })
-                            .collect::<Vec<_>>()
-                            .join(" "),
-                        TuneValue::String(s) => format!("\"{}\"", s),
-                        TuneValue::Bool(b) => if *b { "true" } else { "false" }.to_string(),
-                    };
+                    let value_str = format_tune_value(value);
                     let attrs = self
                         .constant_attrs
                         .get(name)
@@ -1341,32 +1292,116 @@ impl TuneFile {
     }
 }
 
+/// Format an `f64` as the shortest decimal that round-trips back to the same
+/// value.
+///
+/// This used to be `format!("{:.17}", v)` followed by a trailing-zero trim, but
+/// `.17` is seventeen *decimal places*, not significant digits: `14.7` is
+/// exactly `14.699999999999999289…` as an `f64`, so the trim left
+/// `14.69999999999999929` in the file. `f64`'s `Display` already emits the
+/// shortest representation that parses back exactly, which is what both
+/// TunerStudio and a human reader expect.
+fn format_f64(v: f64) -> String {
+    if !v.is_finite() {
+        // Neither `NaN` nor `inf` is a legal MSQ number; write a benign 0.
+        return "0".to_string();
+    }
+    if v == 0.0 {
+        // Also normalises `-0.0`.
+        return "0".to_string();
+    }
+    v.to_string()
+}
+
+/// Escape the five XML predefined entities so a value containing `&`, `<`,
+/// `>`, `"` or `'` cannot break the document.
+///
+/// Without this an author of `R&D` or a string constant containing `<` made
+/// the saved `.msq` malformed: TunerStudio rejects it outright, and this
+/// file's own reader — which locates a tag's end with `find('>')` and an
+/// attribute's end with the next `"` — walks straight past the attribute list.
+/// [`xml_unescape`] is its inverse, applied on the read side.
+fn xml_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&apos;"),
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
+/// Decode the entities [`xml_escape`] writes, plus numeric character
+/// references, so a value survives a save/load round trip unchanged.
+fn xml_unescape(s: &str) -> String {
+    if !s.contains('&') {
+        return s.to_string();
+    }
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+    while let Some(amp) = rest.find('&') {
+        out.push_str(&rest[..amp]);
+        let tail = &rest[amp..];
+        let Some(semi) = tail.find(';').filter(|&i| i <= 10) else {
+            // Not an entity — a bare `&` from a file some other writer produced.
+            out.push('&');
+            rest = &tail[1..];
+            continue;
+        };
+        let entity = &tail[1..semi];
+        match entity {
+            "amp" => out.push('&'),
+            "lt" => out.push('<'),
+            "gt" => out.push('>'),
+            "quot" => out.push('"'),
+            "apos" => out.push('\''),
+            _ => {
+                let code = entity
+                    .strip_prefix("#x")
+                    .or_else(|| entity.strip_prefix("#X"))
+                    .and_then(|h| u32::from_str_radix(h, 16).ok())
+                    .or_else(|| entity.strip_prefix('#').and_then(|d| d.parse().ok()))
+                    .and_then(char::from_u32);
+                match code {
+                    Some(c) => out.push(c),
+                    // Unknown entity: keep it verbatim rather than losing text.
+                    None => out.push_str(&tail[..=semi]),
+                }
+            }
+        }
+        rest = &tail[semi + 1..];
+    }
+    out.push_str(rest);
+    out
+}
+
+/// Escape a string for use inside an XML comment.
+///
+/// Comments cannot contain `--` or end with `-`, and entities are not expanded
+/// inside them, so the only safe treatment is to break up the offending runs.
+fn xml_comment_escape(s: &str) -> String {
+    let mut out = s.replace("--", "- -");
+    if out.ends_with('-') {
+        out.push(' ');
+    }
+    out
+}
+
 /// Format a TuneValue for XML output with high precision
 fn format_tune_value(value: &TuneValue) -> String {
     match value {
-        TuneValue::Scalar(v) => {
-            let formatted = format!("{:.17}", v);
-            let trimmed = formatted.trim_end_matches('0').trim_end_matches('.');
-            if trimmed.is_empty() {
-                "0".to_string()
-            } else {
-                trimmed.to_string()
-            }
-        }
+        TuneValue::Scalar(v) => format_f64(*v),
         TuneValue::Array(arr) => arr
             .iter()
-            .map(|v| {
-                let formatted = format!("{:.17}", v);
-                let trimmed = formatted.trim_end_matches('0').trim_end_matches('.');
-                if trimmed.is_empty() {
-                    "0".to_string()
-                } else {
-                    trimmed.to_string()
-                }
-            })
+            .map(|v| format_f64(*v))
             .collect::<Vec<_>>()
             .join(" "),
-        TuneValue::String(s) => format!("\"{}\"", s),
+        TuneValue::String(s) => format!("\"{}\"", xml_escape(s)),
         TuneValue::Bool(b) => if *b { "true" } else { "false" }.to_string(),
     }
 }
@@ -1770,5 +1805,93 @@ mod msq_metadata_tests {
         assert!(tune.ecu_settings.is_empty());
         assert!(written.contains(r#"<constant name="reqFuel">"#));
         assert!(!written.contains("<settings"));
+    }
+
+    /// An `&`, `<`, `>` or `"` in any emitted value must be XML-escaped, and
+    /// the reader must decode it again, or the saved tune is not well-formed
+    /// XML - TunerStudio refuses it and LibreTune's own `find('>')` tag scan
+    /// walks off the end of the attribute list.
+    #[test]
+    fn msq_escapes_and_decodes_xml_special_characters() {
+        let raw_author = r#"R&D "quoted" <lab>"#;
+        let raw_note = r#"R&D "quoted" <x> 'y'"#;
+
+        let mut tune = TuneFile::new("speeduino 202501");
+        tune.author = Some(raw_author.to_string());
+        tune.set_constant("noteText", TuneValue::String(raw_note.to_string()));
+
+        let dir = std::env::temp_dir().join(format!("lt_xml_escape_{}", std::process::id()));
+        let _ = fs::create_dir_all(&dir);
+        let path = dir.join("escaped.msq");
+        tune.save(&path).expect("save");
+        let written = fs::read_to_string(&path).expect("read");
+
+        assert!(
+            written.contains("&amp;") && written.contains("&lt;") && written.contains("&quot;"),
+            "values were not escaped:\n{written}"
+        );
+        assert!(
+            !written.contains("R&D"),
+            "raw ampersand survived into the file:\n{written}"
+        );
+        assert!(
+            !written.contains("<lab>"),
+            "raw angle brackets survived into the file:\n{written}"
+        );
+
+        let reloaded = TuneFile::load(&path).expect("reload");
+        assert_eq!(reloaded.author.as_deref(), Some(raw_author));
+        match reloaded.constants.get("noteText") {
+            Some(TuneValue::String(s)) => assert_eq!(s, raw_note),
+            other => panic!("string constant did not survive the round trip: {other:?}"),
+        }
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// `{:.17}` is seventeen *decimal places*, not significant digits, so
+    /// `14.7` (exactly 14.699999999999999289... as an f64) was written as
+    /// `14.69999999999999929`. `f64`'s `Display` already emits the shortest
+    /// decimal that round-trips.
+    #[test]
+    fn msq_scalars_use_the_shortest_round_tripping_form() {
+        let mut tune = TuneFile::new("speeduino 202501");
+        tune.set_constant("stoich", TuneValue::Scalar(14.7));
+        tune.set_constant("reqFuel", TuneValue::Scalar(0.1));
+        tune.set_constant("zero", TuneValue::Scalar(0.0));
+        tune.set_constant("bins", TuneValue::Array(vec![14.7, 1.0, -0.3]));
+        tune.set_pc_variable("pcStoich", TuneValue::Scalar(14.7));
+
+        let dir = std::env::temp_dir().join(format!("lt_msq_fmt_{}", std::process::id()));
+        let _ = fs::create_dir_all(&dir);
+        let path = dir.join("fmt.msq");
+        tune.save(&path).expect("save");
+        let written = fs::read_to_string(&path).expect("read");
+
+        assert!(
+            written.contains(">14.7<"),
+            "stoich not shortest:\n{written}"
+        );
+        assert!(
+            written.contains(">0.1<"),
+            "reqFuel not shortest:\n{written}"
+        );
+        assert!(written.contains(">0<"), "zero not shortest:\n{written}");
+        assert!(
+            written.contains(">14.7 1 -0.3<"),
+            "array not shortest:\n{written}"
+        );
+        assert!(
+            written.matches(">14.7<").count() >= 2,
+            "pcVariable not shortest:\n{written}"
+        );
+
+        let reloaded = TuneFile::load(&path).expect("reload");
+        match reloaded.constants.get("stoich") {
+            Some(TuneValue::Scalar(v)) => assert!((v - 14.7).abs() < f64::EPSILON),
+            other => panic!("stoich did not round trip: {other:?}"),
+        }
+
+        let _ = fs::remove_dir_all(&dir);
     }
 }

--- a/crates/libretune-core/tests/table_ops.rs
+++ b/crates/libretune-core/tests/table_ops.rs
@@ -161,6 +161,119 @@ fn test_rebin_table_clamps_outside_range() {
     assert!((result.z_values[2][2] - 110.0).abs() < 0.001);
 }
 
+/// Regression: `interpolate_z: false` must not zero out the table. It should
+/// copy old Z values by cell index, preserving them when dims are unchanged.
+#[test]
+fn test_rebin_table_no_interpolate_same_size_preserves_values() {
+    let old_x_bins = vec![500.0, 1000.0, 2000.0, 3000.0];
+    let old_y_bins = vec![20.0, 40.0, 60.0, 80.0];
+    let old_z_values = vec![
+        vec![10.0, 15.0, 20.0, 25.0],
+        vec![20.0, 25.0, 30.0, 35.0],
+        vec![30.0, 35.0, 40.0, 45.0],
+        vec![40.0, 45.0, 50.0, 55.0],
+    ];
+
+    let result = rebin_table(
+        &old_x_bins,
+        &old_y_bins,
+        &old_z_values,
+        old_x_bins.clone(),
+        old_y_bins.clone(),
+        false,
+    );
+
+    assert_eq!(result.z_values, old_z_values);
+}
+
+/// Growing the grid with `interpolate_z: false` must preserve the original
+/// cells by index and fill new edge cells with the nearest (clamped) old
+/// cell rather than zeros.
+#[test]
+fn test_rebin_table_no_interpolate_grow_clamps_to_nearest_old_cell() {
+    let old_x_bins = vec![1.0, 2.0, 3.0];
+    let old_y_bins = vec![1.0, 2.0, 3.0];
+    let old_z_values = vec![
+        vec![1.0, 2.0, 3.0],
+        vec![4.0, 5.0, 6.0],
+        vec![7.0, 8.0, 9.0],
+    ];
+
+    let new_x_bins = vec![1.0, 2.0, 3.0, 4.0];
+    let new_y_bins = vec![1.0, 2.0, 3.0, 4.0];
+
+    let result = rebin_table(
+        &old_x_bins,
+        &old_y_bins,
+        &old_z_values,
+        new_x_bins,
+        new_y_bins,
+        false,
+    );
+
+    // Original 3x3 block preserved by index.
+    for (y, old_row) in old_z_values.iter().enumerate() {
+        assert_eq!(&result.z_values[y][..3], &old_row[..]);
+    }
+
+    // New row/col at index 3 has no old counterpart, so it clamps to the
+    // nearest existing old cell (index 2, the old grid's last row/col).
+    assert_eq!(result.z_values[3][0], old_z_values[2][0]);
+    assert_eq!(result.z_values[0][3], old_z_values[0][2]);
+    assert_eq!(result.z_values[3][3], old_z_values[2][2]);
+}
+
+/// Shrinking the grid with `interpolate_z: false` must keep the top-left
+/// block of old values (every new index still exists in the old grid).
+#[test]
+fn test_rebin_table_no_interpolate_shrink_keeps_top_left() {
+    let old_x_bins = vec![1.0, 2.0, 3.0, 4.0];
+    let old_y_bins = vec![1.0, 2.0, 3.0, 4.0];
+    let old_z_values = vec![
+        vec![1.0, 2.0, 3.0, 4.0],
+        vec![5.0, 6.0, 7.0, 8.0],
+        vec![9.0, 10.0, 11.0, 12.0],
+        vec![13.0, 14.0, 15.0, 16.0],
+    ];
+
+    let new_x_bins = vec![1.0, 2.0];
+    let new_y_bins = vec![1.0, 2.0];
+
+    let result = rebin_table(
+        &old_x_bins,
+        &old_y_bins,
+        &old_z_values,
+        new_x_bins,
+        new_y_bins,
+        false,
+    );
+
+    assert_eq!(result.z_values, vec![vec![1.0, 2.0], vec![5.0, 6.0]]);
+}
+
+/// An empty old grid (e.g. a brand-new table) must not panic and should
+/// return zeros for the new grid.
+#[test]
+fn test_rebin_table_no_interpolate_empty_old_grid_returns_zeros_no_panic() {
+    let old_x_bins: Vec<f64> = vec![];
+    let old_y_bins: Vec<f64> = vec![];
+    let old_z_values: Vec<Vec<f64>> = vec![];
+
+    let new_x_bins = vec![1.0, 2.0];
+    let new_y_bins = vec![1.0, 2.0];
+
+    let result = rebin_table(
+        &old_x_bins,
+        &old_y_bins,
+        &old_z_values,
+        new_x_bins,
+        new_y_bins,
+        false,
+    );
+
+    assert_eq!(result.z_values, vec![vec![0.0, 0.0], vec![0.0, 0.0]]);
+}
+
 #[test]
 fn test_smooth_table() {
     let z_values = vec![
@@ -389,4 +502,34 @@ fn test_interpolate_cells_out_of_bounds_selection_is_noop() {
     let result = interpolate_cells(&z_values, selected_cells);
 
     assert_eq!(result, z_values, "out-of-bounds selection must not mutate");
+}
+
+/// A selection left over from before "Set Table Size" shrank the grid must be
+/// a no-op in `smooth_table`, not an out-of-bounds write.
+///
+/// `handleSetTableSize` in `TableEditor2D.tsx` resizes the table without
+/// clearing `selectionRange`, so the next "Smooth" sends coordinates that no
+/// longer exist. A cell exactly one row/col past the edge still has an
+/// in-bounds `(-1,-1)` neighbour, so `weight_sum > 0.0` and the unchecked
+/// `result[y][x]` write panicked.
+#[test]
+fn test_smooth_table_out_of_bounds_selection_is_noop() {
+    let z_values = vec![vec![10.0, 20.0, 30.0]; 3];
+
+    // (3, 3) is one past the last row and column of a 3x3 grid.
+    let result = smooth_table(&z_values, vec![(3, 3)], 1.0);
+
+    assert_eq!(result, z_values, "out-of-bounds selection must not mutate");
+}
+
+/// Same guard, but with a partially-stale multi-cell selection: one valid cell
+/// and one past the edge. The whole operation is rejected rather than half
+/// applied, matching `interpolate_linear`/`fill_region`.
+#[test]
+fn test_smooth_table_partially_stale_selection_is_noop() {
+    let z_values = vec![vec![10.0, 90.0], vec![10.0, 10.0]];
+
+    let result = smooth_table(&z_values, vec![(0, 1), (2, 2)], 1.0);
+
+    assert_eq!(result, z_values, "stale selection must not mutate");
 }


### PR DESCRIPTION
## Description
INI / MSQ parsing and table-op fixes. The first one is user-facing data loss.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made
- **Rebin erased tables**: `rebin_table(interpolate_z: false)` returned an all-zero Z grid and the command persisted it. The RebinDialog exposes that checkbox. Values are now copied by index (clamped at the edges), matching "re-bin without interpolation".
- `smooth_table` was the one op missing the stale-selection bounds guard; reachable via resize-then-smooth.
- MSQ writer never escaped XML, so `&`, `<` or `"` in a string constant / author produced a file TunerStudio rejects. Escaping added on write and unescaping on read; floats use the shortest round-trip form instead of `{:.17}` (`14.7` was written as `14.69999999999999929`).
- `#set` / `#unset` were honoured inside a false `#if` branch; now gated like `#define`.
- `settingOption` attached to `HashMap::iter_mut().last()`, i.e. a random group; now tracks the current group.
- PC variables never got deferred-expression min/max and clamped to 0..255; `parse_bit_range_spec` overflowed `u8` on wide ranges.
- Expression engine: checked shifts, recursion depth limit (nested parens overflowed the stack), strict lexer (unknown chars, trailing tokens and lone `=` are errors; `1e3` / `.5` parse instead of being truncated to `1`).
- `[AxB]` literal shape read row-first while the braced form read column-first. rusEFI's `demo.ini` settles it (`cltIdleCorrTable [8x3]` is driven by an 8-entry `xBins`), so the literal form is now column-first too. Two tests that encoded the old reading were updated.
- `$varName` substitution always resolved to byte 0, ignoring a non-zero `tsCanId` in page identifiers used for protocol framing; it now resolves the declared default.
- `[FrontPage]` `gaugeN` capped at 64 (was an unbounded `Vec` grow).

Each change has a regression test in `tests/table_ops.rs`, `tune/file.rs`, `ini/parser.rs`, `ini/constants.rs`, `ini/expression.rs` or `ini/types.rs`.

## Testing
- [x] I have tested these changes locally
- [x] New and existing tests pass (`cargo test`)
- [ ] The UI works correctly with these changes (not exercised against hardware)

## Checklist
- [x] Code compiles without errors
- [x] No new clippy warnings (`cargo clippy`)
- [x] Code is formatted (`cargo fmt`)
- [x] TypeScript compiles without errors (`npm run typecheck`)
- [ ] Documentation updated if needed
- [x] Commit messages follow conventional format

Part of a full-app audit; each area is a separate PR so they can be reviewed and merged independently. Every finding was verified against the code path by a second pass before being fixed, and each fix has a regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
