### PR TITLE
feat(datalog): stream native .ltlog to disk without filling RAM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2460,6 +2460,7 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
  "wasmtime",
+ "zstd",
 ]
 
 [[package]]

--- a/crates/libretune-app/public/manual/features/datalog.md
+++ b/crates/libretune-app/public/manual/features/datalog.md
@@ -23,21 +23,23 @@ Data logging captures engine parameters over time, allowing you to:
 
 Click **Stop Logging** or press `Ctrl+L` again.
 
-Logs are automatically saved to your project's `logs/` folder.
+Logs are automatically saved to your project's `datalogs/` folder as `.ltlog` files.
 
 ## Log File Format
 
-LibreTune uses CSV format:
-```csv
-Time,RPM,MAP,AFR,CLT,TPS,...
-0.000,850,35.2,14.7,185,1.2,...
-0.100,860,35.5,14.6,185,1.3,...
-```
+LibreTune records to **`.ltlog`**, a compact binary log:
 
-This format is compatible with:
-- MegaLogViewer
-- Excel/Google Sheets
-- Custom analysis scripts
+- Channel names, units, and INI signature are stored once in the header
+- Samples are packed as binary (`f32`) in CRC-checked, zstd-compressed blocks
+- A crash or yanked USB loses only the last incomplete block; earlier samples still load
+- Recording writes straight to disk; RAM holds only a short live-graph tail
+- Opening a large `.ltlog` streams it: the chart shows a downsampled preview, and analysis reads named columns without loading the whole file
+
+Typical size vs CSV (100 channels, 50 Hz): about **10–30× smaller**. A one-hour log that would be ~150 MB of CSV is usually **~5–15 MB** as `.ltlog`.
+
+You can still **open** older LibreTune `.csv` files, TunerStudio `.msl` text exports, and TunerStudio `.mlg` binary logs.
+
+Native recording no longer writes CSV (it grows with every ASCII digit of every channel on every sample).
 
 ## Data Log Viewer
 
@@ -45,7 +47,7 @@ This format is compatible with:
 
 1. Go to **Tools → Data Log Viewer**
 2. Click **Open Log**
-3. Select a CSV file
+3. Select a `.ltlog` file (or an older `.csv` / TunerStudio `.msl` / `.mlg`)
 
 ### Playback Controls
 
@@ -87,10 +89,7 @@ Configure automatic logging in Settings:
 
 ### Sharing Logs
 
-Log CSV files can be:
-- Emailed to tuners for review
-- Opened in MegaLogViewer for detailed analysis
-- Imported into spreadsheets for custom analysis
+`.ltlog` files can be opened in LibreTune. Older CSV logs remain readable. TunerStudio `.msl` / `.mlg` can be imported for analysis.
 
 ## Exporting Tune Data
 

