### PR TITLE
fix(plugins,scripting,llm): resource limits, timeouts, agent wrap-up turn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2460,6 +2460,7 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
  "wasmtime",
+ "wat",
 ]
 
 [[package]]

--- a/crates/libretune-core/Cargo.toml
+++ b/crates/libretune-core/Cargo.toml
@@ -78,6 +78,10 @@ serial_test = "3.2.0"
 tempfile = "3.24.0"
 tokio = { workspace = true, features = ["test-util", "macros"] }
 tracing-subscriber = { workspace = true }
+# WAT text-format assembler, used to build tiny hand-written WASM modules for
+# plugin_system sandbox tests (e.g. an infinite-loop guest). Already pulled
+# in transitively by wasmtime, so this adds no new dependency.
+wat = "1.255.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/libretune-core/src/agent/orchestrator.rs
+++ b/crates/libretune-core/src/agent/orchestrator.rs
@@ -237,8 +237,14 @@ pub async fn run_turn_observed(
             });
         }
 
-        // If we've hit the round cap, tell the model to wrap up.
-        if _round == MAX_READ_ROUNDS {
+        // If we're about to hit the round cap, tell the model to wrap up —
+        // this must fire one round early (MAX_READ_ROUNDS - 1) so the
+        // following iteration still has a `client.chat()` call left in the
+        // `0..=MAX_READ_ROUNDS` bound to actually send it. Firing on
+        // `_round == MAX_READ_ROUNDS` composes the message on the loop's
+        // final iteration, which then exits without ever calling the model
+        // again — the wrap-up request is built but never sent.
+        if _round == MAX_READ_ROUNDS - 1 {
             messages.push(Message::user(
                 "I've gathered enough data. Please give me your final analysis and any proposed changes.",
             ));
@@ -647,5 +653,94 @@ mod tests {
         };
         let pa = map_tool_call(&tc, &inputs, &auth());
         assert!(matches!(pa.validation, ValidationResult::Ok { .. }));
+    }
+
+    /// A [`Provider`](crate::llm::provider::Provider) that always requests a
+    /// read tool call (so `run_turn_observed`'s loop never exits early via
+    /// `reads.is_empty()`) and records every [`ChatRequest`] it was handed,
+    /// so the test below can inspect exactly what the final round sent.
+    struct AlwaysReadsProvider {
+        requests: std::sync::Arc<std::sync::Mutex<Vec<ChatRequest>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::llm::provider::Provider for AlwaysReadsProvider {
+        fn name(&self) -> &str {
+            "always-reads-mock"
+        }
+
+        async fn chat(
+            &self,
+            req: &ChatRequest,
+        ) -> Result<crate::llm::types::ChatResponse, LlmError> {
+            self.requests.lock().unwrap().push(req.clone());
+            Ok(crate::llm::types::ChatResponse {
+                content: String::new(),
+                tool_calls: vec![ToolCall {
+                    id: "1".into(),
+                    name: tools::tool_names::LIST_TABLES.into(),
+                    arguments: "{}".into(),
+                }],
+                finish_reason: FinishReason::ToolCalls,
+                usage: None,
+            })
+        }
+    }
+
+    /// Answers every read tool call with an empty JSON object — its content
+    /// doesn't matter for this test, only that the loop keeps running.
+    struct StubReadExecutor;
+
+    #[async_trait::async_trait]
+    impl ReadToolExecutor for StubReadExecutor {
+        fn handles(&self, _tool_name: &str) -> bool {
+            true
+        }
+
+        async fn execute(&self, _tool_name: &str, _arguments: &str) -> String {
+            "{}".to_string()
+        }
+    }
+
+    /// Regression test for the round-cap wrap-up bug: previously the
+    /// "please wrap up" message was appended to `messages` only after the
+    /// loop's final `client.chat()` call had already happened, so it was
+    /// composed but never actually sent. With the fix (guard moved to
+    /// `MAX_READ_ROUNDS - 1`), the model keeps requesting reads every round,
+    /// so the loop runs all `MAX_READ_ROUNDS + 1` rounds, and the last
+    /// request sent to the client must contain the wrap-up instruction.
+    #[tokio::test]
+    async fn wrap_up_message_is_actually_sent_to_client_at_round_cap() {
+        let recorded: std::sync::Arc<std::sync::Mutex<Vec<ChatRequest>>> = Default::default();
+        let provider = AlwaysReadsProvider {
+            requests: recorded.clone(),
+        };
+        let client = LlmClient::from_provider(Box::new(provider));
+
+        let inputs = OrchestratorInputs {
+            capability_tier: CapabilityTier::Config,
+            ..Default::default()
+        };
+
+        let result = run_turn(&client, &inputs, &auth(), Some(&StubReadExecutor)).await;
+        assert!(result.is_ok(), "run_turn should not error: {result:?}");
+
+        let calls = recorded.lock().unwrap();
+        assert_eq!(
+            calls.len(),
+            MAX_READ_ROUNDS + 1,
+            "expected one client.chat() call per round, including the final round-cap round"
+        );
+
+        let last_request = calls.last().expect("at least one call recorded");
+        let sent_wrap_up = last_request
+            .messages
+            .iter()
+            .any(|m| m.content.contains("I've gathered enough data"));
+        assert!(
+            sent_wrap_up,
+            "expected the final round's request to actually include the wrap-up instruction, got: {:#?}",
+            last_request.messages
+        );
     }
 }

--- a/crates/libretune-core/src/llm/client.rs
+++ b/crates/libretune-core/src/llm/client.rs
@@ -27,4 +27,14 @@ impl LlmClient {
     pub async fn chat(&self, req: &ChatRequest) -> Result<ChatResponse, LlmError> {
         self.provider.chat(req).await
     }
+
+    /// Test-only constructor that wraps an arbitrary [`Provider`] (typically
+    /// a mock/recording one) instead of building one from a
+    /// [`ProviderConfig`]. Lets tests elsewhere in the crate (e.g.
+    /// `agent::orchestrator`) observe exactly what gets sent to the model on
+    /// each round of a turn, without a live provider.
+    #[cfg(test)]
+    pub(crate) fn from_provider(provider: Box<dyn Provider>) -> Self {
+        Self { provider }
+    }
 }

--- a/crates/libretune-core/src/llm/provider.rs
+++ b/crates/libretune-core/src/llm/provider.rs
@@ -2,6 +2,39 @@
 
 use crate::llm::types::{ChatRequest, ChatResponse, LlmError};
 use async_trait::async_trait;
+use std::time::Duration;
+
+/// Total request timeout for the shared LLM HTTP client. Generous on
+/// purpose: a legitimate streaming completion can run long, and this is a
+/// ceiling on the whole request/response, not a per-chunk idle timeout.
+const LLM_REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// TCP connect timeout for the shared LLM HTTP client. Much shorter than
+/// [`LLM_REQUEST_TIMEOUT`] since a healthy endpoint should accept a
+/// connection almost immediately — a stalled connect attempt indicates a
+/// dead/unreachable host, not a slow-but-working one.
+const LLM_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Builds the `reqwest::Client` shared by every provider, with an explicit
+/// request/connect timeout so a stalled endpoint can't hang an agent turn
+/// forever (see [`build_http_client`] for the production timeouts; tests use
+/// [`build_http_client_with_timeouts`] directly with short overrides so they
+/// don't have to wait out the real ones).
+fn build_http_client() -> Result<reqwest::Client, LlmError> {
+    build_http_client_with_timeouts(LLM_REQUEST_TIMEOUT, LLM_CONNECT_TIMEOUT)
+}
+
+fn build_http_client_with_timeouts(
+    request_timeout: Duration,
+    connect_timeout: Duration,
+) -> Result<reqwest::Client, LlmError> {
+    reqwest::Client::builder()
+        .user_agent("LibreTune/0.1 (AI-Assistant)")
+        .timeout(request_timeout)
+        .connect_timeout(connect_timeout)
+        .build()
+        .map_err(|e| LlmError::Config(format!("failed to build HTTP client: {e}")))
+}
 
 /// All configuration needed to talk to one provider, in a provider-agnostic
 /// form. This is what gets stored in user settings.
@@ -37,10 +70,7 @@ pub trait Provider: Send + Sync {
 /// its own `reqwest::Client` (built once, reused) so callers don't have to
 /// thread one through.
 pub fn build_provider(cfg: &ProviderConfig) -> Result<Box<dyn Provider>, LlmError> {
-    let client = reqwest::Client::builder()
-        .user_agent("LibreTune/0.1 (AI-Assistant)")
-        .build()
-        .map_err(|e| LlmError::Config(format!("failed to build HTTP client: {e}")))?;
+    let client = build_http_client()?;
 
     match cfg.provider.to_lowercase().as_str() {
         "openai" | "" => Ok(Box::new(
@@ -70,5 +100,56 @@ pub fn build_provider(cfg: &ProviderConfig) -> Result<Box<dyn Provider>, LlmErro
         other => Err(LlmError::Config(format!(
             "unknown provider '{other}' (expected: openai, anthropic, google)"
         ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Instant;
+
+    #[test]
+    fn test_build_provider_succeeds_for_known_providers() {
+        for provider in ["openai", "anthropic", "google"] {
+            let cfg = ProviderConfig {
+                provider: provider.to_string(),
+                base_url: "http://localhost:11434/v1".to_string(),
+                api_key: String::new(),
+                model: "test-model".to_string(),
+            };
+            assert!(
+                build_provider(&cfg).is_ok(),
+                "expected provider '{provider}' to build successfully"
+            );
+        }
+    }
+
+    /// Exercises the exact `reqwest::ClientBuilder` chain `build_provider`
+    /// uses (short-overridden so the test doesn't have to wait out the real
+    /// 10s production connect timeout) against a non-routable address, which
+    /// silently drops the connection attempt rather than refusing it — the
+    /// only way to observe whether `connect_timeout` is actually wired in
+    /// rather than the client hanging forever.
+    #[tokio::test]
+    async fn test_client_enforces_connect_timeout() {
+        let client =
+            build_http_client_with_timeouts(Duration::from_millis(500), Duration::from_millis(500))
+                .expect("client should build");
+
+        let start = Instant::now();
+        // 10.255.255.1 is a non-routable address: the OS attempts the TCP
+        // handshake and gets no response, so the connection genuinely hangs
+        // until something (here, connect_timeout) gives up on it.
+        let result = client.get("http://10.255.255.1/").send().await;
+        let elapsed = start.elapsed();
+
+        assert!(
+            result.is_err(),
+            "expected the connect timeout to abort the request"
+        );
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "connect_timeout should bound the wait to well under 5s, took {elapsed:?}"
+        );
     }
 }

--- a/crates/libretune-core/src/lua/mod.rs
+++ b/crates/libretune-core/src/lua/mod.rs
@@ -1,7 +1,19 @@
 //! Lua scripting engine (sandboxed)
 
-use mlua::{Lua, LuaOptions, StdLib, Value, Variadic};
+use mlua::{HookTriggers, Lua, LuaOptions, StdLib, Value, Variadic, VmState};
 use std::sync::{Arc, Mutex};
+
+/// Memory ceiling (bytes) for a single [`execute_script`] call. Guards
+/// against a script that allocates without bound (e.g. growing a table
+/// forever) exhausting the host process's memory.
+const LUA_MEMORY_LIMIT_BYTES: usize = 64 * 1024 * 1024;
+
+/// Instruction budget for a single [`execute_script`] call, enforced via a
+/// `set_hook` triggered every `LUA_INSTRUCTION_BUDGET` VM instructions. A
+/// script like `while true do end` runs no host calls and allocates nothing,
+/// so neither a timeout nor the memory limit above would ever stop it —
+/// this hook is what actually bounds a runaway loop's CPU time.
+const LUA_INSTRUCTION_BUDGET: u32 = 10_000_000;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct LuaExecutionResult {
@@ -36,6 +48,21 @@ pub fn execute_script(script: &str) -> Result<LuaExecutionResult, String> {
 
     let lua = Lua::new_with(StdLib::TABLE | StdLib::STRING | StdLib::MATH, lua_options)
         .map_err(|e| format!("Failed to initialize Lua: {e}"))?;
+
+    lua.set_memory_limit(LUA_MEMORY_LIMIT_BYTES)
+        .map_err(|e| format!("Failed to set Lua memory limit: {e}"))?;
+
+    // Errors out of the executing script once it has run past the
+    // instruction budget, turning a runaway `while true do end` into a
+    // returned error instead of a permanently hung tokio worker.
+    lua.set_hook(
+        HookTriggers::new().every_nth_instruction(LUA_INSTRUCTION_BUDGET),
+        |_lua, _debug| -> mlua::Result<VmState> {
+            Err(mlua::Error::RuntimeError(format!(
+                "Script exceeded the instruction budget of {LUA_INSTRUCTION_BUDGET} VM instructions"
+            )))
+        },
+    );
 
     let print_fn = lua
         .create_function(move |_, args: Variadic<Value>| {
@@ -80,4 +107,32 @@ pub fn execute_script(script: &str) -> Result<LuaExecutionResult, String> {
         return_value: format_value(&result_value),
         error,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_infinite_loop_returns_error_instead_of_hanging() {
+        let result = execute_script("while true do end")
+            .expect("execute_script only errors on Lua-init failure, not script errors");
+
+        assert!(
+            result.error.is_some(),
+            "expected the instruction-budget hook to stop an infinite loop with an error"
+        );
+        let error = result.error.unwrap();
+        assert!(
+            error.contains("instruction budget"),
+            "expected the instruction-budget error message, got: {error}"
+        );
+    }
+
+    #[test]
+    fn test_normal_script_still_executes_successfully() {
+        let result = execute_script("return 1 + 1").expect("execute_script should succeed");
+        assert_eq!(result.error, None);
+        assert_eq!(result.return_value, Some("2".to_string()));
+    }
 }

--- a/crates/libretune-core/src/plugin_system.rs
+++ b/crates/libretune-core/src/plugin_system.rs
@@ -25,12 +25,78 @@ use crate::plugin_api;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::Path;
-use wasmtime::{Caller, Engine, Extern, Instance, Linker, Memory, Module, Store};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+use wasmtime::{
+    Caller, Config, Engine, Extern, Instance, Linker, Memory, Module, ResourceLimiter, Store,
+    StoreLimits, StoreLimitsBuilder,
+};
 
 /// Maximum length (bytes) accepted for a guest-supplied string argument
 /// (table/constant/channel name, action JSON). Guards against a malicious or
 /// buggy plugin claiming an absurd `len` and forcing a huge host allocation.
 const MAX_GUEST_STRING_LEN: usize = 64 * 1024;
+
+/// Fuel budget granted before every call into guest code (`plugin_init`,
+/// `plugin_execute`, `plugin_shutdown`, or a test's `call_i32_export`). Most
+/// wasm instructions burn 1 unit of fuel, so this bounds a single call to a
+/// few million executed instructions regardless of what the guest does —
+/// enough headroom for real plugin logic, but a `loop {}` guest exhausts it
+/// and traps instead of hanging the calling thread forever.
+const PLUGIN_FUEL_PER_CALL: u64 = 10_000_000;
+
+/// Maximum bytes a plugin's linear memory may grow to. Applied via
+/// `Store::limiter`; a `memory.grow` past this returns failure to the guest
+/// (or, with `trap_on_grow_failure`, would trap) rather than letting an
+/// unbounded plugin exhaust host memory.
+const PLUGIN_MEMORY_LIMIT_BYTES: usize = 64 * 1024 * 1024;
+
+/// How often the background [`EpochTicker`] advances a plugin's `Engine`
+/// epoch. Combined with [`EPOCH_TICKS_PER_CALL`], this bounds worst-case
+/// wall-clock time per call independently of fuel — a backstop for guest
+/// code whose instructions individually burn little fuel but still block
+/// for a long time (e.g. host calls that spin).
+const EPOCH_TICK_INTERVAL: Duration = Duration::from_millis(50);
+
+/// Epoch ticks allowed per call before wasmtime traps the guest, i.e. a
+/// `EPOCH_TICK_INTERVAL * EPOCH_TICKS_PER_CALL` wall-clock deadline (~1s).
+const EPOCH_TICKS_PER_CALL: u64 = 20;
+
+/// Background thread that periodically calls [`Engine::increment_epoch`] so
+/// `Store::set_epoch_deadline` has something to enforce a wall-clock timeout
+/// against. Epoch checks are injected into compiled guest code, but nothing
+/// advances the epoch on its own while a synchronous `Store` call (like
+/// `plugin_execute`) blocks the calling thread — this ticker is that
+/// external actor. It stops itself (checked once per tick) when the owning
+/// [`PluginInstance`] is dropped.
+struct EpochTicker {
+    stop: Arc<AtomicBool>,
+}
+
+impl EpochTicker {
+    /// Spawn the ticker for `engine`. `Engine` is a cheap `Arc`-backed
+    /// handle, so cloning it into the thread doesn't duplicate the compiled
+    /// module or runtime state.
+    fn start(engine: Engine) -> Self {
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_thread = Arc::clone(&stop);
+        thread::spawn(move || {
+            while !stop_thread.load(Ordering::Relaxed) {
+                thread::sleep(EPOCH_TICK_INTERVAL);
+                engine.increment_epoch();
+            }
+        });
+        Self { stop }
+    }
+}
+
+impl Drop for EpochTicker {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+    }
+}
 
 /// Sentinel return codes shared by every host function. Plugin-side glue code
 /// (bindgen or hand-written) should treat any negative value as failure.
@@ -138,6 +204,8 @@ struct PluginHostState {
     /// `subscribe_channel` handed back — `get_channel_value` resolves ids
     /// through this rather than trusting a guest-supplied name directly.
     subscribed_channels: Vec<String>,
+    /// Enforces [`PLUGIN_MEMORY_LIMIT_BYTES`] via `Store::limiter`.
+    limits: StoreLimits,
 }
 
 /// Fetch the guest's exported linear memory, or an [`host_result::INVALID_ARGS`] error.
@@ -478,6 +546,9 @@ pub struct PluginInstance {
     permissions: Vec<Permission>,
     /// Execution counter for debugging
     exec_count: u64,
+    /// Keeps the epoch-advancing background thread alive for as long as this
+    /// instance exists; never read directly, only relied on for its `Drop`.
+    _epoch_ticker: EpochTicker,
 }
 
 impl PluginInstance {
@@ -515,8 +586,15 @@ impl PluginInstance {
             .copied()
             .collect();
 
-        // Create WASM runtime
-        let engine = Engine::default();
+        // Create WASM runtime. Fuel and epoch interruption both must be
+        // enabled on the `Config` up front — they can't be turned on for a
+        // `Store` after the fact — so that every plugin call can be bounded
+        // with `set_fuel`/`set_epoch_deadline` below, and a memory cap
+        // enforced via `Store::limiter`. Without these a guest `loop {}`
+        // (or an unbounded `memory.grow`) would otherwise hang or OOM the
+        // host thread that's driving it.
+        let engine = Engine::new(Config::new().consume_fuel(true).epoch_interruption(true))
+            .map_err(|e| format!("Failed to create WASM engine: {}", e))?;
 
         // Read WASM file into bytes
         let wasm_bytes =
@@ -531,16 +609,30 @@ impl PluginInstance {
             snapshot: PluginDataSnapshot::default(),
             proposals: Vec::new(),
             subscribed_channels: Vec::new(),
+            limits: StoreLimitsBuilder::new()
+                .memory_size(PLUGIN_MEMORY_LIMIT_BYTES)
+                .build(),
         };
         let mut store = Store::new(&engine, host_state);
+        store.limiter(|state: &mut PluginHostState| &mut state.limits as &mut dyn ResourceLimiter);
         let mut linker: Linker<PluginHostState> = Linker::new(&engine);
         register_host_functions(&mut linker)?;
+
+        // Instantiation runs data/elem segment initialisers and the `start`
+        // function, which consume fuel and count against the epoch deadline
+        // like any other guest code — so it needs a budget too.
+        store
+            .set_fuel(PLUGIN_FUEL_PER_CALL)
+            .map_err(|e| format!("Failed to set plugin fuel budget: {}", e))?;
+        store.set_epoch_deadline(EPOCH_TICKS_PER_CALL);
 
         // Instantiate module against the permission-checked host-function
         // surface registered above.
         let instance = linker
             .instantiate(&mut store, &module)
             .map_err(|e| format!("Failed to instantiate module: {}", e))?;
+
+        let epoch_ticker = EpochTicker::start(engine);
 
         Ok(PluginInstance {
             manifest,
@@ -549,7 +641,22 @@ impl PluginInstance {
             state: PluginState::Loaded,
             permissions: granted,
             exec_count: 0,
+            _epoch_ticker: epoch_ticker,
         })
+    }
+
+    /// Grant this call's fuel and epoch-deadline budget just before invoking
+    /// a guest export (`plugin_init`/`plugin_execute`/`plugin_shutdown`, or a
+    /// test's [`PluginInstance::call_i32_export`]). Must be called anew
+    /// before every such call — fuel and the epoch deadline are both
+    /// consumed/advanced by wasmtime as execution proceeds, so a stale
+    /// budget from a previous call would leave the next one with none.
+    fn arm_call_budget(&mut self) -> Result<(), String> {
+        self.store
+            .set_fuel(PLUGIN_FUEL_PER_CALL)
+            .map_err(|e| format!("Failed to set plugin fuel budget: {}", e))?;
+        self.store.set_epoch_deadline(EPOCH_TICKS_PER_CALL);
+        Ok(())
     }
 
     /// Initialize plugin with configuration.
@@ -570,6 +677,7 @@ impl PluginInstance {
             .instance
             .get_typed_func::<(i32, i32, i32), i32>(&mut self.store, "plugin_init")
         {
+            self.arm_call_budget()?;
             // Pass simple parameters: config size, ecu_type ptr, version ptr
             let _ = init
                 .call(&mut self.store, (0, 0, 0))
@@ -602,6 +710,7 @@ impl PluginInstance {
             .instance
             .get_typed_func::<(), i32>(&mut self.store, name)
             .map_err(|e| format!("Export '{}' not found or wrong signature: {}", name, e))?;
+        self.arm_call_budget()?;
         func.call(&mut self.store, ())
             .map_err(|e| format!("Call to '{}' failed: {}", name, e))
     }
@@ -648,6 +757,7 @@ impl PluginInstance {
             .instance
             .get_typed_func::<(), i32>(&mut self.store, "plugin_execute")
         {
+            self.arm_call_budget()?;
             result_code = Some(
                 exec.call(&mut self.store, ())
                     .map_err(|e| format!("Plugin execution failed: {}", e))?,
@@ -672,6 +782,9 @@ impl PluginInstance {
             .instance
             .get_typed_func::<(), i32>(&mut self.store, "plugin_shutdown")
         {
+            // Best-effort: unloading proceeds regardless of whether the
+            // budget re-arms or the shutdown call itself succeeds.
+            let _ = self.arm_call_budget();
             let _ = shutdown.call(&mut self.store, ()).ok();
         }
 
@@ -902,6 +1015,60 @@ mod tests {
         };
         assert_eq!(stats.exec_count, 5);
         assert_eq!(stats.permissions, 3);
+    }
+
+    /// Builds a tiny WASM module (via WAT text format) that exports a
+    /// `plugin_execute` which loops forever, plus a 1-page linear memory so
+    /// it satisfies `PluginInstance::load`'s usual expectations. Written to a
+    /// temp file so it can be handed to `PluginInstance::load` like any real
+    /// plugin binary.
+    fn write_infinite_loop_plugin(dir: &tempfile::TempDir) -> std::path::PathBuf {
+        let wat_src = r#"
+            (module
+                (memory (export "memory") 1)
+                (func (export "plugin_execute") (result i32)
+                    (loop $forever
+                        br $forever
+                    )
+                    (i32.const 0)
+                )
+            )
+        "#;
+        let wasm_bytes = wat::parse_str(wat_src).expect("valid WAT source");
+        let path = dir.path().join("infinite_loop.wasm");
+        std::fs::write(&path, wasm_bytes).expect("write test wasm module");
+        path
+    }
+
+    #[test]
+    fn test_infinite_loop_plugin_traps_instead_of_hanging() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let wasm_path = write_infinite_loop_plugin(&dir);
+
+        let manifest = PluginManifest {
+            name: "infinite_loop".to_string(),
+            version: "1.0.0".to_string(),
+            description: "Test plugin with a runaway loop".to_string(),
+            author: "Test Author".to_string(),
+            permissions: vec![],
+        };
+
+        let mut plugin = PluginInstance::load(manifest, &wasm_path, &test_config(), &[])
+            .expect("plugin with an infinite loop still loads and instantiates fine");
+        plugin
+            .initialize(&test_config())
+            .expect("plugin has no plugin_init export, so init is a no-op");
+
+        // Without a fuel/epoch budget this call would hang the calling
+        // thread forever; with it, wasmtime traps once the budget set in
+        // PluginInstance::arm_call_budget is exhausted and execute()
+        // surfaces that as an Err instead of blocking.
+        let result = plugin.execute(PluginDataSnapshot::default());
+        assert!(
+            result.is_err(),
+            "expected an infinite loop to be terminated by the fuel/epoch budget, got {:?}",
+            result
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description
Resource limits for the two script sandboxes and timeouts for outbound HTTP.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made
- wasmtime plugins ran with no fuel, memory limit or epoch deadline, so any plugin (even with zero permissions) could hang or OOM the host from `plugin_execute`. Now: `consume_fuel` + per-call fuel, 64 MiB `StoreLimits`, epoch interruption driven by a background ticker, and the budget is armed for instantiation as well (data segments consume fuel).
- Lua console had no instruction hook or memory cap; `while true do end` hung the app. Added `set_memory_limit` and an `every_nth_instruction` hook that errors past the budget.
- The shared `reqwest::Client` for LLM providers had no timeout anywhere; a stalled endpoint hung an assistant turn indefinitely. Connect 10 s, request 120 s.
- Agent orchestrator composed the round-cap "please wrap up" message on the last iteration, after which the loop exited without calling the model again, so long tool-use turns returned an empty reply. The guard is now `MAX_READ_ROUNDS - 1`.

Adds `wat` as a dev-dependency (already in the graph via wasmtime) for the infinite-loop plugin test. A test-only `LlmClient::from_provider` constructor was added to inject a recording mock.

## Testing
- [x] I have tested these changes locally
- [x] New and existing tests pass (`cargo test`)
- [ ] The UI works correctly with these changes (not exercised against hardware)

## Checklist
- [x] Code compiles without errors
- [x] No new clippy warnings (`cargo clippy`)
- [x] Code is formatted (`cargo fmt`)
- [x] TypeScript compiles without errors (`npm run typecheck`)
- [ ] Documentation updated if needed
- [x] Commit messages follow conventional format

Part of a full-app audit; each area is a separate PR so they can be reviewed and merged independently. Every finding was verified against the code path by a second pass before being fixed, and each fix has a regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