--- a/crates/libretune-app/src-tauri/src/commands/agent.rs
+++ b/crates/libretune-app/src-tauri/src/commands/agent.rs
@@ -646,8 +646,9 @@ impl LiveReadExecutor {
 
     /// `query_datalog`: summary stats or tail rows over a saved log (by
     /// name, from the project's `datalogs/` folder) or the current
-    /// in-memory session. Responses are bounded (≤50 channels for summary,
-    /// ≤50 rows × ≤12 columns for tail) to control token cost.
+    /// session file. Responses are bounded (≤50 channels for summary,
+    /// ≤50 rows × ≤12 columns for tail) to control token cost. `.ltlog`
+    /// is streamed; the whole file is never loaded.
     async fn exec_query_datalog(&self, arguments: &str) -> String {
         let state = self.app.state::<AppState>();
         let log_name = json_str_field(arguments, "log");
@@ -659,8 +660,6 @@ impl LiveReadExecutor {
                 match crate::commands::data_logging::load_datalog_file(&state, &name).await {
                     Ok(d) => d,
                     Err(e) => {
-                        // Self-healing: hand back the available log names so
-                        // the model can retry with a real one.
                         let logs = crate::commands::data_logging::list_datalog_files(&state).await;
                         return serde_json::to_string(&serde_json::json!({
                             "error": e,
@@ -673,16 +672,6 @@ impl LiveReadExecutor {
             None => crate::commands::data_logging::current_session_datalog(&state).await,
         };
 
-        if data.entries.is_empty() {
-            return serde_json::to_string(&serde_json::json!({
-                "source": data.source,
-                "entry_count": 0,
-                "note": "no entries recorded; start datalogging or name a saved log ('log' parameter)",
-            }))
-            .unwrap_or_else(|_| json_err("serialize failed"));
-        }
-
-        // Resolve the channel column indexes the caller asked for (or all).
         let indexes: Vec<usize> = data
             .channels
             .iter()
@@ -694,25 +683,75 @@ impl LiveReadExecutor {
             .map(|(i, _)| i)
             .collect();
 
-        let entry_count = data.entries.len();
-        let duration_s = data
-            .entries
-            .last()
-            .map(|e| e.timestamp.as_secs_f64())
-            .unwrap_or(0.0);
+        let stat_idx: Vec<usize> = indexes.iter().copied().take(50).collect();
+        let tail_cols: Vec<(String, usize)> = indexes
+            .iter()
+            .copied()
+            .take(12)
+            .map(|i| (data.channels[i].clone(), i))
+            .collect();
+
+        struct Acc {
+            min: f64,
+            max: f64,
+            sum: f64,
+            n: u64,
+            last: Option<f64>,
+        }
+        let mut stats: Vec<Acc> = stat_idx
+            .iter()
+            .map(|_| Acc {
+                min: f64::INFINITY,
+                max: f64::NEG_INFINITY,
+                sum: 0.0,
+                n: 0,
+                last: None,
+            })
+            .collect();
+        let mut entry_count = 0u64;
+        let mut duration_s = 0.0;
+        let mut ring: std::collections::VecDeque<libretune_core::datalog::LogEntry> =
+            std::collections::VecDeque::with_capacity(50);
+
+        if let Err(e) = data.for_each(|e| {
+            entry_count += 1;
+            duration_s = e.timestamp.as_secs_f64();
+            for (acc, &i) in stats.iter_mut().zip(&stat_idx) {
+                if let Some(&v) = e.values.get(i) {
+                    if v.is_finite() {
+                        acc.min = acc.min.min(v);
+                        acc.max = acc.max.max(v);
+                        acc.sum += v;
+                        acc.n += 1;
+                        acc.last = Some(v);
+                    }
+                }
+            }
+            if mode == "tail" {
+                if ring.len() == 50 {
+                    ring.pop_front();
+                }
+                ring.push_back(e.clone());
+            }
+        }) {
+            return json_err(&e);
+        }
+
+        if entry_count == 0 {
+            return serde_json::to_string(&serde_json::json!({
+                "source": data.source,
+                "entry_count": 0,
+                "note": "no entries recorded; start datalogging or name a saved log ('log' parameter)",
+            }))
+            .unwrap_or_else(|_| json_err("serialize failed"));
+        }
 
         if mode == "tail" {
-            let tail_start = entry_count.saturating_sub(50);
-            let columns: Vec<(String, usize)> = indexes
-                .into_iter()
-                .take(12)
-                .map(|i| (data.channels[i].clone(), i))
-                .collect();
-            let rows: Vec<serde_json::Value> = data.entries[tail_start..]
+            let rows: Vec<serde_json::Value> = ring
                 .iter()
                 .map(|e| {
                     let mut row = serde_json::json!({ "t": e.timestamp.as_secs_f64() });
-                    for (name, i) in &columns {
+                    for (name, i) in &tail_cols {
                         row[name] = serde_json::json!(e.values.get(*i).copied());
                     }
                     row
@@ -728,35 +767,18 @@ impl LiveReadExecutor {
             .unwrap_or_else(|_| json_err("serialize failed"));
         }
 
-        // summary (default)
         let mut channel_stats: Vec<serde_json::Value> = Vec::new();
-        for &i in indexes.iter().take(50) {
-            let mut min = f64::INFINITY;
-            let mut max = f64::NEG_INFINITY;
-            let mut sum = 0.0;
-            let mut n = 0u64;
-            let mut last = None;
-            for e in &data.entries {
-                if let Some(v) = e.values.get(i) {
-                    if v.is_finite() {
-                        min = min.min(*v);
-                        max = max.max(*v);
-                        sum += *v;
-                        n += 1;
-                        last = Some(*v);
-                    }
-                }
-            }
-            if n == 0 {
+        for (acc, &i) in stats.iter().zip(&stat_idx) {
+            if acc.n == 0 {
                 continue;
             }
             channel_stats.push(serde_json::json!({
                 "channel": data.channels[i],
-                "min": min,
-                "max": max,
-                "mean": sum / n as f64,
-                "last": last,
-                "samples": n,
+                "min": acc.min,
+                "max": acc.max,
+                "mean": acc.sum / acc.n as f64,
+                "last": acc.last,
+                "samples": acc.n,
             }));
         }
         serde_json::to_string(&serde_json::json!({

--- a/crates/libretune-app/src-tauri/src/commands/analyse_log.rs
+++ b/crates/libretune-app/src-tauri/src/commands/analyse_log.rs
@@ -5,19 +5,119 @@
 //! table is discovered, axis-corrected and anchored identically — an offline
 //! answer that disagreed with the live one would be worse than none.
 //!
-//! The log arrives already parsed, as one array per channel. Parsing stays in
-//! the frontend because that is where the `.msl` preamble handling and its
-//! tests already live, and re-implementing it here would give two parsers to
-//! disagree with each other.
+//! `.ltlog` is streamed from disk (named columns only). Other formats still
+//! arrive pre-parsed from the frontend, where `.msl` preamble handling lives.
 
 use crate::state::AppState;
 use libretune_core::autotune::replay::{replay, LogChannels, ReplayConfig, ReplayReport};
+use serde::Deserialize;
 
 use super::start_autotune::resolve_reference_tables;
+
+/// Channel names in the file that map onto AutoTune's required columns.
+#[derive(Debug, Deserialize)]
+pub struct LogColumnMap {
+    pub rpm: String,
+    pub load: String,
+    pub afr: String,
+    #[serde(default)]
+    pub ve: Option<String>,
+    #[serde(default)]
+    pub clt: Option<String>,
+    #[serde(default)]
+    pub tps: Option<String>,
+    #[serde(default)]
+    pub tps_rate: Option<String>,
+    #[serde(default)]
+    pub fuel_cut: Option<String>,
+    #[serde(default)]
+    pub accel_enrich: Option<String>,
+}
 
 #[tauri::command]
 pub async fn analyse_log(
     state: tauri::State<'_, AppState>,
+    table_name: String,
+    log: LogChannels,
+    config: ReplayConfig,
+    target_afr_table_name: Option<String>,
+    lambda_delay_table_name: Option<String>,
+) -> Result<ReplayReport, String> {
+    analyse_channels(
+        &state,
+        table_name,
+        log,
+        config,
+        target_afr_table_name,
+        lambda_delay_table_name,
+    )
+    .await
+}
+
+/// Stream a `.ltlog` and run AutoTune on it. Only the named columns are
+/// kept in RAM — not the whole 100-channel file.
+#[tauri::command]
+pub async fn analyse_log_file(
+    state: tauri::State<'_, AppState>,
+    path: String,
+    table_name: String,
+    columns: LogColumnMap,
+    config: ReplayConfig,
+    target_afr_table_name: Option<String>,
+    lambda_delay_table_name: Option<String>,
+) -> Result<ReplayReport, String> {
+    let names = [
+        columns.rpm.as_str(),
+        columns.load.as_str(),
+        columns.afr.as_str(),
+        columns.ve.as_deref().unwrap_or(""),
+        columns.clt.as_deref().unwrap_or(""),
+        columns.tps.as_deref().unwrap_or(""),
+        columns.tps_rate.as_deref().unwrap_or(""),
+        columns.fuel_cut.as_deref().unwrap_or(""),
+        columns.accel_enrich.as_deref().unwrap_or(""),
+    ];
+    let wanted: Vec<&str> = names.iter().copied().filter(|s| !s.is_empty()).collect();
+    let (_, mut time_ms, cols) =
+        libretune_core::datalog::ltlog::extract_ltlog_columns(&path, &wanted)
+            .map_err(|e| format!("Failed to read log: {e}"))?;
+    if time_ms.is_empty() {
+        return Err("The log has no samples with rpm, load and AFR.".into());
+    }
+    let t0 = time_ms[0];
+    for t in &mut time_ms {
+        *t -= t0;
+    }
+    let mut by_name = std::collections::HashMap::new();
+    for (name, col) in wanted.iter().zip(cols) {
+        by_name.insert(*name, col);
+    }
+    let mut take = |n: &str| by_name.remove(n).unwrap_or_default();
+    let log = LogChannels {
+        time_ms,
+        rpm: take(&columns.rpm),
+        load: take(&columns.load),
+        afr: take(&columns.afr),
+        ve: take(columns.ve.as_deref().unwrap_or("")),
+        clt: take(columns.clt.as_deref().unwrap_or("")),
+        tps: take(columns.tps.as_deref().unwrap_or("")),
+        tps_rate: take(columns.tps_rate.as_deref().unwrap_or("")),
+        fuel_cut: take(columns.fuel_cut.as_deref().unwrap_or("")),
+        accel_enrich: take(columns.accel_enrich.as_deref().unwrap_or("")),
+    };
+    analyse_channels(
+        &state,
+        table_name,
+        log,
+        config,
+        target_afr_table_name,
+        lambda_delay_table_name,
+    )
+    .await
+}
+
+async fn analyse_channels(
+    state: &AppState,
     table_name: String,
     log: LogChannels,
     config: ReplayConfig,
@@ -39,9 +139,6 @@ pub async fn analyse_log(
         .get_table_by_name_or_map(&table_name)
         .ok_or_else(|| format!("Table {table_name} not found in the definition"))?;
 
-    // The table's own axes. Analysing against invented bins would place every
-    // sample in the wrong cell while looking perfectly successful, so a failure
-    // to read them is fatal here rather than something to guess around.
     let (x_bins, y_bins) = super::start_autotune::read_table_axes(def, cache, table)
         .ok_or_else(|| format!("Could not read the axes of {table_name}"))?;
 

--- a/crates/libretune-app/src-tauri/src/commands/data_logging.rs
+++ b/crates/libretune-app/src-tauri/src/commands/data_logging.rs
@@ -3,7 +3,9 @@
 use libretune_core::datalog::DataLogger;
 use serde::Serialize;
 use std::collections::HashMap;
+use std::path::PathBuf;
 
+use crate::paths::get_app_data_dir;
 use crate::state::AppState;
 
 /// If `logger` is actively recording, stops it and returns `true`. Pulled
@@ -79,11 +81,7 @@ pub struct LoggingStatus {
     entry_count: usize,
     duration_ms: u64,
     channels: Vec<String>,
-    /// Oldest samples dropped because the in-memory buffer hit its ceiling.
-    /// Nonzero means the log no longer covers the whole session (D7).
-    discarded_count: u64,
-    /// Path of the file the log is being streamed to (saved continuously),
-    /// or null when logging only to memory.
+    /// Path of the file the log is streamed to (or the last finished file).
     stream_path: Option<String>,
 }
 
@@ -95,6 +93,7 @@ pub struct LogEntryData {
 
 #[tauri::command]
 pub async fn start_logging(
+    app: tauri::AppHandle,
     state: tauri::State<'_, AppState>,
     sample_rate: Option<f64>,
 ) -> Result<(), String> {
@@ -121,7 +120,7 @@ pub async fn start_logging(
     };
 
     // Also log the canonical alias names (RPM, MAP, TPS, …) that the realtime
-    // stream adds via apply_channel_aliases, so recorded logs and saved CSVs
+    // stream adds via apply_channel_aliases, so recorded logs
     // use the same channel names as the dashboards and graph pages.
     let mut probe: HashMap<String, f64> = channels.iter().map(|c| (c.clone(), 0.0)).collect();
     super::realtime_stream::apply_channel_aliases(&mut probe);
@@ -131,12 +130,14 @@ pub async fn start_logging(
         }
     }
 
-    // The log is streamed continuously to a timestamped file in the project's
-    // datalogs/ folder (TunerStudio-style: saved the whole time). Grab the dir
-    // before taking the logger lock to avoid holding two locks at once.
+    // Stream to the project's datalogs/ folder, or app-data/datalogs when no
+    // project is open. Recording without a file is not allowed — RAM is not
+    // the log.
     let stream_dir = {
         let proj = state.current_project.lock().await;
-        proj.as_ref().map(|p| p.path.join("datalogs"))
+        proj.as_ref()
+            .map(|p| p.path.join("datalogs"))
+            .unwrap_or_else(|| get_app_data_dir(&app).join("datalogs"))
     };
 
     let mut logger = state.data_logger.lock().await;
@@ -152,22 +153,48 @@ pub async fn start_logging(
         *logger = DataLogger::new(channels);
     }
 
+    let units: Vec<String> = logger
+        .channels()
+        .iter()
+        .map(|c| {
+            def.output_channels
+                .get(c)
+                .map(|o| o.units.clone())
+                .unwrap_or_default()
+        })
+        .collect();
+    let ini_types: Vec<String> = logger
+        .channels()
+        .iter()
+        .map(|c| {
+            def.datalog_entries
+                .iter()
+                .find(|e| e.channel == *c)
+                .map(|e| e.data_type.clone())
+                .unwrap_or_default()
+        })
+        .collect();
+    logger.set_capture_meta(
+        if def.signature.is_empty() {
+            None
+        } else {
+            Some(def.signature.clone())
+        },
+        units,
+        ini_types,
+    );
+
     if let Some(rate) = sample_rate {
         logger.set_sample_rate(rate);
     }
-    logger.start();
 
-    // Open a fresh timestamped file and stream to it (matches TunerStudio's
-    // YYYY-MM-DD_HH.MM.SS naming). Streaming failure is non-fatal — recording
-    // still works in memory and can be saved manually.
-    if let Some(dir) = stream_dir {
-        let name = chrono::Local::now().format("%Y-%m-%d_%H.%M.%S").to_string();
-        let path = dir.join(format!("{name}.csv"));
-        match logger.start_streaming(&path) {
-            Ok(()) => tracing::info!("streaming datalog to {}", path.display()),
-            Err(e) => tracing::warn!("could not stream datalog to {}: {e}", path.display()),
-        }
-    }
+    let name = chrono::Local::now().format("%Y-%m-%d_%H.%M.%S").to_string();
+    let path = stream_dir.join(format!("{name}.ltlog"));
+    logger
+        .start_streaming(&path)
+        .map_err(|e| format!("Could not create log file {}: {e}", path.display()))?;
+    logger.start();
+    tracing::info!("streaming datalog to {}", path.display());
 
     // Reset the dropped-sample counter for this session and mark recording
     // active so the stream tick counts (rather than silently swallows) any
@@ -196,8 +223,7 @@ pub async fn get_logging_status(
         entry_count: logger.entry_count(),
         duration_ms: logger.duration().as_millis() as u64,
         channels: logger.channels().to_vec(),
-        discarded_count: logger.discarded_count(),
-        stream_path: logger.stream_path().map(|p| p.display().to_string()),
+        stream_path: logger.log_path().map(|p| p.display().to_string()),
     })
 }
 
@@ -231,9 +257,7 @@ pub async fn get_log_entries(
     let max_count = count.unwrap_or(1000);
 
     let entries: Vec<LogEntryData> = logger
-        .entries()
-        .skip(start)
-        .take(max_count)
+        .live_window(start, max_count)
         .map(|entry| {
             let mut values = HashMap::with_capacity(selected.len());
             for (i, channel) in &selected {
@@ -260,55 +284,80 @@ pub async fn clear_log(state: tauri::State<'_, AppState>) -> Result<(), String> 
 
 #[tauri::command]
 pub async fn save_log(state: tauri::State<'_, AppState>, path: String) -> Result<(), String> {
-    // Build the CSV string while holding the lock (needed to read the
-    // logger), then drop it before the blocking disk write below — holding
-    // it across std::fs::write stalls every other data-logging command
-    // (stop/status/clear, or a UI status poll) for however long the write
-    // takes.
-    let csv = {
-        let logger = state.data_logger.lock().await;
-        let channels = logger.channels();
-
-        // Skip columns that are zero for the entire log: an INI defines far
-        // more output channels than the ECU (or demo simulator) actually
-        // streams, and those never-seen channels are logged as 0.0. Writing
-        // them out buries the real data in hundreds of dead columns.
-        let mut has_data = vec![false; channels.len()];
-        for entry in logger.entries() {
-            for (i, &val) in entry.values.iter().enumerate() {
-                if val != 0.0 {
-                    has_data[i] = true;
-                }
-            }
-        }
-
-        let mut csv = String::new();
-        csv.push_str("Time (ms)");
-        for (i, channel) in channels.iter().enumerate() {
-            if has_data[i] {
-                csv.push(',');
-                csv.push_str(channel);
-            }
-        }
-        csv.push('\n');
-
-        for entry in logger.entries() {
-            csv.push_str(&format!("{}", entry.timestamp.as_millis()));
-            for (i, val) in entry.values.iter().enumerate() {
-                if has_data[i] {
-                    csv.push(',');
-                    csv.push_str(&format!("{:.4}", val));
-                }
-            }
-            csv.push('\n');
-        }
-
-        csv
+    let src = {
+        let mut logger = state.data_logger.lock().await;
+        logger
+            .flush_stream()
+            .map_err(|e| format!("Failed to flush log: {e}"))?;
+        logger
+            .log_path()
+            .map(|p| p.to_path_buf())
+            .ok_or_else(|| "No log file to save".to_string())?
     };
-
-    std::fs::write(&path, csv).map_err(|e| format!("Failed to save log: {}", e))?;
-
+    if src.as_os_str() == std::path::Path::new(&path).as_os_str() {
+        return Ok(());
+    }
+    std::fs::copy(&src, &path).map_err(|e| format!("Failed to save log: {e}"))?;
     Ok(())
+}
+
+#[derive(Serialize)]
+pub struct LoadedLogSample {
+    /// Timestamp in milliseconds, matching `parseLogFile` / DataLogView.
+    x: f64,
+    values: HashMap<String, f64>,
+}
+
+#[derive(Serialize)]
+pub struct LoadedLogFile {
+    channels: Vec<String>,
+    samples: Vec<LoadedLogSample>,
+    /// True sample count on disk (may be larger than `samples.len()`).
+    sample_count: u64,
+}
+
+/// Load a `.ltlog` / `.mlg` / `.csv` from an arbitrary path for the UI.
+///
+/// `.ltlog` is downsampled so a long session cannot fill RAM or the webview.
+#[tauri::command]
+pub async fn load_log_file(path: String) -> Result<LoadedLogFile, String> {
+    let path_ref = std::path::Path::new(&path);
+    let (channels, entries, sample_count) =
+        if libretune_core::datalog::LogFormat::from_extension(path_ref)
+            == Some(libretune_core::datalog::LogFormat::Ltlog)
+        {
+            let (schema, entries, n) = libretune_core::datalog::ltlog::downsample_ltlog(
+                &path,
+                libretune_core::datalog::ltlog::UI_SAMPLE_CAP,
+            )
+            .map_err(|e| format!("Failed to read log: {e}"))?;
+            (schema.channel_names(), entries, n)
+        } else {
+            let (channels, entries) = libretune_core::datalog::format::read_log(&path)
+                .map_err(|e| format!("Failed to read log: {e}"))?;
+            let n = entries.len() as u64;
+            (channels, entries, n)
+        };
+    let samples = entries
+        .into_iter()
+        .map(|entry| {
+            let mut values = HashMap::with_capacity(channels.len());
+            for (i, channel) in channels.iter().enumerate() {
+                if let Some(&val) = entry.values.get(i) {
+                    values.insert(channel.clone(), val);
+                }
+            }
+            LoadedLogSample {
+                x: entry.timestamp.as_secs_f64() * 1000.0,
+                values,
+            }
+        })
+        .collect();
+    Ok(LoadedLogFile {
+        channels,
+        samples,
+        sample_count,
+    })
 }
 
 #[tauri::command]
@@ -385,14 +434,36 @@ pub(crate) async fn list_datalog_files(state: &AppState) -> Vec<DatalogListing> 
     listings.into_iter().map(|(_, l)| l).collect()
 }
 
-/// The data the `query_datalog` tool works over: channel names plus the
-/// entries (timestamp + values) of either a saved log file or the current
-/// in-memory session.
+/// The data the `query_datalog` tool works over.
+///
+/// `.ltlog` is referenced by path and streamed; only a tiny in-memory tail is
+/// kept when there is no file yet.
 pub(crate) struct DatalogData {
     pub channels: Vec<String>,
-    pub entries: Vec<libretune_core::datalog::LogEntry>,
-    /// Where the data came from (for error messages / payload labels).
     pub source: String,
+    pub path: Option<PathBuf>,
+    pub tail: Vec<libretune_core::datalog::LogEntry>,
+}
+
+impl DatalogData {
+    /// Walk samples without requiring the whole log in RAM.
+    pub(crate) fn for_each<F>(&self, mut f: F) -> Result<(), String>
+    where
+        F: FnMut(&libretune_core::datalog::LogEntry),
+    {
+        if let Some(path) = &self.path {
+            libretune_core::datalog::format::visit_log(path, |e| {
+                f(e);
+                Ok(())
+            })
+            .map_err(|e| e.to_string())?;
+        } else {
+            for e in &self.tail {
+                f(e);
+            }
+        }
+        Ok(())
+    }
 }
 
 /// Load a saved log by file name from the project's `datalogs/` folder.
@@ -409,21 +480,45 @@ pub(crate) async fn load_datalog_file(state: &AppState, name: &str) -> Result<Da
             .ok_or_else(|| "No project loaded".to_string())?
     };
     let path = dir.join(name);
+    if libretune_core::datalog::LogFormat::from_extension(&path)
+        == Some(libretune_core::datalog::LogFormat::Ltlog)
+    {
+        let schema = libretune_core::datalog::ltlog::read_ltlog_schema(&path)
+            .map_err(|e| format!("could not read log '{name}': {e}"))?;
+        return Ok(DatalogData {
+            channels: schema.channel_names(),
+            source: name.to_string(),
+            path: Some(path),
+            tail: Vec::new(),
+        });
+    }
     let (channels, entries) = libretune_core::datalog::format::read_log(&path)
         .map_err(|e| format!("could not read log '{name}': {e}"))?;
     Ok(DatalogData {
         channels,
-        entries,
         source: name.to_string(),
+        path: None,
+        tail: entries,
     })
 }
 
-/// Snapshot the current in-memory logging session (may be empty).
+/// Snapshot the current logging session without loading the file into RAM.
 pub(crate) async fn current_session_datalog(state: &AppState) -> DatalogData {
-    let logger = state.data_logger.lock().await;
+    let mut logger = state.data_logger.lock().await;
+    let _ = logger.flush_stream();
+    let channels = logger.channels().to_vec();
+    if let Some(path) = logger.log_path().map(|p| p.to_path_buf()) {
+        return DatalogData {
+            channels,
+            source: "current session".to_string(),
+            path: Some(path),
+            tail: Vec::new(),
+        };
+    }
     DatalogData {
-        channels: logger.channels().to_vec(),
-        entries: logger.entries().cloned().collect(),
+        channels,
         source: "current session".to_string(),
+        path: None,
+        tail: logger.entries().cloned().collect(),
     }
 }

--- a/crates/libretune-app/src-tauri/src/lib.rs
+++ b/crates/libretune-app/src-tauri/src/lib.rs
@@ -82,8 +82,8 @@ use commands::dash_layout::{
     reset_dashboards_to_defaults,
 };
 use commands::data_logging::{
-    clear_log, get_log_entries, get_logging_status, read_text_file, save_log, start_logging,
-    stop_logging, write_text_file,
+    clear_log, get_log_entries, get_logging_status, load_log_file, read_text_file, save_log,
+    start_logging, stop_logging, write_text_file,
 };
 use commands::debug_realtime::debug_single_realtime_read;
 use commands::demo::{get_demo_mode, set_demo_mode};
@@ -412,6 +412,7 @@ pub fn run() {
             get_log_entries,
             clear_log,
             save_log,
+            load_log_file,
             read_text_file,
             write_text_file,
             // Diagnostic commands (stubs)
@@ -423,6 +424,7 @@ pub fn run() {
             commands::tooth_logger::list_diagnostic_loggers,
             commands::ini_meta::list_tunable_tables,
             commands::analyse_log::analyse_log,
+            commands::analyse_log::analyse_log_file,
             compare_tables,
             reset_tune_to_defaults,
             export_tune_as_csv,

--- a/crates/libretune-app/src/components/tuner-ui/DataLogView.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/DataLogView.tsx
@@ -11,7 +11,7 @@ import { parseLogFile } from '../../utils/parseLogFile';
 import './DataLogView.css';
 
 /** Hard cap on samples kept in the frontend; the oldest are dropped beyond it. */
-const MAX_FRONTEND_SAMPLES = 100_000;
+const MAX_FRONTEND_SAMPLES = 4096;
 
 interface LoggingStatus {
   is_recording: boolean;
@@ -294,8 +294,8 @@ export const DataLogView: React.FC = () => {
         const st = await invoke<LoggingStatus>('get_logging_status');
         if (st.entry_count === 0) return;
         const entries = await invoke<LogEntry[]>('get_log_entries', {
-          startIndex: 0,
-          count: st.entry_count,
+          startIndex: Math.max(0, st.entry_count - MAX_FRONTEND_SAMPLES),
+          count: MAX_FRONTEND_SAMPLES,
           channels: neededChannelsRef.current
         });
         setLogData(entries.map(e => ({ x: e.timestamp_ms, values: e.values })));
@@ -332,8 +332,8 @@ export const DataLogView: React.FC = () => {
           setIsRecording(true);
           if (st.entry_count > 0) {
             const entries = await invoke<LogEntry[]>('get_log_entries', {
-              startIndex: 0,
-              count: st.entry_count,
+              startIndex: Math.max(0, st.entry_count - MAX_FRONTEND_SAMPLES),
+              count: MAX_FRONTEND_SAMPLES,
               channels: neededChannelsRef.current,
             });
             setLogData(entries.map((e) => ({ x: e.timestamp_ms, values: e.values })));
@@ -484,8 +484,8 @@ export const DataLogView: React.FC = () => {
       const p2 = (x: number) => String(x).padStart(2, '0');
       const stamp = `${n.getFullYear()}-${p2(n.getMonth() + 1)}-${p2(n.getDate())}_${p2(n.getHours())}.${p2(n.getMinutes())}.${p2(n.getSeconds())}`;
       const path = await save({
-        defaultPath: `${stamp}.csv`,
-        filters: [{ name: 'CSV Files', extensions: ['csv'] }]
+        defaultPath: `${stamp}.ltlog`,
+        filters: [{ name: 'LibreTune Log', extensions: ['ltlog'] }]
       });
       
       if (path) {
@@ -517,26 +517,45 @@ export const DataLogView: React.FC = () => {
     try {
       const selected = await open({
         multiple: false,
-        filters: [{ name: 'Log Files', extensions: ['csv', 'msl', 'log'] }]
+        filters: [
+          { name: 'LibreTune Log', extensions: ['ltlog'] },
+          { name: 'Log Files', extensions: ['ltlog', 'csv', 'msl', 'mlg', 'log'] },
+        ]
       });
       
-      if (!selected) return;
-      
-      // Read and parse the file
-      const content = await invoke<string>('read_text_file', { path: selected });
-      const fileName = typeof selected === 'string' 
-        ? selected.split('/').pop() || selected.split('\\').pop() || 'log.csv'
-        : 'log.csv';
-      
-      const { data, channels } = parseLogCsv(content, fileName);
+      if (!selected || typeof selected !== 'string') return;
+
+      const fileName =
+        selected.split('/').pop() || selected.split('\\').pop() || 'log.ltlog';
+      const ext = fileName.toLowerCase().split('.').pop();
+
+      let data: { x: number; values: Record<string, number> }[] = [];
+      let channels: string[] = [];
+      let sampleCount = 0;
+
+      if (ext === 'ltlog' || ext === 'mlg') {
+        const loaded = await invoke<{
+          channels: string[];
+          samples: { x: number; values: Record<string, number> }[];
+          sample_count?: number;
+        }>('load_log_file', { path: selected });
+        data = loaded.samples;
+        channels = loaded.channels;
+        if (typeof loaded.sample_count === 'number') {
+          sampleCount = loaded.sample_count;
+        }
+      } else {
+        const content = await invoke<string>('read_text_file', { path: selected });
+        const parsed = parseLogCsv(content, fileName);
+        data = parsed.data;
+        channels = parsed.channels;
+      }
       
       if (data.length === 0) {
-        // Previously this only reached the console, so picking an unreadable
-        // log looked like the button had done nothing at all.
         console.error('No valid data found in log file');
         setLoadError(
           `Could not read any data from "${fileName}". ` +
-          `Supported formats are TunerStudio .msl and comma-separated .csv logs.`
+          `Supported formats are LibreTune .ltlog, TunerStudio .msl/.mlg, and .csv logs.`
         );
         return;
       }
@@ -555,7 +574,7 @@ export const DataLogView: React.FC = () => {
       const duration = data.length > 0 ? data[data.length - 1].x - data[0].x : 0;
       setStatus({
         is_recording: false,
-        entry_count: data.length,
+        entry_count: sampleCount || data.length,
         duration_ms: duration,
         channels: channels
       });

--- a/crates/libretune-app/src/components/tuner-ui/DatalogViewer.tsx
+++ b/crates/libretune-app/src/components/tuner-ui/DatalogViewer.tsx
@@ -76,6 +76,8 @@ export interface DatalogViewerProps {
 
 export const DatalogViewer: React.FC<DatalogViewerProps> = ({ tableName, isConnected }) => {
   const [samples, setSamples] = useState<LogSample[]>([]);
+  const [logPath, setLogPath] = useState<string | null>(null);
+  const [sampleCount, setSampleCount] = useState(0);
   const [logName, setLogName] = useState<string>('');
   const [channels, setChannels] = useState<string[]>([]);
   const [tables, setTables] = useState<string[]>([]);
@@ -124,13 +126,27 @@ export const DatalogViewer: React.FC<DatalogViewerProps> = ({ tableName, isConne
       const path = await open({
         multiple: false,
         filters: [
-          { name: 'Data logs', extensions: ['csv', 'msl', 'txt'] },
+          { name: 'Data logs', extensions: ['ltlog', 'csv', 'msl', 'mlg', 'txt'] },
           { name: 'All files', extensions: ['*'] },
         ],
       });
       if (!path || typeof path !== 'string') return;
-      const text = await invoke<string>('read_file_contents', { path });
-      const parsed = parseLogFile(text);
+      const ext = path.toLowerCase().split('.').pop();
+      let parsed: { data: LogSample[]; channels: string[] };
+      let count = 0;
+      if (ext === 'ltlog' || ext === 'mlg') {
+        const loaded = await invoke<{
+          channels: string[];
+          samples: LogSample[];
+          sample_count?: number;
+        }>('load_log_file', { path });
+        parsed = { data: loaded.samples, channels: loaded.channels };
+        count = loaded.sample_count ?? loaded.samples.length;
+      } else {
+        const text = await invoke<string>('read_file_contents', { path });
+        parsed = parseLogFile(text);
+        count = parsed.data.length;
+      }
       if (!parsed.data.length) {
         setError('No samples could be read from that file.');
         return;
@@ -138,6 +154,8 @@ export const DatalogViewer: React.FC<DatalogViewerProps> = ({ tableName, isConne
       setSamples(parsed.data);
       setChannels(parsed.channels);
       setLogName(path.split(/[\\/]/).pop() || path);
+      setLogPath(ext === 'ltlog' ? path : null);
+      setSampleCount(count);
       setReport(null);
     } catch (e) {
       setError(String(e));
@@ -168,58 +186,74 @@ export const DatalogViewer: React.FC<DatalogViewerProps> = ({ tableName, isConne
         if (!name) return [];
         return samples.map((s) => s.values[name] ?? NaN);
       };
-      // Timestamps are re-based: an .msl exported from a longer recording
-      // carries offsets from the original, which would put every sample in one
-      // validation block.
-      const t0 = Math.min(...samples.map((s) => s.x));
-      const report = await invoke<ReplayReport>('analyse_log', {
-        tableName: table,
-        log: {
-          time_ms: samples.map((s) => s.x - t0),
-          rpm: col('rpm'), load: col('load'), afr: col('afr'),
-          ve: col('ve'), clt: col('clt'), tps: col('tps'),
-          tps_rate: col('tps_rate'),
-          fuel_cut: col('fuel_cut'), accel_enrich: col('accel_enrich'),
+      const config = {
+        settings: {
+          target_afr: 14.7,
+          algorithm: 'simple',
+          update_rate_ms: 100,
+          lambda_delay_ms: delayMs,
+          lambda_delay_flow_scaled: false,
+          lambda_delay_floor_ms: 120,
+          hit_weighting: weighting,
+          base_weight: baseWeight,
+          min_change: minChange,
         },
-        config: {
-          settings: {
-            target_afr: 14.7,
-            algorithm: 'simple',
-            update_rate_ms: 100,
-            lambda_delay_ms: delayMs,
-            lambda_delay_flow_scaled: false,
-            lambda_delay_floor_ms: 120,
-            hit_weighting: weighting,
-            base_weight: baseWeight,
-            min_change: minChange,
-          },
-          filters: {
-            min_rpm: 1000, max_rpm: 8000,
-            min_y_axis: null, max_y_axis: null,
-            min_clt: minClt, custom_filter: null,
-            max_tps_rate: maxTpsRate,
-            exclude_accel_enrich: true,
-            min_steady_ms: minSteadyMs,
-          },
-          authority: {
-            max_cell_value_change: 10,
-            max_cell_percentage_change: 20,
-            min_cell_value: 0,
-            max_cell_value: 255,
-          },
-          strict_lambda_match: true,
-          validate: true,
+        filters: {
+          min_rpm: 1000, max_rpm: 8000,
+          min_y_axis: null, max_y_axis: null,
+          min_clt: minClt, custom_filter: null,
+          max_tps_rate: maxTpsRate,
+          exclude_accel_enrich: true,
+          min_steady_ms: minSteadyMs,
         },
-        targetAfrTableName: null,
-        lambdaDelayTableName: null,
-      });
+        authority: {
+          max_cell_value_change: 10,
+          max_cell_percentage_change: 20,
+          min_cell_value: 0,
+          max_cell_value: 255,
+        },
+        strict_lambda_match: true,
+        validate: true,
+      };
+      const report = logPath
+        ? await invoke<ReplayReport>('analyse_log_file', {
+            path: logPath,
+            tableName: table,
+            columns: {
+              rpm: mapping.rpm,
+              load: mapping.load,
+              afr: mapping.afr,
+              ve: mapping.ve,
+              clt: mapping.clt,
+              tps: mapping.tps,
+              tps_rate: mapping.tps_rate,
+              fuel_cut: mapping.fuel_cut,
+              accel_enrich: mapping.accel_enrich,
+            },
+            config,
+            targetAfrTableName: null,
+            lambdaDelayTableName: null,
+          })
+        : await invoke<ReplayReport>('analyse_log', {
+            tableName: table,
+            log: {
+              time_ms: samples.map((s) => s.x - Math.min(...samples.map((s) => s.x))),
+              rpm: col('rpm'), load: col('load'), afr: col('afr'),
+              ve: col('ve'), clt: col('clt'), tps: col('tps'),
+              tps_rate: col('tps_rate'),
+              fuel_cut: col('fuel_cut'), accel_enrich: col('accel_enrich'),
+            },
+            config,
+            targetAfrTableName: null,
+            lambdaDelayTableName: null,
+          });
       setReport(report);
     } catch (e) {
       setError(String(e));
     } finally {
       setBusy(false);
     }
-  }, [samples, table, mapping, weighting, baseWeight, minChange, minSteadyMs, minClt, maxTpsRate, delayMs]);
+  }, [samples, logPath, table, mapping, weighting, baseWeight, minChange, minSteadyMs, minClt, maxTpsRate, delayMs]);
 
   const apply = useCallback(async () => {
     if (!report || !tableData) return;
@@ -275,7 +309,7 @@ export const DatalogViewer: React.FC<DatalogViewerProps> = ({ tableName, isConne
           <Check size={15} /> Apply {changed > 0 ? `${changed} cells` : ''}
         </button>
         {samples.length > 0 && (
-          <span className="dv-meta">{samples.length.toLocaleString()} samples</span>
+          <span className="dv-meta">{(sampleCount || samples.length).toLocaleString()} samples</span>
         )}
         {!isConnected && <span className="dv-meta dv-warn">offline — reading the project tune</span>}
       </div>
@@ -370,7 +404,6 @@ export const DatalogViewer: React.FC<DatalogViewerProps> = ({ tableName, isConne
           )}
           {report && (
             <Timeline
-              samples={samples}
               verdicts={report.verdicts}
               selected={selected}
             />
@@ -528,10 +561,9 @@ const VERDICT_COLOURS: Record<string, string> = {
  * happened to land last.
  */
 const Timeline: React.FC<{
-  samples: LogSample[];
   verdicts: SampleVerdict[];
   selected: [number, number] | null;
-}> = ({ samples, verdicts, selected }) => {
+}> = ({ verdicts, selected }) => {
   const ref = useRef<HTMLCanvasElement>(null);
   const [hover, setHover] = useState<string | null>(null);
 
@@ -542,7 +574,7 @@ const Timeline: React.FC<{
     if (!ctx) return;
     const w = cv.width, h = cv.height;
     ctx.clearRect(0, 0, w, h);
-    const n = Math.min(samples.length, verdicts.length);
+    const n = verdicts.length;
     if (!n) return;
 
     for (let px = 0; px < w; px++) {
@@ -567,7 +599,7 @@ const Timeline: React.FC<{
         ctx.fillRect(px, h - 4, 1, 4);
       }
     }
-  }, [samples, verdicts, selected]);
+  }, [verdicts, selected]);
 
   const legend = useMemo(() => {
     const tally: Record<string, number> = {};

--- a/crates/libretune-core/Cargo.toml
+++ b/crates/libretune-core/Cargo.toml
@@ -31,6 +31,9 @@ tracing = { workspace = true }
 # CRC for protocol
 crc32fast = { workspace = true }
 
+# zstd for .ltlog sample blocks
+zstd = "0.13"
+
 # Date/time
 chrono = { workspace = true }
 

--- a/crates/libretune-core/src/datalog/format.rs
+++ b/crates/libretune-core/src/datalog/format.rs
@@ -11,10 +11,12 @@ use super::LogEntry;
 /// Supported log file formats
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LogFormat {
-    /// Comma-separated values
+    /// Comma-separated values (import of older LibreTune logs)
     Csv,
-    /// MegaLogViewer format (.mlg)
+    /// MegaLogViewer format (.mlg) — read only
     Mlg,
+    /// Native LibreTune binary log
+    Ltlog,
 }
 
 impl LogFormat {
@@ -23,6 +25,7 @@ impl LogFormat {
         match path.extension()?.to_str()?.to_lowercase().as_str() {
             "csv" => Some(LogFormat::Csv),
             "mlg" => Some(LogFormat::Mlg),
+            "ltlog" => Some(LogFormat::Ltlog),
             _ => None,
         }
     }
@@ -32,6 +35,32 @@ impl LogFormat {
         match self {
             LogFormat::Csv => "csv",
             LogFormat::Mlg => "mlg",
+            LogFormat::Ltlog => "ltlog",
+        }
+    }
+}
+
+/// Visit every sample without requiring the caller to hold the whole log.
+///
+/// `.ltlog` is streamed. CSV / `.mlg` still load, then iterate (those formats
+/// have no block reader).
+pub fn visit_log<P, F>(path: P, mut visit: F) -> io::Result<Vec<String>>
+where
+    P: AsRef<Path>,
+    F: FnMut(&LogEntry) -> io::Result<()>,
+{
+    let path = path.as_ref();
+    match LogFormat::from_extension(path) {
+        Some(LogFormat::Ltlog) => {
+            let schema = super::ltlog::visit_ltlog(path, visit)?;
+            Ok(schema.channel_names())
+        }
+        _ => {
+            let (channels, entries) = read_log(path)?;
+            for e in &entries {
+                visit(e)?;
+            }
+            Ok(channels)
         }
     }
 }
@@ -42,6 +71,7 @@ pub fn read_log<P: AsRef<Path>>(path: P) -> io::Result<(Vec<String>, Vec<LogEntr
     match LogFormat::from_extension(path) {
         Some(LogFormat::Csv) => read_csv(path),
         Some(LogFormat::Mlg) => super::mlg::read_mlg(path),
+        Some(LogFormat::Ltlog) => super::ltlog::read_ltlog(path),
         None => Err(io::Error::new(
             io::ErrorKind::InvalidInput,
             format!("{} is not a log format LibreTune reads", path.display()),
@@ -186,6 +216,10 @@ mod tests {
         assert_eq!(
             LogFormat::from_extension(Path::new("log.mlg")),
             Some(LogFormat::Mlg)
+        );
+        assert_eq!(
+            LogFormat::from_extension(Path::new("log.ltlog")),
+            Some(LogFormat::Ltlog)
         );
         assert_eq!(LogFormat::from_extension(Path::new("log.txt")), None);
     }

--- a/crates/libretune-core/src/datalog/ltlog.rs
+++ b/crates/libretune-core/src/datalog/ltlog.rs
@@ -1,0 +1,740 @@
+//! LibreTune native datalog (`.ltlog`).
+//!
+//! Compact, little-endian, crash-tolerant binary log. A torn write or a
+//! corrupt block loses only that block: earlier CRC-valid blocks still read.
+//!
+//! ```text
+//! header     "LTLg" u16 version u16 flags u32 schema_len
+//!            schema JSON (UTF-8)  u32 crc32(schema)
+//! block*     "LTBK" u32 raw_len u32 zstd_len u32 crc32(zstd)
+//!            zstd payload:
+//!              u16 n_samples  u64 t0_us
+//!              per sample: u32 dt_us  f32[n_channels]
+//! footer     "LTFT" u64 samples u32 blocks u64 duration_us u32 crc32
+//!            (optional; a file without one is still valid)
+//! ```
+
+use std::fs::File;
+use std::io::{self, BufReader, BufWriter, Read, Seek, SeekFrom, Write};
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use serde::{Deserialize, Serialize};
+
+use super::LogEntry;
+
+const MAGIC: &[u8; 4] = b"LTLg";
+const BLOCK_SYNC: &[u8; 4] = b"LTBK";
+const FOOTER_SYNC: &[u8; 4] = b"LTFT";
+const VERSION: u16 = 1;
+/// Flush a block once this many samples are pending.
+const BLOCK_SAMPLES: usize = 128;
+/// Also flush if a block has been open this long (crash window).
+const BLOCK_WALL_FLUSH: Duration = Duration::from_secs(1);
+const ZSTD_LEVEL: i32 = 3;
+
+/// Channel metadata stored once in the file header.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LtlogChannel {
+    pub name: String,
+    #[serde(default)]
+    pub unit: String,
+    #[serde(default)]
+    pub ini_type: String,
+}
+
+/// Self-describing schema written as JSON after the binary preamble.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LtlogSchema {
+    pub created_utc: String,
+    #[serde(default)]
+    pub ini_signature: Option<String>,
+    pub sample_rate_hz: f64,
+    pub channels: Vec<LtlogChannel>,
+}
+
+impl LtlogSchema {
+    pub fn channel_names(&self) -> Vec<String> {
+        self.channels.iter().map(|c| c.name.clone()).collect()
+    }
+}
+
+/// Streaming writer used by the live recorder.
+pub struct LtlogWriter {
+    file: BufWriter<File>,
+    n_channels: usize,
+    pending: Vec<LogEntry>,
+    samples_written: u64,
+    blocks_written: u32,
+    last_flush: Instant,
+    finished: bool,
+    last_duration_us: u64,
+}
+
+impl LtlogWriter {
+    /// Create (overwrite) `path` and write the header immediately.
+    pub fn create<P: AsRef<Path>>(path: P, schema: &LtlogSchema) -> io::Result<Self> {
+        let path = path.as_ref();
+        if let Some(dir) = path.parent() {
+            let _ = std::fs::create_dir_all(dir);
+        }
+        let mut file = BufWriter::new(File::create(path)?);
+        write_header(&mut file, schema)?;
+        file.flush()?;
+        Ok(Self {
+            file,
+            n_channels: schema.channels.len(),
+            pending: Vec::with_capacity(BLOCK_SAMPLES),
+            samples_written: 0,
+            blocks_written: 0,
+            last_flush: Instant::now(),
+            finished: false,
+            last_duration_us: 0,
+        })
+    }
+
+    /// Buffer a sample; may compress-and-append a block.
+    pub fn push(&mut self, entry: &LogEntry) -> io::Result<()> {
+        if self.finished {
+            return Err(io::Error::other("ltlog writer already finished"));
+        }
+        if entry.values.len() != self.n_channels {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "ltlog sample has {} values, schema has {} channels",
+                    entry.values.len(),
+                    self.n_channels
+                ),
+            ));
+        }
+        self.last_duration_us = entry.timestamp.as_micros() as u64;
+        self.pending.push(entry.clone());
+        if self.pending.len() >= BLOCK_SAMPLES || self.last_flush.elapsed() >= BLOCK_WALL_FLUSH {
+            self.flush_block()?;
+        }
+        Ok(())
+    }
+
+    fn flush_block(&mut self) -> io::Result<()> {
+        if self.pending.is_empty() {
+            return Ok(());
+        }
+        let n = self.pending.len();
+        write_block(&mut self.file, self.n_channels, &self.pending)?;
+        self.samples_written += n as u64;
+        self.blocks_written += 1;
+        self.pending.clear();
+        self.last_flush = Instant::now();
+        self.file.flush()?;
+        Ok(())
+    }
+
+    /// Write any pending samples so a concurrent reader sees them.
+    pub fn flush_pending(&mut self) -> io::Result<()> {
+        if self.finished {
+            return Ok(());
+        }
+        self.flush_block()
+    }
+
+    /// Flush the last block and write the optional footer.
+    pub fn finish(&mut self) -> io::Result<()> {
+        if self.finished {
+            return Ok(());
+        }
+        self.flush_block()?;
+        write_footer(
+            &mut self.file,
+            self.samples_written,
+            self.blocks_written,
+            self.last_duration_us,
+        )?;
+        self.file.flush()?;
+        self.finished = true;
+        Ok(())
+    }
+}
+
+impl Drop for LtlogWriter {
+    fn drop(&mut self) {
+        if !self.finished {
+            let _ = self.finish();
+        }
+    }
+}
+
+/// Write a complete log in one shot (manual save).
+pub fn write_ltlog<P: AsRef<Path>>(
+    path: P,
+    schema: &LtlogSchema,
+    entries: &[LogEntry],
+) -> io::Result<()> {
+    let mut w = LtlogWriter::create(path, schema)?;
+    for e in entries {
+        w.push(e)?;
+    }
+    w.finish()
+}
+
+/// Chart / IPC cap: the file stays on disk; the UI only ever sees this many
+/// points (evenly strided), so a multi-hour log cannot fill RAM.
+pub const UI_SAMPLE_CAP: usize = 4096;
+
+/// Read only the header (channel names, rate, signature). No samples.
+pub fn read_ltlog_schema<P: AsRef<Path>>(path: P) -> io::Result<LtlogSchema> {
+    let mut r = BufReader::new(File::open(path)?);
+    read_header(&mut r)
+}
+
+/// Visit every sample without accumulating the log. RAM is one compressed
+/// block (~128 rows) plus whatever the callback keeps.
+pub fn visit_ltlog<P, F>(path: P, mut visit: F) -> io::Result<LtlogSchema>
+where
+    P: AsRef<Path>,
+    F: FnMut(&LogEntry) -> io::Result<()>,
+{
+    let mut r = BufReader::new(File::open(path)?);
+    let schema = read_header(&mut r)?;
+    let n_channels = schema.channels.len();
+    loop {
+        match read_next_block(&mut r, n_channels) {
+            Ok(Some(block)) => {
+                for e in &block {
+                    visit(e)?;
+                }
+            }
+            Ok(None) => break,
+            Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => break,
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(schema)
+}
+
+/// Read a `.ltlog` into `(channel names, entries)`.
+///
+/// Loads the whole file. Prefer [`visit_ltlog`], [`downsample_ltlog`], or
+/// [`extract_ltlog_columns`] for anything that might be large.
+///
+/// A truncated or CRC-failed last block is skipped. Earlier valid blocks are
+/// kept. A header-only file (crash before the first block) returns the
+/// channel list and no samples.
+pub fn read_ltlog<P: AsRef<Path>>(path: P) -> io::Result<(Vec<String>, Vec<LogEntry>)> {
+    let mut entries = Vec::new();
+    let schema = visit_ltlog(path, |e| {
+        entries.push(e.clone());
+        Ok(())
+    })?;
+    Ok((schema.channel_names(), entries))
+}
+
+/// Evenly stride the file down to at most `max_points` samples.
+///
+/// Returns `(schema, preview, true_sample_count)`. RAM is O(max_points).
+pub fn downsample_ltlog<P: AsRef<Path>>(
+    path: P,
+    max_points: usize,
+) -> io::Result<(LtlogSchema, Vec<LogEntry>, u64)> {
+    let path = path.as_ref();
+    let max_points = max_points.max(1);
+    let n = match footer_sample_count(path) {
+        Some(n) => n,
+        None => {
+            let mut n = 0u64;
+            visit_ltlog(path, |_| {
+                n += 1;
+                Ok(())
+            })?;
+            n
+        }
+    };
+    if n == 0 {
+        let schema = read_ltlog_schema(path)?;
+        return Ok((schema, Vec::new(), 0));
+    }
+    if n as usize <= max_points {
+        let mut entries = Vec::with_capacity(n as usize);
+        let schema = visit_ltlog(path, |e| {
+            entries.push(e.clone());
+            Ok(())
+        })?;
+        return Ok((schema, entries, n));
+    }
+    let stride = n as f64 / max_points as f64;
+    let mut out = Vec::with_capacity(max_points);
+    let mut next = 0.0f64;
+    let mut i = 0u64;
+    let schema = visit_ltlog(path, |e| {
+        if (i as f64) >= next && out.len() < max_points {
+            out.push(e.clone());
+            next += stride;
+        }
+        i += 1;
+        Ok(())
+    })?;
+    Ok((schema, out, n))
+}
+
+/// Pull named columns in one pass. Missing names yield empty vectors.
+///
+/// Used by offline analysis so a 100-channel log never sits in RAM — only
+/// the handful of channels the caller asked for.
+pub fn extract_ltlog_columns<P: AsRef<Path>>(
+    path: P,
+    names: &[&str],
+) -> io::Result<(LtlogSchema, Vec<f64>, Vec<Vec<f64>>)> {
+    let schema = read_ltlog_schema(&path)?;
+    let idx: Vec<Option<usize>> = names
+        .iter()
+        .map(|want| schema.channels.iter().position(|c| c.name == *want))
+        .collect();
+    let mut time_ms = Vec::new();
+    let mut cols: Vec<Vec<f64>> = names.iter().map(|_| Vec::new()).collect();
+    visit_ltlog(path, |e| {
+        time_ms.push(e.timestamp.as_secs_f64() * 1000.0);
+        for (col, src) in cols.iter_mut().zip(&idx) {
+            if let Some(i) = *src {
+                col.push(e.values.get(i).copied().unwrap_or(f64::NAN));
+            }
+        }
+        Ok(())
+    })?;
+    Ok((schema, time_ms, cols))
+}
+
+fn footer_sample_count(path: &Path) -> Option<u64> {
+    let mut f = File::open(path).ok()?;
+    let len = f.metadata().ok()?.len();
+    if len < 28 {
+        return None;
+    }
+    f.seek(SeekFrom::End(-28)).ok()?;
+    let mut buf = [0u8; 28];
+    f.read_exact(&mut buf).ok()?;
+    if &buf[0..4] != FOOTER_SYNC {
+        return None;
+    }
+    let crc = u32::from_le_bytes(buf[24..28].try_into().ok()?);
+    if crc32fast::hash(&buf[4..24]) != crc {
+        return None;
+    }
+    Some(u64::from_le_bytes(buf[4..12].try_into().ok()?))
+}
+
+fn write_header<W: Write>(w: &mut W, schema: &LtlogSchema) -> io::Result<()> {
+    let json = serde_json::to_vec(schema).map_err(io::Error::other)?;
+    let crc = crc32fast::hash(&json);
+    w.write_all(MAGIC)?;
+    w.write_u16::<LittleEndian>(VERSION)?;
+    w.write_u16::<LittleEndian>(0)?;
+    w.write_u32::<LittleEndian>(json.len() as u32)?;
+    w.write_all(&json)?;
+    w.write_u32::<LittleEndian>(crc)?;
+    Ok(())
+}
+
+fn read_header<R: Read>(r: &mut R) -> io::Result<LtlogSchema> {
+    let mut magic = [0u8; 4];
+    r.read_exact(&mut magic)?;
+    if &magic != MAGIC {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "not an .ltlog file (bad magic)",
+        ));
+    }
+    let version = r.read_u16::<LittleEndian>()?;
+    if version != VERSION {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("unsupported ltlog version {version}"),
+        ));
+    }
+    let _flags = r.read_u16::<LittleEndian>()?;
+    let schema_len = r.read_u32::<LittleEndian>()? as usize;
+    if schema_len > 16 * 1024 * 1024 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "ltlog schema is implausibly large",
+        ));
+    }
+    let mut json = vec![0u8; schema_len];
+    r.read_exact(&mut json)?;
+    let crc = r.read_u32::<LittleEndian>()?;
+    if crc32fast::hash(&json) != crc {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "ltlog header CRC mismatch",
+        ));
+    }
+    serde_json::from_slice(&json).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+}
+
+fn write_block<W: Write>(w: &mut W, n_channels: usize, entries: &[LogEntry]) -> io::Result<()> {
+    let raw = pack_samples(n_channels, entries)?;
+    let compressed = zstd::encode_all(raw.as_slice(), ZSTD_LEVEL).map_err(io::Error::other)?;
+    let crc = crc32fast::hash(&compressed);
+    w.write_all(BLOCK_SYNC)?;
+    w.write_u32::<LittleEndian>(raw.len() as u32)?;
+    w.write_u32::<LittleEndian>(compressed.len() as u32)?;
+    w.write_u32::<LittleEndian>(crc)?;
+    w.write_all(&compressed)?;
+    Ok(())
+}
+
+fn pack_samples(n_channels: usize, entries: &[LogEntry]) -> io::Result<Vec<u8>> {
+    let n = u16::try_from(entries.len()).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "ltlog block has too many samples",
+        )
+    })?;
+    let t0_us = entries
+        .first()
+        .map(|e| e.timestamp.as_micros() as u64)
+        .unwrap_or(0);
+    let mut raw = Vec::with_capacity(10 + entries.len() * (4 + 4 * n_channels));
+    raw.write_u16::<LittleEndian>(n)?;
+    raw.write_u64::<LittleEndian>(t0_us)?;
+    let mut prev = t0_us;
+    for (i, e) in entries.iter().enumerate() {
+        let us = e.timestamp.as_micros() as u64;
+        let dt = if i == 0 {
+            0u32
+        } else {
+            us.saturating_sub(prev).min(u32::MAX as u64) as u32
+        };
+        raw.write_u32::<LittleEndian>(dt)?;
+        for v in &e.values {
+            raw.write_f32::<LittleEndian>(*v as f32)?;
+        }
+        prev = prev.saturating_add(dt as u64);
+    }
+    Ok(raw)
+}
+
+fn unpack_samples(n_channels: usize, raw: &[u8]) -> io::Result<Vec<LogEntry>> {
+    let mut cur = raw;
+    let n = cur.read_u16::<LittleEndian>()? as usize;
+    let t0_us = cur.read_u64::<LittleEndian>()?;
+    let mut prev = t0_us;
+    let mut out = Vec::with_capacity(n);
+    let row = 4 + 4 * n_channels;
+    for i in 0..n {
+        if cur.len() < row {
+            break;
+        }
+        let dt = cur.read_u32::<LittleEndian>()?;
+        let us = if i == 0 {
+            t0_us
+        } else {
+            prev.saturating_add(dt as u64)
+        };
+        prev = us;
+        let mut values = Vec::with_capacity(n_channels);
+        for _ in 0..n_channels {
+            values.push(cur.read_f32::<LittleEndian>()? as f64);
+        }
+        out.push(LogEntry::new(Duration::from_micros(us), values));
+    }
+    Ok(out)
+}
+
+/// Read one sample block, skipping junk until the next `LTBK` (or EOF / footer).
+///
+/// On a bad CRC or decompress, seek one byte past the false sync and scan
+/// again so a corrupt length field cannot swallow the next real block.
+fn read_next_block<R: Read + Seek>(
+    r: &mut R,
+    n_channels: usize,
+) -> io::Result<Option<Vec<LogEntry>>> {
+    loop {
+        match find_sync(r, BLOCK_SYNC, FOOTER_SYNC)? {
+            SyncFound::Block => {}
+            SyncFound::Footer | SyncFound::Eof => return Ok(None),
+        }
+        let after_sync = r.stream_position()?;
+        let raw_len = match r.read_u32::<LittleEndian>() {
+            Ok(v) => v as usize,
+            Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => return Ok(None),
+            Err(e) => return Err(e),
+        };
+        let zlen = match r.read_u32::<LittleEndian>() {
+            Ok(v) => v as usize,
+            Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => return Ok(None),
+            Err(e) => return Err(e),
+        };
+        let crc = match r.read_u32::<LittleEndian>() {
+            Ok(v) => v,
+            Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => return Ok(None),
+            Err(e) => return Err(e),
+        };
+        if zlen > 64 * 1024 * 1024 || raw_len > 128 * 1024 * 1024 {
+            r.seek(SeekFrom::Start(after_sync.saturating_sub(3)))?;
+            continue;
+        }
+        let mut compressed = vec![0u8; zlen];
+        if r.read_exact(&mut compressed).is_err() {
+            return Ok(None);
+        }
+        if crc32fast::hash(&compressed) != crc {
+            continue;
+        }
+        let raw = match zstd::decode_all(compressed.as_slice()) {
+            Ok(v) if v.len() == raw_len => v,
+            _ => continue,
+        };
+        return Ok(Some(unpack_samples(n_channels, &raw)?));
+    }
+}
+
+enum SyncFound {
+    Block,
+    Footer,
+    Eof,
+}
+
+fn find_sync<R: Read>(r: &mut R, block: &[u8; 4], footer: &[u8; 4]) -> io::Result<SyncFound> {
+    let mut window = [0u8; 4];
+    match r.read(&mut window)? {
+        0 => return Ok(SyncFound::Eof),
+        1..=3 => return Ok(SyncFound::Eof),
+        _ => {}
+    }
+    loop {
+        if &window == block {
+            return Ok(SyncFound::Block);
+        }
+        if &window == footer {
+            return Ok(SyncFound::Footer);
+        }
+        window.copy_within(1.., 0);
+        let mut b = [0u8; 1];
+        match r.read(&mut b)? {
+            0 => return Ok(SyncFound::Eof),
+            _ => window[3] = b[0],
+        }
+    }
+}
+
+fn write_footer<W: Write>(
+    w: &mut W,
+    samples: u64,
+    blocks: u32,
+    duration_us: u64,
+) -> io::Result<()> {
+    let mut body = [0u8; 20];
+    {
+        let mut c = &mut body[..];
+        c.write_u64::<LittleEndian>(samples)?;
+        c.write_u32::<LittleEndian>(blocks)?;
+        c.write_u64::<LittleEndian>(duration_us)?;
+    }
+    let crc = crc32fast::hash(&body);
+    w.write_all(FOOTER_SYNC)?;
+    w.write_all(&body)?;
+    w.write_u32::<LittleEndian>(crc)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn schema(names: &[&str]) -> LtlogSchema {
+        LtlogSchema {
+            created_utc: "2026-01-01T00:00:00Z".into(),
+            ini_signature: Some("speeduino 202501".into()),
+            sample_rate_hz: 50.0,
+            channels: names
+                .iter()
+                .map(|n| LtlogChannel {
+                    name: (*n).into(),
+                    unit: "rpm".into(),
+                    ini_type: "float".into(),
+                })
+                .collect(),
+        }
+    }
+
+    fn sample(t_ms: u64, values: Vec<f64>) -> LogEntry {
+        LogEntry::new(Duration::from_millis(t_ms), values)
+    }
+
+    #[test]
+    fn round_trips_samples_and_channel_names() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("run.ltlog");
+        let sch = schema(&["rpm", "map"]);
+        let entries = vec![
+            sample(0, vec![800.0, 40.0]),
+            sample(20, vec![1200.0, 55.5]),
+            sample(40, vec![3000.0, 100.0]),
+        ];
+        write_ltlog(&path, &sch, &entries).unwrap();
+
+        let (names, read) = read_ltlog(&path).unwrap();
+        assert_eq!(names, vec!["rpm", "map"]);
+        assert_eq!(read.len(), 3);
+        assert!((read[1].values[0] - 1200.0).abs() < 0.01);
+        assert_eq!(read[2].timestamp, Duration::from_millis(40));
+    }
+
+    #[test]
+    fn header_only_file_returns_channels_and_no_samples() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("empty.ltlog");
+        write_ltlog(&path, &schema(&["rpm"]), &[]).unwrap();
+        let (names, entries) = read_ltlog(&path).unwrap();
+        assert_eq!(names, vec!["rpm"]);
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn truncated_tail_keeps_earlier_block() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("trunc.ltlog");
+        let sch = schema(&["rpm"]);
+        let mut entries = Vec::new();
+        for i in 0..200 {
+            entries.push(sample(i * 10, vec![i as f64]));
+        }
+        write_ltlog(&path, &sch, &entries).unwrap();
+
+        let mut bytes = std::fs::read(&path).unwrap();
+        bytes.truncate(bytes.len() - 40);
+        std::fs::write(&path, &bytes).unwrap();
+
+        let (_, read) = read_ltlog(&path).unwrap();
+        assert!(read.len() >= BLOCK_SAMPLES, "got {} samples", read.len());
+        assert!(read.len() < 200);
+        assert_eq!(read[0].values[0], 0.0);
+    }
+
+    #[test]
+    fn corrupt_later_block_keeps_earlier_samples() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("corrupt.ltlog");
+        let sch = schema(&["rpm"]);
+        let mut entries = Vec::new();
+        for i in 0..200 {
+            entries.push(sample(i * 10, vec![i as f64]));
+        }
+        write_ltlog(&path, &sch, &entries).unwrap();
+
+        let mut bytes = std::fs::read(&path).unwrap();
+        let first = find_nth(&bytes, BLOCK_SYNC, 0).expect("first block");
+        let second = find_nth(&bytes, BLOCK_SYNC, first + 4).expect("second block");
+        // Flip a byte inside the second block's compressed payload.
+        let flip = second + 16;
+        bytes[flip] ^= 0xff;
+        std::fs::write(&path, &bytes).unwrap();
+
+        let (_, read) = read_ltlog(&path).unwrap();
+        assert_eq!(read.len(), BLOCK_SAMPLES);
+        assert_eq!(read[0].values[0], 0.0);
+        assert_eq!(
+            read[BLOCK_SAMPLES - 1].values[0],
+            (BLOCK_SAMPLES - 1) as f64
+        );
+    }
+
+    fn find_nth(hay: &[u8], needle: &[u8], start: usize) -> Option<usize> {
+        hay[start..]
+            .windows(needle.len())
+            .position(|w| w == needle)
+            .map(|i| start + i)
+    }
+
+    #[test]
+    fn ltlog_is_much_smaller_than_csv_for_a_typical_session() {
+        // 100 channels, 50 Hz, 10 s. Most ECU channels sit still or drift
+        // slowly; only a handful move like RPM/MAP. That is what zstd eats.
+        let n_ch = 100usize;
+        let names: Vec<String> = (0..n_ch).map(|i| format!("ch{i:03}")).collect();
+        let sch = LtlogSchema {
+            created_utc: "2026-01-01T00:00:00Z".into(),
+            ini_signature: None,
+            sample_rate_hz: 50.0,
+            channels: names
+                .iter()
+                .map(|n| LtlogChannel {
+                    name: n.clone(),
+                    unit: String::new(),
+                    ini_type: String::new(),
+                })
+                .collect(),
+        };
+        let mut entries = Vec::new();
+        for s in 0..500 {
+            let t = s as f64 * 0.02;
+            let rpm = 800.0 + t * 40.0;
+            let map = 35.0 + (t * 0.7).sin() * 8.0;
+            let values: Vec<f64> = (0..n_ch)
+                .map(|c| match c {
+                    0 => rpm,
+                    1 => map,
+                    2 => 14.7,
+                    3 => 90.0 + t * 0.05,
+                    _ if c < 20 => 0.0,
+                    _ => 1.0,
+                })
+                .collect();
+            entries.push(LogEntry::new(Duration::from_secs_f64(t), values));
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let lt = dir.path().join("a.ltlog");
+        let csv = dir.path().join("a.csv");
+        write_ltlog(&lt, &sch, &entries).unwrap();
+        crate::datalog::format::write_csv(&csv, &names, &entries).unwrap();
+        let lt_sz = std::fs::metadata(&lt).unwrap().len() as f64;
+        let csv_sz = std::fs::metadata(&csv).unwrap().len() as f64;
+        let ratio = csv_sz / lt_sz;
+        eprintln!("size check: csv={csv_sz:.0} ltlog={lt_sz:.0} ratio={ratio:.1}x");
+        assert!(
+            ratio >= 8.0,
+            "expected .ltlog to be at least 8× smaller than CSV, got {ratio:.1}x (csv={csv_sz}, ltlog={lt_sz})"
+        );
+    }
+
+    #[test]
+    fn downsample_keeps_bounds_not_every_sample() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("big.ltlog");
+        let sch = schema(&["rpm"]);
+        let entries: Vec<_> = (0..500).map(|i| sample(i * 10, vec![i as f64])).collect();
+        write_ltlog(&path, &sch, &entries).unwrap();
+
+        let mut visited = 0u64;
+        visit_ltlog(&path, |_| {
+            visited += 1;
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(visited, 500);
+
+        let (_, preview, n) = downsample_ltlog(&path, 50).unwrap();
+        assert_eq!(n, 500);
+        assert!(preview.len() <= 50);
+        assert!(preview.len() >= 40);
+        assert_eq!(preview[0].values[0], 0.0);
+        assert!(preview.last().unwrap().values[0] >= 450.0);
+    }
+
+    #[test]
+    fn extract_columns_skips_unknown_names() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cols.ltlog");
+        write_ltlog(
+            &path,
+            &schema(&["rpm", "map"]),
+            &[sample(0, vec![800.0, 40.0]), sample(20, vec![1200.0, 55.0])],
+        )
+        .unwrap();
+        let (_, time, cols) = extract_ltlog_columns(&path, &["map", "nope"]).unwrap();
+        assert_eq!(time.len(), 2);
+        assert_eq!(cols[0], vec![40.0, 55.0]);
+        assert!(cols[1].is_empty());
+    }
+}

--- a/crates/libretune-core/src/datalog/mlg.rs
+++ b/crates/libretune-core/src/datalog/mlg.rs
@@ -1,7 +1,7 @@
 //! MegaLogViewer binary logs (`.mlg`, format version 2).
 //!
 //! The format TunerStudio writes and MegaLogViewer reads. Only reading is
-//! implemented: LibreTune records to CSV, and the reason to understand `.mlg`
+//! implemented: LibreTune records to `.ltlog`, and the reason to understand `.mlg`
 //! is to open logs captured by TunerStudio.
 //!
 //! Layout, all values big-endian:

--- a/crates/libretune-core/src/datalog/mod.rs
+++ b/crates/libretune-core/src/datalog/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod dyno;
 pub mod format;
+pub mod ltlog;
 pub mod mlg;
 mod playback;
 mod recorder;

--- a/crates/libretune-core/src/datalog/recorder.rs
+++ b/crates/libretune-core/src/datalog/recorder.rs
@@ -1,35 +1,25 @@
 //! Data logger / recorder
 //!
-//! Records real-time data from the ECU.
+//! Samples are written straight to a `.ltlog` file. RAM holds only a short
+//! live-graph tail plus the writer's current compression block.
 
 use std::collections::VecDeque;
-use std::fs::File;
-use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
+use super::ltlog::{LtlogChannel, LtlogSchema, LtlogWriter};
 use super::LogEntry;
 
-/// Hard ceiling on entries kept in memory. Once reached, the oldest entries
-/// are discarded (and counted — see `discarded`).
-///
-/// The old ceiling was 10,000 samples. At the ~8 Hz the legacy read path
-/// managed that was ~21 minutes, and an ordinary 28-minute drive silently
-/// lost its first ~7 minutes (D7). Raising the realtime read rate (the
-/// expected-length read exit) makes this far worse: at 50 Hz, 10,000 samples
-/// is only ~3.3 minutes. This ceiling gives ~66 min at 50 Hz / ~5.5 h at
-/// 10 Hz. At ~77 f64 channels/entry that is roughly 120 MB worst case, which
-/// is acceptable for a desktop tool; streaming straight to disk removes the
-/// ceiling entirely and is the longer-term fix.
-const MAX_BUFFER_SIZE: usize = 200_000;
+/// Samples kept in RAM for the live graph. The file is the log.
+const LIVE_TAIL: usize = 2048;
 
 /// Data logger state
 pub struct DataLogger {
     /// Channel names
     channels: Vec<String>,
-    /// In-memory log buffer
-    buffer: VecDeque<LogEntry>,
-    /// Start time of logging
+    /// Rolling window for the live graph only — not the session log.
+    tail: VecDeque<LogEntry>,
+    /// Start time of the current file
     start_time: Option<Instant>,
     /// Whether logging is active
     is_recording: bool,
@@ -37,79 +27,129 @@ pub struct DataLogger {
     sample_rate: f64,
     /// Last sample time
     last_sample: Option<Instant>,
-    /// Oldest entries discarded because the buffer hit `max_buffer_size`.
-    /// Nonzero means the saved log is missing its earliest samples — surfaced
-    /// so the truncation is never silent (the failure mode behind D7).
-    discarded: u64,
-    /// Hard ceiling on retained entries. Defaults to `MAX_BUFFER_SIZE`; a
-    /// field (rather than the const directly) so tests can exercise the
-    /// discard path without pushing hundreds of thousands of samples.
-    max_buffer_size: usize,
-    /// Continuous stream-to-disk writer (TunerStudio-style: the log is written
-    /// to a file as it is recorded, so it is saved the whole time and survives
-    /// a crash). `None` = in-memory only.
-    stream: Option<BufWriter<File>>,
-    /// Path of the file being streamed to, if any.
+    /// Timestamp of the last accepted sample in this file
+    last_timestamp: Duration,
+    /// Continuous stream-to-disk writer. `None` = not streaming.
+    stream: Option<LtlogWriter>,
+    /// Path of the file currently being written.
     stream_path: Option<PathBuf>,
-    /// Rows written to the stream file (used to flush periodically).
+    /// Directory used to open timestamped files (for rotate-on-clear).
+    stream_dir: Option<PathBuf>,
+    /// Last finished file, so Save As / AI can still find it after stop.
+    finished_path: Option<PathBuf>,
+    /// Rows written to the current file (and accepted without a stream in tests).
     rows_written: u64,
     /// Rows dropped because their column count did not match `channels` — a
     /// torn/misaligned serial read. Nonzero means a few samples were skipped
     /// (never written with wrong columns), surfaced rather than silent.
     malformed: u64,
+    /// ECU INI signature captured into the `.ltlog` header.
+    ini_signature: Option<String>,
+    /// Per-channel units (parallel to `channels`; empty strings if unknown).
+    channel_units: Vec<String>,
+    /// Per-channel INI type names (parallel to `channels`).
+    channel_ini_types: Vec<String>,
 }
 
 impl DataLogger {
     /// Create a new data logger with the given channels
     pub fn new(channels: Vec<String>) -> Self {
+        let n = channels.len();
         Self {
             channels,
-            buffer: VecDeque::with_capacity(MAX_BUFFER_SIZE),
+            tail: VecDeque::with_capacity(LIVE_TAIL),
             start_time: None,
             is_recording: false,
             sample_rate: 10.0, // Default 10 Hz
             last_sample: None,
-            discarded: 0,
-            max_buffer_size: MAX_BUFFER_SIZE,
+            last_timestamp: Duration::ZERO,
             stream: None,
             stream_path: None,
+            stream_dir: None,
+            finished_path: None,
             rows_written: 0,
             malformed: 0,
+            ini_signature: None,
+            channel_units: vec![String::new(); n],
+            channel_ini_types: vec![String::new(); n],
         }
     }
 
-    /// Begin streaming the log to `path` as CSV (`Time` + channel columns),
-    /// written as each sample is recorded. Overwrites any existing file.
-    /// Returns the error if the file cannot be created.
+    /// Begin streaming the log to `path` as `.ltlog`.
+    /// Overwrites any existing file. Returns the error if the file cannot be created.
     pub fn start_streaming<P: AsRef<Path>>(&mut self, path: P) -> std::io::Result<()> {
+        if let Some(mut prev) = self.stream.take() {
+            let _ = prev.finish();
+            if let Some(old) = self.stream_path.take() {
+                self.finished_path = Some(old);
+            }
+        }
         let path = path.as_ref().to_path_buf();
         if let Some(dir) = path.parent() {
-            let _ = std::fs::create_dir_all(dir);
+            self.stream_dir = Some(dir.to_path_buf());
         }
-        let mut w = BufWriter::new(File::create(&path)?);
-        write!(w, "Time")?;
-        for c in &self.channels {
-            write!(w, ",{c}")?;
-        }
-        writeln!(w)?;
-        w.flush()?;
-        self.stream = Some(w);
+        let writer = LtlogWriter::create(&path, &self.capture_schema())?;
+        self.stream = Some(writer);
         self.stream_path = Some(path);
         self.rows_written = 0;
+        self.tail.clear();
+        self.last_timestamp = Duration::ZERO;
         Ok(())
     }
 
-    /// Path of the file being streamed to, if streaming is active.
+    /// INI signature / channel units written into the `.ltlog` header.
+    pub fn set_capture_meta(
+        &mut self,
+        signature: Option<String>,
+        units: Vec<String>,
+        ini_types: Vec<String>,
+    ) {
+        self.ini_signature = signature.filter(|s| !s.is_empty());
+        if units.len() == self.channels.len() {
+            self.channel_units = units;
+        }
+        if ini_types.len() == self.channels.len() {
+            self.channel_ini_types = ini_types;
+        }
+    }
+
+    /// Schema that a manual save or stream file should carry.
+    pub fn capture_schema(&self) -> LtlogSchema {
+        LtlogSchema {
+            created_utc: chrono::Utc::now().to_rfc3339(),
+            ini_signature: self.ini_signature.clone(),
+            sample_rate_hz: self.sample_rate,
+            channels: self
+                .channels
+                .iter()
+                .enumerate()
+                .map(|(i, name)| LtlogChannel {
+                    name: name.clone(),
+                    unit: self.channel_units.get(i).cloned().unwrap_or_default(),
+                    ini_type: self.channel_ini_types.get(i).cloned().unwrap_or_default(),
+                })
+                .collect(),
+        }
+    }
+
+    /// Path of the file being streamed to, if a writer is open.
     pub fn stream_path(&self) -> Option<&Path> {
         self.stream_path.as_deref()
     }
 
-    /// Override the buffer ceiling. Test-only: lets the discard/counter path
-    /// be exercised without pushing `MAX_BUFFER_SIZE` samples through the
-    /// real-time rate limiter.
-    #[cfg(test)]
-    fn set_max_buffer_size(&mut self, n: usize) {
-        self.max_buffer_size = n;
+    /// Current open file, or the last file that was finished.
+    pub fn log_path(&self) -> Option<&Path> {
+        self.stream_path
+            .as_deref()
+            .or(self.finished_path.as_deref())
+    }
+
+    /// Flush pending compressed samples so a reader/copy sees them.
+    pub fn flush_stream(&mut self) -> std::io::Result<()> {
+        if let Some(w) = self.stream.as_mut() {
+            w.flush_pending()?;
+        }
+        Ok(())
     }
 
     /// Set the target sample rate in Hz
@@ -122,37 +162,37 @@ impl DataLogger {
         self.sample_rate
     }
 
-    /// Start (or resume) recording.
-    ///
-    /// Recording appends to the existing buffer: the timeline continues from
-    /// the last recorded entry, so stop/start cycles produce one continuous
-    /// log with no gaps. Use [`clear`](Self::clear) to begin a fresh log.
+    /// Start recording into the current stream file (timeline from zero).
     pub fn start(&mut self) {
-        let now = Instant::now();
-        let elapsed = self.duration();
-        self.start_time = now.checked_sub(elapsed).or(Some(now));
+        self.start_time = Some(Instant::now());
         self.is_recording = true;
         self.last_sample = None;
+        self.last_timestamp = Duration::ZERO;
+        self.rows_written = 0;
+        self.tail.clear();
     }
 
-    /// Stop recording and finalize the continuous log file.
-    ///
-    /// The stream writer is flushed and dropped (closing the OS file handle), so
-    /// the on-disk log is complete and nothing further can be appended to it.
-    /// This is what ends logging cleanly on ECU disconnect: with the stream
-    /// closed and recording off, the file can never grow with post-disconnect
-    /// junk or be left half-open. A fresh `start_streaming` opens a new file.
+    /// Stop recording and finalize the log file.
     pub fn stop(&mut self) {
         self.is_recording = false;
         if let Some(mut w) = self.stream.take() {
-            let _ = w.flush();
+            let _ = w.finish();
         }
-        self.stream_path = None;
+        if let Some(path) = self.stream_path.take() {
+            self.finished_path = Some(path);
+        }
     }
 
     /// Check if recording is active
     pub fn is_recording(&self) -> bool {
         self.is_recording
+    }
+
+    /// Test helper: record ignoring the sample-rate limiter.
+    #[cfg(test)]
+    fn record_unthrottled(&mut self, values: Vec<f64>) {
+        self.last_sample = None;
+        self.record(values);
     }
 
     /// Record a sample
@@ -162,10 +202,9 @@ impl DataLogger {
         }
 
         // Guard the append point against a torn/misaligned read. A row with the
-        // wrong column count would either desync every column after it (stream)
-        // or store a short/over-long entry (buffer); dropping it and counting
-        // is safer than persisting corrupt data. Empty `channels` = no schema
-        // to check against, so accept (keeps existing behaviour/tests).
+        // wrong column count would desync every column after it; dropping it
+        // and counting is safer than persisting corrupt data. Empty `channels`
+        // = no schema to check against, so accept (keeps existing tests).
         if !self.channels.is_empty() && values.len() != self.channels.len() {
             if self.malformed == 0 {
                 tracing::warn!(
@@ -194,66 +233,32 @@ impl DataLogger {
             .map(|start| now.duration_since(start))
             .unwrap_or_default();
 
-        // Stream this sample straight to disk (saved the whole time). Any error
-        // here is a disk/file I/O failure (disk full, file gone) — NOT ECU data:
-        // engine cut codes and the like are ordinary channel values and are
-        // recorded in `values` above. Rather than fail silently, a write error
-        // is logged once and the stream is dropped, so a broken file surfaces
-        // instead of quietly stopping and never stalls the realtime path.
-        if self.stream.is_some() {
-            self.rows_written += 1;
-            let should_flush = self.rows_written.is_multiple_of(25);
-            let ts = timestamp.as_secs_f64();
-            let w = self.stream.as_mut().unwrap();
-            let res: std::io::Result<()> = (|| {
-                write!(w, "{ts:.3}")?;
-                for v in &values {
-                    write!(w, ",{v}")?;
-                }
-                writeln!(w)?;
-                if should_flush {
-                    w.flush()?;
-                }
-                Ok(())
-            })();
-            if let Err(e) = res {
+        let entry = LogEntry::new(timestamp, values);
+
+        // Disk is the log. A write failure stops recording rather than
+        // silently filling RAM.
+        if let Some(w) = self.stream.as_mut() {
+            if let Err(e) = w.push(&entry) {
                 tracing::warn!(
-                    "Data log stream write failed ({e}); stopping the continuous \
-                     file at {:?}. In-memory recording continues and can still be \
-                     saved manually.",
+                    "Data log stream write failed ({e}); stopping recording at {:?}.",
                     self.stream_path
                 );
                 self.stream = None;
-                self.stream_path = None;
+                if let Some(path) = self.stream_path.take() {
+                    self.finished_path = Some(path);
+                }
+                self.is_recording = false;
+                return;
             }
         }
 
-        let entry = LogEntry::new(timestamp, values);
-
-        // Manage buffer size. Discarding the oldest entry means the saved log
-        // will be missing its start; count it (and warn the first time) so the
-        // loss is visible rather than silent (D7).
-        if self.buffer.len() >= self.max_buffer_size {
-            self.buffer.pop_front();
-            if self.discarded == 0 {
-                tracing::warn!(
-                    "Data log hit the {}-sample memory ceiling; oldest samples are now \
-                     being discarded. Save more often, or lower the sample rate, to keep \
-                     the whole session.",
-                    self.max_buffer_size
-                );
-            }
-            self.discarded += 1;
+        self.rows_written += 1;
+        self.last_timestamp = timestamp;
+        if self.tail.len() >= LIVE_TAIL {
+            self.tail.pop_front();
         }
-
-        self.buffer.push_back(entry);
+        self.tail.push_back(entry);
         self.last_sample = Some(now);
-    }
-
-    /// Number of oldest samples discarded because the buffer hit its memory
-    /// ceiling. Nonzero means the log no longer covers the whole session.
-    pub fn discarded_count(&self) -> u64 {
-        self.discarded
     }
 
     /// Rows dropped for having the wrong column count (a torn serial read).
@@ -261,14 +266,26 @@ impl DataLogger {
         self.malformed
     }
 
-    /// Get the number of recorded entries
+    /// Samples written to the current file (session length, not RAM size).
     pub fn entry_count(&self) -> usize {
-        self.buffer.len()
+        self.rows_written as usize
     }
 
-    /// Get all entries
+    /// Live-graph tail (not the full session).
     pub fn entries(&self) -> impl Iterator<Item = &LogEntry> {
-        self.buffer.iter()
+        self.tail.iter()
+    }
+
+    /// Slice of the live tail using absolute session indices.
+    pub fn live_window(&self, start_index: usize, count: usize) -> impl Iterator<Item = &LogEntry> {
+        let total = self.rows_written as usize;
+        let origin = total.saturating_sub(self.tail.len());
+        let start = start_index.min(total);
+        let end = start.saturating_add(count).min(total);
+        let from = start.max(origin);
+        let skip = from.saturating_sub(origin);
+        let take = end.saturating_sub(from);
+        self.tail.iter().skip(skip).take(take)
     }
 
     /// Get the channel names
@@ -276,16 +293,33 @@ impl DataLogger {
         &self.channels
     }
 
-    /// Clear all recorded data
+    /// Reset the live session. The file on disk is kept; if still recording,
+    /// a new timestamped file is opened in the same directory.
     pub fn clear(&mut self) {
-        self.buffer.clear();
-        self.start_time = None;
-        self.discarded = 0;
+        self.tail.clear();
+        self.rows_written = 0;
+        self.last_timestamp = Duration::ZERO;
+        self.malformed = 0;
+        if self.is_recording {
+            if let Some(dir) = self.stream_dir.clone() {
+                let name = chrono::Local::now().format("%Y-%m-%d_%H.%M.%S").to_string();
+                let path = dir.join(format!("{name}.ltlog"));
+                if self.start_streaming(&path).is_ok() {
+                    self.start_time = Some(Instant::now());
+                    self.last_sample = None;
+                    return;
+                }
+            }
+            self.start_time = Some(Instant::now());
+            self.last_sample = None;
+        } else {
+            self.start_time = None;
+        }
     }
 
-    /// Get the duration of the log
+    /// Get the duration of the current file
     pub fn duration(&self) -> Duration {
-        self.buffer.back().map(|e| e.timestamp).unwrap_or_default()
+        self.last_timestamp
     }
 }
 
@@ -298,6 +332,20 @@ impl Default for DataLogger {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn temp_path(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "lt_rec_{}_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos(),
+            name
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir.join("session.ltlog")
+    }
 
     #[test]
     fn test_logger_basic() {
@@ -332,7 +380,7 @@ mod tests {
     }
 
     #[test]
-    fn test_restart_appends_with_continuous_timeline() {
+    fn start_begins_a_new_timeline() {
         let mut logger = DataLogger::new(vec!["rpm".into()]);
         logger.set_sample_rate(200.0);
 
@@ -340,16 +388,12 @@ mod tests {
         logger.record(vec![1000.0]);
         logger.stop();
         assert_eq!(logger.entry_count(), 1);
-        let first_ts = logger.duration();
 
-        // Restarting must keep the previous entries and continue the timeline
         logger.start();
         std::thread::sleep(Duration::from_millis(10));
         logger.record(vec![2000.0]);
-        assert_eq!(logger.entry_count(), 2);
-        assert!(logger.duration() >= first_ts);
+        assert_eq!(logger.entry_count(), 1);
 
-        // Only clear() wipes the log
         logger.clear();
         assert_eq!(logger.entry_count(), 0);
         logger.start();
@@ -358,33 +402,33 @@ mod tests {
     }
 
     #[test]
-    fn discards_oldest_past_ceiling_and_counts_them() {
+    fn live_tail_stays_bounded_full_log_is_the_file() {
+        let path = temp_path("tail");
         let mut logger = DataLogger::new(vec!["rpm".into()]);
-        logger.set_max_buffer_size(3);
-        logger.set_sample_rate(200.0); // 5 ms min interval
+        logger.set_sample_rate(200.0);
+        logger.start_streaming(&path).expect("open stream file");
         logger.start();
 
-        // Push 5 samples spaced past the rate-limit interval so each is kept.
-        for i in 0..5 {
-            logger.record(vec![i as f64]);
-            std::thread::sleep(Duration::from_millis(7));
+        let n = LIVE_TAIL + 32;
+        for i in 0..n {
+            logger.record_unthrottled(vec![i as f64]);
         }
+        logger.stop();
 
-        // Buffer holds only the last 3; the 2 oldest were discarded and counted.
-        assert_eq!(logger.entry_count(), 3);
-        assert_eq!(logger.discarded_count(), 2);
+        assert_eq!(logger.entry_count(), n);
+        assert_eq!(logger.entries().count(), LIVE_TAIL);
 
-        // clear() resets the discard counter for a fresh session.
-        logger.clear();
-        assert_eq!(logger.discarded_count(), 0);
+        let (_, entries) = crate::datalog::ltlog::read_ltlog(&path).expect("read stream file");
+        assert_eq!(entries.len(), n);
+        let _ = std::fs::remove_file(&path);
+        if let Some(dir) = path.parent() {
+            let _ = std::fs::remove_dir_all(dir);
+        }
     }
 
     #[test]
     fn streams_samples_to_disk_continuously() {
-        // Each recorded sample must land in the file as it happens (saved the
-        // whole time), with a Time + channel header.
-        let dir = std::env::temp_dir().join(format!("lt_stream_{}", std::process::id()));
-        let path = dir.join("session.csv");
+        let path = temp_path("stream");
         let mut logger = DataLogger::new(vec!["rpm".into(), "map".into()]);
         logger.set_sample_rate(200.0);
         logger.start_streaming(&path).expect("open stream file");
@@ -393,13 +437,21 @@ mod tests {
         logger.record(vec![1000.0, 50.0]);
         std::thread::sleep(Duration::from_millis(7));
         logger.record(vec![2000.0, 60.0]);
-        logger.stop(); // flushes
+        logger.stop();
 
-        let content = std::fs::read_to_string(&path).expect("read stream file");
-        let lines: Vec<&str> = content.lines().collect();
-        assert_eq!(lines[0], "Time,rpm,map");
-        assert!(lines.len() >= 3, "header + 2 rows, got {}", lines.len());
-        assert!(lines[1].contains("1000") && lines[1].contains("50"));
-        let _ = std::fs::remove_dir_all(&dir);
+        let (channels, entries) =
+            crate::datalog::ltlog::read_ltlog(&path).expect("read stream file");
+        assert_eq!(channels, vec!["rpm", "map"]);
+        assert!(
+            entries.len() >= 2,
+            "expected 2 samples, got {}",
+            entries.len()
+        );
+        assert!((entries[0].values[0] - 1000.0).abs() < 0.01);
+        assert!((entries[1].values[1] - 60.0).abs() < 0.01);
+        let _ = std::fs::remove_file(&path);
+        if let Some(dir) = path.parent() {
+            let _ = std::fs::remove_dir_all(dir);
+        }
     }
 }

--- a/docs/src/features/datalog.md
+++ b/docs/src/features/datalog.md
@@ -23,21 +23,23 @@ Data logging captures engine parameters over time, allowing you to:
 
 Click **Stop Logging** or press `Ctrl+L` again.
 
-Logs are automatically saved to your project's `logs/` folder.
+Logs are automatically saved to your project's `datalogs/` folder as `.ltlog` files.
 
 ## Log File Format
 
-LibreTune uses CSV format:
-```csv
-Time,RPM,MAP,AFR,CLT,TPS,...
-0.000,850,35.2,14.7,185,1.2,...
-0.100,860,35.5,14.6,185,1.3,...
-```
+LibreTune records to **`.ltlog`**, a compact binary log:
 
-This format is compatible with:
-- MegaLogViewer
-- Excel/Google Sheets
-- Custom analysis scripts
+- Channel names, units, and INI signature are stored once in the header
+- Samples are packed as binary (`f32`) in CRC-checked, zstd-compressed blocks
+- A crash or yanked USB loses only the last incomplete block; earlier samples still load
+- Recording writes straight to disk; RAM holds only a short live-graph tail
+- Opening a large `.ltlog` streams it: the chart shows a downsampled preview, and analysis reads named columns without loading the whole file
+
+Typical size vs CSV (100 channels, 50 Hz): about **10–30× smaller**. A one-hour log that would be ~150 MB of CSV is usually **~5–15 MB** as `.ltlog`.
+
+You can still **open** older LibreTune `.csv` files, TunerStudio `.msl` text exports, and TunerStudio `.mlg` binary logs.
+
+Native recording no longer writes CSV (it grows with every ASCII digit of every channel on every sample).
 
 ## Data Log Viewer
 
@@ -45,7 +47,7 @@ This format is compatible with:
 
 1. Go to **Tools → Data Log Viewer**
 2. Click **Open Log**
-3. Select a CSV file
+3. Select a `.ltlog` file (or an older `.csv` / TunerStudio `.msl` / `.mlg`)
 
 ### Playback Controls
 
@@ -87,10 +89,7 @@ Configure automatic logging in Settings:
 
 ### Sharing Logs
 
-Log CSV files can be:
-- Emailed to tuners for review
-- Opened in MegaLogViewer for detailed analysis
-- Imported into spreadsheets for custom analysis
+`.ltlog` files can be opened in LibreTune. Older CSV logs remain readable. TunerStudio `.msl` / `.mlg` can be imported for analysis.
 
 ## Exporting Tune Data
 


### PR DESCRIPTION
Record compressed .ltlog directly to project datalogs (or app data). Keep only a live-graph tail in memory, and stream large files for charts and analysis instead of loading every sample.